### PR TITLE
fix: rebind StationAgent.passengerStop after PassengerStop refresh

### DIFF
--- a/FUSE/Runtime/API/FusePassengerStopComponent.cs
+++ b/FUSE/Runtime/API/FusePassengerStopComponent.cs
@@ -199,10 +199,12 @@ namespace FUSE.Runtime.API
             PassengerStopSpansField?.SetValue(passengerStop, boundSpans);
             PassengerStopMarkersField?.SetValue(passengerStop, RebuildPassengerStopMarkers(passengerStop.transform, boundSpans));
             var cacheCount = RefreshPassengerStopCache();
+            var reboundAgents = StationAPI.RebindStationAgentsForPassengerStop(passengerStop);
             FuseLog.Info(
                 $"FUSE passenger stop refreshed id='{stopIdentifier}' " +
                 $"component='{Identifier}' spanCount={boundSpans.Length} " +
-                $"loadId='{PassengerLoad.id ?? string.Empty}' cacheCount={cacheCount}.");
+                $"loadId='{PassengerLoad.id ?? string.Empty}' cacheCount={cacheCount} " +
+                $"reboundStationAgents={reboundAgents}.");
         }
 
         private List<TrackSpan> ResolveBoundSpans()

--- a/FUSE/Runtime/API/StationAPI.cs
+++ b/FUSE/Runtime/API/StationAPI.cs
@@ -90,6 +90,68 @@ namespace FUSE.Runtime.API
             return UnityEngine.Object.FindObjectsOfType<StationAgent>(true);
         }
 
