### PR TITLE
fix: stop legacy converter from reparenting industries to first Area

### DIFF
--- a/FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs
@@ -1,0 +1,218 @@
+using FUSE.Authoring.Serialization;
+using FUSE.Loading;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    /// <summary>
+    /// Pin the legacy "industries" → FUSE conversion contract. SC packages
+    /// routinely patch an existing base-game industry (e.g.
+    /// <c>{ "industries": { "whittier-sawmill": { "components": {
+    /// "r1": { ... } } } } }</c>) without supplying an areaId, position or
+    /// rotation. Earlier versions of the converter always emitted
+    /// <c>position</c>/<c>rotation</c> as <c>{x:0,y:0,z:0}</c> and deserialized
+    /// <c>FuseIndustry.AreaId</c> as null, after which
+    /// <see cref="FUSE.Runtime.API.IndustryAPI.UpdateIndustry"/> reparented
+    /// the existing base-game industry to the arbitrary first Area and yanked
+    /// its transform to the origin — visible in-game as Map Enhancer
+    /// painting Whittier Sawmill / progression dropoff tracks with the wrong
+    /// area colour. These tests lock in that the converter no longer fabricates
+    /// transform/area directives when the source did not author them.
+    /// </summary>
+    public class FuseLegacyIndustryConverterTests
+    {
+        private static (JObject root, JObject industries) ConvertIndustries(JObject source)
+        {
+            var manifest = new FuseLegacyPackageManifest
+            {
+                PackageId = "test-pkg",
+                DisplayName = "Test Package",
+                Author = "tester",
+                Version = "1.0.0"
+            };
+            var root = FuseLegacyDataConverter.CreateSkeleton(manifest, "industry-fragment");
+            FuseLegacyDataConverter.ConvertSource(source, root, manifest);
+            var industries = (JObject)root["operations"]["industries"];
+            return (root, industries);
+        }
+
+        public class TopLevelPartialPatch
+        {
+            [Fact]
+            public void NoAreaIdNoPositionNoRotation_ConverterOmitsTransformDirectives()
+            {
+                var source = new JObject
+                {
+                    ["industries"] = new JObject
+                    {
+                        ["whittier-sawmill"] = new JObject
+                        {
+                            ["components"] = new JObject
+                            {
+                                ["r1"] = new JObject
+                                {
+                                    ["trackSpans"] = new JArray("whittier-r1-span")
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var (_, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var entry = (JObject)industries["whittier-sawmill"];
+                Assert.NotNull(entry);
+                Assert.False(entry.ContainsKey("areaId"),
+                    "no areaId in source -> no areaId in converted output");
+                Assert.False(entry.ContainsKey("position"),
+                    "no position in source -> no position in converted output (unconditional position used to drag the existing industry to the origin)");
+                Assert.False(entry.ContainsKey("rotation"),
+                    "no rotation in source -> no rotation in converted output");
+            }
+
+            [Fact]
+            public void NoAreaIdNoPositionNoRotation_DeserializedDefinitionIsNullForAllThreeFields()
+            {
+                var source = new JObject
+                {
+                    ["industries"] = new JObject
+                    {
+                        ["whittier-sawmill"] = new JObject
+                        {
+                            ["components"] = new JObject
+                            {
+                                ["r1"] = new JObject
+                                {
+                                    ["trackSpans"] = new JArray("whittier-r1-span")
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var (root, _) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var definition = FuseSerializer.FromJson(root.ToString());
+                var industry = definition.Operations.Industries["whittier-sawmill"];
+                Assert.Null(industry.AreaId);
+                Assert.False(industry.Position.HasValue);
+                Assert.False(industry.Rotation.HasValue);
+            }
+
+            [Fact]
+            public void ExplicitPositionAndRotation_RoundTripThroughConverter()
+            {
+                var source = new JObject
+                {
+                    ["industries"] = new JObject
+                    {
+                        ["new-industry"] = new JObject
+                        {
+                            ["areaId"] = "whittier",
+                            ["position"] = new JObject
+                            {
+                                ["x"] = 10f,
+                                ["y"] = 0f,
+                                ["z"] = -25f
+                            },
+                            ["rotation"] = new JObject
+                            {
+                                ["x"] = 0f,
+                                ["y"] = 90f,
+                                ["z"] = 0f
+                            },
+                            ["components"] = new JObject()
+                        }
+                    }
+                };
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var entry = (JObject)industries["new-industry"];
+                Assert.Equal("whittier", (string)entry["areaId"]);
+                Assert.True(entry.ContainsKey("position"));
+                Assert.True(entry.ContainsKey("rotation"));
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                var industry = definition.Operations.Industries["new-industry"];
+                Assert.Equal("whittier", industry.AreaId);
+                Assert.True(industry.Position.HasValue);
+                Assert.Equal(10f, industry.Position.Value.x);
+                Assert.Equal(-25f, industry.Position.Value.z);
+                Assert.True(industry.Rotation.HasValue);
+                Assert.Equal(90f, industry.Rotation.Value.y);
+            }
+
+            [Fact]
+            public void ExplicitZeroPosition_IsHonoredNotDroppedByConverter()
+            {
+                // A package that genuinely wants the industry at the origin
+                // must still be able to express that. Only the absence of the
+                // key suppresses the directive — an explicit { x:0, y:0, z:0 }
+                // round-trips as a real Vector3 value.
+                var source = new JObject
+                {
+                    ["industries"] = new JObject
+                    {
+                        ["origin-industry"] = new JObject
+                        {
+                            ["areaId"] = "whittier",
+                            ["position"] = new JObject
+                            {
+                                ["x"] = 0f,
+                                ["y"] = 0f,
+                                ["z"] = 0f
+                            },
+                            ["components"] = new JObject()
+                        }
+                    }
+                };
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var entry = (JObject)industries["origin-industry"];
+                Assert.True(entry.ContainsKey("position"));
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                var industry = definition.Operations.Industries["origin-industry"];
+                Assert.True(industry.Position.HasValue);
+                Assert.Equal(0f, industry.Position.Value.x);
+                Assert.Equal(0f, industry.Position.Value.y);
+                Assert.Equal(0f, industry.Position.Value.z);
+            }
+        }
+
+        public class AreaNestedIndustry
+        {
+            [Fact]
+            public void AreaNestedIndustry_GetsAreaIdFromParent()
+            {
+                // Industries authored under areas.{a}.industries.{id} carry
+                // the area context implicitly. The converter passes the area
+                // name as the areaId argument so the apply path can parent
+                // the new industry to the correct Area transform.
+                var source = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["whittier"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["whittier-sawmill-r1"] = new JObject
+                                {
+                                    ["components"] = new JObject()
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var entry = (JObject)industries["whittier-sawmill-r1"];
+                Assert.Equal("whittier", (string)entry["areaId"]);
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                var industry = definition.Operations.Industries["whittier-sawmill-r1"];
+                Assert.Equal("whittier", industry.AreaId);
+            }
+        }
+    }
+}

--- a/FUSE/Authoring/Data/Operations/FuseOperationsDefinition.cs
+++ b/FUSE/Authoring/Data/Operations/FuseOperationsDefinition.cs
@@ -40,8 +40,12 @@ namespace FUSE.Authoring.Data
         public string Name { get; set; }
         public string AreaId { get; set; }
         public int? Order { get; set; }
-        public Vector3 Position { get; set; }
-        public Vector3 Rotation { get; set; }
+        // Nullable so partial legacy SC industry patches that omit position
+        // and rotation can update components without relocating or re-rotating
+        // an existing industry to the origin. The apply path skips the
+        // transform mutation when these are null.
+        public Vector3? Position { get; set; }
+        public Vector3? Rotation { get; set; }
         public bool UsesContract { get; set; }
         public bool MergeComponents { get; set; }
 

--- a/FUSE/Loading/FuseLegacyDataConverter.World.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.World.cs
@@ -391,18 +391,45 @@ namespace FUSE.Loading
                     "trims any vanilla components not in the converted set.");
             }
 
-            return CleanObject(new JObject
+            // Emit areaId / position / rotation only when the SC source
+            // actually provided them. Vector(null, false) returns
+            // {x:0,y:0,z:0}, which CleanObject would NOT strip — so
+            // unconditional emission used to feed FuseIndustry.Position =
+            // (0,0,0) into UpdateIndustry and yank existing base-game
+            // industries to the origin. Same story for areaId on top-level
+            // industry patches (e.g.
+            // industries.whittier-sawmill.components.{R1: {...}}): a
+            // string-typed JValue with null content survives CleanObject and
+            // gets deserialized as a directive that reparents the industry
+            // to an arbitrary first Area.
+            var positionToken = item["localPosition"] ?? item["position"];
+            var rotationToken = item["localRotation"] ?? item["rotation"];
+            var resolvedAreaId = areaId ?? ReadString(item, "areaId", "area");
+            var result = new JObject
             {
                 ["name"] = ReadString(item, "name") ?? id,
-                ["areaId"] = areaId ?? ReadString(item, "areaId", "area"),
                 ["order"] = Clone(item["order"]),
-                ["position"] = Vector(item["localPosition"] ?? item["position"], false),
-                ["rotation"] = Vector(item["localRotation"] ?? item["rotation"], false),
                 ["usesContract"] = ReadBool(item, "usesContract", false),
                 ["mergeComponents"] = !isReplace,
                 ["replaceComponents"] = isReplace,
                 ["components"] = components
-            });
+            };
+            if (!string.IsNullOrWhiteSpace(resolvedAreaId))
+            {
+                result["areaId"] = resolvedAreaId;
+            }
+
+            if (positionToken != null && positionToken.Type != JTokenType.Null)
+            {
+                result["position"] = Vector(positionToken, false);
+            }
+
+            if (rotationToken != null && rotationToken.Type != JTokenType.Null)
+            {
+                result["rotation"] = Vector(rotationToken, false);
+            }
+
+            return CleanObject(result);
         }
 
         // Looks for a top-level <c>$replace</c> entry whose value is the

--- a/FUSE/Runtime/API/IndustryAPI.cs
+++ b/FUSE/Runtime/API/IndustryAPI.cs
@@ -88,8 +88,8 @@ namespace FUSE.Runtime.API
             var gameObject = new GameObject(displayName);
             gameObject.SetActive(false);
             gameObject.transform.SetParent(root, false);
-            gameObject.transform.localPosition = definition.Position;
-            gameObject.transform.localRotation = Quaternion.Euler(definition.Rotation);
+            gameObject.transform.localPosition = definition.Position ?? Vector3.zero;
+            gameObject.transform.localRotation = Quaternion.Euler(definition.Rotation ?? Vector3.zero);
 
             var industry = gameObject.AddComponent<Industry>();
             industry.identifier = id;
@@ -126,17 +126,37 @@ namespace FUSE.Runtime.API
             }
 
             var displayName = string.IsNullOrWhiteSpace(definition.Name) ? id : definition.Name;
-            var root = GetIndustryRoot(definition);
-            if (root != null && industry.transform.parent != root)
+            // Only reparent / relocate / re-rotate when the definition
+            // explicitly specifies these fields. Legacy SC patches against an
+            // existing base-game industry (e.g. a top-level
+            // industries.whittier-sawmill.components.{...} patch) routinely
+            // omit areaId / position / rotation; running unconditional
+            // mutations here used to drag the industry into the first Area
+            // and the origin, after which MapEnhancer's
+            // OpsController.Shared.Areas -> area.Industries lookup picked the
+            // wrong Area's tagColor for every component on it.
+            if (!string.IsNullOrWhiteSpace(definition.AreaId))
             {
-                industry.transform.SetParent(root, false);
-                FuseLog.Info($"FUSE reparented industry '{id}' to '{DescribeIndustryParent(root)}'.");
+                var root = GetIndustryRoot(definition);
+                if (root != null && industry.transform.parent != root)
+                {
+                    industry.transform.SetParent(root, false);
+                    FuseLog.Info($"FUSE reparented industry '{id}' to '{DescribeIndustryParent(root)}'.");
+                }
             }
 
             industry.gameObject.name = displayName;
             industry.name = displayName;
-            industry.transform.localPosition = definition.Position;
-            industry.transform.localRotation = Quaternion.Euler(definition.Rotation);
+            if (definition.Position.HasValue)
+            {
+                industry.transform.localPosition = definition.Position.Value;
+            }
+
+            if (definition.Rotation.HasValue)
+            {
+                industry.transform.localRotation = Quaternion.Euler(definition.Rotation.Value);
+            }
+
             industry.usesContract = definition.UsesContract;
             RememberIndustryOrder(id, definition.Order);
             FuseCreatedIndustryIds.Add(id);
@@ -443,9 +463,10 @@ namespace FUSE.Runtime.API
                     return matchedArea.transform;
                 }
 
+                var probePosition = definition.Position ?? Vector3.zero;
                 var nearestArea = areas
                     .Where(area => area != null)
-                    .OrderBy(area => (area.transform.localPosition - definition.Position).sqrMagnitude)
+                    .OrderBy(area => (area.transform.localPosition - probePosition).sqrMagnitude)
                     .FirstOrDefault();
                 if (nearestArea != null)
                 {


### PR DESCRIPTION
## 🔗 Related Issue

No tracking issue — surfaced from in-game reports of Whittier Sawmill R1 and progression dropoff industries rendering with the wrong area colour in Map Enhancer when loaded via the legacy SC→FUSE conversion path.

## 📝 Description of the Change

`FuseLegacyDataConverter.ConvertIndustry` unconditionally emitted `position`, `rotation`, and (as a string-typed `JValue` with null content) `areaId` for every converted industry, even when the SC source omitted them. `CleanObject` doesn't strip either form. The resulting `FuseIndustry` definition reached `IndustryAPI.UpdateIndustry` with `AreaId=null`, `Position=(0,0,0)`, `Rotation=(0,0,0)`, which were then applied unconditionally:

- `GetIndustryRoot` saw an empty `AreaId` and returned the first `Area` in the scene.
- The existing base-game industry (e.g. `whittier-sawmill`) was reparented to that arbitrary Area.
- Its `localPosition` and `localRotation` were assigned `(0,0,0)`.

Map Enhancer's `IndustryComponent.Start` postfix walks `OpsController.Shared.Areas → area.Industries → industry.Components` to attribute an `Area` color to each component's segments (`Area.Industries` is a `GetComponentsInChildren<Industry>()` hierarchy walk). After the reparent, the lookup found the components under the wrong `Area` and painted their tracks with that `Area.tagColor`. If the registry walk failed entirely, the position fallback (`ClosestAreaForGamePosition(WorldToGame(component.transform.position))`) was computed against the relocated origin and picked whichever Area happened to be closest to the world origin.

This PR closes the gap with three coordinated changes:

1. **Model** — `FuseIndustry.Position` and `FuseIndustry.Rotation` become `Vector3?`, mirroring the pattern already used by `FuseArea` (where `TrackAPI.Areas` already conditionally applies `definition.Position.HasValue` mutations).
2. **Converter** — `ConvertIndustry` now adds `areaId` / `position` / `rotation` to the converted `JObject` only when the SC source actually authored them. Explicit `{x:0,y:0,z:0}` still round-trips as a real value.
3. **Apply path** — `IndustryAPI.AddIndustry` falls back to `Vector3.zero` only when creating a brand-new industry. `IndustryAPI.UpdateIndustry` skips the reparent entirely when `AreaId` is null/empty, and skips the `localPosition` / `localRotation` assignments when those nullables are absent. `GetIndustryRoot`'s nearest-area fallback uses `definition.Position ?? Vector3.zero`.

## 🔄 Alternatives Considered

- **Detect partial intent heuristically in the apply path** (e.g. "if `Position == Vector3.zero` and the existing industry is non-zero, skip"). Rejected — the heuristic fails for any author who genuinely wants the industry at the origin.
- **Only fix the converter** (omit the keys but leave `FuseIndustry.Position` non-nullable). Rejected — FUSE-native packages and the authoring persistence service create `FuseIndustry` instances directly without specifying position, and the default-`Vector3.zero` would still leak through on the FUSE-native path.
- **Validate at schema time** and reject converted packages missing `position`. Rejected — would break every legacy SC mod in the wild that uses top-level industry patches against base-game industries (e.g. Foxy's East Whittier patches).

## ⚠️ Possible Drawbacks

- `FuseIndustry.Position` and `FuseIndustry.Rotation` are now nullable on the public authoring surface. Any external consumer reading these directly will need to handle `HasValue` (no such consumer exists in this repo; all internal call sites are updated).
- Save compatibility: this is a converter + apply-path behaviour change only — no save schema is touched, and existing FUSE-native packages that emit explicit `position` continue to round-trip identically.
- The converter no longer writes `"areaId": null` / `"position": {x:0,y:0,z:0}` placeholder values into the in-memory converted JObject for partial patches. Any downstream code that was relying on those placeholders to decide "this industry came from a partial patch" would need to use `definition.AreaId == null` instead — but no such consumer exists.

## ✅ Verification Process

- Added 5 regression tests in `FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs` covering: top-level patch without areaId/position/rotation omits all three keys; the deserialized `FuseIndustry` reports `AreaId==null` and `!Position.HasValue`; explicit position/rotation/areaId still round-trip; explicit `{x:0,y:0,z:0}` is preserved (not dropped); area-nested industries still inherit `areaId` from their parent.
- `dotnet build FUSE/FUSE.csproj -c Release` — 0 warnings, 0 errors.
- `dotnet test FUSE.Tests/FUSE.Tests.csproj -c Release` — 721 passed, 0 failed.
- Reviewed all in-repo consumers of `FuseIndustry.Position` / `Rotation` / `AreaId` (`IndustryAPI.cs`, `FuseAuthoringPersistenceService.cs`, validator, migrations, tests). The `FuseAuthoringPersistenceService` stub-creation path (`new FuseIndustry { Name = industryId }`) now produces `Position=null` instead of `Vector3.zero`, which is the correct behaviour: applying that stub at runtime no longer relocates the existing industry.

## 💡 Additional Information

Pairs with the previous fix in [`a721353`](https://github.com/F-U-S-E-E/FuseDevelopmentGroup/commit/a721353d58712830b48727ca9c66d54b875a2abb) (`fix: propagate area tagColor through legacy SC->FUSE converter`) — that one made sure the `Area` itself carried the right `tagColor` through conversion; this one makes sure the `Industry` ends up inside that `Area`.