### PR TITLE
Persist mandela disables, route null removals, add debug overlays

### DIFF
--- a/API/IndustryAPI.cs
+++ b/API/IndustryAPI.cs
@@ -120,8 +120,61 @@ namespace FUSE.API
         public static void RemoveIndustry(string id)
         {
             var industry = RequireIndustry(id);
+            DestroyIndustryInternal(id, industry);
+        }
+
+        /// <summary>
+        /// Removes the industry with <paramref name="id"/> if it exists. Returns false when the
+        /// industry is not currently in the scene/cache — used by the legacy-conversion apply
+        /// path so that "industries: { id: null }" directives can be expressed without
+        /// throwing when the industry was already absent.
+        /// </summary>
+        public static bool TryRemoveIndustry(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return false;
+            }
+
+            var industry = GetIndustry(id);
+            if (industry == null)
+            {
+                return false;
+            }
+
+            DestroyIndustryInternal(id, industry);
+            return true;
+        }
+
+        private static void DestroyIndustryInternal(string id, Industry industry)
+        {
+            // Synchronously tear down every IndustryComponent before destroying the Industry
+            // GameObject and use DestroyImmediate throughout so the runtime objects are fully
+            // gone before the post-remove IndustriesDidChange notification fires. Deferred
+            // Destroy leaves the dead Industry alive until end-of-frame; downstream
+            // IndustriesDidChange handlers can then still walk it and re-activate scene clones
+            // by name match, defeating package mandelas that disabled the matching scenery.
             industry.gameObject.SetActive(false);
-            UnityEngine.Object.Destroy(industry.gameObject);
+
+            var components = industry.GetComponentsInChildren<IndustryComponent>(true);
+            for (var index = 0; index < components.Length; index++)
+            {
+                var component = components[index];
+                if (component == null)
+                {
+                    continue;
+                }
+
+                var subIdentifier = component.subIdentifier;
+                if (!string.IsNullOrWhiteSpace(subIdentifier))
+                {
+                    FuseIndustryComponentRuntimeIndex.Instance.Remove(GetComponentIdentifier(industry, component));
+                }
+
+                UnityEngine.Object.DestroyImmediate(component);
+            }
+
+            UnityEngine.Object.DestroyImmediate(industry.gameObject);
             FuseIndustryRuntimeIndex.Instance.Remove(id);
             FuseCreatedIndustryIds.Remove(id);
             FuseRuntimeDefinitionCache.Remove(FuseDefinitionKind.Industry, id);

--- a/API/ProgressionAPI.cs
+++ b/API/ProgressionAPI.cs
@@ -109,6 +109,24 @@ namespace FUSE.API
             return UnityEngine.Object.FindObjectsOfType<MapFeature>(true);
         }
 
+        internal static bool TryGetMapFeatureEnabledState(MapFeature feature, out bool enabled)
+        {
+            enabled = false;
+            if (feature == null || string.IsNullOrWhiteSpace(feature.identifier))
+            {
+                return false;
+            }
+
+            var manager = MapFeatureManager.Shared;
+            if (manager == null)
+            {
+                return false;
+            }
+
+            enabled = IsFeatureEnabled(feature, ReadFeatureEnables(manager));
+            return true;
+        }
+
         public static FuseMapFeature GetMapFeatureDefinition(string id)
         {
             return GetDefinition(GetMapFeature(id));

--- a/API/SceneCloneAPI.cs
+++ b/API/SceneCloneAPI.cs
@@ -87,6 +87,116 @@ namespace FUSE.API
             return GetDefinition(GetSceneClone(id));
         }
 
+        /// <summary>
+        /// Re-applies the cached <c>FuseSceneClone.Enabled</c> active state to every scene clone
+        /// in the scene. Called after the game's state snapshot restore so that a saved-state
+        /// reactivation cannot defeat package mandela disables. No-op for clones whose cached
+        /// definition leaves Enabled null.
+        /// </summary>
+        public static int ReapplyEnabledFromCache(string reason)
+        {
+            var reapplied = 0;
+            var enabledForced = 0;
+            var disabledForced = 0;
+            var markers = UnityEngine.Object.FindObjectsOfType<FuseSceneCloneMarker>(true);
+            for (var index = 0; index < markers.Length; index++)
+            {
+                var marker = markers[index];
+                if (marker == null || marker.gameObject == null)
+                {
+                    continue;
+                }
+
+                var id = marker.Id;
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    continue;
+                }
+
+                if (!FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.SceneClone, id, out FuseSceneClone definition) ||
+                    definition?.Enabled == null)
+                {
+                    continue;
+                }
+
+                marker.DesiredEnabled = definition.Enabled;
+                marker.Source = definition.Source;
+                var desired = definition.Enabled.Value;
+                var previous = marker.gameObject.activeSelf;
+                if (previous == desired)
+                {
+                    continue;
+                }
+
+                marker.gameObject.SetActive(desired);
+                LogEnabledReapplyObject(reason, marker, definition, previous, desired);
+                reapplied++;
+                if (desired)
+                {
+                    enabledForced++;
+                }
+                else
+                {
+                    disabledForced++;
+                }
+            }
+
+            if (reapplied > 0)
+            {
+                FuseLog.Info(
+                    $"FUSE scene clone enabled-state reapply for '{reason ?? "snapshot"}' " +
+                    $"reapplied={reapplied} (forcedEnabled={enabledForced}, forcedDisabled={disabledForced}) " +
+                    $"of {markers.Length} marker(s).");
+            }
+
+            return reapplied;
+        }
+
+        private static void LogEnabledReapplyObject(
+            string reason,
+            FuseSceneCloneMarker marker,
+            FuseSceneClone definition,
+            bool previous,
+            bool desired)
+        {
+            var gameObject = marker?.gameObject;
+            var path = gameObject != null ? GetTransformPath(gameObject.transform) : string.Empty;
+            var targetPath = !string.IsNullOrWhiteSpace(marker?.TargetPath)
+                ? marker.TargetPath
+                : (!string.IsNullOrWhiteSpace(definition?.TargetPath) ? definition.TargetPath : path);
+
+            FuseLog.Info(
+                $"FUSE scene clone enabled-state reapply object reason='{reason ?? "snapshot"}' " +
+                $"id='{marker?.Id ?? string.Empty}' target='{targetPath ?? string.Empty}' " +
+                $"path='{path}' source='{definition?.Source ?? string.Empty}' " +
+                $"previousActive='{(previous ? "true" : "false")}' desiredActive='{(desired ? "true" : "false")}'.");
+        }
+
+        /// <summary>
+        /// If <paramref name="gameObject"/> carries a FUSE scene clone marker, returns the FUSE scene clone id
+        /// and the original target path. Used by diagnostics to identify hovered scene clones without
+        /// exposing the private marker component type.
+        /// </summary>
+        public static bool TryGetSceneCloneInfo(GameObject gameObject, out string id, out string targetPath)
+        {
+            id = null;
+            targetPath = null;
+            if (gameObject == null)
+            {
+                return false;
+            }
+
+            var marker = gameObject.GetComponent<FuseSceneCloneMarker>();
+            if (marker == null)
+            {
+                return false;
+            }
+
+            id = marker.Id;
+            targetPath = marker.TargetPath;
+            return true;
+        }
+
         public static FuseSceneClone GetDefinition(GameObject sceneClone)
         {
             if (sceneClone == null)
@@ -166,6 +276,8 @@ namespace FUSE.API
             var marker = targetObject.GetComponent<FuseSceneCloneMarker>() ?? targetObject.AddComponent<FuseSceneCloneMarker>();
             marker.Id = id;
             marker.TargetPath = definition.TargetPath;
+            marker.DesiredEnabled = definition.Enabled;
+            marker.Source = definition.Source;
 
             if (clonedFromSource)
             {
@@ -420,6 +532,31 @@ namespace FUSE.API
         {
             public string Id;
             public string TargetPath;
+            public bool? DesiredEnabled;
+            public string Source;
+            private bool _enforcing;
+
+            private void OnEnable()
+            {
+                if (_enforcing || DesiredEnabled != false || gameObject == null)
+                {
+                    return;
+                }
+
+                _enforcing = true;
+                try
+                {
+                    FuseLog.Info(
+                        $"FUSE scene clone disabled-on-enable guard id='{Id ?? string.Empty}' " +
+                        $"target='{TargetPath ?? string.Empty}' path='{GetTransformPath(transform)}' " +
+                        $"source='{Source ?? string.Empty}' message='object was re-enabled after package disabled it; forcing inactive again'.");
+                    gameObject.SetActive(false);
+                }
+                finally
+                {
+                    _enforcing = false;
+                }
+            }
         }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Added clearly marked temporary legacy support for `container:<id>` mixinto fragments and old `zsc://...` asset-pack references, allowing legacy car/load-model patches to bind to FUSE direct asset stores.
 - Applied legacy `$find`, `$replace`, `$add`, and `$remove` directives inside temporary `container:<id>` compatibility patches before passing cloned car definitions to the base deserializer.
 - Added a robust aggregate material lookup path so exact installed material definitions such as `aggregateModelLoadId=gondola-woodchips` remain visible when custom asset packs are mounted.
+- Added a hover-to-inspect scenery debug overlay (`FuseSettings.ShowSceneryDebugOverlay` master, `FuseSettings.ShowSceneryDebugAdvanced` sub-setting). Tooltip identifies the hovered scenery as FUSE scenery, scene clone, or vanilla — and reports owning package, asset identifier, scene path, and any suppressing packages so authoring conflicts on world buildings can be diagnosed without dumping the runtime graph.
+- Both the scenery and track debug overlays now include a "Progressions impacting" block that lists every map feature and progression section whose unlock effects reference the hovered scenery game object or track group, so progression-gated buildings and track sections can be traced from the cursor.
+- Routed legacy `industries: { id: null }` directives to a dedicated `operations.removals.industries` array in the converter, and added a staged `apply-operations-removals` phase plus `IndustryAPI.TryRemoveIndustry` so the vanilla industry is actually destroyed instead of left ticking with broken component references. Fixes the destroyed-GameObject `NullReferenceException` thrown from `Industry.Tick` and the matching authoring conflicts (e.g. AspenCrazyMap removing `whittier-stenzel` while its mandela disable of `Stenzel Mfg` previously failed to take effect).
 
 ### Converter
 
@@ -29,6 +32,7 @@
 
 ### Schema
 
+- Removed the non-negative floor on monetary fields so packages can express negative-cost (rebate/subsidy/penalty) values: `progression.sections[].deliveryPhases[].cost`, `operations.loads[].payPerQuantity`, `operations.loads[].costPerUnit`, and industry-component `costPerUnit`.
 - Added `schemaVersion` handling and migration notes.
 - Added mixinto metadata support.
 - Added audio definitions for whistles, horns, and bells.

--- a/Data/Operations/FuseOperationsDefinition.cs
+++ b/Data/Operations/FuseOperationsDefinition.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -10,6 +11,12 @@ namespace FUSE.Data
         public Dictionary<string, FuseLoader> Loaders { get; set; } = new Dictionary<string, FuseLoader>();
         public Dictionary<string, FuseTurntable> Turntables { get; set; } = new Dictionary<string, FuseTurntable>();
         public Dictionary<string, FuseStation> Stations { get; set; } = new Dictionary<string, FuseStation>();
+        public FuseOperationsRemovals Removals { get; set; } = new FuseOperationsRemovals();
+    }
+
+    public sealed class FuseOperationsRemovals
+    {
+        public string[] Industries { get; set; } = Array.Empty<string>();
     }
 
     public sealed class FuseLoad

--- a/FusePlugin.cs
+++ b/FusePlugin.cs
@@ -74,6 +74,7 @@ namespace FUSE
                 FuseEditor.OnFuseLoad();
                 FuseHealthUi.Ensure();
                 FuseTrackDebugOverlay.Ensure();
+                FuseSceneryDebugOverlay.Ensure();
                 FuseLegacyAssemblyHost.EnsureStartupHost();
 
                 modEntry.OnUnload = OnUnload;
@@ -190,8 +191,10 @@ namespace FUSE
 
             FuseLegacyAssemblyHost.Shutdown();
             FuseLegacySupportAssemblyShim.Shutdown();
+            FuseRuntimeRebindService.Shutdown();
             FuseHealthUi.Shutdown();
             FuseTrackDebugOverlay.Shutdown();
+            FuseSceneryDebugOverlay.Shutdown();
 
             if (_isLoaded)
             {

--- a/Infrastructure/FuseSettings.cs
+++ b/Infrastructure/FuseSettings.cs
@@ -16,6 +16,8 @@ namespace FUSE.Infrastructure
         public const bool DefaultShowAdvancedHealthDetails = false;
         public const bool DefaultShowTrackDebugOverlay = false;
         public const bool DefaultShowTrackDebugSpanPaths = false;
+        public const bool DefaultShowSceneryDebugOverlay = false;
+        public const bool DefaultShowSceneryDebugAdvanced = false;
         public const float ExperimentalEarlyScenePathSuppressionTimeoutSeconds = 8f;
 
         public static bool EnableExperimentalEarlyScenePathSuppression { get; private set; } =
@@ -36,6 +38,10 @@ namespace FUSE.Infrastructure
 
         public static bool ShowTrackDebugSpanPaths { get; private set; } = DefaultShowTrackDebugSpanPaths;
 
+        public static bool ShowSceneryDebugOverlay { get; private set; } = DefaultShowSceneryDebugOverlay;
+
+        public static bool ShowSceneryDebugAdvanced { get; private set; } = DefaultShowSceneryDebugAdvanced;
+
         public static void Load(UnityModManager.ModEntry modEntry)
         {
             EnableExperimentalEarlyScenePathSuppression = DefaultEnableExperimentalEarlyScenePathSuppression;
@@ -46,6 +52,8 @@ namespace FUSE.Infrastructure
             ShowAdvancedHealthDetails = DefaultShowAdvancedHealthDetails;
             ShowTrackDebugOverlay = DefaultShowTrackDebugOverlay;
             ShowTrackDebugSpanPaths = DefaultShowTrackDebugSpanPaths;
+            ShowSceneryDebugOverlay = DefaultShowSceneryDebugOverlay;
+            ShowSceneryDebugAdvanced = DefaultShowSceneryDebugAdvanced;
             FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
 
             var infoPath = Path.Combine(modEntry?.Path ?? string.Empty, "Info.json");
@@ -75,6 +83,10 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, "ShowTrackDebugOverlay", DefaultShowTrackDebugOverlay);
                 ShowTrackDebugSpanPaths =
                     ReadBool(settings, "ShowTrackDebugSpanPaths", DefaultShowTrackDebugSpanPaths);
+                ShowSceneryDebugOverlay =
+                    ReadBool(settings, "ShowSceneryDebugOverlay", DefaultShowSceneryDebugOverlay);
+                ShowSceneryDebugAdvanced =
+                    ReadBool(settings, "ShowSceneryDebugAdvanced", DefaultShowSceneryDebugAdvanced);
                 ApplyUserOverrides();
                 FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
 
@@ -88,6 +100,8 @@ namespace FUSE.Infrastructure
                     $"ShowAdvancedHealthDetails={ShowAdvancedHealthDetails} " +
                     $"ShowTrackDebugOverlay={ShowTrackDebugOverlay} " +
                     $"ShowTrackDebugSpanPaths={ShowTrackDebugSpanPaths} " +
+                    $"ShowSceneryDebugOverlay={ShowSceneryDebugOverlay} " +
+                    $"ShowSceneryDebugAdvanced={ShowSceneryDebugAdvanced} " +
                     $"timeoutSeconds={ExperimentalEarlyScenePathSuppressionTimeoutSeconds}.");
             }
             catch (Exception ex)
