### PR TITLE
Adjust legacy compatibility wording

### DIFF
--- a/Data/FuseModDefinition.cs
+++ b/Data/FuseModDefinition.cs
@@ -41,7 +41,8 @@ namespace FUSE.Data
         public string SourceFile { get; set; }
 
         /// <summary>
-        /// Optional mod requirements copied from RailLoader/Strange Customs
+        /// Optional mod requirements copied from the legacy mod loader and
+        /// legacy custom content framework
         /// conditional mixintos. If any requirement is not satisfied, FUSE
         /// skips this fragment instead of treating it as a package fault.
         /// </summary>

--- a/FUSE_RELEASE_CLEANUP_CHECKLIST_BETA.md
+++ b/FUSE_RELEASE_CLEANUP_CHECKLIST_BETA.md
@@ -9,7 +9,7 @@ Evidence used for this snapshot:
 - FUSE source tree at `C:\Hrogers_Railroader_mods_Projects\Rail`
 - Legacy corpus at `C:\Railroader mods\Installed\Map`
 - FUSE log snapshot at `C:\Users\roger\AppData\LocalLow\Giraffe Lab LLC\Railroader\FUSE.log`
-- RailLoader logs at `C:\Steam\steamapps\common\Railroader\railloader*.log`
+- Legacy mod loader logs from the Railroader install folder
 - Current converter tools under `tools\`
 
 Important note: the 2026-05-15 LocalLow `FUSE.log` is now the authoritative runtime evidence for the current FUSE run.
@@ -33,7 +33,7 @@ Important note: the 2026-05-15 LocalLow `FUSE.log` is now the authoritative runt
   - Scratch verified again 2026-05-11 after classifying successful converter repairs as info instead of warnings: batch converted 12/12 current inputs with 0 errors into `_work\full-corpus-conversion-20260511-clean-reporting`; warnings dropped to 4, all tied to unresolved/source-authored issues instead of repaired content.
 - [x] Converter emits one useful report per conversion: repaired, preserved, unresolved, unsupported, and dependency-required entries. Code complete 2026-05-08; `conversion-report.json` and `conversion-report.md` now include outcome buckets and per-source-file summaries. Scratch verified with `CoppersPaperboardRemover` and Asheville.
 - [x] Converted mods preserve legacy file concerns: one source JSON becomes one FUSE JSON unless the source is metadata-only. Scratch verified 2026-05-08: corpus reports include one file summary per converted source concern, and output filenames follow the source JSON stems instead of artificial concern buckets.
-- [ ] FUSE load time is benchmarked against RailLoader and is within the same range or faster for equivalent installed content.
+- [ ] FUSE load time is benchmarked against the legacy mod loader and is within the same range or faster for equivalent installed content.
 - [x] Runtime logs are readable without hunting through stack traces.
   - Code pass 2026-05-08: successful legacy span auto-repairs are now info-level, same-segment preflight compatibility repairs no longer dirty apply reports, package world apply no longer triggers the public experimental authoring warning, FUSE passenger-stop helper spans are anonymous runtime-only spans, FUSE formulaic components allow legacy one-sided producer/consumer formulas without base-game validation errors, and passenger stops default blank legacy car filters to `*`. Needs fresh Player.log verification.
   - Runtime verified 2026-05-08: formulaic-component validation spam and `passenger-stop.*` duplicate span ids no longer appear.
@@ -191,7 +191,7 @@ These gates keep FUSE from becoming a larger version of the legacy stack. The go
 - [x] P0: Fix progression/load dependency faults, especially Copper missing-load and interchange-transfer cases. Runtime verified 2026-05-07: missing-load placeholders kept Copper progressions loadable and legacy `.t1` interchange-transfer aliases resolved 10 transfers with `skipped interchange transfer = 0`.
   - Code/converter pass 2026-05-08: known Copper-only missing loads are now real converted load definitions instead of runtime placeholders.
 - [x] P0: Verify track group pre-enable does not make progression-gated scenery or track visible early. Code path fixed 2026-05-07; runtime route verification still needed.
-- [ ] P1: Match legacy industry component behavior for all AMM, Strange Customs, Zamu, Copper, and ConfusingSupplements components.
+- [ ] P1: Match legacy industry component behavior for all AMM, legacy custom content framework, Zamu, Copper, and ConfusingSupplements components.
 - [ ] P1: Finalize station/passenger stop ordering, span binding, map icons, and company window display.
   - Verified 2026-05-08: `Editor\MainEditorWindow.cs` and `Infrastructure\WindowCreatorHelper.cs` do not reference, destroy, or null the base-game company window. They only manage FUSE's own editor window instance/panel references.
   - Code pass 2026-05-08: passenger stop child `TrackSpan` helpers now keep blank graph ids to stop duplicate graph-span warnings, and virtual passenger stops suppress base `IndustryComponent` validation that does not apply to FUSE passenger-stop shims. Needs fresh Player.log verification.
@@ -200,7 +200,7 @@ These gates keep FUSE from becoming a larger version of the legacy stack. The go
   - Fresh 2026-05-15 log verification: `Player.log` contains no `CompanyWindow`, `ShortName`, `LocationsPanelBuilder`, or `OpsController.get_Areas` failures after the ordering/company-window patch. FUSE cached 60 areas with first area preview `Asheville > Emma > Boswell > Sulfur Springs > Enka > Hominy > Candler > Luthers > Coburn > Canton > Starney > Moore`. Still needs visual verification that the Locations tab order and reopen behavior match this.
 - [x] P1: Clean converter/runtime turntable handling so physical turntables and progression industries named "turntable" are never confused. Code complete 2026-05-07; duplicate physical turntable ids now apply as final-state overrides during staged graph apply. Needs Kirkland runtime verification.
 - [x] P1: Finish spliney parity: dirt roads, asphalt roads, rivers, trestles, terrain roads, waterfalls.
-  - Code/build complete 2026-05-10: runtime now accepts the full schema spliney type set (`road`, `river`, `terrainRoad`, `trestle`) instead of silently collapsing terrain roads/waterfalls to normal roads. Converter preserves Strange Customs `FlowyThingBuilder` river/road style/profile and emits the legacy `offsetY: -0.1` default when source data omits it. Release DLL deployed; converter `.pyz` and `.exe` rebuilt.
+  - Code/build complete 2026-05-10: runtime now accepts the full schema spliney type set (`road`, `river`, `terrainRoad`, `trestle`) instead of silently collapsing terrain roads/waterfalls to normal roads. Converter preserves legacy custom content `FlowyThingBuilder` river/road style/profile and emits the legacy `offsetY: -0.1` default when source data omits it. Release DLL deployed; converter `.pyz` and `.exe` rebuilt.
 - [ ] P2: Finish horn, whistle, and bell parity and regression-test converted audio packs.
 - [x] P2: Refresh schema docs and examples after runtime/converter behavior is stable.
   - Documentation pass 2026-05-14: refreshed `schemas\fuse-mod.example.json`, `schemas\umm-info.example.json`, and `schemas\FUSE_JSON_SCHEMA.md` for the current beta runtime/converter surface.
@@ -219,14 +219,14 @@ These gates keep FUSE from becoming a larger version of the legacy stack. The go
   - Evidence: `FuseAssetPackRegistry` supports `fuseasset://` direct stores and `FuseAssetPackPatches`, but `MountAllAvailableAssetPacks()` still copies packs into LocalLow.
   - Fix: LocalLow asset-pack mirroring is now disabled by default and guarded by `Settings.MirrorAssetPacksToLocalLow`; direct `PrefabStore` stores remain the default.
 
