### PR TITLE
Add hover-to-inspect track debug overlay

### DIFF
--- a/FusePlugin.cs
+++ b/FusePlugin.cs
@@ -73,6 +73,7 @@ namespace FUSE
 
                 FuseEditor.OnFuseLoad();
                 FuseHealthUi.Ensure();
+                FuseTrackDebugOverlay.Ensure();
                 FuseLegacyAssemblyHost.EnsureStartupHost();
 
                 modEntry.OnUnload = OnUnload;
@@ -190,6 +191,7 @@ namespace FUSE
             FuseLegacyAssemblyHost.Shutdown();
             FuseLegacySupportAssemblyShim.Shutdown();
             FuseHealthUi.Shutdown();
+            FuseTrackDebugOverlay.Shutdown();
 
             if (_isLoaded)
             {

--- a/Infrastructure/FuseSettings.cs
+++ b/Infrastructure/FuseSettings.cs
@@ -14,6 +14,8 @@ namespace FUSE.Infrastructure
         public const bool DefaultVerboseApplyReportDetails = false;
         public const bool DefaultBlockNonHostMultiplayerClientWorldApply = false;
         public const bool DefaultShowAdvancedHealthDetails = false;
+        public const bool DefaultShowTrackDebugOverlay = false;
+        public const bool DefaultShowTrackDebugSpanPaths = false;
         public const float ExperimentalEarlyScenePathSuppressionTimeoutSeconds = 8f;
 
         public static bool EnableExperimentalEarlyScenePathSuppression { get; private set; } =
@@ -30,6 +32,10 @@ namespace FUSE.Infrastructure
 
         public static bool ShowAdvancedHealthDetails { get; private set; } = DefaultShowAdvancedHealthDetails;
 
+        public static bool ShowTrackDebugOverlay { get; private set; } = DefaultShowTrackDebugOverlay;
+
+        public static bool ShowTrackDebugSpanPaths { get; private set; } = DefaultShowTrackDebugSpanPaths;
+
         public static void Load(UnityModManager.ModEntry modEntry)
         {
             EnableExperimentalEarlyScenePathSuppression = DefaultEnableExperimentalEarlyScenePathSuppression;
@@ -38,6 +44,8 @@ namespace FUSE.Infrastructure
             VerboseApplyReportDetails = DefaultVerboseApplyReportDetails;
             BlockNonHostMultiplayerClientWorldApply = DefaultBlockNonHostMultiplayerClientWorldApply;
             ShowAdvancedHealthDetails = DefaultShowAdvancedHealthDetails;
+            ShowTrackDebugOverlay = DefaultShowTrackDebugOverlay;
+            ShowTrackDebugSpanPaths = DefaultShowTrackDebugSpanPaths;
             FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
 
             var infoPath = Path.Combine(modEntry?.Path ?? string.Empty, "Info.json");
@@ -63,6 +71,10 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, "BlockNonHostMultiplayerClientWorldApply", DefaultBlockNonHostMultiplayerClientWorldApply);
                 ShowAdvancedHealthDetails =
                     ReadBool(settings, "ShowAdvancedHealthDetails", DefaultShowAdvancedHealthDetails);
+                ShowTrackDebugOverlay =
+                    ReadBool(settings, "ShowTrackDebugOverlay", DefaultShowTrackDebugOverlay);
+                ShowTrackDebugSpanPaths =
+                    ReadBool(settings, "ShowTrackDebugSpanPaths", DefaultShowTrackDebugSpanPaths);
                 ApplyUserOverrides();
                 FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
 
@@ -74,6 +86,8 @@ namespace FUSE.Infrastructure
                     $"VerboseApplyReportDetails={VerboseApplyReportDetails} " +
                     $"BlockNonHostMultiplayerClientWorldApply={BlockNonHostMultiplayerClientWorldApply} " +
                     $"ShowAdvancedHealthDetails={ShowAdvancedHealthDetails} " +
+                    $"ShowTrackDebugOverlay={ShowTrackDebugOverlay} " +
+                    $"ShowTrackDebugSpanPaths={ShowTrackDebugSpanPaths} " +
                     $"timeoutSeconds={ExperimentalEarlyScenePathSuppressionTimeoutSeconds}.");
             }
             catch (Exception ex)
