### PR TITLE
Harden package path containment

### DIFF
--- a/API/FuseAudioAPI.cs
+++ b/API/FuseAudioAPI.cs
@@ -577,12 +577,9 @@ namespace FUSE.API
             }
 
             text = text.Trim().Trim('"', '\'');
-            if (Path.IsPathRooted(text))
-            {
-                return Path.GetFullPath(text);
-            }
-
-            return Path.GetFullPath(Path.Combine(packageFolder ?? string.Empty, text));
+            return FusePathSafety.TryResolvePackageRelativePath(packageFolder, text, out var resolved)
+                ? resolved
+                : string.Empty;
         }
 
         private static string NormalizeId(string id, string fallback)

--- a/Infrastructure/FusePathSafety.cs
+++ b/Infrastructure/FusePathSafety.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+
+namespace FUSE.Infrastructure
+{
+    internal static class FusePathSafety
+    {
+        public static bool TryResolvePackageRelativePath(string packageRoot, string relativePath, out string fullPath)
+        {
+            fullPath = string.Empty;
+            if (string.IsNullOrWhiteSpace(packageRoot) || string.IsNullOrWhiteSpace(relativePath))
+            {
+                return false;
+            }
+
+            var trimmed = relativePath.Trim();
+            if (Path.IsPathRooted(trimmed))
+            {
+                return false;
+            }
+
+            try
+            {
+                var root = Path.GetFullPath(packageRoot);
+                var candidate = Path.GetFullPath(Path.Combine(root, trimmed));
+                if (!IsUnderRoot(root, candidate))
+                {
+                    return false;
+                }
+
+                fullPath = candidate;
+                return true;
+            }
+            catch
+            {
+                fullPath = string.Empty;
+                return false;
+            }
+        }
+
+        public static bool IsUnderRoot(string rootPath, string candidatePath)
+        {
+            if (string.IsNullOrWhiteSpace(rootPath) || string.IsNullOrWhiteSpace(candidatePath))
+            {
+                return false;
+            }
+
+            try
+            {
+                var root = Path.GetFullPath(rootPath);
+                var candidate = Path.GetFullPath(candidatePath);
+                if (string.Equals(root, candidate, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                var rootWithSeparator = AppendDirectorySeparatorChar(root);
+                return candidate.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string AppendDirectorySeparatorChar(string path)
+        {
+            if (string.IsNullOrEmpty(path) ||
+                path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) ||
+                path.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+            {
+                return path;
+            }
+
+            return path + Path.DirectorySeparatorChar;
+        }
+    }
+}

--- a/Loading/FuseAssetPackRegistry.cs
+++ b/Loading/FuseAssetPackRegistry.cs
@@ -258,9 +258,7 @@ namespace FUSE.Loading
                 return 0;
             }
 
-            var packageRoot = Path.GetFullPath(packagePath);
-            var sourcePath = Path.GetFullPath(Path.Combine(packageRoot, relativeSource));
-            if (!sourcePath.StartsWith(packageRoot, StringComparison.OrdinalIgnoreCase))
+            if (!FusePathSafety.TryResolvePackageRelativePath(packagePath, relativeSource, out var sourcePath))
             {
                 FuseLog.Warning($"FUSE ignored asset pack source outside package root: '{relativeSource}'.");
                 return 0;
@@ -457,9 +455,7 @@ namespace FUSE.Loading
                 yield break;
             }
 
-            var packageRoot = Path.GetFullPath(packagePath);
-            var sourcePath = Path.GetFullPath(Path.Combine(packageRoot, relativeSource));
-            if (!sourcePath.StartsWith(packageRoot, StringComparison.OrdinalIgnoreCase) ||
+            if (!FusePathSafety.TryResolvePackageRelativePath(packagePath, relativeSource, out var sourcePath) ||
                 !Directory.Exists(sourcePath))
             {
                 yield break;

--- a/Loading/FuseMapTileRegistry.cs
+++ b/Loading/FuseMapTileRegistry.cs
@@ -265,9 +265,7 @@ namespace FUSE.Loading
                 return string.Empty;
             }
 
-            var packageRoot = Path.GetFullPath(modFolder);
-            var resolved = Path.GetFullPath(Path.Combine(packageRoot, sourceFolder));
-            return resolved.StartsWith(packageRoot, StringComparison.OrdinalIgnoreCase)
+            return FusePathSafety.TryResolvePackageRelativePath(modFolder, sourceFolder, out var resolved)
                 ? resolved
                 : string.Empty;
         }

--- a/Loading/FuseModLoader.cs
+++ b/Loading/FuseModLoader.cs
@@ -2238,7 +2238,11 @@ namespace FUSE.Loading
 
         private static string ResolveExistingDefinitionPath(string modFolder, string railDataFile)
         {
-            var explicitPath = Path.Combine(modFolder, railDataFile);
+            if (!FusePathSafety.TryResolvePackageRelativePath(modFolder, railDataFile, out var explicitPath))
+            {
+                throw new FileNotFoundException($"FUSE data file '{railDataFile}' is outside package root '{modFolder}'.");
+            }
+
             if (!File.Exists(explicitPath))
             {
                 throw new FileNotFoundException($"FUSE data file '{railDataFile}' was not found in '{modFolder}'.", explicitPath);


### PR DESCRIPTION
## Summary
- Add a shared package-relative path resolver that rejects rooted paths and paths escaping the package root.
- Use it for FUSE data files, asset pack sources, relative map tile folders, and loose audio file references.
- Preserve the existing absolute-path support for map tile migration workflows while hardening package-relative inputs.

## Root Cause
Several loaders resolved package-relative paths with raw Path.Combine/StartsWith checks. That could accept sibling paths sharing the same prefix, and some call sites had no containment check at all.

## Validation
- git diff --check
- Searched for remaining raw StartsWith(packageRoot) / Path.Combine(packageRoot) patterns in C# files; none remain.
- dotnet build FUSE.csproj --no-restore /p:EnableModDeploy=false is blocked locally because UnityModManagerNet.dll or UnityModManager.dll is not installed at the configured Railroader/UMM path.