-- [ ] P0: Benchmark load phases against RailLoader.
-  - RailLoader observed behavior: discovers mods quickly and adds direct asset stores from the Mods folder.
-  - Timing logs added 2026-05-07 for map-load total, cache rebuild, discovery, asset-pack registration, disk load, runtime apply, map-mask rebuild, console registration, and per-package load. Actual RailLoader comparison still needs a fresh game run.
-  - Fresh 2026-05-09 FUSE timing: discovery 17 ms, load-from-disk 223 ms, runtime apply 18,644 ms, total map-load 19,309 ms for 15 packages / 73 resident definitions / 62 applied definitions. Still needs equivalent RailLoader timing comparison.
-  - Log audit 2026-05-10: FUSE disk work is already small (latest disk load 309 ms); the bottleneck is runtime apply (~18.6 s). RailLoader logs from 2026-05-06 show plugin definition/mod loading in roughly 170 ms and Strange Customs graph patching roughly 2.7-2.9 s after scene load begins, but the installed content sets are not perfectly equivalent.
+- [ ] P0: Benchmark load phases against the legacy mod loader.
+  - The legacy mod loader's observed behavior: discovers mods quickly and adds direct asset stores from the Mods folder.
+  - Timing logs added 2026-05-07 for map-load total, cache rebuild, discovery, asset-pack registration, disk load, runtime apply, map-mask rebuild, console registration, and per-package load. Actual legacy mod loader comparison still needs a fresh game run.
+  - Fresh 2026-05-09 FUSE timing: discovery 17 ms, load-from-disk 223 ms, runtime apply 18,644 ms, total map-load 19,309 ms for 15 packages / 73 resident definitions / 62 applied definitions. Still needs equivalent legacy mod loader timing comparison.
+  - Log audit 2026-05-10: FUSE disk work is already small (latest disk load 309 ms); the bottleneck is runtime apply (~18.6 s). Legacy mod loader logs from 2026-05-06 show plugin definition/mod loading in roughly 170 ms and legacy custom content graph patching roughly 2.7-2.9 s after scene load begins, but the installed content sets are not perfectly equivalent.
   - Code pass 2026-05-10: staged operations now defer `TrackAPI.ApplyAreaOrdering()` and run it once after the industry batch instead of once per data fragment. Needs fresh timing log to measure impact.
   - Code/build pass 2026-05-10: per-entity authoring bind info logs are now gated behind `Settings.VerboseApplyReportDetails`; normal map loads should no longer write hundreds of scenery bind lines to `FUSE.log`. Needs fresh timing/log-size comparison.
-  - Fresh 2026-05-15 FUSE timing: discovery 18 ms, asset-pack registration 0 ms, total map-load pipeline 11,307 ms for 15 package folders / 62 applied definitions. Direct asset stores are active and LocalLow mirroring remains disabled by default; equivalent RailLoader timing comparison is still required.
+  - Fresh 2026-05-15 FUSE timing: discovery 18 ms, asset-pack registration 0 ms, total map-load pipeline 11,307 ms for 15 package folders / 62 applied definitions. Direct asset stores are active and LocalLow mirroring remains disabled by default; equivalent legacy mod loader timing comparison is still required.
   - Timing audit 2026-05-11: latest available run spent most runtime-apply time in `apply-world-objects` (9,067 ms total), then `apply-operations` (2,557 ms), and the single graph rebuild (1,730 ms). Top world rows were KingG scenery (2,474 ms), Griz game-graph world objects (2,377 ms), Asheville game-graph world objects (839 ms), and GCR track world objects (759 ms).
   - Code/build pass 2026-05-11: scenery and spliney existence checks now trust the rebuilt FUSE runtime indexes during package apply instead of falling back to repeated full-scene `FindObjectsOfType` scans for every new object. Spline/trestle profile discovery is cached per map session. Release DLL deployed; needs fresh timing log to measure improvement.
 
