### PR TITLE
Show legacy FUSE mods in UMM as non-toggleable rows

### DIFF
--- a/FusePlugin.cs
+++ b/FusePlugin.cs
@@ -75,6 +75,7 @@ namespace FUSE
                 FuseHealthUi.Ensure();
                 FuseTrackDebugOverlay.Ensure();
                 FuseLegacyAssemblyHost.EnsureStartupHost();
+                FuseUmmInjector.InjectLegacyEntries(modEntry.Path, ReadInfoJsonString(Path.Combine(modEntry.Path ?? string.Empty, "Info.json"), "Version"));
 
                 modEntry.OnUnload = OnUnload;
                 _isLoaded = true;

--- a/Info.json
+++ b/Info.json
@@ -13,6 +13,7 @@
     "MirrorAssetPacksToLocalLow": false,
     "VerboseApplyReportDetails": false,
     "BlockNonHostMultiplayerClientWorldApply": false,
-    "ShowAdvancedHealthDetails": false
+    "ShowAdvancedHealthDetails": false,
+    "ShowLegacyModsInUmm": true
   }
 }

--- a/Infrastructure/FuseSettings.cs
+++ b/Infrastructure/FuseSettings.cs
@@ -16,6 +16,7 @@ namespace FUSE.Infrastructure
         public const bool DefaultShowAdvancedHealthDetails = false;
         public const bool DefaultShowTrackDebugOverlay = false;
         public const bool DefaultShowTrackDebugSpanPaths = false;
+        public const bool DefaultShowLegacyModsInUmm = true;
         public const float ExperimentalEarlyScenePathSuppressionTimeoutSeconds = 8f;
 
         public static bool EnableExperimentalEarlyScenePathSuppression { get; private set; } =
@@ -36,6 +37,8 @@ namespace FUSE.Infrastructure
 
         public static bool ShowTrackDebugSpanPaths { get; private set; } = DefaultShowTrackDebugSpanPaths;
 
+        public static bool ShowLegacyModsInUmm { get; private set; } = DefaultShowLegacyModsInUmm;
+
         public static void Load(UnityModManager.ModEntry modEntry)
         {
             EnableExperimentalEarlyScenePathSuppression = DefaultEnableExperimentalEarlyScenePathSuppression;
@@ -46,6 +49,7 @@ namespace FUSE.Infrastructure
             ShowAdvancedHealthDetails = DefaultShowAdvancedHealthDetails;
             ShowTrackDebugOverlay = DefaultShowTrackDebugOverlay;
             ShowTrackDebugSpanPaths = DefaultShowTrackDebugSpanPaths;
+            ShowLegacyModsInUmm = DefaultShowLegacyModsInUmm;
             FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
 
             var infoPath = Path.Combine(modEntry?.Path ?? string.Empty, "Info.json");
@@ -75,6 +79,8 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, "ShowTrackDebugOverlay", DefaultShowTrackDebugOverlay);
                 ShowTrackDebugSpanPaths =
                     ReadBool(settings, "ShowTrackDebugSpanPaths", DefaultShowTrackDebugSpanPaths);
+                ShowLegacyModsInUmm =
+                    ReadBool(settings, "ShowLegacyModsInUmm", DefaultShowLegacyModsInUmm);
                 ApplyUserOverrides();
                 FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
 
@@ -88,6 +94,7 @@ namespace FUSE.Infrastructure
                     $"ShowAdvancedHealthDetails={ShowAdvancedHealthDetails} " +
                     $"ShowTrackDebugOverlay={ShowTrackDebugOverlay} " +
                     $"ShowTrackDebugSpanPaths={ShowTrackDebugSpanPaths} " +
+                    $"ShowLegacyModsInUmm={ShowLegacyModsInUmm} " +
                     $"timeoutSeconds={ExperimentalEarlyScenePathSuppressionTimeoutSeconds}.");
             }
             catch (Exception ex)
@@ -100,6 +107,7 @@ namespace FUSE.Infrastructure
                 ShowAdvancedHealthDetails = DefaultShowAdvancedHealthDetails;
                 ShowTrackDebugOverlay = DefaultShowTrackDebugOverlay;
                 ShowTrackDebugSpanPaths = DefaultShowTrackDebugSpanPaths;
