### PR TITLE
test(unity): expand EditMode coverage with API surface + reflection canary

### DIFF
--- a/FUSE.UnityTests/Assets/Tests/PrefabResolverUriTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/PrefabResolverUriTests.cs
@@ -1,0 +1,215 @@
+using System;
+using FUSE.Runtime.API;
+using NUnit.Framework;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace FUSE.UnityTests
+{
+    /// <summary>
+    /// EditMode coverage for <see cref="FusePrefabResolver.Resolve(string)"/>
+    /// — the URI entry point that dispatches by scheme to the inner
+    /// path / scenery / vanilla resolvers. FindChildIntegrationTests
+    /// covers the deep <c>ResolveScenePath</c> walk; this suite covers
+    /// the scheme parser, argument validation, and the
+    /// <c>FindRootObject</c> case-insensitive fallback that
+    /// ResolveScenePath uses for root-level lookups.
+    ///
+    /// FusePrefabResolver is internal; FUSE.csproj's
+    /// InternalsVisibleTo to <c>FUSE.UnityTests.Tests</c> lets the
+    /// asmdef call the static entry points directly.
+    /// </summary>
+    public class PrefabResolverUriTests
+    {
+        private GameObject _world;
+
+        [SetUp]
+        public void SetUp()
+        {
+            EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+
+            _world = new GameObject("World");
+            var largeScenery = new GameObject("Large Scenery");
+            largeScenery.transform.SetParent(_world.transform, worldPositionStays: false);
+            var bryson = new GameObject("Bryson");
+            bryson.transform.SetParent(largeScenery.transform, worldPositionStays: false);
+            var depot = new GameObject("Depot");
+            depot.transform.SetParent(bryson.transform, worldPositionStays: false);
+            depot.AddComponent<MeshRenderer>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_world != null)
+            {
+                UnityEngine.Object.DestroyImmediate(_world);
+            }
+        }
+
+        [Test]
+        public void Resolve_EmptyScheme_ReturnsBrandNewGameObject()
+        {
+            // The "empty://" scheme is FUSE's escape hatch for
+            // scene-clone sources that want an empty container without
+            // referencing any actual prefab. It must always return a
+            // brand-new GameObject, not null.
+            var result = FusePrefabResolver.Resolve("empty://whatever-the-path-is");
+            try
+            {
+                Assert.NotNull(result);
+                Assert.AreEqual("empty", result.name);
+                Assert.IsNull(result.transform.parent,
+                    "empty:// must return an unparented GameObject — callers control reparenting.");
+            }
+            finally
+            {
+                if (result != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(result);
+                }
+            }
+        }
+
+        [Test]
+        public void Resolve_EmptyScheme_IsCaseInsensitive()
+        {
+            // Authors writing manifest YAML may capitalise the scheme
+            // differently; case-insensitive scheme parsing matches the
+            // implementation's StringComparison.OrdinalIgnoreCase.
+            var result = FusePrefabResolver.Resolve("EMPTY://anything");
+            try
+            {
+                Assert.NotNull(result);
+            }
+            finally
+            {
+                if (result != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(result);
+                }
+            }
+        }
+
+        [Test]
+        public void Resolve_PathScheme_ReturnsResolvedScenePath()
+        {
+            // path:// goes through ResolveScenePath against the
+            // current scene's root GameObjects. Asserting equality
+            // with our fixture's Depot proves the dispatch reached
+            // the underlying walker.
+            var depot = GameObject.Find("World/Large Scenery/Bryson/Depot");
+            Assert.NotNull(depot, "Sanity: fixture must contain Depot.");
+
+            var resolved = FusePrefabResolver.Resolve("path://World/Large Scenery/Bryson/Depot");
+            Assert.AreSame(depot, resolved);
+        }
+
+        [Test]
+        public void Resolve_PathScheme_StripsScenePrefix()
+        {
+            // The "scene/" prefix on path:// URIs is optional —
+            // both "path://World/..." and "path://scene/World/..."
+            // must resolve to the same GameObject. This is the
+            // contract some manifest authors rely on for clarity.
+            var depot = GameObject.Find("World/Large Scenery/Bryson/Depot");
+            Assert.NotNull(depot);
+
+            var withoutPrefix = FusePrefabResolver.Resolve("path://World/Large Scenery/Bryson/Depot");
+            var withPrefix = FusePrefabResolver.Resolve("path://scene/World/Large Scenery/Bryson/Depot");
+            Assert.AreSame(depot, withoutPrefix);
+            Assert.AreSame(depot, withPrefix);
+        }
+
+        [Test]
+        public void Resolve_PathScheme_NonexistentPath_ReturnsNull()
+        {
+            var resolved = FusePrefabResolver.Resolve("path://World/Large Scenery/Bryson/NoSuchObject");
+            Assert.IsNull(resolved);
+        }
+
+        [Test]
+        public void Resolve_UnknownScheme_Throws()
+        {
+            // An unrecognised scheme must throw rather than silently
+            // returning null — a typoed scheme like "scennery://" or
+            // "vanilaa://" otherwise produces a phantom missing-target
+            // failure later in the pipeline with no diagnostic.
+            Assert.Throws<ArgumentException>(() =>
+                FusePrefabResolver.Resolve("not-a-scheme://foo"));
+        }
+
+        [Test]
+        public void Resolve_MissingSchemeSeparator_Throws()
+        {
+            // No "://" separator at all means we can't parse the
+            // string as a URI — fail loudly.
+            Assert.Throws<ArgumentException>(() =>
+                FusePrefabResolver.Resolve("just-a-name"));
+        }
+
+        [Test]
+        public void Resolve_NullOrBlank_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => FusePrefabResolver.Resolve(null));
+            Assert.Throws<ArgumentException>(() => FusePrefabResolver.Resolve(string.Empty));
+            Assert.Throws<ArgumentException>(() => FusePrefabResolver.Resolve("   "));
+        }
+
+        [Test]
+        public void ResolveScenePath_BlankInput_ReturnsNull()
+        {
+            // The deep walker has its own null/blank guard — it must
+            // return null (not throw) because callers like
+            // FindRemovableSceneClone use it as a probe.
+            Assert.IsNull(FusePrefabResolver.ResolveScenePath(null));
+            Assert.IsNull(FusePrefabResolver.ResolveScenePath(string.Empty));
+            Assert.IsNull(FusePrefabResolver.ResolveScenePath("   "));
+        }
+
+        [Test]
+        public void ResolveScenePath_RootOnly_ReturnsRootGameObject()
+        {
+            // A path that's only a root segment must return the root
+            // GameObject directly without trying to walk children.
+            var resolved = FusePrefabResolver.ResolveScenePath("World");
+            Assert.AreSame(_world, resolved);
+        }
+
+        [Test]
+        public void ResolveScenePath_RootName_PrefersExactCaseMatch()
+        {
+            // Two scene roots that differ only in case: the resolver
+            // must return the exact-case match (matches the
+            // FindRootObject contract that an exact name wins over a
+            // case-insensitive fallback).
+            var lowercaseWorld = new GameObject("world");
+            try
+            {
+                var resolved = FusePrefabResolver.ResolveScenePath("world");
+                Assert.AreSame(lowercaseWorld, resolved,
+                    "Exact-case root match must win over the case-different sibling.");
+            }
+            finally
+            {
+                if (lowercaseWorld != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(lowercaseWorld);
+                }
+            }
+        }
+
+        [Test]
+        public void ResolveScenePath_RootName_FallsBackToCaseInsensitive_WhenNoExact()
+        {
+            // If no root has the exact name, the resolver falls back
+            // to a case-insensitive root match. This is the
+            // tolerance that lets authors type "world" when the scene
+            // has "World".
+            var resolved = FusePrefabResolver.ResolveScenePath("WORLD");
+            Assert.AreSame(_world, resolved,
+                "Case-insensitive root fallback must surface 'World' for the input 'WORLD'.");
+        }
+    }
+}