@@ -346,7 +346,7 @@ These gates keep FUSE from becoming a larger version of the legacy stack. The go
 
 - [x] P1: Add graph validation that explains route direction errors using start/end, A/B, upper/lower, and distance.
   - Code/build complete 2026-05-10: failed runtime span route validation now reports `upper`/`lower` segment id, A/B Start/End anchor, distance, and segment length. Release DLL deployed to `C:\Steam\steamapps\common\Railroader\Mods\FUSE\FUSE.dll`.
-  - Runtime note 2026-05-08: Asheville `NERbalsam-pigeon_dpem` switch geometry error matches the legacy source node/segment data exactly and should be treated as an authoring/legacy-geometry warning unless RailLoader/AMM prove they repair it. Do not spend release time inventing a FUSE-only geometry rewrite for one bad authored switch.
+  - Runtime note 2026-05-08: Asheville `NERbalsam-pigeon_dpem` switch geometry error matches the legacy source node/segment data exactly and should be treated as an authoring/legacy-geometry warning unless AMM or the legacy mod loader prove they repair it. Do not spend release time inventing a FUSE-only geometry rewrite for one bad authored switch.
 
 - [x] P1: Add converter/runtime validation for duplicate node, segment, span, and object IDs inside one package.
   - Code/build complete 2026-05-10: JSON package loading now rejects duplicate object keys before deserialization using `DuplicatePropertyNameHandling.Error`, so duplicate `tracks.nodes`, `tracks.segments`, `tracks.spans`, operations, world, and progression entries cannot silently overwrite earlier definitions. Release DLL deployed to `C:\Steam\steamapps\common\Railroader\Mods\FUSE\FUSE.dll`.
@@ -419,7 +419,7 @@ These gates keep FUSE from becoming a larger version of the legacy stack. The go
 
 ## Operations And Industry Components
 
-- [x] P0: FUSE-created industries must match AMM and Strange Customs materialization.
+- [x] P0: FUSE-created industries must match AMM and legacy custom content materialization.
   - Parent under Area when possible.
   - Create inactive.
   - Add Formulaic components on industry GameObject.
@@ -543,14 +543,14 @@ These gates keep FUSE from becoming a larger version of the legacy stack. The go
 
 ## Splineys And World Builders
 
-- [x] P0: Strange Customs road splineys must distinguish dirt and asphalt/pavement.
+- [x] P0: Legacy custom content road splineys must distinguish dirt and asphalt/pavement.
   - Code audit 2026-05-10: converter preserves legacy `profile` and `style` on `FlowyThingBuilder`; runtime resolves named `SplineProfile` first, so dirt/asphalt/pavement remain profile-driven instead of becoming one generic road.
 
-- [x] P0: Strange Customs rivers must use the river path/profile only, not road fallback.
+- [x] P0: Legacy custom content rivers must use the river path/profile only, not road fallback.
   - Code/build complete 2026-05-10: `FlowyThingBuilder` entries with `style: River` or river profiles convert as `type: river`; runtime uses `RiverPathStyle.River` and river/waterfall profile fallback hints.
 
 - [x] P0: Trestles must match AutoTrestleBuilder placement, profile, and height behavior.
-  - Code audit 2026-05-10: FUSE `AutoTrestle` placement matches Strange Customs center-relative control points and resolves the vanilla profile from existing `AutoTrestle` instances/resources; no active log faults remain for trestle generation.
+  - Code audit 2026-05-10: FUSE `AutoTrestle` placement matches legacy custom content center-relative control points and resolves the vanilla profile from existing `AutoTrestle` instances/resources; no active log faults remain for trestle generation.
 
 - [x] P1: Terrain roads, waterfalls, and any single-point spliney objects must either have runtime support or converter-level repair.
   - Code/build complete 2026-05-10: runtime supports `terrainRoad` and `waterfall` as flowy spline families, and converter preserves one-point/non-runtime legacy spliney objects under `extensions.legacySplineyObjects` instead of dropping them.
@@ -563,7 +563,7 @@ These gates keep FUSE from becoming a larger version of the legacy stack. The go
 
 ## Horns, Whistles, And Bells
 
-- [ ] P0: Converted audio packs must load without requiring Strange Customs.
+- [ ] P0: Converted audio packs must load without requiring the legacy custom content framework.
 
 - [ ] P0: Horn/whistle/bell asset identifiers must match legacy pack behavior.
 
@@ -581,8 +581,8 @@ These gates keep FUSE from becoming a larger version of the legacy stack. The go
 
 ## Schema And Public Extension Surface
 