+                ShowLegacyModsInUmm = DefaultShowLegacyModsInUmm;
                 FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
                 FuseLog.Warning($"FUSE failed to parse Info.json settings; experimental early scene-path suppression remains disabled: {ex.Message}");
             }
@@ -199,6 +207,8 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, nameof(ShowTrackDebugOverlay), ShowTrackDebugOverlay);
                 ShowTrackDebugSpanPaths =
                     ReadBool(settings, nameof(ShowTrackDebugSpanPaths), ShowTrackDebugSpanPaths);
+                ShowLegacyModsInUmm =
+                    ReadBool(settings, nameof(ShowLegacyModsInUmm), ShowLegacyModsInUmm);
                 FuseLog.Info($"FUSE user setting overrides loaded from '{path}'.");
             }
             catch (Exception ex)

--- a/Infrastructure/FuseUmmInjector.cs
+++ b/Infrastructure/FuseUmmInjector.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using FUSE.Loading;
+using UnityModManagerNet;
+
+namespace FUSE.Infrastructure
+{
+    internal static class FuseUmmInjector
+    {
+        public const string LegacySupportId = "FUSE-LegacySupport";
+        public const string LegacySupportDisplayName = "FUSE Legacy Support";
+        public const string LegacySupportAuthor = "FUSE";
+        // UMM's ModEntry.Toggleable returns `OnToggle != null || !HasAssembly`, and
+        // HasAssembly returns true iff Info.AssemblyName or Info.EntryMethod is non-empty.
+        // Setting both to point at the no-op below makes HasAssembly true; leaving OnToggle null
+        // therefore makes Toggleable false, which hides the enable/disable toggle in UMM's UI.
+        private const string SyntheticAssemblyName = "FUSE.dll";
+        private const string SyntheticEntryMethod = "FUSE.Infrastructure.FuseUmmInjector.SyntheticEntryNoop";
+
+        private static readonly FieldInfo ModEntriesField =
+            typeof(UnityModManager).GetField("modEntries", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+        private static readonly HashSet<string> InjectedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private static bool _ranOnce;
+
+        public static void InjectLegacyEntries(string fuseModEntryPath, string fuseVersion)
+        {
+            if (!FuseSettings.ShowLegacyModsInUmm)
+            {
+                if (!_ranOnce)
+                {
+                    FuseLog.Info("FUSE legacy UMM visibility is disabled in settings; not injecting synthetic mod entries.");
+                }
+                _ranOnce = true;
+                return;
+            }
+
+            _ranOnce = true;
+            var entries = ModEntriesField?.GetValue(null) as IList;
+            if (entries == null)
+            {
+                FuseLog.Warning("FUSE could not access UnityModManager.modEntries to inject synthetic legacy mod entries; UMM listing will not include legacy data packages.");
+                return;
+            }
+
+            var supportInjected = TryInjectSupportEntry(entries, fuseModEntryPath, fuseVersion);
+            var legacyInjected = TryInjectLegacyPackageEntries(entries);
+
+            FuseLog.Info(
+                $"FUSE UMM injection complete: legacySupportInjected={supportInjected} legacyPackagesInjected={legacyInjected} totalEntries={entries.Count}.");
+        }
+
+        private static bool TryInjectSupportEntry(IList entries, string fuseModEntryPath, string fuseVersion)
+        {
+            if (ContainsEntryWithId(entries, LegacySupportId))
+            {
+                return false;
+            }
+
+            var entry = TryCreateModEntry(
+                id: LegacySupportId,
+                displayName: LegacySupportDisplayName,
+                author: LegacySupportAuthor,
+                version: string.IsNullOrWhiteSpace(fuseVersion) ? "0.0.0" : fuseVersion,
+                requirements: new[] { "FUSE" },
+                folderPath: fuseModEntryPath ?? string.Empty);
+            if (entry == null)
+            {
+                return false;
+            }
+
+            entries.Add(entry);
+            InjectedIds.Add(LegacySupportId);
+            FuseLog.Info($"FUSE injected synthetic UMM entry id='{LegacySupportId}' to advertise legacy-mod compatibility.");
+            return true;
+        }
+
+        private static int TryInjectLegacyPackageEntries(IList entries)
+        {
+            var modsRoot = FuseDataPackageDiscovery.GetModsRoot();
+            if (string.IsNullOrWhiteSpace(modsRoot) || !Directory.Exists(modsRoot))
+            {
+                FuseLog.Info("FUSE skipped legacy UMM injection because the Mods folder could not be located.");
+                return 0;
+            }
+
+            string[] folders;
+            try
+            {
+                folders = Directory.GetDirectories(modsRoot)
+                    .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning($"FUSE could not enumerate '{modsRoot}' to inject legacy UMM entries: {ex.GetBaseException().Message}");
+                return 0;
+            }
+
+            var injectedCount = 0;
+            foreach (var folder in folders)
+            {
+                if (!FuseLegacyDataConverter.TryReadLegacyManifest(folder, out var manifest))
+                {
+                    continue;
+                }
+
+                if (ContainsEntryForFolder(entries, folder) || ContainsEntryWithId(entries, manifest.PackageId))
+                {
+                    continue;
+                }
+
+                var entry = TryCreateModEntry(
+                    id: manifest.PackageId,
+                    displayName: string.IsNullOrWhiteSpace(manifest.DisplayName) ? manifest.LegacyId : manifest.DisplayName,
+                    author: manifest.Author ?? string.Empty,
+                    version: manifest.Version ?? string.Empty,
+                    requirements: new[] { LegacySupportId },
+                    folderPath: folder);
+                if (entry == null)
+                {
+                    continue;
+                }
+
+                entries.Add(entry);
+                InjectedIds.Add(manifest.PackageId);
+                injectedCount++;
+                FuseLog.Info(
+                    $"FUSE injected synthetic UMM entry id='{manifest.PackageId}' " +
+                    $"displayName='{manifest.DisplayName}' folder='{Path.GetFileName(folder)}'.");
+            }
+
+            return injectedCount;
+        }
+
+        private static object TryCreateModEntry(
+            string id,
+            string displayName,
+            string author,
+            string version,
+            string[] requirements,
+            string folderPath)
+        {
+            try
+            {
+                var info = new UnityModManager.ModInfo
+                {
+                    Id = id ?? string.Empty,
+                    DisplayName = string.IsNullOrWhiteSpace(displayName) ? id : displayName,
+                    Author = author ?? string.Empty,
+                    Version = version ?? string.Empty,
+                    ManagerVersion = string.Empty,
+                    GameVersion = string.Empty,
+                    Requirements = requirements ?? Array.Empty<string>(),
+                    LoadAfter = Array.Empty<string>(),
+                    AssemblyName = SyntheticAssemblyName,
+                    EntryMethod = SyntheticEntryMethod,
+                    HomePage = string.Empty,
+                    Repository = string.Empty,
+                    ContentType = string.Empty
+                };
+
+                var entry = new UnityModManager.ModEntry(info, folderPath ?? string.Empty);
+                entry.Enabled = true;
+                SetPrivateBool(entry, "mStarted", true);
+                SetPrivateBool(entry, "mActive", true);
+                SetPrivateBool(entry, "mFirstLoading", false);
+                SetPrivateBool(entry, "mErrorOnLoading", false);
+                return entry;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not construct synthetic UMM mod entry id='{id}' folder='{folderPath ?? string.Empty}': " +
+                    $"{ex.GetBaseException().Message}");
+                return null;
+            }
+        }
+
+        private static bool ContainsEntryWithId(IList entries, string id)
+        {
+            if (entries == null || string.IsNullOrWhiteSpace(id))
+            {
+                return false;
+            }
+
+            foreach (var entry in entries)
+            {
+                if (entry == null)
+                {
+                    continue;
+                }
+
+                var info = entry.GetType().GetField("Info", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.GetValue(entry);
+                var entryId = info?.GetType().GetField("Id", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.GetValue(info) as string;
+                if (string.Equals(entryId, id, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ContainsEntryForFolder(IList entries, string folderPath)
+        {
+            if (entries == null || string.IsNullOrWhiteSpace(folderPath))
+            {
+                return false;
+            }
+
+            var normalized = NormalizePath(folderPath);
+            foreach (var entry in entries)
+            {
+                if (entry == null)
+                {
+                    continue;
+                }
+
+                var pathField = entry.GetType().GetField("Path", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                var entryPath = pathField?.GetValue(entry) as string;
+                if (string.IsNullOrWhiteSpace(entryPath))
+                {
+                    continue;
+                }
+
+                if (string.Equals(NormalizePath(entryPath), normalized, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string NormalizePath(string path)
+        {
+            try
+            {
+                return Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+            catch
+            {
+                return path.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+        }
+
+        public static bool SyntheticEntryNoop(UnityModManager.ModEntry modEntry)
+        {
+            FuseLog.Info(
+                $"FUSE synthetic UMM entry no-op invoked for id='{modEntry?.Info?.Id ?? "<unknown>"}'; " +
+                "FUSE manages legacy data packages internally and the synthetic UMM row carries no assembly.");
+            return true;
+        }
+
+        private static void SetPrivateBool(object instance, string fieldName, bool value)
+        {
+            if (instance == null || string.IsNullOrWhiteSpace(fieldName))
+            {
+                return;
+            }
+
+            var field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            if (field != null && field.FieldType == typeof(bool))
+            {
+                field.SetValue(instance, value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Legacy data packages (Strange Customs / Alina's Map Mod / DKW.DKWSpliney / etc.) were invisible to Unity Mod Manager because the `FuseLegacyDataConverter` path bypasses UMM registration. This adds a synthetic `UnityModManager.ModEntry` per detected legacy folder so they appear in UMM's mod list with their id, version, author, and a `FUSE-LegacySupport` requirement.
- Also injects a `FUSE-LegacySupport` entry (Requirements: `["FUSE"]`) so the requirement string in legacy rows resolves to something visible in the UMM UI.
- Toggle/Reload buttons are intentionally suppressed on injected rows. UMM's `Toggleable` getter is `OnToggle != null || !HasAssembly`, so setting `Info.AssemblyName`/`Info.EntryMethod` to non-empty values (`FUSE.dll` + a no-op `SyntheticEntryNoop`) flips `HasAssembly` to true and `Toggleable` to false. FUSE owns the legacy load lifecycle; a UMM-side toggle would be misleading.
- Gated by a new `ShowLegacyModsInUmm` setting in `Info.json` (default `true`), with the same user-override path as the existing FUSE settings.

## Implementation notes

- `Infrastructure/FuseUmmInjector.cs` reflects on `UnityModManager.modEntries` (same reflection surface already used by `FuseUmmState`), constructs entries via the public `ModEntry(ModInfo, string)` ctor, and sets private `mStarted`/`mActive`/`mFirstLoading`/`mErrorOnLoading` so UMM treats the rows as healthy.
- Idempotent: re-injection skips entries that match an existing id or folder path.
- `SyntheticEntryNoop(ModEntry)` is a real `public static bool` that returns `true`, so if UMM ever calls `Load()` on a synthetic entry (e.g. via a future hot-reload path), it resolves cleanly instead of marking the row errored.
- Call site is the tail of `FusePlugin.Load` after `FuseLegacyAssemblyHost.EnsureStartupHost()`, which is after UMM finishes its own mod enumeration so we don't race against UMM's startup scan.

## Test plan

- [ ] Launch Railroader with at least one legacy data package (e.g. an Alina's Map Mod folder) in `Mods/` and confirm a row appears in UMM's mod list with the legacy id and version.
- [ ] Confirm a `FUSE Legacy Support` row appears in UMM and lists `FUSE` as its requirement.
- [ ] Confirm the legacy rows show `FUSE-LegacySupport` in their Requirements column.
- [ ] Confirm no enable/disable toggle and no Reload button appear on either the synthetic support row or legacy rows.
- [ ] Set `ShowLegacyModsInUmm: false` in `Info.json` and confirm no synthetic rows appear.
- [ ] Confirm the FUSE startup log contains `FUSE UMM injection complete: ...` and a per-entry `FUSE injected synthetic UMM entry id=...` line.