@@ -100,6 +114,8 @@ namespace FUSE.Infrastructure
                 ShowAdvancedHealthDetails = DefaultShowAdvancedHealthDetails;
                 ShowTrackDebugOverlay = DefaultShowTrackDebugOverlay;
                 ShowTrackDebugSpanPaths = DefaultShowTrackDebugSpanPaths;
+                ShowSceneryDebugOverlay = DefaultShowSceneryDebugOverlay;
+                ShowSceneryDebugAdvanced = DefaultShowSceneryDebugAdvanced;
                 FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
                 FuseLog.Warning($"FUSE failed to parse Info.json settings; experimental early scene-path suppression remains disabled: {ex.Message}");
             }
@@ -147,6 +163,20 @@ namespace FUSE.Infrastructure
             ShowTrackDebugSpanPaths = enabled;
             SaveUserOverride(nameof(ShowTrackDebugSpanPaths), enabled);
             FuseLog.Info($"FUSE setting changed: {nameof(ShowTrackDebugSpanPaths)}={enabled}.");
+        }
+
+        public static void SetShowSceneryDebugOverlay(bool enabled)
+        {
+            ShowSceneryDebugOverlay = enabled;
+            SaveUserOverride(nameof(ShowSceneryDebugOverlay), enabled);
+            FuseLog.Info($"FUSE setting changed: {nameof(ShowSceneryDebugOverlay)}={enabled}.");
+        }
+
+        public static void SetShowSceneryDebugAdvanced(bool enabled)
+        {
+            ShowSceneryDebugAdvanced = enabled;
+            SaveUserOverride(nameof(ShowSceneryDebugAdvanced), enabled);
+            FuseLog.Info($"FUSE setting changed: {nameof(ShowSceneryDebugAdvanced)}={enabled}.");
         }
 
         public static string GetUserSettingsPath()
@@ -199,6 +229,10 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, nameof(ShowTrackDebugOverlay), ShowTrackDebugOverlay);
                 ShowTrackDebugSpanPaths =
                     ReadBool(settings, nameof(ShowTrackDebugSpanPaths), ShowTrackDebugSpanPaths);
+                ShowSceneryDebugOverlay =
+                    ReadBool(settings, nameof(ShowSceneryDebugOverlay), ShowSceneryDebugOverlay);
+                ShowSceneryDebugAdvanced =
+                    ReadBool(settings, nameof(ShowSceneryDebugAdvanced), ShowSceneryDebugAdvanced);
                 FuseLog.Info($"FUSE user setting overrides loaded from '{path}'.");
             }
             catch (Exception ex)