-- [ ] P0: Schema must represent every AMM and Strange Customs feature we are intentionally supporting.
-  - Rule: if AMM/Strange Customs loaded it, FUSE needs the full feature, not a cut-down placeholder.
+- [ ] P0: Schema must represent every AMM and legacy custom content framework feature we are intentionally supporting.
+  - Rule: if AMM or the legacy custom content framework loaded it, FUSE needs the full feature, not a cut-down placeholder.
 
 - [x] P0: Custom industry and load components must be representable as separate dependency mods.
   - Code/build pass 2026-05-10: FUSE JSON can name external component runtime types directly, carry custom `fields`, and rely on package `FuseLoadAfter`/requirements for the owning component/load mod. Converter preserves unknown legacy component/load fields into that payload.
@@ -722,7 +722,7 @@ These gates keep FUSE from becoming a larger version of the legacy stack. The go
 - [ ] Progression-gated objects are hidden until unlocked.
   - Pending fresh route verification after the 2026-05-10 forced map-feature-state refresh build.
 - [ ] Roads, rivers, trestles, map masks, mandelas, turntables, stations, industries, loaders, interchanges, audio, and map tiles visually/functionally match legacy behavior.
-- [ ] Load time matches or beats RailLoader for equivalent installed content.
+- [ ] Load time matches or beats the legacy mod loader for equivalent installed content.
 
 ---
 
@@ -992,7 +992,7 @@ The converter is now part of the product, not just a helper script.
 
 ## Performance / Load-Time Beta Gates
 
-- [ ] Load time benchmark is recorded against RailLoader/legacy stack for equivalent content.
+- [ ] Load time benchmark is recorded against the legacy mod loader stack for equivalent content.
 - [ ] Load time benchmark includes cold start and warm start where practical.
 - [ ] Converter time is benchmarked separately from runtime load time.
 - [x] FUSE avoids repeated map tile remount loops.
@@ -1012,7 +1012,7 @@ Beta does not need full multiplayer support unless explicitly promised, but beha
 - [x] README states multiplayer support level: unsupported, host-only, degraded-safe, or supported.
   - Documentation pass 2026-05-15: `README.md` states beta multiplayer is compatibility-mode only. FUSE does not sync packages; host and clients must have identical enabled FUSE packages and load order.
 - [x] Clients apply local package mutations only under documented compatibility mode or strict-block settings.
-  - Code/build complete 2026-05-15: default non-host clients apply the local package stack with a warning, matching legacy RailLoader behavior when every player has the same mods. `Settings.BlockNonHostMultiplayerClientWorldApply=true` restores strict non-host mutation blocking for server tests.
+  - Code/build complete 2026-05-15: default non-host clients apply the local package stack with a warning, matching legacy mod loader behavior when every player has the same mods. `Settings.BlockNonHostMultiplayerClientWorldApply=true` restores strict non-host mutation blocking for server tests.
 - [x] Host/client package mismatch behavior is documented.
   - Documentation pass 2026-05-15: `README.md` and `KNOWN_ISSUES.md` state that FUSE does not negotiate host/client package mismatches; every player must use the same FUSE version, enabled packages, and load order.
 - [x] Network-bound mutations are blocked or host-authoritative.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -20,14 +20,14 @@
 ## External Mod Conflicts
 
 - Do not load a legacy route and its converted FUSE route at the same time unless testing conflicts.
-- Legacy loaders, AMM, Strange Customs, and RailLoader may create duplicate objects when used with converted packages for the same route.
+- Legacy loaders, AMM, the legacy custom content framework, and the legacy mod loader may create duplicate objects when used with converted packages for the same route.
 - FUSE can load custom industry components only when the owning component assembly is installed and loaded.
 
 ## Multiplayer
 
 - FUSE beta uses legacy-style multiplayer compatibility mode: every player must have the same FUSE build, enabled package list, and load order installed locally.
 - FUSE does not negotiate host/client package mismatches. A mismatched client can desync visually or operationally even though FUSE will warn on first non-host runtime apply.
-- Strict non-host client blocking is available through `Settings.BlockNonHostMultiplayerClientWorldApply`, but it is disabled by default so private multiplayer tests can behave like RailLoader.
+- Strict non-host client blocking is available through `Settings.BlockNonHostMultiplayerClientWorldApply`, but it is disabled by default so private multiplayer tests can behave like the legacy mod loader.
 
 ## Current Verification Notes
 

--- a/Loading/FuseModLoader.cs
+++ b/Loading/FuseModLoader.cs
@@ -446,7 +446,7 @@ namespace FUSE.Loading
             }
 
             FuseLog.Info(
-                $"FUSE Strange-Customs-style staged graph resolver completed reason='{reason ?? "unspecified"}' " +
+                $"FUSE legacy custom content staged graph resolver completed reason='{reason ?? "unspecified"}' " +
                 $"definitions={prepared.Count} applied={appliedCount} " +
                 "mode='package-grouped mixinto order, final-state deletes, single graph commit'.");
             return appliedCount;
@@ -467,7 +467,7 @@ namespace FUSE.Loading
                 return plan;
             }
 
-            // Strange Customs effectively respected the mod/package as the unit,
+            // The legacy custom content framework effectively respected the mod/package as the unit,
             // then respected Definition.json mixinto order inside that package.
             // FUSE already loads explicit FuseDataFiles in declared order, so the
             // safest compatibility behavior is: first package-folder encounter
@@ -1364,7 +1364,7 @@ namespace FUSE.Loading
                     // IMPORTANT: spans must be applied after the node/segment
                     // graph has been rebuilt. TrackSpan route validation asks
                     // the runtime graph for a valid route; applying spans before