@@ -84,6 +98,8 @@ namespace FUSE.Infrastructure
                 VerboseApplyReportDetails = DefaultVerboseApplyReportDetails;
                 BlockNonHostMultiplayerClientWorldApply = DefaultBlockNonHostMultiplayerClientWorldApply;
                 ShowAdvancedHealthDetails = DefaultShowAdvancedHealthDetails;
+                ShowTrackDebugOverlay = DefaultShowTrackDebugOverlay;
+                ShowTrackDebugSpanPaths = DefaultShowTrackDebugSpanPaths;
                 FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
                 FuseLog.Warning($"FUSE failed to parse Info.json settings; experimental early scene-path suppression remains disabled: {ex.Message}");
             }
@@ -117,6 +133,20 @@ namespace FUSE.Infrastructure
             ShowAdvancedHealthDetails = enabled;
             SaveUserOverride(nameof(ShowAdvancedHealthDetails), enabled);
             FuseLog.Info($"FUSE setting changed: {nameof(ShowAdvancedHealthDetails)}={enabled}.");
+        }
+
+        public static void SetShowTrackDebugOverlay(bool enabled)
+        {
+            ShowTrackDebugOverlay = enabled;
+            SaveUserOverride(nameof(ShowTrackDebugOverlay), enabled);
+            FuseLog.Info($"FUSE setting changed: {nameof(ShowTrackDebugOverlay)}={enabled}.");
+        }
+
+        public static void SetShowTrackDebugSpanPaths(bool enabled)
+        {
+            ShowTrackDebugSpanPaths = enabled;
+            SaveUserOverride(nameof(ShowTrackDebugSpanPaths), enabled);
+            FuseLog.Info($"FUSE setting changed: {nameof(ShowTrackDebugSpanPaths)}={enabled}.");
         }
 
         public static string GetUserSettingsPath()
@@ -165,6 +195,10 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, nameof(BlockNonHostMultiplayerClientWorldApply), BlockNonHostMultiplayerClientWorldApply);
                 ShowAdvancedHealthDetails =
                     ReadBool(settings, nameof(ShowAdvancedHealthDetails), ShowAdvancedHealthDetails);
+                ShowTrackDebugOverlay =
+                    ReadBool(settings, nameof(ShowTrackDebugOverlay), ShowTrackDebugOverlay);
+                ShowTrackDebugSpanPaths =
+                    ReadBool(settings, nameof(ShowTrackDebugSpanPaths), ShowTrackDebugSpanPaths);
                 FuseLog.Info($"FUSE user setting overrides loaded from '{path}'.");
             }
             catch (Exception ex)