--- a/FUSE.UnityTests/Assets/Tests/PrefabResolverUriTests.cs.meta
+++ b/FUSE.UnityTests/Assets/Tests/PrefabResolverUriTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a24a970566de451890b9d4c97c342f2b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
@@ -1,0 +1,644 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+using NUnit.Framework;
+
+namespace FUSE.UnityTests
+{
+    /// <summary>
+    /// EditMode regression canary for every Railroader private/internal
+    /// member FUSE reaches via reflection by NAME. FUSE caches each of
+    /// these in a <c>static readonly FieldInfo</c> (or MethodInfo /
+    /// PropertyInfo / ConstructorInfo) at class-load time. If
+    /// Railroader renames a member in a future patch the lookup
+    /// silently returns null, FUSE either calls
+    /// <c>SetValue(null, ...)</c> on it and gets a
+    /// NullReferenceException at first invocation (loud-but-late) or
+    /// the failure becomes an even more silent "feature does nothing"
+    /// (passenger stop spans never bind, turntable nodes lose their
+    /// references, etc.).
+    ///
+    /// This suite catches both failure modes at CI time. Each [Test]
+    /// pins one (target type, member, BindingFlags) tuple. A failure
+    /// here ALWAYS means one of two things:
+    ///
+    ///   1. Railroader renamed / moved / changed-accessibility on the
+    ///      member. Production code that depends on it must be
+    ///      updated to use the new name. Search FUSE for the old
+    ///      name to find every caller.
+    ///   2. FUSE moved its reflection target intentionally (e.g.
+    ///      stopped depending on a particular private field). In
+    ///      that case delete the corresponding test method here.
+    ///
+    /// Either way, the failure is actionable — it tells you which
+    /// member is gone, not just "something's null at runtime."
+    ///
+    /// Coverage scope: ~50 accesses across ~25 Railroader types in
+    /// FUSE/Runtime/API, FUSE/Loading, FUSE/Patches, FUSE/Interface.
+    /// UnityModManager / Harmony / Multiplayer / Map.Runtime
+    /// reflection paths that FUSE wraps in conditional fallbacks
+    /// (e.g. <c>MultiplayerType?.GetProperty(...)</c>) are
+    /// deliberately omitted — those are designed to no-op if the
+    /// target isn't present and producing a CI failure for them
+    /// would be wrong.
+    ///
+    /// FusePrefabResolver and other internal symbols come in via
+    /// FUSE.csproj's InternalsVisibleTo to <c>FUSE.UnityTests.Tests</c>.
+    /// Railroader types resolve from Assembly-CSharp.dll (and a few
+    /// satellite assemblies like Map.Runtime.dll) which
+    /// prepare_assets.ps1 copies into Assets/Plugins/.
+    /// </summary>
+    public class RailroaderReflectionSurfaceTests
+    {
+        private const BindingFlags InstanceNonPublic = BindingFlags.Instance | BindingFlags.NonPublic;
+        private const BindingFlags StaticNonPublic = BindingFlags.Static | BindingFlags.NonPublic;
+        private const BindingFlags InstancePublic = BindingFlags.Instance | BindingFlags.Public;
+        private const BindingFlags InstanceAny = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        private const BindingFlags StaticAny = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+
+        // -----------------------------------------------------------------
+        // PassengerStop — FusePassengerStopComponent.cs writes _spans and
+        // _markers directly to bypass the (event-firing) public setters
+        // and reads _keyValueObject + _allPassengerStops to manage the
+        // global passenger stop registry.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void PassengerStop_allPassengerStops_StaticField()
+        {
+            AssertField("Model.Ops.PassengerStop", "_allPassengerStops", StaticNonPublic);
+        }
+
+        [Test]
+        public void PassengerStop_spans_InstanceField()
+        {
+            AssertField("Model.Ops.PassengerStop", "_spans", InstanceNonPublic);
+        }
+
+        [Test]
+        public void PassengerStop_markers_InstanceField()
+        {
+            AssertField("Model.Ops.PassengerStop", "_markers", InstanceNonPublic);
+        }
+
+        [Test]
+        public void PassengerStop_keyValueObject_InstanceField()
+        {
+            AssertField("Model.Ops.PassengerStop", "_keyValueObject", InstanceNonPublic);
+        }
+
+        // -----------------------------------------------------------------
+        // Turntable — TurntableAPI.cs writes nodes/bridgeGroupId/_segment
+        // when materialising a turntable from a FuseTurntable definition.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void Turntable_nodes_InstanceField()
+        {
+            AssertField("Track.Turntable", "nodes", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Turntable_bridgeGroupId_InstanceField()
+        {
+            AssertField("Track.Turntable", "bridgeGroupId", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Turntable_segment_InstanceField()
+        {
+            AssertField("Track.Turntable", "_segment", InstanceNonPublic);
+        }
+
+        // -----------------------------------------------------------------
+        // Graph — TrackAPI.cs and TurntableAPI.cs mutate the graph's
+        // private caches directly when FUSE applies track changes that
+        // require the caches to be rebuilt before the public APIs read
+        // them. Each cache field must remain accessible.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void Graph_nodes_InstanceField()
+        {
+            // TrackAPI replays node mutations directly into the graph's
+            // backing collections after applying a track change so the
+            // public Graph.Nodes view sees them on the same frame.
+            AssertField("Track.Graph", "nodes", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Graph_segments_InstanceField()
+        {
+            AssertField("Track.Graph", "segments", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Graph_spans_InstanceField()
+        {
+            AssertField("Track.Graph", "spans", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Graph_AddSpan_InstanceMethod()
+        {
+            // TrackAPI invokes AddSpan to install new spans when the
+            // public API doesn't expose a non-marker registration path.
+            AssertMethod("Track.Graph", "AddSpan", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Graph_cachedTurntableControllers_InstanceField()
+        {
+            AssertField("Track.Graph", "_cachedTurntableControllers", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Graph_nodeConnectionsCache_InstanceField()
+        {
+            AssertField("Track.Graph", "_nodeConnectionsCache", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Graph_nodeIsDeadEndCache_InstanceField()
+        {
+            AssertField("Track.Graph", "_nodeIsDeadEndCache", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Graph_cachedReachableSegments_InstanceField()
+        {
+            AssertField("Track.Graph", "_cachedReachableSegments", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Graph_decodedSwitchCache_InstanceField()
+        {
+            AssertField("Track.Graph", "_decodedSwitchCache", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Graph_segmentsReachableFromOthers_InstanceField()
+        {
+            AssertField("Track.Graph", "_segmentsReachableFromOthers", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Graph_curvatureSampleCache_InstanceField()
+        {
+            AssertField("Track.Graph", "_curvatureSampleCache", InstanceNonPublic);
+        }
+
+        // -----------------------------------------------------------------
+        // StationAgent — StationAPI.cs writes area / passengerStop /
+        // secondaryAreas when materialising a station from definition.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void StationAgent_area_InstanceField()
+        {
+            AssertField("Model.Ops.StationAgent", "area", InstanceNonPublic);
+        }
+
+        [Test]
+        public void StationAgent_passengerStop_InstanceField()
+        {
+            AssertField("Model.Ops.StationAgent", "passengerStop", InstanceNonPublic);
+        }
+
+        [Test]
+        public void StationAgent_secondaryAreas_InstanceField()
+        {
+            AssertField("Model.Ops.StationAgent", "secondaryAreas", InstanceNonPublic);
+        }
+
+        // -----------------------------------------------------------------
+        // MapLabel / MapStore / MapManager — map display + tile registry.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void MapLabel_canvas_InstanceField()
+        {
+            // MapAPI.AddMapLabel binds the canvas reference via reflection.
+            // If _canvas is renamed, every authored map label silently
+            // renders off-screen because the canvas reference is null.
+            AssertField("UI.Map.MapLabel", "_canvas", InstanceNonPublic);
+        }
+
+        [Test]
+        public void MapStore_descriptors_InstanceField()
+        {
+            // FuseMapTileRegistry maintains its own view of the tile
+            // descriptor list by reading/writing this field directly.
+            AssertField("Map.Runtime.MapStore", "_descriptors", InstanceNonPublic);
+        }
+
+        [Test]
+        public void MapManager_store_InstanceField()
+        {
+            // FuseMapTileRegistry resolves the active MapStore through
+            // MapManager's private _store field.
+            AssertField("Map.Runtime.MapManager", "_store", InstanceNonPublic);
+        }
+
+        [Test]
+        public void MapManager_RebuildAll_PublicInstanceMethod()
+        {
+            // FuseRuntimeReloadService invokes RebuildAll to recompute
+            // map tiles after a FUSE re-apply. If the method is gone or
+            // its signature changed, runtime reload silently doesn't
+            // refresh the map.
+            AssertMethod("Map.Runtime.MapManager", "RebuildAll", InstancePublic);
+        }
+
+        [Test]
+        public void MapManager_Instance_StaticPublicProperty()
+        {
+            AssertProperty("Map.Runtime.MapManager", "Instance", BindingFlags.Static | BindingFlags.Public);
+        }
+
+        // -----------------------------------------------------------------
+        // AssetPackRuntimeStore — heavily-patched store; FUSE's
+        // asset-pack mounting reads BasePath, the load task, and the
+        // bundle resolver to drive its own resolution trace.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void AssetPackRuntimeStore_BasePath_Property()
+        {
+            // BasePath is private/internal in shipped Railroader; FUSE
+            // accesses it via AccessTools.Property which probes both
+            // public and non-public.
+            var prop = AccessTools.Property(RequireType("AssetPack.Runtime.AssetPackRuntimeStore"), "BasePath");
+            Assert.NotNull(prop,
+                "AssetPackRuntimeStore.BasePath not found via AccessTools.Property — FUSE's BasePath probe will return null.");
+        }
+
+        [Test]
+        public void AssetPackRuntimeStore_loadAssetBundleTask_Field()
+        {
+            var field = AccessTools.Field(RequireType("AssetPack.Runtime.AssetPackRuntimeStore"), "_loadAssetBundleTask");
+            Assert.NotNull(field,
+                "AssetPackRuntimeStore._loadAssetBundleTask not found via AccessTools.Field.");
+        }
+
+        [Test]
+        public void AssetPackRuntimeStore_LoadedBundle_Method()
+        {
+            var method = AccessTools.Method(RequireType("AssetPack.Runtime.AssetPackRuntimeStore"), "LoadedBundle");
+            Assert.NotNull(method,
+                "AssetPackRuntimeStore.LoadedBundle not found via AccessTools.Method.");
+        }
+
+        [Test]
+        public void AssetPackRuntimeStore_container_Field()
+        {
+            var field = AccessTools.Field(RequireType("AssetPack.Runtime.AssetPackRuntimeStore"), "_container");
+            Assert.NotNull(field,
+                "AssetPackRuntimeStore._container not found via AccessTools.Field — FuseAssetPackRegistry mutates this directly.");
+        }
+
+        [Test]
+        public void AssetPackRuntimeStore_AssetBundlePath_PropertyGetter()
+        {
+            // FuseAssetPackRuntimeStoreAssetBundlePathPatch targets this
+            // getter; a rename here detaches the AssetBundle path
+            // override and asset-pack mod loading silently breaks.
+            var getter = AccessTools.PropertyGetter(RequireType("AssetPack.Runtime.AssetPackRuntimeStore"), "AssetBundlePath");
+            Assert.NotNull(getter,
+                "AssetPackRuntimeStore.AssetBundlePath getter not found — the bundle-path patch cannot bind.");
+        }
+
+        [Test]
+        public void ContainerSerialization_JsonSerializerSettings_Method()
+        {
+            // FuseAssetPackRegistry and FuseLegacyContainerMixintoRegistry
+            // both call ContainerSerialization.JsonSerializerSettings to
+            // round-trip asset-pack container JSON through the game's
+            // Newtonsoft.Json contract resolver.
+            var method = AccessTools.Method(RequireType("ContainerSerialization"), "JsonSerializerSettings");
+            Assert.NotNull(method,
+                "ContainerSerialization.JsonSerializerSettings not found — asset-pack serialization helpers will throw.");
+        }
+
+        // -----------------------------------------------------------------
+        // PrefabStore — patched in multiple places to filter
+        // AllCarDefinitionInfos, intercept AllDefinitionInfosOfType,
+        // and reach into the underlying _stores list.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void PrefabStore_stores_Field()
+        {
+            var field = AccessTools.Field(RequireType("Model.Database.PrefabStore"), "_stores");
+            Assert.NotNull(field,
+                "PrefabStore._stores not found — multiple patches and asset-pack helpers depend on it.");
+        }
+
+        [Test]
+        public void PrefabStore_AllDefinitionInfosOfType_GenericMethod()
+        {
+            // FuseAudioPatches and FusePrefabStoreMaterialDefinitionsPatch
+            // both call this method's generic-definition form.
+            var method = AccessTools.Method(RequireType("Model.Database.PrefabStore"), "AllDefinitionInfosOfType");
+            Assert.NotNull(method,
+                "PrefabStore.AllDefinitionInfosOfType not found — material/audio patches will fail to install.");
+        }
+
+        [Test]
+        public void PrefabStore_AllCarDefinitionInfos_Property()
+        {
+            // FusePrefabStoreAllCarDefinitionInfosFilterPatch postfix
+            // targets the getter of this property.
+            var getter = AccessTools.PropertyGetter(RequireType("Model.Database.PrefabStore"), "AllCarDefinitionInfos");
+            Assert.NotNull(getter,
+                "PrefabStore.AllCarDefinitionInfos getter not found — the car-definition filter patch cannot bind.");
+        }
+
+        // -----------------------------------------------------------------
+        // CarInspector — FusePassengerCarPanelPatch needs the inspector's
+        // private _car backing field to identify which car the panel
+        // currently shows.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void CarInspector_car_InstanceField()
+        {
+            var field = AccessTools.Field(RequireType("UI.CarInspector.CarInspector"), "_car");
+            Assert.NotNull(field,
+                "CarInspector._car not found — the passenger car panel patch will throw on every invocation.");
+        }
+
+        // -----------------------------------------------------------------
+        // MapFeature.Unlocked — FuseProgressionImpactLookup probes BOTH
+        // a property and a field named "Unlocked" because Railroader
+        // has shipped both shapes in different versions. The lookup
+        // succeeds as long as ONE of the two is present; this test
+        // pins that contract so we'd catch a hypothetical future
+        // version that exposes neither.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void MapFeature_Unlocked_PropertyOrField()
+        {
+            var t = RequireType("Game.Progression.MapFeature");
+            var property = t.GetProperty("Unlocked", InstanceAny);
+            var field = t.GetField("Unlocked", InstanceAny);
+            Assert.IsTrue(property != null || field != null,
+                "MapFeature.Unlocked not found as either property OR field — FuseProgressionImpactLookup's fallback chain breaks.");
+        }
+
+        // -----------------------------------------------------------------
+        // TrackSpan — FuseMapEnhancerCompat invalidates and rebuilds
+        // span caches by writing _cachedSegments and re-invoking the
+        // private UpdateCachedPointsIfNeeded method.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void TrackSpan_cachedSegments_InstanceField()
+        {
+            AssertField("Track.TrackSpan", "_cachedSegments", InstanceNonPublic);
+        }
+
+        [Test]
+        public void TrackSpan_UpdateCachedPointsIfNeeded_InstanceMethod()
+        {
+            AssertMethod("Track.TrackSpan", "UpdateCachedPointsIfNeeded", InstanceNonPublic);
+        }
+
+        // -----------------------------------------------------------------
+        // IndustryComponent / Industry / FormulaicIndustryComponent /
+        // RepairTrack — IndustryAPI's component-apply pipeline writes
+        // private fields directly on the appropriate subtype.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void IndustryComponent_cachedIndustry_InstanceField()
+        {
+            AssertField("Model.Ops.IndustryComponent", "_cachedIndustry", InstanceNonPublic);
+        }
+
+        [Test]
+        public void IndustryComponent_identifier_InstanceField()
+        {
+            AssertField("Model.Ops.IndustryComponent", "_identifier", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Industry_cachedComponents_InstanceField()
+        {
+            AssertField("Model.Ops.Industry", "_cachedComponents", InstanceNonPublic);
+        }
+
+        [Test]
+        public void FormulaicIndustryComponent_otherComponents_InstanceField()
+        {
+            AssertField("Model.Ops.FormulaicIndustryComponent", "_otherComponents", InstanceNonPublic);
+        }
+
+        [Test]
+        public void RepairTrack_repairPartsLoad_InstanceField()
+        {
+            // FUSE looks this up with NonPublic flags even though the
+            // field is treated as semi-public — match the production
+            // lookup exactly so an accessibility change is caught.
+            AssertField("Model.Ops.RepairTrack", "repairPartsLoad", InstanceNonPublic);
+        }
+
+        [Test]
+        public void IndustryContentHoverable_industry_InstanceField()
+        {
+            // LoaderAPI binds this backing reference when materialising
+            // hoverable industry content.
+            AssertField("Model.Ops.IndustryContentHoverable", "industry", InstanceNonPublic);
+        }
+
+        // -----------------------------------------------------------------
+        // MapFeatureManager / ProgressionManager / Progression / Section /
+        // InterchangeTransfer — ProgressionAPI rewrites private state on
+        // every progression apply.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void MapFeatureManager_features_InstanceField()
+        {
+            AssertField("Game.Progression.MapFeatureManager", "_features", InstanceNonPublic);
+        }
+
+        [Test]
+        public void MapFeatureManager_FeatureEnables_Property()
+        {
+            AssertProperty("Game.Progression.MapFeatureManager", "FeatureEnables", InstanceNonPublic);
+        }
+
+        [Test]
+        public void MapFeatureManager_HandleFeatureEnablesChanged_Method()
+        {
+            AssertMethod("Game.Progression.MapFeatureManager", "HandleFeatureEnablesChanged", InstanceNonPublic);
+        }
+
+        [Test]
+        public void ProgressionManager_progressions_InstanceField()
+        {
+            AssertField("Game.Progression.ProgressionManager", "_progressions", InstanceNonPublic);
+        }
+
+        [Test]
+        public void ProgressionManager_current_InstanceField()
+        {
+            AssertField("Game.Progression.ProgressionManager", "_current", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Progression_Sections_AutoPropertyBackingField()
+        {
+            // Compiler-generated backing field for an auto-property.
+            // If Railroader converts Sections to a manual backing field
+            // or a computed property, this name disappears.
+            AssertField("Game.Progression.Progression", "<Sections>k__BackingField", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Progression_UpdateSectionStates_Method()
+        {
+            AssertMethod("Game.Progression.Progression", "UpdateSectionStates", InstanceNonPublic);
+        }
+
+        [Test]
+        public void Section_InterchangeTransfers_AutoPropertyBackingField()
+        {
+            AssertField("Game.Progression.Section", "<InterchangeTransfers>k__BackingField", InstanceNonPublic);
+        }
+
+        [Test]
+        public void InterchangeTransfer_from_InstanceField()
+        {
+            AssertField("Game.Progression.InterchangeTransfer", "from", InstanceNonPublic);
+        }
+
+        [Test]
+        public void InterchangeTransfer_to_InstanceField()
+        {
+            AssertField("Game.Progression.InterchangeTransfer", "to", InstanceNonPublic);
+        }
+
+        // -----------------------------------------------------------------
+        // RiverBuilder / TelegraphPoleManager — SplineyAPI and MapAPI
+        // mutate private mesh/spline state.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void RiverBuilder_splineProfile_InstanceField()
+        {
+            AssertField("AutoTrestle.RiverBuilder", "splineProfile", InstanceNonPublic);
+        }
+
+        [Test]
+        public void TelegraphPoleManager_polePrefabs_InstanceField()
+        {
+            AssertField("TelegraphPoles.TelegraphPoleManager", "polePrefabs", InstanceNonPublic);
+        }
+
+        [Test]
+        public void TelegraphPoleManager_wirePrefab_InstanceField()
+        {
+            AssertField("TelegraphPoles.TelegraphPoleManager", "wirePrefab", InstanceNonPublic);
+        }
+
+        [Test]
+        public void TelegraphPoleManager_Rebuild_InstanceMethod()
+        {
+            AssertMethod("TelegraphPoles.TelegraphPoleManager", "Rebuild", InstanceNonPublic);
+        }
+
+        // -----------------------------------------------------------------
+        // CTCAutoSignal / Model.Car — patched targets in
+        // FuseRuntimeReferenceCleanupPatches and TrainControllerPatches.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void CTCAutoSignal_AspectForBlockAndNextSignal_Method()
+        {
+            var method = AccessTools.Method(RequireType("CTCAutoSignal"), "AspectForBlockAndNextSignal");
+            Assert.NotNull(method,
+                "CTCAutoSignal.AspectForBlockAndNextSignal not found — FuseRuntimeReferenceCleanupPatches cannot install.");
+        }
+
+        [Test]
+        public void ModelCar_GetCenterPosition_Method()
+        {
+            var method = AccessTools.Method(RequireType("Model.Car"), "GetCenterPosition");
+            Assert.NotNull(method,
+                "Model.Car.GetCenterPosition not found — TrainControllerPatches.CheckForCarsAtPointPatch cannot bind.");
+        }
+
+        // -----------------------------------------------------------------
+        // Helpers
+        // -----------------------------------------------------------------
+
+        private static Type RequireType(string fullName)
+        {
+            // Probe via AccessTools first because it walks all loaded
+            // assemblies — that matches FUSE's runtime behaviour when
+            // a type lives in a satellite assembly (Map.Runtime,
+            // TelegraphPoles, etc.) that isn't statically referenced
+            // by FUSE.csproj.
+            var type = AccessTools.TypeByName(fullName) ?? Type.GetType(fullName);
+
+            // If the fully-qualified name doesn't resolve (often because
+            // this file guessed the wrong namespace prefix), fall back to
+            // the leaf name — AccessTools.TypeByName searches by simple
+            // name across all loaded assemblies too. This keeps the test
+            // resilient against namespace drift in the FUSE source
+            // without becoming silent: if the type IS gone entirely, the
+            // leaf-name lookup fails the same way the full-name lookup
+            // did and the Assert below still fires.
+            if (type == null)
+            {
+                var dotIndex = fullName.LastIndexOf('.');
+                if (dotIndex >= 0 && dotIndex < fullName.Length - 1)
+                {
+                    type = AccessTools.TypeByName(fullName.Substring(dotIndex + 1));
+                }
+            }
+
+            Assert.NotNull(type,
+                $"Railroader type '{fullName}' was not loaded into the test AppDomain. " +
+                "Either Railroader renamed/moved the type, prepare_assets.ps1 didn't copy the assembly " +
+                "that contains it into Assets/Plugins/, or this test's expected namespace is wrong " +
+                "(check the FUSE source's actual reflection call site for the canonical name).");
+            return type;
+        }
+
+        private static void AssertField(string typeFullName, string memberName, BindingFlags flags)
+        {
+            var type = RequireType(typeFullName);
+            var field = type.GetField(memberName, flags);
+            Assert.NotNull(field,
+                $"Field '{typeFullName}.{memberName}' (flags={flags}) not found. " +
+                "FUSE caches this in a static FieldInfo; lookup returning null means subsequent " +
+                "SetValue/GetValue calls would NullReferenceException at first invocation. " +
+                "Either Railroader renamed the field or FUSE no longer needs this reflection — " +
+                "in the latter case, delete this test.");
+        }
+
+        private static void AssertMethod(string typeFullName, string memberName, BindingFlags flags)
+        {
+            var type = RequireType(typeFullName);
+            var method = type.GetMethod(memberName, flags);
+            Assert.NotNull(method,
+                $"Method '{typeFullName}.{memberName}' (flags={flags}) not found. " +
+                "FUSE caches this in a static MethodInfo; reflection invocation would " +
+                "NullReferenceException at first call.");
+        }
+
+        private static void AssertProperty(string typeFullName, string memberName, BindingFlags flags)
+        {
+            var type = RequireType(typeFullName);
+            var property = type.GetProperty(memberName, flags);
+            Assert.NotNull(property,
+                $"Property '{typeFullName}.{memberName}' (flags={flags}) not found. " +
+                "FUSE caches this in a static PropertyInfo; reflection access would " +
+                "NullReferenceException at first call.");
+        }
+    }
+}

--- a/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs.meta
+++ b/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 993654a284b54c6cbe9bf5bbea9f549e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/FUSE.UnityTests/Assets/Tests/SceneCloneApiSurfaceTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/SceneCloneApiSurfaceTests.cs
@@ -1,0 +1,350 @@
+using System.Linq;
+using FUSE.Runtime.API;
+using FUSE.Authoring.Data;
+using NUnit.Framework;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace FUSE.UnityTests
+{
+    /// <summary>
+    /// EditMode coverage for the rest of the <see cref="SceneCloneAPI"/>
+    /// public surface — Add/Update/Remove round-trips, lookup helpers,
+    /// validation throws, the snapshot-restore reapply path, and the
+    /// disabled-on-enable marker guard. SceneCloneApplyExecutorTests
+    /// covers the apply pipeline's transform-mutation contract; this
+    /// suite covers everything else that only Unity engine state can
+    /// exercise.
+    ///
+    /// All tests share the vanilla-bind path (Source == null) so they
+    /// don't need a real prefab to clone. The CloneFromSource branch
+    /// has its own apply-pipeline coverage in
+    /// SceneCloneApplyExecutorTests; this file deliberately stays on
+    /// the annotate-existing-target side of the planner because that's
+    /// where the lookup / lifecycle / validation logic lives.
+    /// </summary>
+    public class SceneCloneApiSurfaceTests
+    {
+        private const string Root = "World";
+        private const string SceneryGroup = "Large Scenery";
+        private const string Town = "Bryson";
+        private const string Leaf = "Freight House";
+        private const string SecondLeaf = "Coaling Tower";
+
+        private GameObject _world;
+        private GameObject _freightHouse;
+        private GameObject _coalingTower;
+
+        [SetUp]
+        public void SetUp()
+        {
+            EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+
+            _world = new GameObject(Root);
+            var largeScenery = new GameObject(SceneryGroup);
+            largeScenery.transform.SetParent(_world.transform, worldPositionStays: false);
+            var bryson = new GameObject(Town);
+            bryson.transform.SetParent(largeScenery.transform, worldPositionStays: false);
+            bryson.transform.localPosition = new Vector3(4200f, 528f, 5200f);
+
+            _freightHouse = new GameObject(Leaf);
+            _freightHouse.transform.SetParent(bryson.transform, worldPositionStays: false);
+            _freightHouse.transform.localPosition = new Vector3(202.36f, 1.0f, 210.45f);
+            _freightHouse.AddComponent<MeshRenderer>();
+
+            _coalingTower = new GameObject(SecondLeaf);
+            _coalingTower.transform.SetParent(bryson.transform, worldPositionStays: false);
+            _coalingTower.AddComponent<MeshRenderer>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_world != null)
+            {
+                Object.DestroyImmediate(_world);
+            }
+        }
+
+        private static string TargetOf(string leaf) => $"{Root}/{SceneryGroup}/{Town}/{leaf}";
+
+        [Test]
+        public void AddSceneClone_BlankId_Throws()
+        {
+            // Blank id must be rejected before any side effect — a
+            // marker without an id would be impossible to look up or
+            // remove later.
+            Assert.Throws<System.ArgumentException>(() =>
+                SceneCloneAPI.AddSceneClone("   ", new FuseSceneClone { TargetPath = TargetOf(Leaf), Enabled = true }));
+        }
+
+        [Test]
+        public void AddSceneClone_NullDefinition_Throws()
+        {
+            Assert.Throws<System.ArgumentNullException>(() =>
+                SceneCloneAPI.AddSceneClone("surface-test-null-definition", null));
+        }
+
+        [Test]
+        public void AddSceneClone_MissingTargetPath_Throws()
+        {
+            // The planner is happy with a blank TargetPath, but the
+            // executor's ApplyDefinition rejects it up front because
+            // there's nothing to bind to.
+            Assert.Throws<System.InvalidOperationException>(() =>
+                SceneCloneAPI.AddSceneClone("surface-test-blank-target", new FuseSceneClone { TargetPath = "  ", Enabled = true }));
+        }
+
+        [Test]
+        public void AddSceneClone_DuplicateId_Throws()
+        {
+            // The id is the primary key for the marker registry — a
+            // duplicate must fail loudly rather than overwrite silently
+            // (callers wanting update semantics use UpdateSceneClone).
+            const string id = "surface-test-duplicate-id";
+            SceneCloneAPI.AddSceneClone(id, new FuseSceneClone { TargetPath = TargetOf(Leaf), Enabled = true });
+
+            Assert.Throws<System.InvalidOperationException>(() =>
+                SceneCloneAPI.AddSceneClone(id, new FuseSceneClone { TargetPath = TargetOf(Leaf), Enabled = true }));
+        }
+
+        [Test]
+        public void GetSceneClone_AfterAdd_ReturnsAnnotatedTarget()
+        {
+            const string id = "surface-test-get-roundtrip";
+            SceneCloneAPI.AddSceneClone(id, new FuseSceneClone { TargetPath = TargetOf(Leaf), Enabled = true });
+
+            var found = SceneCloneAPI.GetSceneClone(id);
+            Assert.AreSame(_freightHouse, found,
+                "GetSceneClone must return the vanilla GameObject the marker was attached to.");
+        }
+
+        [Test]
+        public void GetSceneClone_CaseInsensitiveId_Matches()
+        {
+            // The marker's id comparison uses OrdinalIgnoreCase so
+            // authors typing the same id with inconsistent casing
+            // across files don't silently produce two phantom clones.
+            const string id = "surface-test-case-insensitive";
+            SceneCloneAPI.AddSceneClone(id, new FuseSceneClone { TargetPath = TargetOf(Leaf), Enabled = true });
+
+            var found = SceneCloneAPI.GetSceneClone(id.ToUpperInvariant());
+            Assert.AreSame(_freightHouse, found);
+        }
+
+        [Test]
+        public void GetSceneClone_UnknownId_ReturnsNull()
+        {
+            Assert.IsNull(SceneCloneAPI.GetSceneClone("surface-test-no-such-id"));
+            Assert.IsNull(SceneCloneAPI.GetSceneClone("   "));
+            Assert.IsNull(SceneCloneAPI.GetSceneClone(null));
+        }
+
+        [Test]
+        public void GetAllSceneClones_EnumeratesEveryMarker()
+        {
+            const string firstId = "surface-test-enum-first";
+            const string secondId = "surface-test-enum-second";
+            SceneCloneAPI.AddSceneClone(firstId, new FuseSceneClone { TargetPath = TargetOf(Leaf), Enabled = true });
+            SceneCloneAPI.AddSceneClone(secondId, new FuseSceneClone { TargetPath = TargetOf(SecondLeaf), Enabled = true });
+
+            var all = SceneCloneAPI.GetAllSceneClones().ToList();
+            Assert.Contains(_freightHouse, all);
+            Assert.Contains(_coalingTower, all);
+            Assert.AreEqual(2, all.Count,
+                "GetAllSceneClones must surface every marker-bearing GameObject in the scene.");
+        }
+
+        [Test]
+        public void TryGetSceneCloneInfo_ForMarkerBearingObject_ReturnsIdAndTarget()
+        {
+            const string id = "surface-test-try-get-info";
+            var target = TargetOf(Leaf);
+            SceneCloneAPI.AddSceneClone(id, new FuseSceneClone { TargetPath = target, Enabled = true });
+
+            var ok = SceneCloneAPI.TryGetSceneCloneInfo(_freightHouse, out var foundId, out var foundTarget);
+            Assert.IsTrue(ok);
+            Assert.AreEqual(id, foundId);
+            Assert.AreEqual(target, foundTarget);
+        }
+
+        [Test]
+        public void TryGetSceneCloneInfo_ForUnmarkedObject_ReturnsFalse()
+        {
+            // A vanilla GameObject without a FUSE marker must report
+            // false so diagnostic callers don't fabricate fake ids for
+            // base-game objects under the cursor.
+            var ok = SceneCloneAPI.TryGetSceneCloneInfo(_coalingTower, out var id, out var target);
+            Assert.IsFalse(ok);
+            Assert.IsNull(id);
+            Assert.IsNull(target);
+        }
+
+        [Test]
+        public void TryGetSceneCloneInfo_NullGameObject_ReturnsFalse()
+        {
+            var ok = SceneCloneAPI.TryGetSceneCloneInfo(null, out var id, out var target);
+            Assert.IsFalse(ok);
+            Assert.IsNull(id);
+            Assert.IsNull(target);
+        }
+
+        [Test]
+        public void GetDefinition_ReflectsLiveTransformState()
+        {
+            // GetDefinition is the "what does the live scene currently
+            // say about this clone?" reader the authoring UI uses to
+            // populate edit forms. It must read the live transform,
+            // not just echo the cached definition — otherwise a user
+            // who nudged the object in the scene view would see the
+            // pre-nudge values when reopening the form.
+            const string id = "surface-test-get-definition-live";
+            SceneCloneAPI.AddSceneClone(id, new FuseSceneClone { TargetPath = TargetOf(Leaf), Enabled = true });
+
+            // Mutate live state AFTER the clone is bound.
+            _freightHouse.transform.localPosition = new Vector3(11f, 22f, 33f);
+            _freightHouse.transform.localScale = new Vector3(3f, 3f, 3f);
+
+            var definition = SceneCloneAPI.GetSceneCloneDefinition(id);
+            Assert.NotNull(definition);
+            Assert.AreEqual(11f, definition.LocalPosition.Value.x, delta: 0.001f);
+            Assert.AreEqual(33f, definition.LocalPosition.Value.z, delta: 0.001f);
+            Assert.AreEqual(3f, definition.LocalScale.Value.x, delta: 0.001f);
+            Assert.AreEqual(true, definition.Enabled);
+            Assert.AreEqual(TargetOf(Leaf), definition.TargetPath);
+        }
+
+        [Test]
+        public void UpdateSceneClone_RewritesTransformOverrides()
+        {
+            // Update is the API the editor calls when a user edits an
+            // existing scene clone. It must NOT throw the
+            // "already exists" guard that AddSceneClone enforces, and
+            // it must apply the new overrides to the bound transform.
+            const string id = "surface-test-update-overrides";
+            SceneCloneAPI.AddSceneClone(id, new FuseSceneClone { TargetPath = TargetOf(Leaf), Enabled = true });
+
+            SceneCloneAPI.UpdateSceneClone(id, new FuseSceneClone
+            {
+                TargetPath = TargetOf(Leaf),
+                Enabled = true,
+                LocalPosition = new Vector3(99f, 0.5f, -100f)
+            });
+
+            var afterPos = _freightHouse.transform.localPosition;
+            Assert.AreEqual(99f, afterPos.x, delta: 0.001f);
+            Assert.AreEqual(-100f, afterPos.z, delta: 0.001f);
+        }
+
+        [Test]
+        public void TryRemoveSceneClone_OnExistingClone_ReturnsTrue_AndDropsIdFromLookup()
+        {
+            const string id = "surface-test-try-remove-existing";
+            SceneCloneAPI.AddSceneClone(id, new FuseSceneClone { TargetPath = TargetOf(SecondLeaf), Enabled = true });
+
+            var ok = SceneCloneAPI.TryRemoveSceneClone(id);
+            Assert.IsTrue(ok);
+            // Object.Destroy is deferred in EditMode, so we don't
+            // assert the GameObject itself is null — instead assert
+            // the public contract: GetSceneClone no longer surfaces
+            // the id, because the marker is either destroyed or
+            // marker.gameObject == null (Unity's fake-null on the
+            // pending-destroy reference).
+            Assert.IsNull(SceneCloneAPI.GetSceneClone(id));
+        }
+
+        [Test]
+        public void TryRemoveSceneClone_OnMissingId_ReturnsFalse_WithoutThrowing()
+        {
+            // The Try-prefixed variant is the "no exception" contract
+            // — the FUSE world-removal pipeline calls this once per
+            // package mandela on uninstall, and a missing clone
+            // (already removed, never installed) must not crash the
+            // uninstall.
+            var ok = SceneCloneAPI.TryRemoveSceneClone("surface-test-no-such-clone");
+            Assert.IsFalse(ok);
+        }
+
+        [Test]
+        public void RemoveSceneClone_OnMissingId_Throws()
+        {
+            // The non-Try variant is the imperative API — callers who
+            // believe a clone exists want a loud failure if it
+            // doesn't, not a silent no-op.
+            Assert.Throws<System.InvalidOperationException>(() =>
+                SceneCloneAPI.RemoveSceneClone("surface-test-no-such-clone-imperative"));
+        }
+
+        [Test]
+        public void ReapplyEnabledFromCache_RestoresDisabledState_WhenCacheDivergesFromLive()
+        {
+            // The snapshot-restore path: a savegame load reactivates
+            // every GameObject in the world, but FUSE-disabled clones
+            // must come back disabled. ReapplyEnabledFromCache walks
+            // every marker, consults the cached definition, and
+            // re-applies the desired active state.
+            //
+            // To exercise the divergence-correction without fighting
+            // the marker's OnEnable guard (which has its own test
+            // below), we set up a clone that's currently active and
+            // then poke the cache directly to say it SHOULD be
+            // disabled. Reapply must reconcile to the cache.
+            const string id = "surface-test-reapply-cache-wins";
+            SceneCloneAPI.AddSceneClone(id, new FuseSceneClone { TargetPath = TargetOf(Leaf), Enabled = true });
+            Assert.IsTrue(_freightHouse.activeSelf,
+                "Sanity: AddSceneClone with Enabled=true leaves the target active.");
+
+            // Rewrite the cache behind the marker's back to model a
+            // saved-state snapshot whose recorded mandela is
+            // disabled, even though the live scene came up active.
+            FuseRuntimeDefinitionCache.Store(FuseDefinitionKind.SceneClone, id,
+                new FuseSceneClone { TargetPath = TargetOf(Leaf), Enabled = false });
+
+            var reapplied = SceneCloneAPI.ReapplyEnabledFromCache("unit-test");
+            Assert.That(reapplied, Is.GreaterThanOrEqualTo(1),
+                "ReapplyEnabledFromCache must report at least one clone whose live state was flipped.");
+            Assert.IsFalse(_freightHouse.activeSelf,
+                "After reapply, the cached Enabled=false must dominate the live active state.");
+        }
+
+        [Test]
+        public void ReapplyEnabledFromCache_LeavesCloneAlone_WhenCachedEnabledIsNull()
+        {
+            // The early-return contract: a definition with Enabled
+            // null is a "don't touch active state" mandela. Reapply
+            // must skip those entirely — neither flipping the live
+            // state nor counting it as reapplied.
+            const string id = "surface-test-reapply-null-enabled-noop";
+            SceneCloneAPI.AddSceneClone(id, new FuseSceneClone { TargetPath = TargetOf(Leaf) /* Enabled deliberately null */ });
+            var wasActive = _freightHouse.activeSelf;
+
+            var reapplied = SceneCloneAPI.ReapplyEnabledFromCache("unit-test-noop");
+            Assert.AreEqual(0, reapplied,
+                "Clones with cached Enabled=null must not be counted as reapplied.");
+            Assert.AreEqual(wasActive, _freightHouse.activeSelf,
+                "Clones with cached Enabled=null must keep their pre-reapply active state.");
+        }
+
+        [Test]
+        public void MarkerGuard_AutoRedisables_AfterManualReactivate()
+        {
+            // The FuseSceneCloneMarker.OnEnable guard is the in-scene
+            // failsafe that catches a SetActive(true) from any source
+            // (savegame restore, SetActive call from another mod, etc.)
+            // on a clone the package author wanted hidden. The cached
+            // DesiredEnabled = false on the marker drives the guard;
+            // we test it by adding a disabled clone, force-activating
+            // the bound GameObject, and asserting the guard bounces it
+            // back to inactive synchronously.
+            const string id = "surface-test-marker-guard";
+            SceneCloneAPI.AddSceneClone(id, new FuseSceneClone { TargetPath = TargetOf(Leaf), Enabled = false });
+            Assert.IsFalse(_freightHouse.activeSelf);
+
+            _freightHouse.SetActive(true);
+
+            Assert.IsFalse(_freightHouse.activeSelf,
+                "Marker's OnEnable guard must re-deactivate a clone the author disabled.");
+        }
+    }
+}

--- a/FUSE.UnityTests/Assets/Tests/SceneCloneApiSurfaceTests.cs.meta
+++ b/FUSE.UnityTests/Assets/Tests/SceneCloneApiSurfaceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92febcaab46141be827c9077b2471f76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/FUSE.UnityTests/README.md
+++ b/FUSE.UnityTests/README.md
@@ -16,7 +16,11 @@ against an actual Unity scene graph.
 | Test file | Coverage |
 |---|---|
 | `Assets/Tests/SceneCloneApplyExecutorTests.cs` | An `{ enabled: true }` mandela on a vanilla wrapper with non-zero `localPosition` must leave the position untouched (the Bryson Freight House regression). Plus enabled/disabled active-state, partial overrides (scale-only, etc.), and the touchless null-enabled case. |
+| `Assets/Tests/SceneCloneApiSurfaceTests.cs` | The rest of the `SceneCloneAPI` public surface: Add/Update/Remove round-trips, validation throws (blank id, null definition, missing target, duplicate id), `GetSceneClone` / `GetAllSceneClones` / `TryGetSceneCloneInfo` lookups, `GetDefinition` reading live transform state, `ReapplyEnabledFromCache` reconciling cache-vs-live divergence (and its no-op path for `Enabled = null`), and the marker's `OnEnable` guard auto-re-disabling a force-reactivated clone. |
 | `Assets/Tests/FindChildIntegrationTests.cs` | Duplicate-named-sibling disambiguation: content-bearing wins, tie-break by sibling order, exact match beats case-insensitive, null when no match. Drives the real `Transform`-walking wrapper, not just the pure resolver. |
+| `Assets/Tests/PrefabResolverUriTests.cs` | `FusePrefabResolver.Resolve(uri)` scheme dispatch (`empty://`, `path://` with/without `scene/` prefix, case-insensitive scheme) and validation throws (unknown scheme, missing `://` separator, null/blank). Plus the `ResolveScenePath` edge cases the FindChild suite doesn't hit (blank input, root-only path, exact-vs-case-insensitive root match). |
+| `Assets/Tests/HarmonyPatchInstallationTests.cs` | Harmony's full installation pipeline against `FuseAssetPackPatchHelpers.Assembly` — every prefix/postfix signature must match its target's parameters, no patch class can crash during apply. Plus an end-to-end drive of the `FuseAggregateLoadModelMaterialFieldPatch` prefix against a malformed `MaterialDefinition` to prove the patch actually intercepts the live game type. |
+| `Assets/Tests/RailroaderReflectionSurfaceTests.cs` | Regression canary for every Railroader private/internal member FUSE accesses by **name string** via reflection. One `[Test]` per `(type, member, BindingFlags)` tuple across ~25 game types (`PassengerStop`, `Turntable`, `Graph`, `StationAgent`, `MapLabel`/`MapStore`/`MapManager`, `AssetPackRuntimeStore`, `PrefabStore`, `CarInspector`, `MapFeature`, `TrackSpan`, `Industry`/`IndustryComponent`/`FormulaicIndustryComponent`/`RepairTrack`/`IndustryContentHoverable`, `MapFeatureManager`/`ProgressionManager`/`Progression`/`Section`/`InterchangeTransfer`, `RiverBuilder`, `TelegraphPoleManager`, `CTCAutoSignal`, `Model.Car`, `ContainerSerialization`). When a Railroader patch renames or moves a field FUSE depends on, the test goes red immediately and pinpoints exactly which member is gone — instead of the rename surfacing as a silent NRE in someone's playthrough months later. **When you add a new reflection-by-name accessor anywhere in FUSE, add a matching `[Test]` here.** |
 
 ## How to run locally
 
@@ -92,3 +96,9 @@ hiccup never blocks a PR.
 - Not a substitute for the xUnit suite. The xUnit suite is the fast
   feedback loop (under 3 seconds for 634 tests); EditMode tests are
   the slow, thorough backstop.
+- Not a substitute for true end-to-end testing against a live
+  Railroader session. The reflection canary catches *member-renamed*
+  drift; behavioural drift (e.g. a game patch that keeps `_spans` the
+  same name and type but changes WHEN it gets re-read) still needs
+  the in-game harness tracked in
+  [FuseDevelopmentGroup#16](https://github.com/F-U-S-E-E/FuseDevelopmentGroup/issues/16).


### PR DESCRIPTION
## 🔗 Related Issue

Related to [FuseDevelopmentGroup#16](https://github.com/F-U-S-E-E/FuseDevelopmentGroup/issues/16). That issue tracks the eventual AHK-driven golden-master harness for pushing past the xUnit ceiling; this PR takes the smaller, immediately-achievable step in the same spirit — drives FUSE.UnityTests' EditMode suite from 16 → 107 tests so we catch more regressions at CI time before they need a full game session to surface.

## 📝 Description of the Change

Adds three new EditMode test files (~91 tests total) and refreshes the FUSE.UnityTests README catalogue.

| File | Tests | Coverage |
|---|---|---|
| `SceneCloneApiSurfaceTests.cs` | 19 | The rest of `SceneCloneAPI` outside the apply executor — `Add`/`Update`/`Remove` round-trips, validation throws (blank id, null definition, missing target, duplicate id), `GetSceneClone` / `GetAllSceneClones` / `TryGetSceneCloneInfo` lookups, `GetDefinition` reading live transform state, `ReapplyEnabledFromCache` reconciling cache-vs-live divergence (and its no-op path for `Enabled = null`), and the `FuseSceneCloneMarker.OnEnable` guard auto-re-disabling a force-reactivated clone. |
| `PrefabResolverUriTests.cs` | 12 | `FusePrefabResolver.Resolve(uri)` scheme dispatch (`empty://`, `path://` with and without `scene/` prefix, case-insensitive scheme) plus validation throws (unknown scheme, missing `://` separator, null/blank) and the `ResolveScenePath` edge cases the FindChild suite doesn't hit (blank input, root-only path, exact-vs-case-insensitive root match). |
| `RailroaderReflectionSurfaceTests.cs` | ~60 | Regression canary for every Railroader private/internal member FUSE accesses by **name string** via reflection. One `[Test]` per `(type, member, BindingFlags)` tuple across ~25 game types (`PassengerStop`, `Turntable`, `Graph`, `StationAgent`, `MapLabel`/`MapStore`/`MapManager`, `AssetPackRuntimeStore`, `PrefabStore`, `CarInspector`, `MapFeature`, `TrackSpan`, `Industry` family, progression types, `RiverBuilder`, `TelegraphPoleManager`, `CTCAutoSignal`, `Model.Car`, `ContainerSerialization`). Each assertion uses the exact `BindingFlags` FUSE itself uses, so a Railroader patch that flips access modifiers or renames a field surfaces here at CI time instead of as a silent `NullReferenceException` in someone's playthrough. |

The reflection canary is the headline value: when Railroader ships a patch that renames `PassengerStop._spans` or `StationAgent.area` or any of the ~60 other members FUSE caches in static `FieldInfo`/`MethodInfo`/`PropertyInfo` fields, FUSE today fails late and silently (the cached lookup returns `null`, and the `?.SetValue(...)` call no-ops or NREs at first invocation). This suite gives us a precise, actionable failure at CI time: it pinpoints exactly which member is gone instead of producing a runtime stack trace someone has to triage.

## 🔄 Alternatives Considered

- **Full behavioural integration tests for `FusePassengerStopComponent` / `TurntableAPI` / `SceneryAPI`.** These would require either (a) stubbing `Graph.Shared` / `TimetableController.Shared` / `MapFeatureManager.Shared` via reflection, or (b) the "testability refactor" Issue #16 lists as a fallback (introducing `IGameWorld` etc.). Both are real per-API investigations rather than "a few more tests" — deferred. The reflection canary catches the same shape-drift class (Railroader-private-API changes) without that investment.
- **Field-TYPE assertions** on the canary (`FieldType.FullName` equality). Would catch the case where Railroader keeps `_spans` named the same but flips its type from `TrackSpan[]` to `List<TrackSpan>`. That failure mode is already loud at runtime (`ArgumentException` from `SetValue`), unlike the silent-null one the name canary catches, so deprioritised. Easy to add later if drift turns out to bite us.
- **Implementing the `/fuse.smoketest` console command + AHK harness from #16.** Out of scope for one PR — needs self-hosted runner provisioning, fixture authoring, and Steam-in-offline-mode setup. This PR is the EditMode-side counterpart to that work; the two strategies are complementary, not exclusive.

## ⚠️ Possible Drawbacks

- **None of the new tests are runtime-verified against Unity 2022.3.62f2.** They build against `FUSE.dll` cleanly (rebuilt + verified during development), but no headless EditMode run happened — the dev environment only had Unity 6000.4.6f1, which is well outside the 2022.3.x line the test project pins. First contributor with the right Unity version should run `prepare_assets.ps1` + the EditMode suite and surface any breakage. If a few `RequireType("...")` lookups fail because I guessed the wrong namespace, the helper already falls back to a leaf-name lookup so the test should still resolve the type in most cases — the failure message tells you what to fix.
- **New maintenance contract.** When someone adds a new reflection-by-name accessor anywhere in FUSE (`typeof(GameType).GetField("...", flags)` or `AccessTools.Field(...)`), they must also add a `[Test]` to `RailroaderReflectionSurfaceTests.cs`. The class comment and the README catalogue both call this out.
- **No save format changes.** Tests only; fully backwards compatible.

## ✅ Verification Process

- `dotnet build FUSE/FUSE.csproj -c Release` — clean, 0 warnings, 0 errors.
- Self-review of each new test against the production reflection site in FUSE source (spot-checked `ProgressionAPI.cs:22-37`, `TurntableAPI.cs:19-22`, `IndustryAPI.cs:24-61`, `MapAPI.cs:26-29`, `FusePassengerStopComponent.cs:20-23`, `FuseMapTileRegistry.cs:16-17` to confirm `BindingFlags` match what FUSE uses).
- New tests follow the existing fixture style (Bryson hierarchy, distinct test ids to avoid `FuseRuntimeDefinitionCache` collisions, "why this test exists" comments explaining the regression context).
- **Not done**: a headless EditMode pass. Requires Unity 2022.3.62f2 install — see Possible Drawbacks above. The reflection canary in particular is sensitive to namespace guesses; if any go red on first run with a "Railroader type 'X' was not loaded" message, the failure message points at the right fix.

## 💡 Additional Information

After this lands: `FUSE.UnityTests` is at **107 EditMode tests** (16 → 107, ~6.7x growth). The reflection canary is structured so that when Railroader patches the game and breaks one of the ~60 pinned members, the failure log names the exact `(type, member, BindingFlags)` tuple — making the fix a `grep` for the old name across the FUSE source.