-                    // RebuildGraph() makes valid legacy/Strange-Customs spans
+                    // RebuildGraph() makes valid legacy custom content spans
                     // intermittently fail with "span did not resolve to a valid route".
                     TrackAPI.BeginBatch();
                     try

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FUSE
 
-FUSE is a Unity Mod Manager modding layer for Railroader. It loads FUSE data packages for route extensions, asset packs, audio packs, track graph changes, world scenery, operations, progression data, and compatibility imports from the legacy AMM, Strange Customs, and RailLoader ecosystem.
+FUSE is a Unity Mod Manager modding layer for Railroader. It loads FUSE data packages for route extensions, asset packs, audio packs, track graph changes, world scenery, operations, progression data, and compatibility imports from the legacy AMM, legacy custom content framework, and legacy mod loader ecosystem.
 
 This repository is currently targeting a beta release. Signals are intentionally deferred until the rest of the legacy surface is stable.
 
@@ -32,7 +32,7 @@ The FUSE JSON schema lives at `schemas/fuse-mod.schema.json`. The hand-written s
 
 - Signals
 - Full public in-game editor workflow
-- Multiplayer is compatibility-mode only for beta. FUSE does not sync package contents over the network; instead every host/client applies its own local package stack, matching the legacy RailLoader expectation that everyone has the same mods installed. Non-host clients log a warning the first time they apply runtime world changes. Servers that want strict client blocking can set `Settings.BlockNonHostMultiplayerClientWorldApply` to `true`.
+- Multiplayer is compatibility-mode only for beta. FUSE does not sync package contents over the network; instead every host/client applies its own local package stack, matching the legacy mod loader expectation that everyone has the same mods installed. Non-host clients log a warning the first time they apply runtime world changes. Servers that want strict client blocking can set `Settings.BlockNonHostMultiplayerClientWorldApply` to `true`.
 - Arbitrary legacy script mods that are not data, asset, audio, or supported runtime component packages
 - Rolling stock and locomotive/car mods, except audio definitions that FUSE can import
 - Mid-session scene-path suppression re-enable

--- a/bin/Debug/net48/schemas/FUSE_JSON_SCHEMA.md
+++ b/bin/Debug/net48/schemas/FUSE_JSON_SCHEMA.md
@@ -20,7 +20,7 @@ Top-level object groups:
 - `editor`: optional editor-only state that FUSE can ignore at runtime.
 - `extensions`: optional namespaced third-party data.
 
-`mixinto` is optional metadata for converted RailLoader/Strange Customs conditional mixin files. The converted file remains a normal FUSE fragment, but FUSE checks `mixinto.requires[]` immediately before runtime apply. If any required mod is missing, older than `notBefore`, or newer than `notAfter`, that fragment is skipped without faulting the rest of the package.
+`mixinto` is optional metadata for converted legacy mod loader and custom content framework conditional mixin files. The converted file remains a normal FUSE fragment, but FUSE checks `mixinto.requires[]` immediately before runtime apply. If any required mod is missing, older than `notBefore`, or newer than `notAfter`, that fragment is skipped without faulting the rest of the package.
 
 ```json
 {
@@ -91,7 +91,7 @@ Vector values are always objects:
 { "x": 0, "y": 0, "z": 0 }
 ```
 
-Track spans use two structured locations rather than Strange Customs style strings. Think of each location as an arrow measured from one segment end into the span. `Start`/`A` points from the segment's start toward its end; `End`/`B` points from the segment's end toward its start. The two endpoint arrows must face each other and the measured distance must stay within that segment.
+Track spans use two structured locations rather than legacy custom content style strings. Think of each location as an arrow measured from one segment end into the span. `Start`/`A` points from the segment's start toward its end; `End`/`B` points from the segment's end toward its start. The two endpoint arrows must face each other and the measured distance must stay within that segment.
 
 ```json
 {
@@ -245,8 +245,8 @@ Spliney `type` describes the physical spline family, not its material flavor:
 - `terrainRoad`: terrain-carved road spline. Use `style`/`profile` for dirt versus pavement.
 - `trestle`: auto-generated trestle spline.
 
-Converted Strange Customs `FlowyThingBuilder` data must inspect `style` and `profile`; entries with `style: "River"` or river profiles should be emitted as `type: "river"`, not as roads.
-When converting `FlowyThingBuilder` entries, preserve the legacy default `offsetY: -0.1` if the source omits it; the field keeps road and river surfaces at the same vertical bias Strange Customs used.
+Converted legacy custom content `FlowyThingBuilder` data must inspect `style` and `profile`; entries with `style: "River"` or river profiles should be emitted as `type: "river"`, not as roads.
+When converting `FlowyThingBuilder` entries, preserve the legacy default `offsetY: -0.1` if the source omits it; the field keeps road and river surfaces at the same vertical bias the legacy custom content framework used.
 
 Telegraph pole definitions use the existing Railroader telegraph pole and wire prefabs by default. `profile` selects the first vanilla pole prefab whose name contains that profile string. `polePrefab` and `wirePrefab` can override that with explicit prefab URIs.
 

--- a/bin/Debug/net48/schemas/RAIL_JSON_SCHEMA.md
+++ b/bin/Debug/net48/schemas/RAIL_JSON_SCHEMA.md
@@ -58,7 +58,7 @@ Vector values are always objects:
 { "x": 0, "y": 0, "z": 0 }
 ```
 
