### PR TITLE
Fix map feature display name from legacy conversion

### DIFF
--- a/Loading/FuseLegacyDataConverter.cs
+++ b/Loading/FuseLegacyDataConverter.cs
@@ -2178,8 +2178,9 @@ namespace FUSE.Loading
             switch (lower)
             {
                 case "displayname":
-                case "name":
                     return "displayName";
+                case "name":
+                    return "name";
                 case "defaultenableinsandbox":
                     return "initiallyEnabled";
                 case "prerequisites":


### PR DESCRIPTION
﻿<!--

Requirements for Pull Requests

- Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
- The pull request must contribute a change that has been endorsed by a maintainer. Before starting work, please discuss your idea for the fix or implementation in the comments of the related issue. There are often several ways to fix a problem and it's possible that someone else may have a plan for the issue, or that there's context you should know before starting implementation.

-->


## 🔗 Related Issue

The Map Features list in sandbox mode is populating "name" for the display name of features instead of "displayName"

## 📝 Description of the Change

Fixes switch statement in `NormalizeProgressionKey`

## ✅ Verification Process

Before:
<img width="1777" height="710" alt="Screenshot 2026-05-21 202057" src="https://github.com/user-attachments/assets/c0d29159-155b-4583-a005-88bdf02368e6" />

After:
<img width="915" height="709" alt="Screenshot 2026-05-21 211447" src="https://github.com/user-attachments/assets/1f25d731-ee4e-4161-a375-f3ee4d25dfa4" />