--- a/Interface/FuseHealthUi.cs
+++ b/Interface/FuseHealthUi.cs
@@ -818,6 +818,28 @@ namespace FUSE.Interface
                 });
             AddSettingToggle(
                 builder,
+                "Scenery Debug Overlay",
+                FuseSettings.ShowSceneryDebugOverlay ? "enabled (hover scenery)" : "disabled",
+                FuseSettings.ShowSceneryDebugOverlay ? "Disable" : "Enable",
+                () =>
+                {
+                    FuseSettings.SetShowSceneryDebugOverlay(!FuseSettings.ShowSceneryDebugOverlay);
+                    RebuildWindow();
+                });
+            AddSettingToggle(
+                builder,
+                "Scenery Debug Details",
+                FuseSettings.ShowSceneryDebugAdvanced
+                    ? (FuseSettings.ShowSceneryDebugOverlay ? "shown in overlay" : "shown when overlay on")
+                    : "hidden",
+                FuseSettings.ShowSceneryDebugAdvanced ? "Hide" : "Show",
+                () =>
+                {
+                    FuseSettings.SetShowSceneryDebugAdvanced(!FuseSettings.ShowSceneryDebugAdvanced);
+                    RebuildWindow();
+                });
+            AddSettingToggle(
+                builder,
                 "Early Suppression",
                 FuseSettings.EnableExperimentalEarlyScenePathSuppression ? "enabled" : "disabled",
                 FuseSettings.EnableExperimentalEarlyScenePathSuppression ? "Disable" : "Enable",

--- a/Interface/FusePackageSourceLookup.cs
+++ b/Interface/FusePackageSourceLookup.cs
@@ -1,0 +1,160 @@
+using System;
+using System.IO;
+using FUSE.Data;
+using FUSE.Loading;
+
+namespace FUSE.Interface
+{
+    /// <summary>
+    /// Reverse lookup from a runtime item id back to the FUSE-loaded sub-package that
+    /// defined it, so the debug overlays can show "this came from AspenCrazyMap/acm-edits.json"
+    /// without dumping the runtime graph or scanning JSON files by hand.
+    /// </summary>
+    internal static class FusePackageSourceLookup
+    {
+        public enum ItemKind
+        {
+            Scenery,
+            SceneClone,
+            Segment,
+            Node,
+            Span,
+            Spliney
+        }
+
+        public readonly struct Source
+        {
+            public Source(string packageId, string folderName, string fileName)
+            {
+                PackageId = packageId;
+                FolderName = folderName;
+                FileName = fileName;
+            }
+
+            public string PackageId { get; }
+            public string FolderName { get; }
+            public string FileName { get; }
+
+            public string Display
+            {
+                get
+                {
+                    if (string.IsNullOrEmpty(FolderName))
+                    {
+                        return string.IsNullOrEmpty(FileName) ? "<unknown>" : FileName;
+                    }
+
+                    return string.IsNullOrEmpty(FileName) ? FolderName : FolderName + "/" + FileName;
+                }
+            }
+        }
+
+        public static bool TryGetSource(ItemKind kind, string id, out Source source)
+        {
+            source = default;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return false;
+            }
+
+            System.Collections.Generic.IReadOnlyList<FuseLoadedMod> mods;
+            try
+            {
+                mods = FuseModLoader.GetLoadedModsInOrder();
+            }
+            catch
+            {
+                return false;
+            }
+
+            if (mods == null)
+            {
+                return false;
+            }
+
+            for (var index = 0; index < mods.Count; index++)
+            {
+                var mod = mods[index];
+                var definition = mod?.Definition;
+                if (definition == null)
+                {
+                    continue;
+                }
+
+                if (!ContainsId(definition, kind, id))
+                {
+                    continue;
+                }
+
+                source = new Source(
+                    definition.Id,
+                    ExtractFolderName(mod.FolderPath),
+                    NormalizeDefinitionPath(mod.DefinitionPath));
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool ContainsId(FuseModDefinition definition, ItemKind kind, string id)
+        {
+            switch (kind)
+            {
+                case ItemKind.Scenery:
+                    return definition.World?.Scenery != null && definition.World.Scenery.ContainsKey(id);
+                case ItemKind.SceneClone:
+                    return definition.World?.SceneClones != null && definition.World.SceneClones.ContainsKey(id);
+                case ItemKind.Spliney:
+                    return definition.World?.Splineys != null && definition.World.Splineys.ContainsKey(id);
+                case ItemKind.Segment:
+                    return definition.Tracks?.Segments != null && definition.Tracks.Segments.ContainsKey(id);
+                case ItemKind.Node:
+                    return definition.Tracks?.Nodes != null && definition.Tracks.Nodes.ContainsKey(id);
+                case ItemKind.Span:
+                    return definition.Tracks?.Spans != null && definition.Tracks.Spans.ContainsKey(id);
+                default:
+                    return false;
+            }
+        }
+
+        private static string ExtractFolderName(string folderPath)
+        {
+            if (string.IsNullOrWhiteSpace(folderPath))
+            {
+                return null;
+            }
+
+            try
+            {
+                return new DirectoryInfo(folderPath).Name;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string NormalizeDefinitionPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return null;
+            }
+
+            // Legacy converter records source files as 'legacy://<filename>'.
+            const string LegacyPrefix = "legacy://";
+            if (path.StartsWith(LegacyPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return path.Substring(LegacyPrefix.Length);
+            }
+
+            const string FusePrefix = "fuse://";
+            if (path.StartsWith(FusePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return path.Substring(FusePrefix.Length);
+            }
+
+            return path;
+        }
+    }
+}

--- a/Interface/FuseProgressionImpactLookup.cs
+++ b/Interface/FuseProgressionImpactLookup.cs
@@ -1,0 +1,419 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using FUSE.API;
+using FUSE.Data;
+using Game.Progression;
+
+namespace FUSE.Interface
+{
+    /// <summary>
+    /// Walks loaded FUSE map features and progression sections to surface which progression
+    /// constructs reference a given scenery game object or track group. Used by the debug
+    /// overlays so authors can see "this building is gated by Stage 2 of progression X"
+    /// without dumping the runtime graph.
+    /// </summary>
+    internal static class FuseProgressionImpactLookup
+    {
+        private static readonly PropertyInfo MapFeatureUnlockedProperty =
+            typeof(MapFeature).GetProperty("Unlocked", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        private static readonly FieldInfo MapFeatureUnlockedField =
+            typeof(MapFeature).GetField("Unlocked", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        public readonly struct Impact
+        {
+            public Impact(string sourceKind, string sourceId, string effect, string state = null, string target = null)
+            {
+                SourceKind = sourceKind;
+                SourceId = sourceId;
+                Effect = effect;
+                State = state;
+                Target = target;
+            }
+
+            public string SourceKind { get; }
+            public string SourceId { get; }
+            public string Effect { get; }
+            public string State { get; }
+            public string Target { get; }
+        }
+
+        public static List<Impact> FindForGameObject(string scenePath, string leafName, string fuseId)
+        {
+            var hits = new List<Impact>();
+            var candidates = BuildCandidateSet(scenePath, leafName, fuseId);
+            if (candidates.Count == 0)
+            {
+                return hits;
+            }
+
+            CollectFromMapFeatures(hits, feature =>
+            {
+                AddIfMatches(hits, candidates, "MapFeature", feature.Identifier, "enables game object on unlock", feature.Definition?.GameObjectsEnableOnUnlock, feature.State);
+            });
+
+            CollectFromSections(hits, section =>
+            {
+                AddIfMatches(hits, candidates, "Section", section.QualifiedId, "enables game object on unlock", section.Definition?.GameObjectsEnableOnUnlock);
+            });
+
+            return hits;
+        }
+
+        public static List<Impact> FindForTrackGroup(string groupId)
+        {
+            var hits = new List<Impact>();
+            if (string.IsNullOrWhiteSpace(groupId))
+            {
+                return hits;
+            }
+
+            var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { groupId };
+
+            CollectFromMapFeatures(hits, feature =>
+            {
+                AddIfMatches(hits, candidates, "MapFeature", feature.Identifier, "enables track group on unlock", feature.Definition?.TrackGroupsEnableOnUnlock, feature.State);
+                AddIfMatches(hits, candidates, "MapFeature", feature.Identifier, "makes track group available on unlock", feature.Definition?.TrackGroupsAvailableOnUnlock, feature.State);
+            });
+
+            CollectFromSections(hits, section =>
+            {
+                AddIfMatches(hits, candidates, "Section", section.QualifiedId, "enables track group on unlock", section.Definition?.TrackGroupsEnableOnUnlock);
+                AddIfMatches(hits, candidates, "Section", section.QualifiedId, "makes track group available on unlock", section.Definition?.TrackGroupsAvailableOnUnlock);
+            });
+
+            return hits;
+        }
+
+        public static List<Impact> FindForIndustry(string industryId)
+        {
+            var hits = new List<Impact>();
+            if (string.IsNullOrWhiteSpace(industryId))
+            {
+                return hits;
+            }
+
+            var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { industryId };
+
+            CollectFromMapFeatures(hits, feature =>
+            {
+                AddIfMatches(hits, candidates, "MapFeature", feature.Identifier, "include industry on unlock", feature.Definition?.UnlockIncludeIndustries, feature.State);
+                AddIfMatches(hits, candidates, "MapFeature", feature.Identifier, "exclude industry on unlock", feature.Definition?.UnlockExcludeIndustries, feature.State);
+            });
+
+            CollectFromSections(hits, section =>
+            {
+                AddIfMatches(hits, candidates, "Section", section.QualifiedId, "include industry on unlock", section.Definition?.UnlockIncludeIndustries);
+                AddIfMatches(hits, candidates, "Section", section.QualifiedId, "exclude industry on unlock", section.Definition?.UnlockExcludeIndustries);
+            });
+
+            return hits;
+        }
+
+        public static List<Impact> FindForArea(string areaId)
+        {
+            var hits = new List<Impact>();
+            if (string.IsNullOrWhiteSpace(areaId))
+            {
+                return hits;
+            }
+
+            var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { areaId };
+
+            CollectFromMapFeatures(hits, feature =>
+            {
+                AddIfMatches(hits, candidates, "MapFeature", feature.Identifier, "enables area on unlock", feature.Definition?.AreasEnableOnUnlock, feature.State);
+            });
+
+            CollectFromSections(hits, section =>
+            {
+                AddIfMatches(hits, candidates, "Section", section.QualifiedId, "enables area on unlock", section.Definition?.AreasEnableOnUnlock);
+            });
+
+            return hits;
+        }
+
+        private static HashSet<string> BuildCandidateSet(string scenePath, string leafName, string fuseId)
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (!string.IsNullOrWhiteSpace(scenePath))
+            {
+                set.Add(scenePath);
+            }
+
+            if (!string.IsNullOrWhiteSpace(leafName))
+            {
+                set.Add(leafName);
+            }
+
+            if (!string.IsNullOrWhiteSpace(fuseId))
+            {
+                set.Add(fuseId);
+            }
+
+            return set;
+        }
+
+        private static void CollectFromMapFeatures(List<Impact> hits, Action<MapFeatureEntry> visitor)
+        {
+            IEnumerable<MapFeature> features;
+            try
+            {
+                features = ProgressionAPI.GetAllMapFeatures();
+            }
+            catch
+            {
+                return;
+            }
+
+            if (features == null)
+            {
+                return;
+            }
+
+            foreach (var feature in features)
+            {
+                if (feature == null || string.IsNullOrWhiteSpace(feature.identifier))
+                {
+                    continue;
+                }
+
+                FuseMapFeature definition = null;
+                try
+                {
+                    definition = ProgressionAPI.GetDefinition(feature);
+                }
+                catch
+                {
+                    definition = null;
+                }
+
+                if (definition == null)
+                {
+                    continue;
+                }
+
+                visitor(new MapFeatureEntry(feature.identifier, definition, FormatMapFeatureState(feature)));
+            }
+        }
+
+        private static void CollectFromSections(List<Impact> hits, Action<SectionEntry> visitor)
+        {
+            IEnumerable<Progression> progressions;
+            try
+            {
+                progressions = ProgressionAPI.GetAllProgressions();
+            }
+            catch
+            {
+                return;
+            }
+
+            if (progressions == null)
+            {
+                return;
+            }
+
+            foreach (var progression in progressions)
+            {
+                if (progression == null || string.IsNullOrWhiteSpace(progression.identifier))
+                {
+                    continue;
+                }
+
+                FuseProgression definition = null;
+                try
+                {
+                    definition = ProgressionAPI.GetDefinition(progression);
+                }
+                catch
+                {
+                    definition = null;
+                }
+
+                if (definition?.Sections == null)
+                {
+                    continue;
+                }
+
+                foreach (var pair in definition.Sections)
+                {
+                    if (pair.Value == null || string.IsNullOrWhiteSpace(pair.Key))
+                    {
+                        continue;
+                    }
+
+                    visitor(new SectionEntry(progression.identifier + "/" + pair.Key, pair.Value));
+                }
+            }
+        }
+
+        private static void AddIfMatches(
+            List<Impact> hits,
+            HashSet<string> candidates,
+            string sourceKind,
+            string sourceId,
+            string effect,
+            string[] targets,
+            string state = null)
+        {
+            if (targets == null || targets.Length == 0 || candidates.Count == 0)
+            {
+                return;
+            }
+
+            for (var index = 0; index < targets.Length; index++)
+            {
+                var target = targets[index];
+                if (string.IsNullOrWhiteSpace(target))
+                {
+                    continue;
+                }
+
+                if (MatchesAny(candidates, target))
+                {
+                    hits.Add(new Impact(sourceKind, sourceId, effect, state, target));
+                    return;
+                }
+            }
+        }
+
+        private static string FormatMapFeatureState(MapFeature feature)
+        {
+            if (feature == null)
+            {
+                return null;
+            }
+
+            var parts = new List<string>();
+            if (ProgressionAPI.TryGetMapFeatureEnabledState(feature, out var enabled))
+            {
+                parts.Add("enabled=" + BoolText(enabled));
+            }
+
+            var unlocked = TryReadMapFeatureUnlocked(feature);
+            if (unlocked.HasValue)
+            {
+                parts.Add("unlocked=" + BoolText(unlocked.Value));
+            }
+
+            parts.Add("defaultSandbox=" + BoolText(feature.defaultEnableInSandbox));
+            return string.Join(", ", parts.ToArray());
+        }
+
+        private static bool? TryReadMapFeatureUnlocked(MapFeature feature)
+        {
+            if (feature == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                var propertyValue = MapFeatureUnlockedProperty?.GetValue(feature, null);
+                if (propertyValue is bool propertyBool)
+                {
+                    return propertyBool;
+                }
+            }
+            catch
+            {
+                // Fall through to the backing field probe below.
+            }
+
+            try
+            {
+                var fieldValue = MapFeatureUnlockedField?.GetValue(feature);
+                if (fieldValue is bool fieldBool)
+                {
+                    return fieldBool;
+                }
+            }
+            catch
+            {
+                return null;
+            }
+
+            return null;
+        }
+
+        private static string BoolText(bool value)
+        {
+            return value ? "true" : "false";
+        }
+
+        private static bool MatchesAny(HashSet<string> candidates, string target)
+        {
+            if (candidates.Contains(target))
+            {
+                return true;
+            }
+
+            // Allow leaf-name matches when the candidate is a full path and the target is a leaf,
+            // or vice versa. Cheap heuristic that catches the common scene-path / id mismatch.
+            var targetLeaf = LeafName(target);
+            if (!string.IsNullOrWhiteSpace(targetLeaf) && candidates.Contains(targetLeaf))
+            {
+                return true;
+            }
+
+            foreach (var candidate in candidates)
+            {
+                var candidateLeaf = LeafName(candidate);
+                if (!string.IsNullOrWhiteSpace(candidateLeaf) &&
+                    string.Equals(candidateLeaf, targetLeaf, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                if (candidate.EndsWith("/" + target, StringComparison.OrdinalIgnoreCase) ||
+                    target.EndsWith("/" + candidate, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string LeafName(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return path;
+            }
+
+            var lastSlash = path.LastIndexOf('/');
+            return lastSlash >= 0 && lastSlash + 1 < path.Length
+                ? path.Substring(lastSlash + 1)
+                : path;
+        }
+
+        private readonly struct MapFeatureEntry
+        {
+            public MapFeatureEntry(string identifier, FuseMapFeature definition, string state)
+            {
+                Identifier = identifier;
+                Definition = definition;
+                State = state;
+            }
+
+            public string Identifier { get; }
+            public FuseMapFeature Definition { get; }
+            public string State { get; }
+        }
+
+        private readonly struct SectionEntry
+        {
+            public SectionEntry(string qualifiedId, FuseSection definition)
+            {
+                QualifiedId = qualifiedId;
+                Definition = definition;
+            }
+
+            public string QualifiedId { get; }
+            public FuseSection Definition { get; }
+        }
+    }
+}

--- a/Interface/FuseSceneryDebugOverlay.cs
+++ b/Interface/FuseSceneryDebugOverlay.cs
@@ -1,0 +1,871 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FUSE.API;
+using FUSE.Cache;
+using FUSE.Data;
+using FUSE.Infrastructure;
+using FUSE.Registry;
+using Helpers;
+using Model.Definition.Data;
+using Track;
+using UnityEngine;
+
+namespace FUSE.Interface
+{
+    internal sealed class FuseSceneryDebugOverlay : MonoBehaviour
+    {
+        private const float PickScreenSlackPixels = 4f;
+        private const float PickScreenFallbackRadiusPixels = 16f;
+        private const float RefreshInterval = 0.08f;
+        private const int MaxSuppressorsToShow = 8;
+        private const int MaxComponentsToShow = 12;
+
+        private static GameObject _host;
+
+        private GUIStyle _boxStyle;
+        private GUIStyle _labelStyle;
+        private Texture2D _backgroundTexture;
+        private float _nextRefreshAt;
+        private string _cachedText;
+        private bool _hasHover;
+        private Vector2 _lastMouseGui;
+
+        public static void Ensure()
+        {
+            if (_host != null)
+            {
+                return;
+            }
+
+            _host = new GameObject("FUSE Scenery Debug Overlay");
+            DontDestroyOnLoad(_host);
+            _host.hideFlags = HideFlags.HideAndDontSave;
+            _host.AddComponent<FuseSceneryDebugOverlay>();
+            FuseLog.Info("FUSE scenery debug overlay initialized.");
+        }
+
+        public static void Shutdown()
+        {
+            if (_host != null)
+            {
+                Destroy(_host);
+                _host = null;
+            }
+        }
+
+        private void OnGUI()
+        {
+            if (!FuseSettings.ShowSceneryDebugOverlay)
+            {
+                _hasHover = false;
+                _cachedText = null;
+                return;
+            }
+
+            var evt = Event.current;
+            if (evt == null)
+            {
+                return;
+            }
+
+            if (evt.type == EventType.MouseMove || evt.type == EventType.Layout || evt.type == EventType.Repaint)
+            {
+                _lastMouseGui = evt.mousePosition;
+            }
+
+            if (evt.type == EventType.Layout)
+            {
+                MaybeRefresh();
+            }
+
+            if (evt.type != EventType.Repaint || !_hasHover || string.IsNullOrEmpty(_cachedText))
+            {
+                return;
+            }
+
+            EnsureGuiStyles();
+
+            var screenX = _lastMouseGui.x + 18f;
+            var screenY = _lastMouseGui.y + 18f;
+
+            var content = new GUIContent(_cachedText);
+            var size = _labelStyle.CalcSize(content);
+            var width = Mathf.Min(Mathf.Max(300f, size.x + 16f), Screen.width - 32f);
+            var height = Mathf.Min(_labelStyle.CalcHeight(content, width - 16f) + 16f, Screen.height - 32f);
+
+            if (screenX + width > Screen.width - 8f)
+            {
+                screenX = Mathf.Max(8f, Screen.width - width - 8f);
+            }
+
+            if (screenY + height > Screen.height - 8f)
+            {
+                screenY = Mathf.Max(8f, Screen.height - height - 8f);
+            }
+
+            var boxRect = new Rect(screenX, screenY, width, height);
+            GUI.Box(boxRect, GUIContent.none, _boxStyle);
+            GUI.Label(new Rect(screenX + 8f, screenY + 8f, width - 16f, height - 16f), content, _labelStyle);
+        }
+
+        private void OnDestroy()
+        {
+            if (_backgroundTexture != null)
+            {
+                Destroy(_backgroundTexture);
+                _backgroundTexture = null;
+            }
+        }
+
+        private void MaybeRefresh()
+        {
+            if (Time.unscaledTime < _nextRefreshAt)
+            {
+                return;
+            }
+
+            _nextRefreshAt = Time.unscaledTime + RefreshInterval;
+
+            try
+            {
+                var mouseScreen = GuiToScreen(_lastMouseGui);
+                var hit = FindObjectNearCursor(mouseScreen);
+                if (hit == null)
+                {
+                    _hasHover = false;
+                    _cachedText = null;
+                    return;
+                }
+
+                _cachedText = BuildReport(hit);
+                _hasHover = !string.IsNullOrEmpty(_cachedText);
+            }
+            catch (Exception ex)
+            {
+                _hasHover = false;
+                _cachedText = null;
+                FuseLog.Warning($"FUSE scenery debug overlay refresh failed: {ex.GetBaseException().Message}");
+            }
+        }
+
+        private static Vector2 GuiToScreen(Vector2 guiPosition)
+        {
+            return new Vector2(guiPosition.x, Screen.height - guiPosition.y);
+        }
+
+        private static GameObject FindObjectNearCursor(Vector2 mouseScreen)
+        {
+            var camera = Camera.main ?? Camera.current;
+            if (camera == null)
+            {
+                return null;
+            }
+
+            if (mouseScreen.x < 0f || mouseScreen.y < 0f ||
+                mouseScreen.x > Screen.width || mouseScreen.y > Screen.height)
+            {
+                return null;
+            }
+
+            return FindByRendererBounds(camera, mouseScreen);
+        }
+
+        private static GameObject FindByRendererBounds(Camera camera, Vector2 mouseScreen)
+        {
+            GameObject bestInside = null;
+            var bestInsideDepth = float.MaxValue;
+            var bestInsideArea = float.MaxValue;
+
+            GameObject bestNear = null;
+            var bestNearDistance = PickScreenFallbackRadiusPixels;
+            var bestNearDepth = float.MaxValue;
+
+            void Consider(GameObject root)
+            {
+                if (root == null)
+                {
+                    return;
+                }
+
+                var renderers = root.GetComponentsInChildren<Renderer>(true);
+                if (renderers.Length == 0)
+                {
+                    return;
+                }
+
+                if (!TryAggregateBounds(renderers, out var bounds))
+                {
+                    return;
+                }
+
+                if (!TryProjectBoundsToScreen(camera, bounds, out var screenMin, out var screenMax, out var avgDepth))
+                {
+                    return;
+                }
+
+                var insideX = mouseScreen.x >= screenMin.x - PickScreenSlackPixels &&
+                              mouseScreen.x <= screenMax.x + PickScreenSlackPixels;
+                var insideY = mouseScreen.y >= screenMin.y - PickScreenSlackPixels &&
+                              mouseScreen.y <= screenMax.y + PickScreenSlackPixels;
+
+                if (insideX && insideY)
+                {
+                    var area = Mathf.Max(1f, (screenMax.x - screenMin.x) * (screenMax.y - screenMin.y));
+                    if (avgDepth < bestInsideDepth - 0.5f ||
+                        (Mathf.Abs(avgDepth - bestInsideDepth) < 0.5f && area < bestInsideArea))
+                    {
+                        bestInside = root;
+                        bestInsideDepth = avgDepth;
+                        bestInsideArea = area;
+                    }
+
+                    return;
+                }
+
+                if (bestInside != null)
+                {
+                    // Already have an inside-AABB hit; skip the near-edge fallback to avoid noise.
+                    return;
+                }
+
+                var clampedX = Mathf.Clamp(mouseScreen.x, screenMin.x, screenMax.x);
+                var clampedY = Mathf.Clamp(mouseScreen.y, screenMin.y, screenMax.y);
+                var distance = Vector2.Distance(mouseScreen, new Vector2(clampedX, clampedY));
+                if (distance > bestNearDistance)
+                {
+                    return;
+                }
+
+                if (distance < bestNearDistance - 0.5f || avgDepth < bestNearDepth)
+                {
+                    bestNear = root;
+                    bestNearDistance = distance;
+                    bestNearDepth = avgDepth;
+                }
+            }
+
+            try
+            {
+                foreach (var clone in SceneCloneAPI.GetAllSceneClones())
+                {
+                    Consider(clone);
+                }
+            }
+            catch
+            {
+                // Ignore enumeration failures so the fallback can still consider scenery.
+            }
+
+            try
+            {
+                foreach (var scenery in SceneryAPI.GetAllScenery())
+                {
+                    if (scenery != null)
+                    {
+                        Consider(scenery.gameObject);
+                    }
+                }
+            }
+            catch
+            {
+                // Ignore enumeration failures; no hit is better than a noisy one.
+            }
+
+            return bestInside ?? bestNear;
+        }
+
+        private static bool TryProjectBoundsToScreen(
+            Camera camera,
+            Bounds bounds,
+            out Vector2 screenMin,
+            out Vector2 screenMax,
+            out float avgDepth)
+        {
+            screenMin = default;
+            screenMax = default;
+            avgDepth = float.MaxValue;
+
+            var min = bounds.min;
+            var max = bounds.max;
+
+            var minX = float.MaxValue;
+            var minY = float.MaxValue;
+            var maxX = float.MinValue;
+            var maxY = float.MinValue;
+            var depthTotal = 0f;
+            var depthCount = 0;
+
+            for (var index = 0; index < 8; index++)
+            {
+                var corner = new Vector3(
+                    (index & 1) == 0 ? min.x : max.x,
+                    (index & 2) == 0 ? min.y : max.y,
+                    (index & 4) == 0 ? min.z : max.z);
+
+                var projected = camera.WorldToScreenPoint(corner);
+                if (projected.z <= 0f)
+                {
+                    continue;
+                }
+
+                if (projected.x < minX)
+                {
+                    minX = projected.x;
+                }
+
+                if (projected.y < minY)
+                {
+                    minY = projected.y;
+                }
+
+                if (projected.x > maxX)
+                {
+                    maxX = projected.x;
+                }
+
+                if (projected.y > maxY)
+                {
+                    maxY = projected.y;
+                }
+
+                depthTotal += projected.z;
+                depthCount++;
+            }
+
+            // Require at least half the corners to be in front of the camera. Fewer than that
+            // means the object straddles the near plane and the projected AABB would be misleading.
+            if (depthCount < 4)
+            {
+                return false;
+            }
+
+            screenMin = new Vector2(minX, minY);
+            screenMax = new Vector2(maxX, maxY);
+            avgDepth = depthTotal / depthCount;
+            return true;
+        }
+
+        private static bool TryAggregateBounds(IReadOnlyList<Renderer> renderers, out Bounds bounds)
+        {
+            bounds = default;
+            var found = false;
+            for (var index = 0; index < renderers.Count; index++)
+            {
+                var renderer = renderers[index];
+                if (renderer == null)
+                {
+                    continue;
+                }
+
+                if (!found)
+                {
+                    bounds = renderer.bounds;
+                    found = true;
+                }
+                else
+                {
+                    bounds.Encapsulate(renderer.bounds);
+                }
+            }
+
+            return found;
+        }
+
+        private static string BuildReport(GameObject hit)
+        {
+            var classification = Classify(hit);
+            var builder = new StringBuilder();
+            switch (classification.Kind)
+            {
+                case HitKind.FuseScenery:
+                    BuildFuseSceneryReport(builder, classification);
+                    break;
+                case HitKind.SceneClone:
+                    BuildSceneCloneReport(builder, classification);
+                    break;
+                case HitKind.VanillaScenery:
+                    BuildVanillaSceneryReport(builder, classification);
+                    break;
+                default:
+                    BuildSceneObjectReport(builder, classification);
+                    break;
+            }
+
+            AppendScenePathSuppression(builder, classification.ScenePath);
+            AppendProgressionImpacts(builder, classification);
+
+            if (FuseSettings.ShowSceneryDebugAdvanced)
+            {
+                AppendAdvancedDetails(builder, classification);
+            }
+
+            return builder.ToString().TrimEnd();
+        }
+
+        private static void AppendProgressionImpacts(StringBuilder builder, HitInfo info)
+        {
+            var leafName = info.Root != null ? info.Root.name : null;
+            var fuseId = info.Scenery != null
+                ? info.Scenery.name
+                : info.SceneCloneId;
+
+            List<FuseProgressionImpactLookup.Impact> impacts;
+            try
+            {
+                impacts = FuseProgressionImpactLookup.FindForGameObject(info.ScenePath, leafName, fuseId);
+            }
+            catch
+            {
+                return;
+            }
+
+            if (impacts == null || impacts.Count == 0)
+            {
+                return;
+            }
+
+            builder.AppendLine();
+            builder.Append("<b>Progressions impacting</b> (").Append(impacts.Count).AppendLine(")");
+            var shown = 0;
+            const int MaxToShow = 8;
+            foreach (var impact in impacts)
+            {
+                if (shown++ >= MaxToShow)
+                {
+                    builder.Append("  + ").Append(impacts.Count - MaxToShow).AppendLine(" more");
+                    break;
+                }
+
+                builder.Append("  - ")
+                    .Append(impact.SourceKind)
+                    .Append(" '").Append(SafeId(impact.SourceId)).Append("'  ")
+                    .Append(impact.Effect);
+                if (!string.IsNullOrWhiteSpace(impact.State))
+                {
+                    builder.Append(" [").Append(impact.State).Append("]");
+                }
+
+                if (!string.IsNullOrWhiteSpace(impact.Target))
+                {
+                    builder.Append(" -> ").Append(impact.Target);
+                }
+
+                builder.AppendLine();
+            }
+        }
+
+        private static HitInfo Classify(GameObject hit)
+        {
+            var info = new HitInfo
+            {
+                Leaf = hit,
+                Root = hit
+            };
+
+            // Walk up to find a meaningful root (SceneryAssetInstance, FuseSceneCloneMarker, or stop at root)
+            var cursor = hit != null ? hit.transform : null;
+            while (cursor != null)
+            {
+                var scenery = cursor.GetComponent<SceneryAssetInstance>();
+                if (scenery != null)
+                {
+                    info.Kind = HitKind.VanillaScenery;
+                    info.Root = cursor.gameObject;
+                    info.Scenery = scenery;
+                    if (FuseSceneryRuntimeIndex.Instance.TryGetValue(scenery.name, out _))
+                    {
+                        info.Kind = HitKind.FuseScenery;
+                    }
+
+                    info.ScenePath = GetTransformPath(cursor);
+                    return info;
+                }
+
+                if (SceneCloneAPI.TryGetSceneCloneInfo(cursor.gameObject, out var cloneId, out var targetPath))
+                {
+                    info.Kind = HitKind.SceneClone;
+                    info.Root = cursor.gameObject;
+                    info.SceneCloneId = cloneId;
+                    info.SceneCloneTargetPath = targetPath;
+                    info.ScenePath = !string.IsNullOrWhiteSpace(targetPath) ? targetPath : GetTransformPath(cursor);
+                    return info;
+                }
+
+                cursor = cursor.parent;
+            }
+
+            info.Kind = HitKind.SceneObject;
+            info.ScenePath = hit != null ? GetTransformPath(hit.transform) : "<null>";
+            return info;
+        }
+
+        private static void BuildFuseSceneryReport(StringBuilder builder, HitInfo info)
+        {
+            builder.AppendLine("<b>FUSE Scenery</b>");
+            var scenery = info.Scenery;
+            var id = scenery != null ? scenery.name : null;
+            builder.Append("id: ").AppendLine(SafeId(id));
+            builder.Append("asset: ").AppendLine(SafeId(scenery != null ? scenery.identifier : null));
+
+            var owner = TryGetOwner(FuseClaimKind.Scenery, id);
+            if (!string.IsNullOrWhiteSpace(owner))
+            {
+                builder.Append("owner: ").AppendLine(owner);
+            }
+
+            AppendSource(builder, FusePackageSourceLookup.ItemKind.Scenery, id);
+
+            FuseScenery definition = null;
+            try
+            {
+                definition = SceneryAPI.GetDefinition(scenery);
+            }
+            catch
+            {
+                definition = null;
+            }
+
+            AppendTransformBlock(builder, scenery != null ? scenery.transform : info.Root.transform);
+
+            if (definition?.AnchorSpanIds != null && definition.AnchorSpanIds.Length > 0)
+            {
+                builder.Append("anchorSpans: ").AppendLine(string.Join(", ", definition.AnchorSpanIds));
+            }
+
+            if (!string.IsNullOrWhiteSpace(definition?.Model) &&
+                !string.Equals(definition.Model, scenery?.identifier, StringComparison.Ordinal))
+            {
+                builder.Append("modelHint: ").AppendLine(definition.Model);
+            }
+
+            AppendScenePath(builder, info.ScenePath);
+            AppendActiveLine(builder, info.Root);
+        }
+
+        private static void BuildVanillaSceneryReport(StringBuilder builder, HitInfo info)
+        {
+            builder.AppendLine("<b>Scenery</b> (vanilla)");
+            var scenery = info.Scenery;
+            builder.Append("name: ").AppendLine(SafeId(scenery != null ? scenery.name : info.Root.name));
+            builder.Append("asset: ").AppendLine(SafeId(scenery != null ? scenery.identifier : null));
+            AppendTransformBlock(builder, scenery != null ? scenery.transform : info.Root.transform);
+            AppendScenePath(builder, info.ScenePath);
+            AppendActiveLine(builder, info.Root);
+        }
+
+        private static void BuildSceneCloneReport(StringBuilder builder, HitInfo info)
+        {
+            builder.AppendLine("<b>FUSE Scene Clone</b>");
+            builder.Append("id: ").AppendLine(SafeId(info.SceneCloneId));
+            builder.Append("target: ").AppendLine(SafeId(info.SceneCloneTargetPath));
+            AppendSource(builder, FusePackageSourceLookup.ItemKind.SceneClone, info.SceneCloneId);
+
+            // Read the original package definition from the cache directly. SceneCloneAPI.GetDefinition
+            // overwrites Enabled with the live activeSelf, which hides authoring/runtime mismatches.
+            FuseSceneClone cached = null;
+            try
+            {
+                FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.SceneClone, info.SceneCloneId, out cached);
+            }
+            catch
+            {
+                cached = null;
+            }
+
+            if (cached != null)
+            {
+                if (!string.IsNullOrWhiteSpace(cached.Source))
+                {
+                    builder.Append("source: ").AppendLine(cached.Source);
+                }
+
+                if (cached.Enabled.HasValue)
+                {
+                    builder.Append("package.enabled: ").AppendLine(cached.Enabled.Value ? "true" : "false");
+                }
+                else
+                {
+                    builder.AppendLine("package.enabled: <unset>");
+                }
+            }
+
+            AppendTransformBlock(builder, info.Root.transform);
+            AppendActiveLine(builder, info.Root);
+        }
+
+        private static void BuildSceneObjectReport(StringBuilder builder, HitInfo info)
+        {
+            builder.AppendLine("<b>Scene Object</b>");
+            builder.Append("name: ").AppendLine(SafeId(info.Root != null ? info.Root.name : null));
+            AppendTransformBlock(builder, info.Root != null ? info.Root.transform : null);
+            AppendScenePath(builder, info.ScenePath);
+            AppendActiveLine(builder, info.Root);
+        }
+
+        private static void AppendTransformBlock(StringBuilder builder, Transform transform)
+        {
+            if (transform == null)
+            {
+                return;
+            }
+
+            var world = transform.position;
+            builder.Append("worldPos: (")
+                .Append(world.x.ToString("0.0")).Append(", ")
+                .Append(world.y.ToString("0.0")).Append(", ")
+                .Append(world.z.ToString("0.0")).AppendLine(")");
+
+            var rotation = transform.eulerAngles;
+            if (rotation.sqrMagnitude > 0.0001f)
+            {
+                builder.Append("rotation: (")
+                    .Append(rotation.x.ToString("0.0")).Append(", ")
+                    .Append(rotation.y.ToString("0.0")).Append(", ")
+                    .Append(rotation.z.ToString("0.0")).AppendLine(")");
+            }
+
+            var scale = transform.localScale;
+            if (scale != Vector3.one && scale.sqrMagnitude > 0.0001f)
+            {
+                builder.Append("scale: (")
+                    .Append(scale.x.ToString("0.000")).Append(", ")
+                    .Append(scale.y.ToString("0.000")).Append(", ")
+                    .Append(scale.z.ToString("0.000")).AppendLine(")");
+            }
+        }
+
+        private static void AppendScenePath(StringBuilder builder, string scenePath)
+        {
+            if (string.IsNullOrWhiteSpace(scenePath))
+            {
+                return;
+            }
+
+            builder.Append("scenePath: ").AppendLine(scenePath);
+        }
+
+        private static void AppendActiveLine(StringBuilder builder, GameObject root)
+        {
+            if (root == null)
+            {
+                return;
+            }
+
+            builder.Append("active: ")
+                .Append(root.activeSelf ? "self=true" : "self=false")
+                .Append(", inHierarchy=")
+                .AppendLine(root.activeInHierarchy ? "true" : "false");
+        }
+
+        private static void AppendScenePathSuppression(StringBuilder builder, string scenePath)
+        {
+            if (string.IsNullOrWhiteSpace(scenePath))
+            {
+                return;
+            }
+
+            IReadOnlyCollection<string> suppressors;
+            try
+            {
+                suppressors = FuseRegistry.GetSharedOwners(FuseClaimKind.SuppressedScenePath, scenePath);
+            }
+            catch
+            {
+                return;
+            }
+
+            if (suppressors == null || suppressors.Count == 0)
+            {
+                return;
+            }
+
+            builder.AppendLine();
+            builder.Append("<b>ScenePath suppressed by</b> (").Append(suppressors.Count).AppendLine(")");
+            var shown = 0;
+            foreach (var packageId in suppressors)
+            {
+                if (shown++ >= MaxSuppressorsToShow)
+                {
+                    builder.Append("  + ").Append(suppressors.Count - MaxSuppressorsToShow).AppendLine(" more");
+                    break;
+                }
+
+                builder.Append("  - ").AppendLine(SafeId(packageId));
+            }
+        }
+
+        private static void AppendAdvancedDetails(StringBuilder builder, HitInfo info)
+        {
+            var root = info.Root;
+            if (root == null)
+            {
+                return;
+            }
+
+            var renderers = root.GetComponentsInChildren<Renderer>(true);
+            var lodGroups = root.GetComponentsInChildren<LODGroup>(true);
+            var enabledRenderers = 0;
+            for (var index = 0; index < renderers.Length; index++)
+            {
+                if (renderers[index] != null && renderers[index].enabled)
+                {
+                    enabledRenderers++;
+                }
+            }
+
+            builder.AppendLine();
+            builder.Append("<b>Renderers</b>: ").Append(renderers.Length)
+                .Append(" total, ").Append(enabledRenderers).Append(" enabled");
+            if (lodGroups.Length > 0)
+            {
+                builder.Append(", ").Append(lodGroups.Length).Append(" LOD group(s)");
+            }
+
+            builder.AppendLine();
+
+            var components = root.GetComponents<Component>();
+            if (components.Length > 1)
+            {
+                builder.Append("<b>Components</b> (").Append(components.Length - 1).AppendLine(")");
+                var shown = 0;
+                for (var index = 0; index < components.Length; index++)
+                {
+                    var component = components[index];
+                    if (component == null || component is Transform)
+                    {
+                        continue;
+                    }
+
+                    if (shown++ >= MaxComponentsToShow)
+                    {
+                        builder.Append("  + more").AppendLine();
+                        break;
+                    }
+
+                    builder.Append("  - ").AppendLine(component.GetType().Name);
+                }
+            }
+
+            if (info.Leaf != null && info.Leaf != info.Root)
+            {
+                builder.Append("hitLeaf: ").AppendLine(GetTransformPath(info.Leaf.transform));
+            }
+        }
+
+        private static void AppendSource(StringBuilder builder, FusePackageSourceLookup.ItemKind kind, string id)
+        {
+            FusePackageSourceLookup.Source source;
+            try
+            {
+                if (!FusePackageSourceLookup.TryGetSource(kind, id, out source))
+                {
+                    return;
+                }
+            }
+            catch
+            {
+                return;
+            }
+
+            builder.Append("source: ").AppendLine(source.Display);
+        }
+
+        private static string TryGetOwner(FuseClaimKind kind, string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return null;
+            }
+
+            try
+            {
+                return FuseRegistry.GetExclusiveOwner(kind, id);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string GetTransformPath(Transform transform)
+        {
+            if (transform == null)
+            {
+                return string.Empty;
+            }
+
+            var names = new Stack<string>();
+            var cursor = transform;
+            while (cursor != null)
+            {
+                names.Push(cursor.name);
+                cursor = cursor.parent;
+            }
+
+            return string.Join("/", names.ToArray());
+        }
+
+        private static string SafeId(string id)
+        {
+            return string.IsNullOrWhiteSpace(id) ? "<none>" : id;
+        }
+
+        private void EnsureGuiStyles()
+        {
+            if (_boxStyle != null && _labelStyle != null)
+            {
+                return;
+            }
+
+            if (_backgroundTexture == null)
+            {
+                _backgroundTexture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+                var pixels = new Color[4];
+                for (var index = 0; index < pixels.Length; index++)
+                {
+                    pixels[index] = new Color(0f, 0f, 0f, 0.78f);
+                }
+
+                _backgroundTexture.SetPixels(pixels);
+                _backgroundTexture.Apply();
+            }
+
+            _boxStyle = new GUIStyle(GUI.skin.box)
+            {
+                normal = { background = _backgroundTexture, textColor = Color.white },
+                border = new RectOffset(2, 2, 2, 2),
+                padding = new RectOffset(8, 8, 8, 8)
+            };
+
+            _labelStyle = new GUIStyle(GUI.skin.label)
+            {
+                richText = true,
+                alignment = TextAnchor.UpperLeft,
+                wordWrap = true,
+                fontSize = 12,
+                normal = { textColor = Color.white }
+            };
+        }
+
+        private enum HitKind
+        {
+            SceneObject,
+            FuseScenery,
+            VanillaScenery,
+            SceneClone
+        }
+
+        private struct HitInfo
+        {
+            public HitKind Kind;
+            public GameObject Leaf;
+            public GameObject Root;
+            public SceneryAssetInstance Scenery;
+            public string SceneCloneId;
+            public string SceneCloneTargetPath;
+            public string ScenePath;
+        }
+    }
+}

--- a/Interface/FuseTrackDebugOverlay.cs
+++ b/Interface/FuseTrackDebugOverlay.cs
@@ -230,6 +230,8 @@ namespace FUSE.Interface
             var builder = new StringBuilder();
             builder.AppendLine("<b>Track Segment</b>");
             builder.Append("id: ").AppendLine(SafeId(segment.id));
+            AppendOwner(builder, segment);
+            AppendSource(builder, segment);
             builder.Append("nodes: ")
                 .Append(SafeId(segment.a != null ? segment.a.id : null))
                 .Append("  ->  ")
@@ -284,6 +286,7 @@ namespace FUSE.Interface
             AppendNodeBlock(builder, "node B", segment.b);
 
             AppendIndustryInfluences(builder, segment);
+            AppendProgressionImpacts(builder, segment);
 
             if (FuseSettings.ShowTrackDebugSpanPaths)
             {
@@ -291,6 +294,48 @@ namespace FUSE.Interface
             }
 
             return builder.ToString().TrimEnd();
+        }
+
+        private static void AppendProgressionImpacts(StringBuilder builder, TrackSegment segment)
+        {
+            if (segment == null || string.IsNullOrWhiteSpace(segment.groupId))
+            {
+                return;
+            }
+
+            List<FuseProgressionImpactLookup.Impact> impacts;
+            try
+            {
+                impacts = FuseProgressionImpactLookup.FindForTrackGroup(segment.groupId);
+            }
+            catch
+            {
+                return;
+            }
+
+            if (impacts == null || impacts.Count == 0)
+            {
+                return;
+            }
+
+            builder.AppendLine();
+            builder.Append("<b>Progressions impacting group '").Append(segment.groupId).Append("'</b> (")
+                .Append(impacts.Count).AppendLine(")");
+            const int MaxToShow = 8;
+            var shown = 0;
+            foreach (var impact in impacts)
+            {
+                if (shown++ >= MaxToShow)
+                {
+                    builder.Append("  + ").Append(impacts.Count - MaxToShow).AppendLine(" more");
+                    break;
+                }
+
+                builder.Append("  - ")
+                    .Append(impact.SourceKind)
+                    .Append(" '").Append(SafeId(impact.SourceId)).Append("'  ")
+                    .AppendLine(impact.Effect);
+            }
         }
 
         private static void AppendNodeBlock(StringBuilder builder, string label, TrackNode node)
@@ -558,6 +603,54 @@ namespace FUSE.Interface
         private static string SafeId(string id)
         {
             return string.IsNullOrWhiteSpace(id) ? "<none>" : id;
+        }
+
+        private static void AppendOwner(StringBuilder builder, TrackSegment segment)
+        {
+            if (segment == null || string.IsNullOrWhiteSpace(segment.id))
+            {
+                return;
+            }
+
+            string owner;
+            try
+            {
+                owner = FUSE.Registry.FuseRegistry.GetExclusiveOwner(FUSE.Registry.FuseClaimKind.Segment, segment.id);
+            }
+            catch
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(owner))
+            {
+                return;
+            }
+
+            builder.Append("owner: ").AppendLine(owner);
+        }
+
+        private static void AppendSource(StringBuilder builder, TrackSegment segment)
+        {
+            if (segment == null || string.IsNullOrWhiteSpace(segment.id))
+            {
+                return;
+            }
+
+            FusePackageSourceLookup.Source source;
+            try
+            {
+                if (!FusePackageSourceLookup.TryGetSource(FusePackageSourceLookup.ItemKind.Segment, segment.id, out source))
+                {
+                    return;
+                }
+            }
+            catch
+            {
+                return;
+            }
+
+            builder.Append("source: ").AppendLine(source.Display);
         }
 
         private void EnsureGuiStyles()

--- a/Lifecycle/FuseRuntimeRebindService.cs
+++ b/Lifecycle/FuseRuntimeRebindService.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using FUSE.API;
 using FUSE.Authoring;
 using FUSE.Cache;
 using FUSE.Infrastructure;
@@ -24,12 +26,29 @@ namespace FUSE.Lifecycle
         private static readonly HashSet<string> LoggedUnknownKinds =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private static readonly object UnknownKindSync = new object();
+        private static FuseRuntimeRebindHost _host;
+        private static bool _deferredSceneCloneReapplyScheduled;
+        private static int _deferredSceneCloneReapplyRequests;
+        private static string _lastDeferredSceneCloneReapplyReason;
 
         public static void ResetUnknownKindLog()
         {
             lock (UnknownKindSync)
             {
                 LoggedUnknownKinds.Clear();
+            }
+        }
+
+        public static void Shutdown()
+        {
+            _deferredSceneCloneReapplyScheduled = false;
+            _deferredSceneCloneReapplyRequests = 0;
+            _lastDeferredSceneCloneReapplyReason = null;
+
+            if (_host != null)
+            {
+                UnityEngine.Object.Destroy(_host.gameObject);
+                _host = null;
             }
         }
 
@@ -77,6 +96,77 @@ namespace FUSE.Lifecycle
                 $"(rebound={rebound}, missing={missing}). No package files reloaded, " +
                 "no world definitions applied, no scenery created or updated, " +
                 "no graph nodes/segments mutated, no SceneryAssetInstance.ReloadComponents calls.");
+
+            ReapplySceneCloneEnabledState(label);
+            ScheduleDeferredSceneCloneEnabledReapply(label);
+        }
+
+        private static void ReapplySceneCloneEnabledState(string label)
+        {
+            try
+            {
+                // FUSE operates at runtime AFTER the base-game managers (OpsController,
+                // MapFeatureManager, ProgressionManager) have already woken and captured
+                // their state. When the game later runs StateManager.PopulateFromRemoteSnapshot
+                // it can re-activate scene clones that a package mandela had disabled,
+                // because the snapshot was captured before FUSE applied. This call
+                // re-asserts each cached FuseSceneClone.Enabled state by toggling only
+                // GameObject.activeSelf; no world objects are created, destroyed, or
+                // otherwise mutated.
+                SceneCloneAPI.ReapplyEnabledFromCache(label);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception($"FUSE snapshot rebind failed to reapply scene clone enabled state for '{label}'.", ex);
+            }
+        }
+
+        private static void ScheduleDeferredSceneCloneEnabledReapply(string reason)
+        {
+            _deferredSceneCloneReapplyRequests++;
+            _lastDeferredSceneCloneReapplyReason = string.IsNullOrWhiteSpace(reason) ? "snapshot" : reason;
+            if (_deferredSceneCloneReapplyScheduled)
+            {
+                return;
+            }
+
+            _deferredSceneCloneReapplyScheduled = true;
+            EnsureHost().StartCoroutine(ReapplySceneCloneEnabledAfterSnapshotFrame());
+        }
+
+        private static IEnumerator ReapplySceneCloneEnabledAfterSnapshotFrame()
+        {
+            yield return null;
+            ReapplySceneCloneEnabledState(BuildDeferredSceneCloneReapplyReason("+1 frame"));
+
+            yield return null;
+            ReapplySceneCloneEnabledState(BuildDeferredSceneCloneReapplyReason("+2 frames"));
+
+            _deferredSceneCloneReapplyScheduled = false;
+            _deferredSceneCloneReapplyRequests = 0;
+            _lastDeferredSceneCloneReapplyReason = null;
+        }
+
+        private static string BuildDeferredSceneCloneReapplyReason(string suffix)
+        {
+            var reason = string.IsNullOrWhiteSpace(_lastDeferredSceneCloneReapplyReason)
+                ? "snapshot restore"
+                : _lastDeferredSceneCloneReapplyReason;
+            return $"{reason} deferred scene-clone reapply {suffix} (requests={_deferredSceneCloneReapplyRequests})";
+        }
+
+        private static FuseRuntimeRebindHost EnsureHost()
+        {
+            if (_host != null)
+            {
+                return _host;
+            }
+
+            var gameObject = new GameObject("FUSE Runtime Rebind");
+            UnityEngine.Object.DontDestroyOnLoad(gameObject);
+            gameObject.hideFlags = HideFlags.HideAndDontSave;
+            _host = gameObject.AddComponent<FuseRuntimeRebindHost>();
+            return _host;
         }
 
         private static bool TryRebindEntityToExistingRuntime(FuseAuthoringEntity entity)
@@ -168,6 +258,10 @@ namespace FUSE.Lifecycle
             }
 
             return false;
+        }
+
+        private sealed class FuseRuntimeRebindHost : MonoBehaviour
+        {
         }
     }
 }

--- a/Loading/FuseLegacyDataConverter.cs
+++ b/Loading/FuseLegacyDataConverter.cs
@@ -578,7 +578,11 @@ namespace FUSE.Loading
                     ["industries"] = new JObject(),
                     ["loaders"] = new JObject(),
                     ["turntables"] = new JObject(),
-                    ["stations"] = new JObject()
+                    ["stations"] = new JObject(),
+                    ["removals"] = new JObject
+                    {
+                        ["industries"] = new JArray()
+                    }
                 },
                 ["world"] = new JObject
                 {
@@ -650,10 +654,19 @@ namespace FUSE.Loading
                         continue;
                     }
 
-                    foreach (var industry in industries.Properties().Where(p => p.Value is JObject))
+                    foreach (var industry in industries.Properties())
                     {
-                        (root["operations"]["industries"] as JObject)[industry.Name] =
-                            ConvertIndustry(industry.Name, (JObject)industry.Value, area.Name);
+                        if (industry.Value.Type == JTokenType.Null)
+                        {
+                            ((JArray)root["operations"]["removals"]["industries"]).Add(industry.Name);
+                            continue;
+                        }
+
+                        if (industry.Value is JObject industryObject)
+                        {
+                            (root["operations"]["industries"] as JObject)[industry.Name] =
+                                ConvertIndustry(industry.Name, industryObject, area.Name);
+                        }
                     }
                 }
             }
