### PR TITLE
Fix fallback JSON definition loading

### DIFF
--- a/Loading/FuseDataPackageDiscovery.cs
+++ b/Loading/FuseDataPackageDiscovery.cs
@@ -618,39 +618,13 @@ namespace FUSE.Loading
         {
             try
             {
-                if (Directory.GetFiles(folderPath, "*.bson", SearchOption.TopDirectoryOnly).Length > 0)
-                {
-                    return true;
-                }
-
-                return Directory.GetFiles(folderPath, "*.json", SearchOption.TopDirectoryOnly)
-                    .Any(IsFallbackDefinitionJsonFile);
+                return FuseDefinitionFileDiscovery.HasFallbackDefinitionFile(folderPath);
             }
             catch (Exception ex)
             {
                 FuseLog.Warning($"FUSE could not inspect package root definition files in '{folderPath}': {ex.Message}");
                 return false;
             }
-        }
-
-        private static bool IsFallbackDefinitionJsonFile(string path)
-        {
-            var fileName = Path.GetFileName(path);
-            if (string.IsNullOrWhiteSpace(fileName))
-            {
-                return false;
-            }
-
-            if (string.Equals(fileName, "Info.json", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(fileName, "conversion-report.json", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(fileName, "Catalog.json", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(fileName, "Definitions.json", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(fileName, "Definition.json", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            return fileName.EndsWith(".fuse.json", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool ContainsFuseReference(JToken token)

--- a/Loading/FuseDefinitionFileDiscovery.cs
+++ b/Loading/FuseDefinitionFileDiscovery.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace FUSE.Loading
+{
+    internal static class FuseDefinitionFileDiscovery
+    {
+        private static readonly string[] ExcludedFallbackJsonFileNames =
+        {
+            "Info.json",
+            "conversion-report.json",
+            "Catalog.json",
+            "Definitions.json",
+            "Definition.json"
+        };
+
+        public static string[] ResolveFallbackDefinitionPaths(string folderPath)
+        {
+            if (string.IsNullOrWhiteSpace(folderPath))
+            {
+                return Array.Empty<string>();
+            }
+
+            var bsonFiles = Directory.GetFiles(folderPath, "*.bson", SearchOption.TopDirectoryOnly)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (bsonFiles.Length > 0)
+            {
+                return new[] { bsonFiles[0] };
+            }
+
+            var jsonFiles = Directory.GetFiles(folderPath, "*.json", SearchOption.TopDirectoryOnly)
+                .Where(IsFallbackDefinitionJsonFile)
+                .OrderBy(GetJsonFallbackRank)
+                .ThenBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            return jsonFiles.Length > 0 ? new[] { jsonFiles[0] } : Array.Empty<string>();
+        }
+
+        public static bool HasFallbackDefinitionFile(string folderPath)
+        {
+            return ResolveFallbackDefinitionPaths(folderPath).Length > 0;
+        }
+
+        private static bool IsFallbackDefinitionJsonFile(string path)
+        {
+            var fileName = Path.GetFileName(path);
+            if (string.IsNullOrWhiteSpace(fileName) ||
+                !string.Equals(Path.GetExtension(fileName), ".json", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return !ExcludedFallbackJsonFileNames.Any(excluded =>
+                string.Equals(fileName, excluded, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static int GetJsonFallbackRank(string path)
+        {
+            var fileName = Path.GetFileName(path);
+            return fileName != null && fileName.EndsWith(".fuse.json", StringComparison.OrdinalIgnoreCase)
+                ? 0
+                : 1;
+        }
+    }
+}

--- a/Loading/FuseModLoader.cs
+++ b/Loading/FuseModLoader.cs
@@ -2143,18 +2143,10 @@ namespace FUSE.Loading
                 }
             }
 
-            var bsonFiles = Directory.GetFiles(modFolder, "*.bson", SearchOption.TopDirectoryOnly);
-            if (bsonFiles.Length > 0)
+            var fallbackPaths = FuseDefinitionFileDiscovery.ResolveFallbackDefinitionPaths(modFolder);
+            if (fallbackPaths.Length > 0)
             {
-                return new[] { bsonFiles[0] };
-            }
-
-            var jsonFiles = Directory.GetFiles(modFolder, "*.json", SearchOption.TopDirectoryOnly)
-                .Where(IsFallbackDefinitionJsonFile)
-                .ToArray();
-            if (jsonFiles.Length > 0)
-            {
-                return new[] { jsonFiles[0] };
+                return fallbackPaths;
             }
 
             throw new FileNotFoundException($"No FUSE .bson or .json definition was found in '{modFolder}'.");
@@ -2163,26 +2155,6 @@ namespace FUSE.Loading
         private static bool HasFuseAssetPacks(JObject info)
         {
             return info != null && info["FuseAssetPacks"] != null;
-        }
-
-        private static bool IsFallbackDefinitionJsonFile(string path)
-        {
-            var fileName = Path.GetFileName(path);
-            if (string.IsNullOrWhiteSpace(fileName))
-            {
-                return false;
-            }
-
-            if (string.Equals(fileName, "Info.json", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(fileName, "conversion-report.json", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(fileName, "Catalog.json", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(fileName, "Definitions.json", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(fileName, "Definition.json", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            return fileName.EndsWith(".fuse.json", StringComparison.OrdinalIgnoreCase);
         }
 
         private static IEnumerable<string> ResolveExplicitDefinitionPaths(string modFolder, JObject info)

--- a/schemas/FUSE_JSON_SCHEMA.md
+++ b/schemas/FUSE_JSON_SCHEMA.md
@@ -330,7 +330,7 @@ MurphyBranch/
 
 FUSE-specific package ordering uses `FuseLoadPriority`, `FuseLoadAfter`, and `FuseLoadBefore`. Lower priority values load earlier; packages with the same priority fall back to dependency order and then package id. Dependency cycles are reported in the log and the involved packages fall back to priority/name order.
 
-If explicit data-file entries are missing, FUSE falls back to the first `.bson` file in the package root, then the first `.json` file other than `Info.json`.
+If explicit data-file entries are missing, FUSE falls back to the first `.bson` file in the package root, then an eligible root `.json` definition file. Files named `Info.json`, `Definition.json`, `Catalog.json`, `Definitions.json`, and `conversion-report.json` are ignored; `.fuse.json` files are preferred before other eligible `.json` files.
 
 Asset-pack-only packages can expose existing Railroader `AssetPack` runtime stores with `FuseAssetPacks`. FUSE registers these folders as direct prefab stores from the mod directory by default; the old LocalLow mirror path is an opt-in compatibility fallback, not the normal load path:
 


### PR DESCRIPTION
﻿## Summary

Fixes fallback FUSE definition discovery so runtime behavior matches the documented package contract.

- Adds a shared fallback definition file resolver used by both package discovery and loading.
- Keeps BSON as the first fallback choice.
- Allows eligible root `.json` definition files when `FuseDataFile` / `FuseDataFiles` are not declared.
- Ignores manifest/report/asset-pack metadata JSON files and prefers `.fuse.json` files before other eligible `.json` files.
- Updates schema documentation to describe the exact fallback behavior.

## Root Cause

Discovery and loading each had a duplicated fallback predicate that only accepted `.fuse.json` files, while the public schema docs said FUSE would fall back to the first root `.json` file other than `Info.json`. Packages following the docs with a plain JSON definition could be skipped or fail to resolve.

## Validation

- `git diff --cached --check` passed before commit.
- `git diff --check` passed before commit.
- `dotnet build FUSE.csproj --no-restore /p:EnableModDeploy=false` was attempted, but this local environment is missing `UnityModManagerNet.dll` / `UnityModManager.dll` from the configured Railroader install path, so the build stops before compiling project code.
