### PR TITLE
fix(loader): tolerate malformed legacy area tagColor + out-of-range span endpoints

### DIFF
--- a/FUSE/Loading/FuseLegacyDataConverter.World.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.World.cs
@@ -347,11 +347,58 @@ namespace FUSE.Loading
                 ["name"] = ReadString(item, "name") ?? id,
                 ["position"] = Vector(item["localPosition"] ?? item["position"], false),
                 ["radius"] = Clone(item["radius"]),
-                ["tagColor"] = Clone(item["tagColor"] ?? item["TagColor"]),
+                ["tagColor"] = NormalizeAreaTagColor(id, item["tagColor"] ?? item["TagColor"]),
                 ["order"] = Clone(item["order"]),
                 ["spanIds"] = ToStringArray(item["spanIds"] ?? item["spans"]),
                 ["groupId"] = ReadString(item, "groupId", "GroupId")
             });
+        }
+
+        /// <summary>
+        /// Coerces a legacy <c>tagColor</c> value into the 3- or 4-element
+        /// RGB / RGBA shape FUSE's schema validator requires. A handful of
+        /// legacy mods (Graham County, Macon County) shipped 6-element
+        /// arrays by accidentally concatenating two RGB triples; trim
+        /// those down. Sub-3 arrays get zero-padded so we never reject
+        /// the package on a malformed color when the data IS otherwise
+        /// loadable. Anything that isn't an array passes through —
+        /// the runtime treats non-array tagColor as the default tint.
+        /// </summary>
+        private static JToken NormalizeAreaTagColor(string areaId, JToken value)
+        {
+            var cloned = Clone(value);
+            if (!(cloned is JArray arr))
+            {
+                return cloned;
+            }
+
+            if (arr.Count >= 3 && arr.Count <= 4)
+            {
+                return arr;
+            }
+
+            if (arr.Count > 4)
+            {
+                FuseLog.Info(
+                    $"FUSE legacy converter: area '{areaId}' tagColor has {arr.Count} values; " +
+                    $"FUSE accepts 3 or 4. Truncated to the first 3 values to keep the package loadable.");
+                var truncated = new JArray();
+                for (int i = 0; i < 3; i++) truncated.Add(arr[i].DeepClone());
+                return truncated;
+            }
+
+            if (arr.Count > 0)
+            {
+                FuseLog.Warning(
+                    $"FUSE legacy converter: area '{areaId}' tagColor has only {arr.Count} value(s); " +
+                    $"FUSE requires 3 or 4. Padded with zeros to length 3 to keep the package loadable.");
+                var padded = new JArray();
+                foreach (var item in arr) padded.Add(item.DeepClone());
+                while (padded.Count < 3) padded.Add(0.0);
+                return padded;
+            }
+
+            return arr;
         }
 
         private static JObject ConvertIndustry(string id, JObject item, string areaId)

--- a/FUSE/Runtime/API/TrackAPI.Graph.cs
+++ b/FUSE/Runtime/API/TrackAPI.Graph.cs
@@ -260,10 +260,23 @@ namespace FUSE.Runtime.API
             var segmentLength = segment.GetLength();
             var distance = definition.Distance ?? ((definition.Normalized ?? 0f) * segmentLength);
             distance += definition.Offset;
+
+            // Out-of-range distances used to throw and kill the whole
+            // apply phase; legacy AlinasMapMod tolerated them and so do
+            // we now. Log the clamp so the package owner can see the
+            // recovery happened, then fall through to the same
+            // Mathf.Clamp the well-formed path already runs. The
+            // downstream span-endpoint pair validator still gets a
+            // chance to re-anchor / reject if the clamped pair is
+            // structurally degenerate.
             if (distance < -SpanDistanceTolerance || distance > segmentLength + SpanDistanceTolerance)
             {
-                throw new InvalidOperationException(
-                    $"Track location on segment '{definition.SegmentId}' is outside the segment length. distance={distance:0.###}, segmentLength={segmentLength:0.###}, end='{definition.End ?? "A"}'.");
+                var clamped = Mathf.Clamp(distance, 0f, segmentLength);
+                FuseLog.Info(
+                    $"FUSE auto-repaired track location on segment '{definition.SegmentId}': " +
+                    $"distance {distance:0.###} outside segment length {segmentLength:0.###} (end='{definition.End ?? "A"}'); " +
+                    $"clamped to {clamped:0.###} to keep the package loadable.");
+                distance = clamped;
             }
 
             return new Location(


### PR DESCRIPTION
## Summary

Two recovery-path fixes for the runtime legacy converter. Both faults are pre-existing on `main` (not caused by any in-flight branch); surfaced by `JR.MaconCounty` and `RZ.GCR` failing to load.

- `FuseLegacyDataConverter.World.ConvertArea` — adds `NormalizeAreaTagColor` for malformed `tagColor` arrays. Several legacy mods ship 6-value arrays (concatenated RGB triples); the runtime previously passed them through unchanged and the FUSE validator rejected the whole package. Now: truncate >4 to first 3 (info entry), pad sub-3 to 3 with zeros (warning), pass 3-4 through unchanged.
- `TrackAPI.Graph.MakeLocation` — replaces the out-of-range throw with a clamp + info log. Legacy AlinasMapMod tolerated these; FUSE used to kill the whole apply phase. The downstream span-endpoint-pair validator (which already re-anchors crossed / same-direction endpoints) now gets a chance to run on a recovered Location instead of dying at the throw.

Both fixes are entirely inline inside `FUSE/Loading/` and `FUSE/Runtime/API/`. No reference to `FUSE.Converter` (the editor's one-time converter and this runtime converter stay independent by design).

## Observed faults this PR resolves

```
[ERROR] FUSE validation error package='JR.MaconCounty.FUSE.al-ms' kind='tracks.areas.Welch.tagColor' message='Area tagColor must contain 3 or 4 values.' value='6'.
[ERROR] FUSE validation error package='JR.MaconCounty.FUSE.al-ms' kind='tracks.areas.Lauada.tagColor' value='6'.
[ERROR] FUSE validation error package='JR.MaconCounty.FUSE.al-ms' kind='tracks.areas.MarpleSprings.tagColor' value='6'.
[ERROR] FUSE validation error package='RZ.GCR.FUSE.gcr-industries' kind='tracks.areas.miltown.tagColor' value='6'.
[ERROR] FUSE base graph span restore failed operation='resolve-base-span' id='P7ev': Track location on segment 'S9cb' is outside the segment length. distance=38.171, segmentLength=24.845, end='A'.
```

## Test plan

- [x] `dotnet build FUSE/FUSE.csproj` clean
- [x] `dotnet test FUSE.Tests/FUSE.Tests.csproj` — 726 / 726 pass
- [ ] Manual: load Railroader with JR.MaconCounty + ZottiKarottis_GCR mods installed; confirm packages load cleanly and the four areas have a visible tagColor at runtime
- [ ] Manual: confirm the JR.MaconCounty 'S9cb' span auto-clamps without killing the package's apply phase