@@ -661,10 +674,19 @@ namespace FUSE.Loading
             var topIndustries = source["industries"] as JObject;
             if (topIndustries != null)
             {
-                foreach (var industry in topIndustries.Properties().Where(p => p.Value is JObject))
+                foreach (var industry in topIndustries.Properties())
                 {
-                    ((JObject)root["operations"]["industries"])[industry.Name] =
-                        ConvertIndustry(industry.Name, (JObject)industry.Value, null);
+                    if (industry.Value.Type == JTokenType.Null)
+                    {
+                        ((JArray)root["operations"]["removals"]["industries"]).Add(industry.Name);
+                        continue;
+                    }
+
+                    if (industry.Value is JObject industryObject)
+                    {
+                        ((JObject)root["operations"]["industries"])[industry.Name] =
+                            ConvertIndustry(industry.Name, industryObject, null);
+                    }
                 }
             }
 

--- a/Loading/FuseModLoader.cs
+++ b/Loading/FuseModLoader.cs
@@ -331,6 +331,7 @@ namespace FUSE.Loading
                         var definition = candidate.Loaded.Definition;
                         var transaction = candidate.Transaction;
                         transaction.RunPhase("staged-apply-world-removals", () => ApplyWorldRemovals(definition, transaction));
+                        transaction.RunPhase("staged-apply-operations-removals", () => ApplyOperationsRemovals(definition, transaction));
                     }
 
                     ApplyMergedTrackGraph(mergedTrackPlan, reason);
