### PR TITLE
Handle merged graph rebuild failures

### DIFF
--- a/Loading/FuseModLoader.cs
+++ b/Loading/FuseModLoader.cs
@@ -641,6 +641,22 @@ namespace FUSE.Loading
             {
                 var graphTransaction = new FuseApplyTransaction("__merged-graph-rebuild__", reason, false);
                 graphTransaction.RunPhase("merged-single-graph-rebuild", () => TrackAPI.RebuildGraph());
+                if (graphTransaction.Report.IsFatal || graphTransaction.Report.HasErrors)
+                {
+                    var failure = FormatMergedGraphRebuildFailure(graphTransaction.Report);
+                    foreach (var candidate in plan.OrderedCandidates.Where(item => item?.Transaction != null && !item.Transaction.Report.IsFatal))
+                    {
+                        var definitionId = candidate.Loaded?.Definition?.Id ?? string.Empty;
+                        candidate.Transaction.RunPhase("merged-single-graph-rebuild", () =>
+                            candidate.Transaction.Fatal("graph", definitionId, failure));
+                    }
+
+                    FuseLog.Warning(
+                        "FUSE merged graph apply operation='merged-single-graph-rebuild' failed; " +
+                        "final span apply and later runtime phases were aborted for active definitions.");
+                    return;
+                }
+
                 foreach (var candidate in plan.OrderedCandidates.Where(item => !item.Transaction.Report.IsFatal))
                 {
                     candidate.Transaction.PostBind("graph", candidate.Loaded.Definition.Id, "merged-rebuilt-before-final-spans");
@@ -665,6 +681,19 @@ namespace FUSE.Loading
             {
                 TrackAPI.EndBatch(false);
             }
+        }
+
+        private static string FormatMergedGraphRebuildFailure(FuseApplyReport report)
+        {
+            var message = report?.FatalReason;
+            if (string.IsNullOrWhiteSpace(message) && report?.Errors != null && report.Errors.Count > 0)
+            {
+                message = report.Errors[0];
+            }
+
+            return string.IsNullOrWhiteSpace(message)
+                ? "merged graph rebuild failed"
+                : "merged graph rebuild failed: " + message;
         }
 
         private static void ApplyMergedSpanRemoval(FuseMergedTrackRemoval removal)


### PR DESCRIPTION
## Summary

- Propagate merged track graph rebuild failures back into every active package apply transaction.
- Stop final span application and later phases when the merged graph rebuild reports fatal/errors.
- Keep the failure reason visible in each affected transaction report.

## Root Cause

ApplyMergedTrackGraph rebuilt the merged single-track graph in a throwaway transaction. If that rebuild failed, the active package transactions could still remain non-fatal and later be marked applied successfully.

## Validation

- git diff --check
- dotnet build FUSE.csproj --no-restore /p:EnableModDeploy=false could not complete locally because the worktree is missing the UnityModManager/Railroader assemblies required by this project.