### PR TITLE
fix: propagate area tagColor through legacy SC->FUSE converter

### DIFF
--- a/FUSE/Loading/FuseLegacyDataConverter.World.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.World.cs
@@ -347,6 +347,7 @@ namespace FUSE.Loading
                 ["name"] = ReadString(item, "name") ?? id,
                 ["position"] = Vector(item["localPosition"] ?? item["position"], false),
                 ["radius"] = Clone(item["radius"]),
+                ["tagColor"] = Clone(item["tagColor"] ?? item["TagColor"]),
                 ["order"] = Clone(item["order"]),
                 ["spanIds"] = ToStringArray(item["spanIds"] ?? item["spans"]),
                 ["groupId"] = ReadString(item, "groupId", "GroupId")


### PR DESCRIPTION
## 🔗 Related Issue

Reported in-session: custom areas on the map render with the default Area color instead of the color the mod author authored.

## 📝 Description of the Change

`FuseLegacyDataConverter.ConvertArea` (the SC-area → FUSE-area JSON converter) emitted `name`, `position`, `radius`, `order`, `spanIds`, and `groupId`, but silently dropped `tagColor`. The downstream `TrackAPI.ApplyAreaDefinition` path is correct — it just never received a color to apply, so `area.tagColor` stayed at the Area default and custom area colors disappeared on the map.

Fix: one line that reads `tagColor` from the source JObject, falling back to the PascalCase `TagColor` that SC's `SerializedArea` contract serializes to. This mirrors the dual-casing pattern already used by other fields in the same method (e.g. `localPosition`/`position`, `spanIds`/`spans`, `groupId`/`GroupId`).

```csharp
["tagColor"] = Clone(item["tagColor"] ?? item["TagColor"]),
```

## 🔄 Alternatives Considered

- Reading the color downstream in the runtime apply path — rejected: the converter is the single point where the legacy → FUSE field set is established; everything downstream consumes the FUSE shape, and routing one field around it would create an inconsistent special case.
- Case-insensitive property lookup via `GetPropertyValue`-style helper — unnecessary here. The two known producers are SC (PascalCase) and FUSE-native/hand-edited (camelCase); the existing convention in `ConvertArea` is the explicit `?? item["AltCasing"]` form, and matching it keeps the diff minimal.

## ⚠️ Possible Drawbacks

None expected. Areas that did not previously have a `tagColor`/`TagColor` key continue to receive no value (the existing `Clone` returns null on missing/null, and `CleanObject` strips nulls). Existing FUSE-native packages already serialize `tagColor` and were unaffected by this bug.

Save-compat: unchanged. The fix only affects what the converter emits into the in-memory FUSE definition during legacy package conversion; no save format changes.

## ✅ Verification Process

- `dotnet build FUSE/FUSE.csproj -c Debug` — clean, 0 warnings, 0 errors.
- `dotnet test FUSE.Tests/FUSE.Tests.csproj -c Debug` — 716 passed, 0 failed.
- Traced the full path: legacy JSON → `ConvertArea` → FuseArea (`tagColor` camelCase per `CamelCasePropertyNamesContractResolver` in `FuseSerializer`) → `ApplyAreaDefinition` → `ParseAreaColor` → `area.tagColor`. The fix is the only missing link; every other step already handled the color correctly (including the snapshot side in `FuseLegacyGameGraphCompatibility.SnapshotAreas`, which has been emitting `tagColor` all along).

## 💡 Additional Information

The `SerializedArea` shim in `Compatibility/StrangeCustomsLegacySupport.cs` (the ColorPatcher-facing legacy surface) declares `TagColor` as PascalCase `float[]`, which is what SC mods serialized with Newtonsoft's default contract. Hand-edited mod JSON in the wild may use either casing, so both are accepted.