@@ -369,6 +370,18 @@ namespace FUSE.Loading
                     ApplyDeferredOperationBindings(
                         active.Select(item => item.Loaded?.Definition?.Id).Where(id => !string.IsNullOrWhiteSpace(id)).ToArray(),
                         reason);
+
+                    // Mandelas (scene clones) run AFTER operations so industries — which can
+                    // share display names with vanilla scene paths — cannot re-activate a
+                    // GameObject the mandela is supposed to disable. This matches the legacy
+                    // patcher's "process mandelas last" ordering.
+                    foreach (var candidate in active.Where(item => !item.Transaction.Report.IsFatal))
+                    {
+                        var definition = candidate.Loaded.Definition;
+                        var loaded = candidate.Loaded;
+                        var transaction = candidate.Transaction;
+                        transaction.RunPhase("apply-scene-clones", () => ApplySceneClones(definition, loaded.DefinitionPath, transaction));
+                    }
 
                     foreach (var candidate in active.Where(item => !item.Transaction.Report.IsFatal))
                     {
@@ -1393,6 +1406,7 @@ namespace FUSE.Loading
                         {
                             ApplyTrackRemovals(definition, transaction);
                             ApplyWorldRemovals(definition, transaction);
+                            ApplyOperationsRemovals(definition, transaction);
                         });
                         transaction.RunPhase("apply-nodes", () =>
                         {
@@ -1457,6 +1471,7 @@ namespace FUSE.Loading
                         TrackAPI.ApplyAreaOrdering();
                     });
                     ApplyDeferredOperationBindings(new[] { definition.Id }, reason);