+        /// <summary>
+        /// Re-binds StationAgent.passengerStop on every FUSE-tracked station whose
+        /// stored definition references <paramref name="stop"/>'s identifier.
+        ///
+        /// FusePassengerStopComponent.RefreshPassengerStop destroys and recreates
+        /// the PassengerStop on every GraphRebuilt. The depot's StationAgent
+        /// keeps a Unity-null C# reference to the destroyed instance, so the
+        /// vanilla StationWindow.Populate check `passengerStop != null` evaluates
+        /// false and silently drops the Passengers tab. This helper is the
+        /// re-bind step the refresh path was missing.
+        /// </summary>
+        internal static int RebindStationAgentsForPassengerStop(PassengerStop stop)
+        {
+            if (stop == null || PassengerStopField == null)
+            {
+                return 0;
+            }
+
+            var stopId = stop.identifier;
+            if (string.IsNullOrWhiteSpace(stopId))
+            {
+                return 0;
+            }
+
+            var rebound = 0;
+            foreach (var cached in FuseStationRuntimeIndex.Instance.Values)
+            {
+                var agent = cached as StationAgent;
+                if (agent == null)
+                {
+                    continue;
+                }
+
+                var agentId = agent.name;
+                if (string.IsNullOrWhiteSpace(agentId))
+                {
+                    continue;
+                }
+
+                if (!FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.Station, agentId, out FuseStation definition) || definition == null)
+                {
+                    continue;
+                }
+
+                if (!string.Equals(definition.PassengerStopId, stopId, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var current = PassengerStopField.GetValue(agent) as PassengerStop;
+                if (ReferenceEquals(current, stop))
+                {
+                    continue;
+                }
+
+                PassengerStopField.SetValue(agent, stop);
+                rebound++;
+            }
+
+            return rebound;
+        }
+
         public static PassengerStop GetPassengerStop(string id)
         {
             return !string.IsNullOrWhiteSpace(id)


### PR DESCRIPTION
## 🔗 Related Issue

None — reported in chat ("custom stations like this one don't have the 'passenger' tab", screenshot of Katers.TuckasegeeSteelWorks' depot showing only Freight).

## 📝 Description of the Change

Vanilla `StationWindow.Populate` only shows the **Passengers** tab when the caller passes a non-null `passengerStop`. That value comes straight from the serialized `StationAgent.passengerStop` field, read in `StationAgent.Activate` at click time.

For FUSE-managed stations, `StationAPI.ApplyDefinition` reflection-writes the matching `PassengerStop` into that field at apply time, and that worked. **The problem:** `FusePassengerStopComponent.RefreshPassengerStop` does `DestroyImmediate(oldStop)` and constructs a fresh `PassengerStop` on every `GraphRebuilt`. Nothing re-syncs the bound StationAgents afterward, so their `passengerStop` C# reference points at a destroyed Unity object. Unity's overloaded `==` then makes `passengerStop != null` evaluate `false`, and `StationWindow.Populate` silently drops the Passengers tab.

This was confirmed in `FUSE.log` against Katers.TuckasegeeSteelWorks:

```
15:01:32.348  TSWStation passenger stop refreshed   (creates instance #1)
15:01:32.369  TSWStation passenger stop refreshed   (destroys #1, creates #2)
15:01:32.391  OKatTSW_wh1a station applied → binds passengerStop = #2  ✓
15:01:34.720  OKatTSW_wh1a re-applied (replay)
15:01:45.953  TSWStation passenger stop refreshed   ← destroys #2, NO rebind from here on
15:01:52.134  TSWStation passenger stop refreshed   ...many more
```

The fix adds the missing re-bind step:

- **`StationAPI.RebindStationAgentsForPassengerStop(PassengerStop stop)`** — walks `FuseStationRuntimeIndex`, looks up each agent's stored `FuseStation` via `FuseRuntimeDefinitionCache`, and reflection-writes the fresh `stop` into agents whose definition's `PassengerStopId` matches. Skips Unity-null cache entries and agents already pointing at the new instance.
- **`FusePassengerStopComponent.RefreshPassengerStop`** calls the helper right after `RefreshPassengerStopCache()` and surfaces the rebind count in the existing INFO log line.

No new state, no new event subscriptions — uses the two indexes that already track this data and are already cleared on world reload.

## 🔄 Alternatives Considered

**Mutate the existing PassengerStop in place** instead of destroy + recreate. Rejected because the existing destroy-and-recreate path may be working around hidden invariants (asset-pack reload ordering etc.), and rewriting it would also incidentally change waiting-passenger queue behavior (currently reset on each refresh) — a much larger blast radius for what's a narrow rebinding bug. Left as a possible future cleanup if we ever investigate why the destroy/recreate exists in the first place.

**Patch `StationAgent.Activate` to re-resolve at click time.** Rejected: requires us to remember the previous identifier somewhere off the StationAgent, and reaches into more vanilla surface than necessary.

## ⚠️ Possible Drawbacks

- The helper iterates `FuseStationRuntimeIndex.Instance.Values` (O(FUSE-managed stations), typically dozens) once per passenger-stop refresh. `RefreshPassengerStop` only fires on `GraphRebuilt`, not per-frame, so cost is negligible.
- No save-format change. Backwards compatible with existing saves.
- The destroy/recreate lifecycle in `RefreshPassengerStop` is intentionally untouched — if there's a related issue with passenger queue state being reset, this PR neither introduces nor addresses it.
- `FusePrefabSanitizer.RelinkStationAgent` (the startup bind path) is untouched.

## ✅ Verification Process

- `dotnet build FUSE/FUSE.csproj` — clean, 0 warnings.
- `dotnet test FUSE.Tests/FUSE.Tests.csproj` — 721 passed, 0 failed (xUnit coverage doesn't include Unity-dependent code; the helper and its call site are Unity-side, so unit-testable surface didn't change).
- In-game verification path:
  1. Load a save with a passenger-stop mod (e.g. `Katers.TuckasegeeSteelWorks`).
  2. Grep `FUSE.log` for `id='TSWStation'`. Every `passenger stop refreshed` line now ends with `reboundStationAgents=N`. The first two during initial apply read `0` (StationAgent doesn't exist yet); every refresh after `15:01:34.720` should read `1`.
  3. Click the depot at Tuckasegee Steel Works — both **Passengers** and **Freight** tabs should render.
  4. Trigger more graph rebuilds (track edit / save / etc.) and re-open the window — Passengers tab should persist.

## 💡 Additional Information

The helper is `internal` rather than `public` — it's plumbing between `FusePassengerStopComponent` and `StationAPI`, not a stable mod-facing API. Easy to promote later if a need surfaces.