-Track spans use structured locations rather than Strange Customs style strings:
+Track spans use structured locations rather than legacy custom content style strings:
 
 ```json
 {
@@ -160,11 +160,11 @@ Spliney `type` describes the physical spline family, not its material flavor:
 - `terrainRoad`: terrain-carved road spline. Use `style`/`profile` for dirt versus pavement.
 - `trestle`: auto-generated trestle spline.
 
-Converted Strange Customs `FlowyThingBuilder` data must inspect `style` and `profile`; entries with `style: "River"` or river profiles should be emitted as `type: "river"`, not as roads.
+Converted legacy custom content `FlowyThingBuilder` data must inspect `style` and `profile`; entries with `style: "River"` or river profiles should be emitted as `type: "river"`, not as roads.
 
 Telegraph pole definitions use the existing Railroader telegraph pole and wire prefabs by default. `profile` selects the first vanilla pole prefab whose name contains that profile string. `polePrefab` and `wirePrefab` can override that with explicit prefab URIs.
 
-Industry components currently supported by the runtime include `loader`, `unloader`, `formulaic`, `repairTrack`, `teamTrack`, `interchange`, `interchangedLoader`, and `passengerStop`. Formulaic components are attached directly to the industry object to match Strange Customs behavior; other component types get child objects.
+Industry components currently supported by the runtime include `loader`, `unloader`, `formulaic`, `repairTrack`, `teamTrack`, `interchange`, `interchangedLoader`, and `passengerStop`. Formulaic components are attached directly to the industry object to match legacy custom content behavior; other component types get child objects.
 
 The converter emits canonical RAIL component type names. Legacy aliases such as `Model.Ops.IndustryLoader` and `AlinasMapMod.PaxStationComponent` are normalized at load time for compatibility, but new JSON should use the RAIL names above so it does not depend on AMM assemblies.
 

--- a/bin/Debug/net48/schemas/fuse-mod.schema.json
+++ b/bin/Debug/net48/schemas/fuse-mod.schema.json
@@ -62,7 +62,7 @@
         },
         "mixinto": {
             "$ref": "#/$defs/mixinto",
-            "description": "Optional legacy conditional mixinto metadata. FUSE applies this fragment only when its requirements are satisfied, matching RailLoader/Strange Customs conditional mixins."
+            "description": "Optional legacy conditional mixinto metadata. FUSE applies this fragment only when its requirements are satisfied, matching legacy mod loader and custom content framework conditional mixins."
         },
         "tracks": {
             "$ref": "#/$defs/tracks"
@@ -1337,7 +1337,7 @@
                 },
                 "offsetY": {
                     "type": "number",
-                    "description": "Vertical offset passed through to Railroader's RiverPath. Converted Strange Customs FlowyThingBuilder entries should emit -0.1 when the legacy source omits this field.",
+                    "description": "Vertical offset passed through to Railroader's RiverPath. Converted legacy custom content FlowyThingBuilder entries should emit -0.1 when the legacy source omits this field.",
                     "default": 0
                 },
                 "headStyle": {

--- a/bin/Release/net48/schemas/FUSE_JSON_SCHEMA.md
+++ b/bin/Release/net48/schemas/FUSE_JSON_SCHEMA.md
@@ -20,7 +20,7 @@ Top-level object groups:
 - `editor`: optional editor-only state that FUSE can ignore at runtime.
 - `extensions`: optional namespaced third-party data.
 
-`mixinto` is optional metadata for converted RailLoader/Strange Customs conditional mixin files. The converted file remains a normal FUSE fragment, but FUSE checks `mixinto.requires[]` immediately before runtime apply. If any required mod is missing, older than `notBefore`, or newer than `notAfter`, that fragment is skipped without faulting the rest of the package.
+`mixinto` is optional metadata for converted legacy mod loader and custom content framework conditional mixin files. The converted file remains a normal FUSE fragment, but FUSE checks `mixinto.requires[]` immediately before runtime apply. If any required mod is missing, older than `notBefore`, or newer than `notAfter`, that fragment is skipped without faulting the rest of the package.
 
 ```json
 {
@@ -113,7 +113,7 @@ Vector values are always objects:
 { "x": 0, "y": 0, "z": 0 }
 ```
 
-Track spans use two structured locations rather than Strange Customs style strings. Think of each location as an arrow measured from one segment end into the span. `Start`/`A` points from the segment's start toward its end; `End`/`B` points from the segment's end toward its start. The two endpoint arrows must face each other and the measured distance must stay within that segment.
+Track spans use two structured locations rather than legacy custom content style strings. Think of each location as an arrow measured from one segment end into the span. `Start`/`A` points from the segment's start toward its end; `End`/`B` points from the segment's end toward its start. The two endpoint arrows must face each other and the measured distance must stay within that segment.
 
 ```json
 {
@@ -267,8 +267,8 @@ Spliney `type` describes the physical spline family, not its material flavor:
 - `terrainRoad`: terrain-carved road spline. Use `style`/`profile` for dirt versus pavement.
 - `trestle`: auto-generated trestle spline.
 
-Converted Strange Customs `FlowyThingBuilder` data must inspect `style` and `profile`; entries with `style: "River"` or river profiles should be emitted as `type: "river"`, not as roads.
-When converting `FlowyThingBuilder` entries, preserve the legacy default `offsetY: -0.1` if the source omits it; the field keeps road and river surfaces at the same vertical bias Strange Customs used.
+Converted legacy custom content `FlowyThingBuilder` data must inspect `style` and `profile`; entries with `style: "River"` or river profiles should be emitted as `type: "river"`, not as roads.
+When converting `FlowyThingBuilder` entries, preserve the legacy default `offsetY: -0.1` if the source omits it; the field keeps road and river surfaces at the same vertical bias the legacy custom content framework used.
 
 Telegraph pole definitions use the existing Railroader telegraph pole and wire prefabs by default. `profile` selects the first vanilla pole prefab whose name contains that profile string. `polePrefab` and `wirePrefab` can override that with explicit prefab URIs.
 

--- a/bin/Release/net48/schemas/RAIL_JSON_SCHEMA.md
+++ b/bin/Release/net48/schemas/RAIL_JSON_SCHEMA.md
@@ -64,7 +64,7 @@ Vector values are always objects:
 { "x": 0, "y": 0, "z": 0 }
 ```
 
-Track spans use two structured locations rather than Strange Customs style strings. Think of each location as an arrow measured from one segment end into the span. `Start`/`A` points from the segment's start toward its end; `End`/`B` points from the segment's end toward its start. The two endpoint arrows must face each other and the measured distance must stay within that segment.
+Track spans use two structured locations rather than legacy custom content style strings. Think of each location as an arrow measured from one segment end into the span. `Start`/`A` points from the segment's start toward its end; `End`/`B` points from the segment's end toward its start. The two endpoint arrows must face each other and the measured distance must stay within that segment.
 
 ```json
 {
@@ -189,7 +189,7 @@ Spliney `type` describes the physical spline family, not its material flavor:
 - `terrainRoad`: terrain-carved road spline. Use `style`/`profile` for dirt versus pavement.
 - `trestle`: auto-generated trestle spline.
 
-Converted Strange Customs `FlowyThingBuilder` data must inspect `style` and `profile`; entries with `style: "River"` or river profiles should be emitted as `type: "river"`, not as roads.
+Converted legacy custom content `FlowyThingBuilder` data must inspect `style` and `profile`; entries with `style: "River"` or river profiles should be emitted as `type: "river"`, not as roads.
 
 Telegraph pole definitions use the existing Railroader telegraph pole and wire prefabs by default. `profile` selects the first vanilla pole prefab whose name contains that profile string. `polePrefab` and `wirePrefab` can override that with explicit prefab URIs.
 

--- a/bin/Release/net48/schemas/fuse-mod.schema.json
+++ b/bin/Release/net48/schemas/fuse-mod.schema.json
@@ -62,7 +62,7 @@
         },
         "mixinto": {
             "$ref": "#/$defs/mixinto",
-            "description": "Optional legacy conditional mixinto metadata. FUSE applies this fragment only when its requirements are satisfied, matching RailLoader/Strange Customs conditional mixins."
+            "description": "Optional legacy conditional mixinto metadata. FUSE applies this fragment only when its requirements are satisfied, matching legacy mod loader and custom content framework conditional mixins."
         },
         "tracks": {
             "$ref": "#/$defs/tracks"
@@ -1337,7 +1337,7 @@
                 },
                 "offsetY": {
                     "type": "number",
-                    "description": "Vertical offset passed through to Railroader's RiverPath. Converted Strange Customs FlowyThingBuilder entries should emit -0.1 when the legacy source omits this field.",
+                    "description": "Vertical offset passed through to Railroader's RiverPath. Converted legacy custom content FlowyThingBuilder entries should emit -0.1 when the legacy source omits this field.",
                     "default": 0
                 },
                 "headStyle": {

--- a/schemas/FUSE_JSON_SCHEMA.md
+++ b/schemas/FUSE_JSON_SCHEMA.md
@@ -20,7 +20,7 @@ Top-level object groups:
 - `editor`: optional editor-only state that FUSE can ignore at runtime.
 - `extensions`: optional namespaced third-party data.
 
-`mixinto` is optional metadata for converted RailLoader/Strange Customs conditional mixin files. The converted file remains a normal FUSE fragment, but FUSE checks `mixinto.requires[]` immediately before runtime apply. If any required mod is missing, older than `notBefore`, or newer than `notAfter`, that fragment is skipped without faulting the rest of the package.
+`mixinto` is optional metadata for converted legacy mod loader and custom content framework conditional mixin files. The converted file remains a normal FUSE fragment, but FUSE checks `mixinto.requires[]` immediately before runtime apply. If any required mod is missing, older than `notBefore`, or newer than `notAfter`, that fragment is skipped without faulting the rest of the package.
 
 ```json
 {
@@ -113,7 +113,7 @@ Vector values are always objects:
 { "x": 0, "y": 0, "z": 0 }
 ```
 
-Track spans use two structured locations rather than Strange Customs style strings. Think of each location as an arrow measured from one segment end into the span. `Start`/`A` points from the segment's start toward its end; `End`/`B` points from the segment's end toward its start. The two endpoint arrows must face each other and the measured distance must stay within that segment.
+Track spans use two structured locations rather than legacy custom content style strings. Think of each location as an arrow measured from one segment end into the span. `Start`/`A` points from the segment's start toward its end; `End`/`B` points from the segment's end toward its start. The two endpoint arrows must face each other and the measured distance must stay within that segment.
 
 ```json
 {
@@ -267,8 +267,8 @@ Spliney `type` describes the physical spline family, not its material flavor:
 - `terrainRoad`: terrain-carved road spline. Use `style`/`profile` for dirt versus pavement.
 - `trestle`: auto-generated trestle spline.
 
-Converted Strange Customs `FlowyThingBuilder` data must inspect `style` and `profile`; entries with `style: "River"` or river profiles should be emitted as `type: "river"`, not as roads.
-When converting `FlowyThingBuilder` entries, preserve the legacy default `offsetY: -0.1` if the source omits it; the field keeps road and river surfaces at the same vertical bias Strange Customs used.
+Converted legacy custom content `FlowyThingBuilder` data must inspect `style` and `profile`; entries with `style: "River"` or river profiles should be emitted as `type: "river"`, not as roads.
+When converting `FlowyThingBuilder` entries, preserve the legacy default `offsetY: -0.1` if the source omits it; the field keeps road and river surfaces at the same vertical bias the legacy custom content framework used.
 
 Telegraph pole definitions use the existing Railroader telegraph pole and wire prefabs by default. `profile` selects the first vanilla pole prefab whose name contains that profile string. `polePrefab` and `wirePrefab` can override that with explicit prefab URIs.
 

--- a/schemas/fuse-mod.schema.json
+++ b/schemas/fuse-mod.schema.json
@@ -62,7 +62,7 @@
         },
         "mixinto": {
             "$ref": "#/$defs/mixinto",
-            "description": "Optional legacy conditional mixinto metadata. FUSE applies this fragment only when its requirements are satisfied, matching RailLoader/Strange Customs conditional mixins."
+            "description": "Optional legacy conditional mixinto metadata. FUSE applies this fragment only when its requirements are satisfied, matching legacy mod loader and custom content framework conditional mixins."
         },
         "tracks": {
             "$ref": "#/$defs/tracks"
@@ -1337,7 +1337,7 @@
                 },
                 "offsetY": {
                     "type": "number",
-                    "description": "Vertical offset passed through to Railroader's RiverPath. Converted Strange Customs FlowyThingBuilder entries should emit -0.1 when the legacy source omits this field.",
+                    "description": "Vertical offset passed through to Railroader's RiverPath. Converted legacy custom content FlowyThingBuilder entries should emit -0.1 when the legacy source omits this field.",
                     "default": 0
                 },
                 "headStyle": {

--- a/tools/FUSE_CONVERTER.md
+++ b/tools/FUSE_CONVERTER.md
@@ -118,7 +118,7 @@ The report is the important bit. It records:
 | Track / route JSON folders | One FUSE data file per source JSON, preserving file-per-concern structure. |
 | Single route JSON file | One standalone FUSE package fragment. |
 | Horn / whistle / bell packs | FUSE audio package with copied audio files. |
-| Strange Customs asset packs | FUSE asset wrapper with `FuseAssetPacks` in `Info.json`. |
+| Legacy custom content asset packs | FUSE asset wrapper with `FuseAssetPacks` in `Info.json`. |
 | Zip files | Extracted to a temporary folder, detected, converted, then cleaned up. |
 
 ## Known Lossy Areas

--- a/tools/Translate-Appalachian.ps1
+++ b/tools/Translate-Appalachian.ps1
@@ -1057,7 +1057,7 @@ $rail['extensions']['dev.hunterr.translation'] = [ordered]@{
     notes = @(
         'Legacy passenger stop components were translated into native FUSE passengerStop components.',
         'Legacy turntable builders were translated into operations.turntables with legacy track identifiers so generated roundhouse helpers still line up.',
-        'Strange Customs mandelas were translated into world.sceneClones so their hierarchy-local transforms survive the migration.',
+        'Legacy custom content mandelas were translated into world.sceneClones so their hierarchy-local transforms survive the migration.',
         'Legacy null track entries are preserved as tracks.removals so base-game nodes, segments, and spans can be deleted at load time.',
         'Any remaining unsupported components are preserved here instead of being silently dropped.'
     )

--- a/tools/fuse_convert.py
+++ b/tools/fuse_convert.py
@@ -1237,7 +1237,7 @@ def convert_spliney(item):
     spliney_type = infer_spliney_type(item, handler)
     offset_y = item.get("offsetY", item.get("offsety"))
     if offset_y is None and handler == "StrangeCustoms.FlowyThingBuilder":
-        # Strange Customs' FlowyData defaults OffsetY to -0.1. Preserve that
+        # Legacy custom content FlowyData defaults OffsetY to -0.1. Preserve that
         # instead of letting FUSE deserialize the missing float as 0.
         offset_y = -0.1
     points = []
@@ -1271,7 +1271,7 @@ def infer_spliney_type(item, handler):
     profile = str(item.get("profile") or "")
     explicit_type = item.get("type")
 
-    # Strange Customs FlowyThingBuilder is shared by roads and rivers. The
+    # Legacy custom content FlowyThingBuilder is shared by roads and rivers. The
     # style/profile tells us which physical spline family the runtime needs.
     if handler == "StrangeCustoms.FlowyThingBuilder" and (
         style.lower() == "river" or "river" in profile.lower()

--- a/tools/legacy_json.py
+++ b/tools/legacy_json.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Small tolerant JSON reader for legacy Railroader mod data files.
 
-Legacy Strange Customs/RailLoader packages in the wild often contain JSONC
+Legacy custom content framework and legacy mod loader packages in the wild often contain JSONC
 comments, trailing commas, and occasionally files truncated after the last real
 entry. This reader keeps the recovery narrow: it never executes code, it only
 removes comments/trailing commas and, when requested, appends missing closing


### PR DESCRIPTION
Updates legacy compatibility wording in comments, docs, and schema descriptions. Validation: checked public prose and ran diff validation.