+                    transaction.RunPhase("apply-scene-clones", () => ApplySceneClones(definition, loaded.DefinitionPath, transaction));
                     transaction.RunPhase("apply-progression", () => ApplyProgressionDefinition(definition, transaction));
                     transaction.RunPhase("apply-world-suppressions", () => FuseWorldSuppressor.ApplyDefinition(definition, transaction));
                     transaction.RunPhase("post-bind-validation", () => ValidatePostBind(definition, transaction));
@@ -2988,24 +3003,35 @@ namespace FUSE.Loading
                 }
             }
 
-            if (definition.World.SceneClones != null)
+            // Scene clones (mandelas) are applied in their own later phase (apply-scene-clones)
+            // so that industries, areas, and progression have already settled. Applying them
+            // here, before apply-operations, lets an industry whose display name collides with a
+            // disabled scene clone path (e.g. a renamed Stenzel Mfg industry under the matching
+            // scenery branch) re-activate the GameObject the mandela just disabled.
+        }
+
+        private static void ApplySceneClones(FuseModDefinition definition, string definitionPath, FuseApplyTransaction transaction)
+        {
+            if (definition?.World?.SceneClones == null)
             {
-                foreach (var sceneClone in definition.World.SceneClones)
+                return;
+            }
+
+            foreach (var sceneClone in definition.World.SceneClones)
+            {
+                var exists = SceneCloneAPI.GetSceneClone(sceneClone.Key) != null;
+                transaction.TryApply("scene clone", sceneClone.Key, exists, () =>
                 {
-                    var exists = SceneCloneAPI.GetSceneClone(sceneClone.Key) != null;
-                    transaction.TryApply("scene clone", sceneClone.Key, exists, () =>
+                    var entity = FuseAuthoringRegistry.Get(sceneClone.Key) as FuseConfigurableStructureEntity ??
+                                 new FuseConfigurableStructureEntity(sceneClone.Key, definition.Id);
+                    entity.InitializeIdentity(sceneClone.Key, definition.Id);
+                    entity.BindDefinition(definition, definitionPath);
+                    entity.LoadDefinition(sceneClone.Value);
+                    if (!FuseAuthoringPersistenceService.ApplyPackageEntityToRuntime(entity))
                     {
-                        var entity = FuseAuthoringRegistry.Get(sceneClone.Key) as FuseConfigurableStructureEntity ??
-                                     new FuseConfigurableStructureEntity(sceneClone.Key, definition.Id);
-                        entity.InitializeIdentity(sceneClone.Key, definition.Id);
-                        entity.BindDefinition(definition, definitionPath);
-                        entity.LoadDefinition(sceneClone.Value);
-                        if (!FuseAuthoringPersistenceService.ApplyPackageEntityToRuntime(entity))
-                        {
-                            throw new InvalidOperationException($"Configurable structure authoring entity '{sceneClone.Key}' failed validation.");
-                        }
-                    });
-                }
+                        throw new InvalidOperationException($"Configurable structure authoring entity '{sceneClone.Key}' failed validation.");
+                    }
+                });
             }
         }
 