--- a/Interface/FuseHealthUi.cs
+++ b/Interface/FuseHealthUi.cs
@@ -796,6 +796,28 @@ namespace FUSE.Interface
                 });
             AddSettingToggle(
                 builder,
+                "Track Debug Overlay",
+                FuseSettings.ShowTrackDebugOverlay ? "enabled (hover tracks)" : "disabled",
+                FuseSettings.ShowTrackDebugOverlay ? "Disable" : "Enable",
+                () =>
+                {
+                    FuseSettings.SetShowTrackDebugOverlay(!FuseSettings.ShowTrackDebugOverlay);
+                    RebuildWindow();
+                });
+            AddSettingToggle(
+                builder,
+                "Track Span Paths",
+                FuseSettings.ShowTrackDebugSpanPaths
+                    ? (FuseSettings.ShowTrackDebugOverlay ? "shown in overlay" : "shown when overlay on")
+                    : "hidden",
+                FuseSettings.ShowTrackDebugSpanPaths ? "Hide" : "Show",
+                () =>
+                {
+                    FuseSettings.SetShowTrackDebugSpanPaths(!FuseSettings.ShowTrackDebugSpanPaths);
+                    RebuildWindow();
+                });
+            AddSettingToggle(
+                builder,
                 "Early Suppression",
                 FuseSettings.EnableExperimentalEarlyScenePathSuppression ? "enabled" : "disabled",
                 FuseSettings.EnableExperimentalEarlyScenePathSuppression ? "Disable" : "Enable",

--- a/Interface/FuseTrackDebugOverlay.cs
+++ b/Interface/FuseTrackDebugOverlay.cs
@@ -1,0 +1,616 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FUSE.API;
+using FUSE.Infrastructure;
+using Model.Ops;
+using Track;
+using UnityEngine;
+
+namespace FUSE.Interface
+{
+    internal sealed class FuseTrackDebugOverlay : MonoBehaviour
+    {
+        private const float PickScreenRadiusPixels = 12f;
+        private const float RefreshInterval = 0.08f;
+        private const int MaxSpanPathsToShow = 8;
+        private const int MaxIndustriesToShow = 12;
+
+        private static GameObject _host;
+
+        private GUIStyle _boxStyle;
+        private GUIStyle _labelStyle;
+        private Texture2D _backgroundTexture;
+        private float _nextRefreshAt;
+        private string _cachedText;
+        private bool _hasHover;
+        private Vector2 _lastMouseGui;
+
+        public static void Ensure()
+        {
+            if (_host != null)
+            {
+                return;
+            }
+
+            _host = new GameObject("FUSE Track Debug Overlay");
+            DontDestroyOnLoad(_host);
+            _host.hideFlags = HideFlags.HideAndDontSave;
+            _host.AddComponent<FuseTrackDebugOverlay>();
+            FuseLog.Info("FUSE track debug overlay initialized.");
+        }
+
+        public static void Shutdown()
+        {
+            if (_host != null)
+            {
+                Destroy(_host);
+                _host = null;
+            }
+        }
+
+        private void OnGUI()
+        {
+            if (!FuseSettings.ShowTrackDebugOverlay)
+            {
+                _hasHover = false;
+                _cachedText = null;
+                return;
+            }
+
+            var evt = Event.current;
+            if (evt == null)
+            {
+                return;
+            }
+
+            if (evt.type == EventType.MouseMove || evt.type == EventType.Layout || evt.type == EventType.Repaint)
+            {
+                _lastMouseGui = evt.mousePosition;
+            }
+
+            if (evt.type == EventType.Layout)
+            {
+                MaybeRefresh();
+            }
+
+            if (evt.type != EventType.Repaint || !_hasHover || string.IsNullOrEmpty(_cachedText))
+            {
+                return;
+            }
+
+            EnsureGuiStyles();
+
+            var screenX = _lastMouseGui.x + 18f;
+            var screenY = _lastMouseGui.y + 18f;
+
+            var content = new GUIContent(_cachedText);
+            var size = _labelStyle.CalcSize(content);
+            var width = Mathf.Min(Mathf.Max(280f, size.x + 16f), Screen.width - 32f);
+            var height = Mathf.Min(_labelStyle.CalcHeight(content, width - 16f) + 16f, Screen.height - 32f);
+
+            if (screenX + width > Screen.width - 8f)
+            {
+                screenX = Mathf.Max(8f, Screen.width - width - 8f);
+            }
+
+            if (screenY + height > Screen.height - 8f)
+            {
+                screenY = Mathf.Max(8f, Screen.height - height - 8f);
+            }
+
+            var boxRect = new Rect(screenX, screenY, width, height);
+            GUI.Box(boxRect, GUIContent.none, _boxStyle);
+            GUI.Label(new Rect(screenX + 8f, screenY + 8f, width - 16f, height - 16f), content, _labelStyle);
+        }
+
+        private void OnDestroy()
+        {
+            if (_backgroundTexture != null)
+            {
+                Destroy(_backgroundTexture);
+                _backgroundTexture = null;
+            }
+        }
+
+        private void MaybeRefresh()
+        {
+            if (Time.unscaledTime < _nextRefreshAt)
+            {
+                return;
+            }
+
+            _nextRefreshAt = Time.unscaledTime + RefreshInterval;
+
+            try
+            {
+                var mouseScreen = GuiToScreen(_lastMouseGui);
+                var segment = FindSegmentNearCursor(mouseScreen);
+                if (segment == null)
+                {
+                    _hasHover = false;
+                    _cachedText = null;
+                    return;
+                }
+
+                _cachedText = BuildSegmentReport(segment);
+                _hasHover = !string.IsNullOrEmpty(_cachedText);
+            }
+            catch (Exception ex)
+            {
+                _hasHover = false;
+                _cachedText = null;
+                FuseLog.Warning($"FUSE track debug overlay refresh failed: {ex.GetBaseException().Message}");
+            }
+        }
+
+        private static Vector2 GuiToScreen(Vector2 guiPosition)
+        {
+            return new Vector2(guiPosition.x, Screen.height - guiPosition.y);
+        }
+
+        private static TrackSegment FindSegmentNearCursor(Vector2 mouseScreen)
+        {
+            var camera = Camera.main ?? Camera.current;
+            if (camera == null)
+            {
+                return null;
+            }
+
+            var graph = Graph.Shared;
+            if (graph == null)
+            {
+                return null;
+            }
+
+            if (mouseScreen.x < 0f || mouseScreen.y < 0f ||
+                mouseScreen.x > Screen.width || mouseScreen.y > Screen.height)
+            {
+                return null;
+            }
+
+            TrackSegment best = null;
+            var bestDistance = PickScreenRadiusPixels;
+            var bestDepth = float.MaxValue;
+
+            foreach (var segment in graph.Segments)
+            {
+                if (segment == null || segment.a == null || segment.b == null)
+                {
+                    continue;
+                }
+
+                var worldA = segment.a.transform.position;
+                var worldB = segment.b.transform.position;
+                var screenA = camera.WorldToScreenPoint(worldA);
+                var screenB = camera.WorldToScreenPoint(worldB);
+                if (screenA.z <= 0f && screenB.z <= 0f)
+                {
+                    continue;
+                }
+
+                var distance = DistanceFromPointToSegment2D(
+                    mouseScreen,
+                    new Vector2(screenA.x, screenA.y),
+                    new Vector2(screenB.x, screenB.y));
+                if (distance > bestDistance)
+                {
+                    continue;
+                }
+
+                var depth = 0.5f * (Mathf.Max(0f, screenA.z) + Mathf.Max(0f, screenB.z));
+                if (distance < bestDistance - 0.5f || depth < bestDepth)
+                {
+                    bestDistance = distance;
+                    bestDepth = depth;
+                    best = segment;
+                }
+            }
+
+            return best;
+        }
+
+        private static float DistanceFromPointToSegment2D(Vector2 point, Vector2 a, Vector2 b)
+        {
+            var ab = b - a;
+            var lengthSquared = ab.sqrMagnitude;
+            if (lengthSquared <= 0.0001f)
+            {
+                return Vector2.Distance(point, a);
+            }
+
+            var t = Mathf.Clamp01(Vector2.Dot(point - a, ab) / lengthSquared);
+            var projection = a + ab * t;
+            return Vector2.Distance(point, projection);
+        }
+
+        private static string BuildSegmentReport(TrackSegment segment)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("<b>Track Segment</b>");
+            builder.Append("id: ").AppendLine(SafeId(segment.id));
+            builder.Append("nodes: ")
+                .Append(SafeId(segment.a != null ? segment.a.id : null))
+                .Append("  ->  ")
+                .AppendLine(SafeId(segment.b != null ? segment.b.id : null));
+
+            string style;
+            try
+            {
+                style = segment.style.ToString();
+            }
+            catch
+            {
+                style = "?";
+            }
+
+            string trackClass;
+            try
+            {
+                trackClass = segment.trackClass.ToString();
+            }
+            catch
+            {
+                trackClass = "?";
+            }
+
+            builder.Append("style: ").Append(style)
+                .Append("  class: ").Append(trackClass)
+                .Append("  speedLimit: ").Append(segment.speedLimit)
+                .Append("  priority: ").AppendLine(segment.priority.ToString());
+
+            if (!string.IsNullOrWhiteSpace(segment.groupId))
+            {
+                builder.Append("group: ").AppendLine(segment.groupId);
+            }
+
+            float length;
+            try
+            {
+                length = segment.GetLength();
+            }
+            catch
+            {
+                length = 0f;
+            }
+
+            if (length > 0f)
+            {
+                builder.Append("length: ").Append(length.ToString("0.0")).AppendLine(" m");
+            }
+
+            AppendNodeBlock(builder, "node A", segment.a);
+            AppendNodeBlock(builder, "node B", segment.b);
+
+            AppendIndustryInfluences(builder, segment);
+
+            if (FuseSettings.ShowTrackDebugSpanPaths)
+            {
+                AppendSpanPaths(builder, segment);
+            }
+
+            return builder.ToString().TrimEnd();
+        }
+
+        private static void AppendNodeBlock(StringBuilder builder, string label, TrackNode node)
+        {
+            if (node == null)
+            {
+                return;
+            }
+
+            builder.Append(label).Append(": ").Append(SafeId(node.id));
+            if (node.flipSwitchStand)
+            {
+                builder.Append("  (flipSwitchStand)");
+            }
+
+            builder.AppendLine();
+        }
+
+        private static void AppendIndustryInfluences(StringBuilder builder, TrackSegment segment)
+        {
+            var hits = CollectIndustryInfluences(segment);
+            builder.AppendLine();
+            builder.Append("<b>Industries influencing</b> (").Append(hits.Count).AppendLine(")");
+            if (hits.Count == 0)
+            {
+                builder.AppendLine("  none");
+                return;
+            }
+
+            foreach (var hit in hits.Take(MaxIndustriesToShow))
+            {
+                builder.Append("  - ")
+                    .Append(hit.IndustryDisplay)
+                    .Append("  [")
+                    .Append(hit.ComponentKind)
+                    .Append("]")
+                    .Append("  via span ")
+                    .AppendLine(SafeId(hit.SpanId));
+            }
+
+            if (hits.Count > MaxIndustriesToShow)
+            {
+                builder.Append("  + ").Append(hits.Count - MaxIndustriesToShow).AppendLine(" more");
+            }
+        }
+
+        private static void AppendSpanPaths(StringBuilder builder, TrackSegment segment)
+        {
+            List<TrackSpan> spans;
+            try
+            {
+                spans = TrackAPI.GetAllSpans()
+                    .Where(span => SpanTouchesSegment(span, segment))
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                builder.AppendLine();
+                builder.Append("<b>Spans</b>: error - ").AppendLine(ex.GetBaseException().Message);
+                return;
+            }
+
+            builder.AppendLine();
+            builder.Append("<b>Spans on this segment</b> (").Append(spans.Count).AppendLine(")");
+            if (spans.Count == 0)
+            {
+                builder.AppendLine("  none");
+                return;
+            }
+
+            var index = 0;
+            foreach (var span in spans)
+            {
+                if (index++ >= MaxSpanPathsToShow)
+                {
+                    builder.Append("  + ").Append(spans.Count - MaxSpanPathsToShow).AppendLine(" more");
+                    break;
+                }
+
+                builder.Append("  - ").Append(SafeId(span.id));
+                float spanLength;
+                try
+                {
+                    spanLength = span.Length;
+                }
+                catch
+                {
+                    spanLength = 0f;
+                }
+
+                if (spanLength > 0f)
+                {
+                    builder.Append("  (").Append(spanLength.ToString("0.0")).Append(" m)");
+                }
+
+                builder.AppendLine();
+                builder.Append("      ").AppendLine(DescribeSpanEndpoint("upper", span.upper));
+                builder.Append("      ").AppendLine(DescribeSpanEndpoint("lower", span.lower));
+
+                var pathIds = CollectSpanSegmentPath(span);
+                if (pathIds.Count > 0)
+                {
+                    builder.Append("      path: ").AppendLine(string.Join(" -> ", pathIds.ToArray()));
+                }
+            }
+        }
+
+        private static IReadOnlyList<string> CollectSpanSegmentPath(TrackSpan span)
+        {
+            if (span == null || !span.IsValid)
+            {
+                return Array.Empty<string>();
+            }
+
+            try
+            {
+                var points = span.GetPoints();
+                if (points == null || points.Count == 0)
+                {
+                    return Array.Empty<string>();
+                }
+            }
+            catch
+            {
+                return Array.Empty<string>();
+            }
+
+            var ids = new List<string>(4);
+            var upperSegmentId = span.upper.HasValue && span.upper.Value.segment != null ? span.upper.Value.segment.id : null;
+            var lowerSegmentId = span.lower.HasValue && span.lower.Value.segment != null ? span.lower.Value.segment.id : null;
+            if (!string.IsNullOrWhiteSpace(upperSegmentId))
+            {
+                ids.Add(upperSegmentId);
+            }
+
+            if (!string.IsNullOrWhiteSpace(lowerSegmentId) &&
+                !string.Equals(upperSegmentId, lowerSegmentId, StringComparison.OrdinalIgnoreCase))
+            {
+                ids.Add(lowerSegmentId);
+            }
+
+            return ids;
+        }
+
+        private static string DescribeSpanEndpoint(string label, Location? location)
+        {
+            if (!location.HasValue)
+            {
+                return label + ": <none>";
+            }
+
+            var value = location.Value;
+            var segmentId = value.segment != null ? value.segment.id : "<null>";
+            var end = value.EndIsA ? "A" : "B";
+            return label + ": " + segmentId + " end=" + end + " distance=" + value.distance.ToString("0.0");
+        }
+
+        private static List<IndustryHit> CollectIndustryInfluences(TrackSegment segment)
+        {
+            var hits = new List<IndustryHit>();
+            if (segment == null || string.IsNullOrWhiteSpace(segment.id))
+            {
+                return hits;
+            }
+
+            IEnumerable<Industry> industries;
+            try
+            {
+                industries = IndustryAPI.GetAllIndustries();
+            }
+            catch
+            {
+                return hits;
+            }
+
+            foreach (var industry in industries)
+            {
+                if (industry == null)
+                {
+                    continue;
+                }
+
+                IndustryComponent[] components;
+                try
+                {
+                    components = industry.GetComponentsInChildren<IndustryComponent>(true);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                foreach (var component in components)
+                {
+                    if (component == null || component.trackSpans == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var span in component.trackSpans)
+                    {
+                        if (!SpanTouchesSegment(span, segment))
+                        {
+                            continue;
+                        }
+
+                        hits.Add(new IndustryHit(
+                            DescribeIndustry(industry),
+                            DescribeComponentKind(component),
+                            span != null ? span.id : null));
+                    }
+                }
+            }
+
+            return hits;
+        }
+
+        private static bool SpanTouchesSegment(TrackSpan span, TrackSegment segment)
+        {
+            if (span == null || segment == null || string.IsNullOrWhiteSpace(segment.id))
+            {
+                return false;
+            }
+
+            var upper = span.upper;
+            var lower = span.lower;
+            if (upper.HasValue && upper.Value.segment != null &&
+                string.Equals(upper.Value.segment.id, segment.id, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (lower.HasValue && lower.Value.segment != null &&
+                string.Equals(lower.Value.segment.id, segment.id, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static string DescribeIndustry(Industry industry)
+        {
+            if (industry == null)
+            {
+                return "<null>";
+            }
+
+            var name = string.IsNullOrWhiteSpace(industry.name) ? industry.identifier : industry.name;
+            return string.IsNullOrWhiteSpace(industry.identifier) ? name : name + " (" + industry.identifier + ")";
+        }
+
+        private static string DescribeComponentKind(IndustryComponent component)
+        {
+            if (component == null)
+            {
+                return "?";
+            }
+
+            var type = component.GetType().Name;
+            var subId = component.subIdentifier;
+            return string.IsNullOrWhiteSpace(subId) ? type : type + ":" + subId;
+        }
+
+        private static string SafeId(string id)
+        {
+            return string.IsNullOrWhiteSpace(id) ? "<none>" : id;
+        }
+
+        private void EnsureGuiStyles()
+        {
+            if (_boxStyle != null && _labelStyle != null)
+            {
+                return;
+            }
+
+            if (_backgroundTexture == null)
+            {
+                _backgroundTexture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+                var pixels = new Color[4];
+                for (var index = 0; index < pixels.Length; index++)
+                {
+                    pixels[index] = new Color(0f, 0f, 0f, 0.78f);
+                }
+
+                _backgroundTexture.SetPixels(pixels);
+                _backgroundTexture.Apply();
+            }
+
+            _boxStyle = new GUIStyle(GUI.skin.box)
+            {
+                normal = { background = _backgroundTexture, textColor = Color.white },
+                border = new RectOffset(2, 2, 2, 2),
+                padding = new RectOffset(8, 8, 8, 8)
+            };
+
+            _labelStyle = new GUIStyle(GUI.skin.label)
+            {
+                richText = true,
+                alignment = TextAnchor.UpperLeft,
+                wordWrap = true,
+                fontSize = 12,
+                normal = { textColor = Color.white }
+            };
+        }
+
+        private readonly struct IndustryHit
+        {
+            public IndustryHit(string industryDisplay, string componentKind, string spanId)
+            {
+                IndustryDisplay = industryDisplay;
+                ComponentKind = componentKind;
+                SpanId = spanId;
+            }
+
+            public string IndustryDisplay { get; }
+
+            public string ComponentKind { get; }
+
+            public string SpanId { get; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New debug overlay in `Interface/FuseTrackDebugOverlay.cs` that shows track info on mouse hover: segment id, start/end node ids, style/class/speed limit/priority/group/length, plus the industries whose components reference any TrackSpan with an endpoint on the hovered segment.
- Two new toggles on the FUSE Health → Settings tab (`FuseSettings.ShowTrackDebugOverlay` master, `FuseSettings.ShowTrackDebugSpanPaths` sub-setting). Both default off and persist through the existing user-override file.
- Sub-setting adds a "Spans on this segment" block to the tooltip with each span's upper/lower endpoint details, for diagnosing patching/path issues.

## Why

There is no in-game way to identify which segment your cursor is on, what industries are wired up to it, or which spans run through it. That context lives in the package JSON, FUSE logs, and the `/fuse.dumpruntimegraph` JSON, none of which are quick to consult while looking at a specific piece of track. This puts the same data on the live track under the cursor for diagnostic work.

## Implementation notes

- Picker runs inside `OnGUI` (Layout pass) rather than `Update`, because the project does not reference `UnityEngine.InputLegacyModule` and so `Input.mousePosition` is unavailable. `Event.current.mousePosition` works without that module.
- Throttled to ~12 Hz refresh to keep the per-frame cost negligible.
- Detection uses straight-line A→B screen-space projection from `Graph.Shared.Segments`, picking the nearest segment within a 12 px screen-space radius, with average projected depth as a tie-breaker so foreground segments win on overlap. Approximate on heavily curved track but accurate enough within the hover threshold.
- Wired into `FusePlugin.Load`/`Shutdown` alongside `FuseHealthUi`. Uses the same `DontDestroyOnLoad` host-GameObject pattern.

## Test plan

- [ ] Build Release; deploy `bin/Release/net48/FUSE.dll` (+ `.pdb`, `Info.json`, `assets/`, `schemas/`) to `Railroader/Mods/FUSE/`.
- [ ] Launch Railroader and load a map.
- [ ] Open FUSE Health (top-right icon) → Settings tab; both new toggles are visible and start "disabled".
- [ ] Toggle "Track Debug Overlay" on; hover over a track segment in the world. Tooltip appears next to cursor with segment/node/industry info; clears when the cursor leaves any track.
- [ ] With overlay on, also toggle "Track Span Paths" on; tooltip gains a "Spans on this segment" block listing each span and its upper/lower endpoints.
- [ ] Toggle the master off; tooltip disappears immediately regardless of sub-setting state.
- [ ] Reload the game; both toggles preserve their state via `%LocalLow%\Giraffe Lab LLC\Railroader\FUSE\settings.json`.