### PR TITLE
Add CODEOWNERS for F-U-S-E-E org members

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Members of the F-U-S-E-E org (https://github.com/F-U-S-E-E) review all changes.
+# Advisory only until branch protection is enabled (requires GitHub Team plan
+# on a private repo, or making the repo public).
+* @Alex6511 @Hrogers-Rog


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` so GitHub auto-requests a review from @Alex6511 and @Hrogers-Rog on every PR.
- Advisory only — branch protection is unavailable on this private repo under the Free org plan (tracked in #58 / #59).

## Test plan
- [ ] On merge, open a follow-up PR and confirm GitHub auto-requests review from one of the F-U-S-E-E members.