@@ -3044,6 +3070,17 @@ namespace FUSE.Loading
             RemoveWorldItems("telegraph pole set", removals.TelegraphPoles, MapAPI.TryRemoveTelegraphPoles, transaction);
             RemoveWorldItems("map label", removals.MapLabels, MapAPI.TryRemoveMapLabel, transaction);
             RemoveWorldItems("map mask", removals.MapMasks, MapAPI.TryRemoveMapMask, transaction);
+        }
+
+        private static void ApplyOperationsRemovals(FuseModDefinition definition, FuseApplyTransaction transaction)
+        {
+            var removals = definition?.Operations?.Removals;
+            if (removals == null)
+            {
+                return;
+            }
+
+            RemoveWorldItems("industry", removals.Industries, IndustryAPI.TryRemoveIndustry, transaction);
         }
 
         private static void RemoveWorldItems(string kind, IEnumerable<string> ids, Func<string, bool> remover, FuseApplyTransaction transaction)

--- a/Validation/FuseDefinitionValidator.cs
+++ b/Validation/FuseDefinitionValidator.cs
@@ -389,15 +389,6 @@ namespace FUSE.Validation
                         result.AddError($"{path}.unitWeightInPounds", "Load unitWeightInPounds must be greater than or equal to 0.", "fuse.operations.loads.unitWeightInPounds", load.Value.UnitWeightInPounds.Value);
                     }
 
-                    if (load.Value.PayPerQuantity.HasValue && load.Value.PayPerQuantity.Value < 0f)
-                    {
-                        result.AddError($"{path}.payPerQuantity", "Load payPerQuantity must be greater than or equal to 0.", "fuse.operations.loads.payPerQuantity", load.Value.PayPerQuantity.Value);
-                    }
-
-                    if (load.Value.CostPerUnit.HasValue && load.Value.CostPerUnit.Value < 0f)
-                    {
-                        result.AddError($"{path}.costPerUnit", "Load costPerUnit must be greater than or equal to 0.", "fuse.operations.loads.costPerUnit", load.Value.CostPerUnit.Value);
-                    }
                 }
             }
 
@@ -835,11 +826,6 @@ namespace FUSE.Validation
                 {
                     result.AddError(phasePath, "Delivery phase is required.", "fuse.progression.deliveryPhase.required");
                     continue;
-                }
-
-                if (phase.Cost < 0)
-                {
-                    result.AddError($"{phasePath}.cost", "Delivery phase cost must be greater than or equal to 0.", "fuse.progression.deliveryPhase.cost", phase.Cost);
                 }
 
                 var deliveries = phase.Deliveries;

--- a/schemas/fuse-mod.schema.json
+++ b/schemas/fuse-mod.schema.json
@@ -560,12 +560,10 @@
                 },
                 "payPerQuantity": {
                     "type": "number",
-                    "minimum": 0,
                     "default": 0
                 },
                 "costPerUnit": {
                     "type": "number",
-                    "minimum": 0,
                     "default": 0
                 },
                 "carTypeFilter": {
@@ -711,8 +709,7 @@
                     "minimum": 0
                 },
                 "costPerUnit": {
-                    "type": "number",
-                    "minimum": 0
+                    "type": "number"
                 },
                 "notBeforeHour": {
                     "type": "number",
@@ -2060,7 +2057,6 @@
             "properties": {
                 "cost": {
                     "type": "integer",
-                    "minimum": 0,
                     "default": 0
                 },
                 "industryComponentId": {


### PR DESCRIPTION
## Summary

- Make package mandela `enabled: false` stick across `StateManager.PopulateFromRemoteSnapshot` and any industry/manager refresh that re-activates GameObjects by name match — `FuseSceneCloneMarker` now carries `DesiredEnabled` and `Source`, and its `OnEnable` re-disables the GameObject in the same frame; `SceneCloneAPI.ReapplyEnabledFromCache` reconciles on rebind hooks plus deferred +1 / +2 frame coroutines.
- Move `apply-scene-clones` to its own phase that runs AFTER `apply-operations` and `ApplyDeferredOperationBindings` (matches the legacy patcher's "mandelas last" ordering) so industries whose display name collides with a vanilla scene path can't re-activate a clone the mandela disabled.
- Route legacy `industries: { id: null }` / `turntables: { id: null }` through new `operations.removals.industries[]` / `operations.removals.turntables[]` arrays; new `staged-apply-operations-removals` phase + `IndustryAPI.TryRemoveIndustry` / `TurntableAPI.TryRemoveTurntable`. `DestroyIndustryInternal` explicitly `DestroyImmediate`s each child `IndustryComponent` before the Industry GameObject so the post-remove `IndustriesDidChange` notification doesn't walk a dead industry and trigger reactivations.
- Drop the non-negative floor from monetary schema fields: `progression.sections[].deliveryPhases[].cost`, `operations.loads[].payPerQuantity`, `operations.loads[].costPerUnit`, and industry-component `costPerUnit` so packages can express rebates/subsidies/penalties.
- New hover-to-inspect scenery debug overlay (`FuseSceneryDebugOverlay`, master + advanced toggle on the Health Settings tab) — identifies the hovered GameObject as FUSE scenery / scene clone / vanilla; tooltip shows id, asset, owner, source file (`Mod/File.json`), scene path, `package.enabled` vs runtime `active`, scenePath suppressors, and progression impacts.
- Track and scenery overlays both include a "Progressions impacting" block via new `FuseProgressionImpactLookup`; source-file display in both via new `FusePackageSourceLookup`; `ProgressionAPI.TryGetMapFeatureEnabledState` exposes current unlock state for the scenery block.
- `FuseRuntimeRebindService.Shutdown` disposes the coroutine host and resets deferred state; wired into `FusePlugin.OnUnload`.

Closes the "Stenzel Mfg / Whittier Saw Mill Culled still visible despite mandela `enabled: false`" report and the matching `NullReferenceException during Industry.Tick` on East Whittier Engine Service / Alarka Copper Co. M1.

## Test plan

- [ ] Build Release, deploy `bin/Release/net48/FUSE.dll` (+ `.pdb`, `Info.json`, `assets/`, `schemas/`) to `Railroader/Mods/FUSE/`.
- [ ] Launch Railroader with the AspenCrazyMap stack installed; load the Whittier area.
- [ ] Hover Stenzel Mfg and Whittier Saw Mill Culled with the new scenery overlay enabled — both report `package.enabled: false` AND `active: self=false, inHierarchy=false`; buildings are not visible.
- [ ] `FUSE.log` shows `FUSE scene clone enabled-state reapply` entries on rebind hooks if the game's restore tried to reactivate clones, plus `FUSE scene clone disabled-on-enable guard` entries from the marker if anything else hit them.
- [ ] No `Industry.Tick` NREs in `Player.log` for `East Whittier Engine Service` or `Alarka Copper Co. M1`.
- [ ] `/fuse.report` shows `faulted=0` (or only the unrelated acm-needmore Nrfr conflict).
- [ ] Toggle the new Health → Settings entries on/off; tooltips appear/disappear immediately, sub-toggles persist across game restart via `%LocalLow%\Giraffe Lab LLC\Railroader\FUSE\settings.json`.
- [ ] Hover a track segment with the existing track overlay; "Progressions impacting group `<id>`" block appears when a MapFeature or progression section's unlock effects reference that group; "source" line shows `Mod/file.json`.
- [ ] Package with `deliveryPhases[].cost: -4300` loads cleanly (no `fuse.progression.deliveryPhase.cost` validation error).