### PR TITLE
Fix to several FUSE regressions around legacy mod compatibility

### DIFF
--- a/FUSE.Tests/Patches/FusePrefabStoreExternalStoresEditorMenuPatchTests.cs
+++ b/FUSE.Tests/Patches/FusePrefabStoreExternalStoresEditorMenuPatchTests.cs
@@ -1,0 +1,22 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public class FusePrefabStoreExternalStoresEditorMenuPatchTests
+    {
+        [Fact]
+        public void ShouldShowExternalStoreIdentifier_HidesFuseDirectStores()
+        {
+            Assert.False(FusePrefabStoreExternalStoresEditorMenuPatch.ShouldShowExternalStoreIdentifier(
+                "fuseasset://C%3A%5CSteam%5Csteamapps%5Ccommon%5CRailroader%5CMods%5CCALW.SceneryAssets%5CSCAssetPacks%5CCALWBuildings"));
+        }
+
+        [Fact]
+        public void ShouldShowExternalStoreIdentifier_KeepsPhysicalStoreIdentifiers()
+        {
+            Assert.True(FusePrefabStoreExternalStoresEditorMenuPatch.ShouldShowExternalStoreIdentifier("CALWBuildings"));
+            Assert.True(FusePrefabStoreExternalStoresEditorMenuPatch.ShouldShowExternalStoreIdentifier("shared"));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseSceneryAssetManagerEditorMenuPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseSceneryAssetManagerEditorMenuPatchTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public class FuseSceneryAssetManagerEditorMenuPatchTests
+    {
+        [Fact]
+        public void FilterDirectOnlyIdentifiersForEditorMenu_RemovesOnlyDirectOnlyEntries()
+        {
+            var identifiers = new[] { "local-low-shed", "mod-folder-tree", "local-low-crossing" };
+            var directOnly = new HashSet<string> { "mod-folder-tree" };
+
+            var filtered = FuseSceneryAssetManagerEditorMenuPatch.FilterDirectOnlyIdentifiersForEditorMenu(
+                identifiers,
+                directOnly);
+
+            Assert.Equal(new[] { "local-low-shed", "local-low-crossing" }, filtered);
+        }
+
+        [Fact]
+        public void FilterDirectOnlyIdentifiersForEditorMenu_PreservesOrderWhenNothingIsDirectOnly()
+        {
+            var identifiers = new[] { "a", "b", "c" };
+
+            var filtered = FuseSceneryAssetManagerEditorMenuPatch.FilterDirectOnlyIdentifiersForEditorMenu(
+                identifiers,
+                new HashSet<string>());
+
+            Assert.Equal(identifiers, filtered);
+        }
+    }
+}

--- a/FUSE/Loading/FuseLegacyAssemblyHost.cs
+++ b/FUSE/Loading/FuseLegacyAssemblyHost.cs
@@ -4,6 +4,8 @@ using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Remoting.Messaging;
+using System.Runtime.Remoting.Proxies;
 using FUSE.Infrastructure;
 using Newtonsoft.Json.Linq;
 using Railloader;
@@ -141,7 +143,7 @@ namespace FUSE.Loading
         /// </summary>
         internal readonly struct HostedPluginInfo
         {
-            public HostedPluginInfo(FuseLegacyAssemblyManifest manifest, Type type, LegacyPluginBase plugin)
+            public HostedPluginInfo(FuseLegacyAssemblyManifest manifest, Type type, object plugin)
             {
                 Manifest = manifest;
                 PluginType = type;
@@ -150,7 +152,7 @@ namespace FUSE.Loading
 
             public FuseLegacyAssemblyManifest Manifest { get; }
             public Type PluginType { get; }
-            public LegacyPluginBase Plugin { get; }
+            public object Plugin { get; }
         }
 
         /// <summary>
@@ -292,7 +294,7 @@ namespace FUSE.Loading
             {
                 try
                 {
-                    hosted.Plugin.OnDisable();
+                    InvokePluginLifecycleMethod(hosted.Plugin, nameof(LegacyPluginBase.OnDisable));
                     FuseLog.Info(
                         $"FUSE legacy support disabled hosted old-loader plugin '{hosted.Type.FullName}' from '{hosted.Manifest.Id}'.");
                 }
@@ -325,7 +327,7 @@ namespace FUSE.Loading
                 return false;
             }
 
-            LegacyPluginBase plugin;
+            object plugin;
             try
             {
                 plugin = CreatePluginInstance(pluginType, context, definition);
@@ -345,7 +347,7 @@ namespace FUSE.Loading
 
             try
             {
-                plugin.OnEnable();
+                InvokePluginLifecycleMethod(plugin, nameof(LegacyPluginBase.OnEnable));
                 HostedPlugins[key] = new HostedLegacyPlugin(manifest, pluginType, plugin);
                 FuseLog.Info(
                     $"FUSE legacy support enabled hosted old-loader plugin '{pluginType.FullName}' " +
@@ -361,23 +363,26 @@ namespace FUSE.Loading
             }
         }
 
-        private static LegacyPluginBase CreatePluginInstance(
+        private static object CreatePluginInstance(
             Type pluginType,
             FuseLegacyModdingContext context,
             FuseLegacyModDefinition definition)
         {
             var constructor = pluginType.GetConstructor(new[] { typeof(IModdingContext), typeof(IModDefinition) });
-            object instance;
             if (constructor != null)
             {
-                instance = constructor.Invoke(new object[] { context, definition });
-            }
-            else
-            {
-                instance = Activator.CreateInstance(pluginType);
+                return constructor.Invoke(new object[] { context, definition });
             }
 
-            return instance as LegacyPluginBase;
+            foreach (var candidate in pluginType.GetConstructors().OrderByDescending(c => c.GetParameters().Length))
+            {
+                if (TryBuildLegacyConstructorArguments(candidate, context, definition, out var arguments))
+                {
+                    return candidate.Invoke(arguments);
+                }
+            }
+
+            return Activator.CreateInstance(pluginType);
         }
 
         private static Assembly LoadOrFindAssembly(string assemblyPath)
@@ -403,7 +408,245 @@ namespace FUSE.Loading
             return type != null &&
                    type.IsClass &&
                    !type.IsAbstract &&
-                   typeof(LegacyPluginBase).IsAssignableFrom(type);
+                   (typeof(LegacyPluginBase).IsAssignableFrom(type) ||
+                    InheritsFromFullName(type, "Railloader.PluginBase"));
+        }
+
+        private static bool TryBuildLegacyConstructorArguments(
+            ConstructorInfo constructor,
+            FuseLegacyModdingContext context,
+            FuseLegacyModDefinition definition,
+            out object[] arguments)
+        {
+            arguments = null;
+            if (constructor == null)
+            {
+                return false;
+            }
+
+            var parameters = constructor.GetParameters();
+            arguments = new object[parameters.Length];
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                var parameterType = parameters[i].ParameterType;
+                if (parameterType.IsInstanceOfType(context))
+                {
+                    arguments[i] = context;
+                    continue;
+                }
+
+                if (parameterType.IsInstanceOfType(definition))
+                {
+                    arguments[i] = definition;
+                    continue;
+                }
+
+                if (string.Equals(parameterType.FullName, "Railloader.IModdingContext", StringComparison.Ordinal))
+                {
+                    arguments[i] = CreateRealModdingContextProxy(parameterType, context);
+                    continue;
+                }
+
+                if (string.Equals(parameterType.FullName, "Railloader.IModDefinition", StringComparison.Ordinal) ||
+                    string.Equals(parameterType.FullName, "Railloader.IMod", StringComparison.Ordinal))
+                {
+                    arguments[i] = CreateRealModDefinitionProxy(parameterType, definition);
+                    continue;
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+
+        private static void InvokePluginLifecycleMethod(object plugin, string methodName)
+        {
+            if (plugin == null)
+            {
+                return;
+            }
+
+            if (plugin is LegacyPluginBase shimPlugin)
+            {
+                if (string.Equals(methodName, nameof(LegacyPluginBase.OnEnable), StringComparison.Ordinal))
+                {
+                    shimPlugin.OnEnable();
+                }
+                else if (string.Equals(methodName, nameof(LegacyPluginBase.OnDisable), StringComparison.Ordinal))
+                {
+                    shimPlugin.OnDisable();
+                }
+
+                return;
+            }
+
+            var method = plugin.GetType().GetMethod(
+                methodName,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                null,
+                Type.EmptyTypes,
+                null);
+            method?.Invoke(plugin, Array.Empty<object>());
+        }
+
+        private static bool InheritsFromFullName(Type type, string fullName)
+        {
+            try
+            {
+                for (var current = type?.BaseType; current != null; current = current.BaseType)
+                {
+                    if (string.Equals(current.FullName, fullName, StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch
+            {
+                return false;
+            }
+
+            return false;
+        }
+
+        private static object CreateRealModDefinitionProxy(Type interfaceType, FuseLegacyModDefinition definition)
+        {
+            return new LegacyInterfaceProxy(interfaceType, (method, args) =>
+                InvokeRealModDefinition(definition, method)).GetTransparentProxy();
+        }
+
+        private static object CreateRealModdingContextProxy(Type interfaceType, FuseLegacyModdingContext context)
+        {
+            return new LegacyInterfaceProxy(interfaceType, (method, args) =>
+                InvokeRealModdingContext(context, method, args)).GetTransparentProxy();
+        }
+
+        private static object InvokeRealModDefinition(FuseLegacyModDefinition definition, MethodInfo method)
+        {
+            switch (method?.Name)
+            {
+                case "get_Id":
+                    return definition.Id;
+                case "get_Name":
+                    return definition.Name;
+                case "get_Version":
+                    return definition.Version;
+                case "get_Directory":
+                    return definition.Directory;
+                case "get_LoadBefore":
+                    return Array.Empty<string>();
+                case "get_LoadAfter":
+                case "get_Requires":
+                case "get_ConflictsWith":
+                case "get_Plugins":
+                    return CreateEmptyArrayForReturnType(method.ReturnType);
+                case "get_IsEnabled":
+                case "get_IsLoaded":
+                    return true;
+                case "get_IsFaulted":
+                    return false;
+                case "ToString":
+                    return definition.Id;
+                default:
+                    return DefaultValue(method?.ReturnType);
+            }
+        }
+
+        private static object InvokeRealModdingContext(FuseLegacyModdingContext context, MethodInfo method, object[] args)
+        {
+            switch (method?.Name)
+            {
+                case "get_RailloaderVersion":
+                    return context.RailloaderVersion;
+                case "get_ModsBaseDirectory":
+                    return context.ModsBaseDirectory;
+                case "get_Mods":
+                    return CreateEmptyArrayForReturnType(method.ReturnType);
+                case "RegisterConsoleCommand":
+                    if (args != null && args.Length > 0 && args[0] is IConsoleCommand command)
+                    {
+                        RegisterConsoleCommand(command);
+                    }
+                    return null;
+                case "LoadSettingsData":
+                    FuseLog.Warning($"FUSE legacy IModdingContext.{method.Name} called through real Railloader bridge; returning null.");
+                    return null;
+                case "SaveSettingsData":
+                    FuseLog.Warning($"FUSE legacy IModdingContext.{method.Name} called through real Railloader bridge; no-op.");
+                    return null;
+                case "GetMixintos":
+                    return CreateEmptyArrayForReturnType(method.ReturnType);
+                case "TryResolveFilePath":
+                    return TryResolveFilePathFromProxy(context, method, args);
+                case "RegisterSubTypeOverload":
+                case "RegisterComponent":
+                    return null;
+                case "ToString":
+                    return "FUSE legacy Railloader context bridge";
+                default:
+                    return DefaultValue(method?.ReturnType);
+            }
+        }
+
+        private static bool TryResolveFilePathFromProxy(FuseLegacyModdingContext context, MethodInfo method, object[] args)
+        {
+            if (args == null)
+            {
+                return false;
+            }
+
+            var parameters = method.GetParameters();
+            var outIndex = Array.FindIndex(parameters, p => p.ParameterType.IsByRef);
+            string resolved;
+            bool result;
+            if (parameters.Length == 4)
+            {
+                result = context.TryResolveFilePath(
+                    args[0] as string,
+                    args[1] as string,
+                    args.Length > 2 && args[2] is bool allow && allow,
+                    out resolved);
+            }
+            else if (parameters.Length == 5)
+            {
+                result = context.TryResolveFilePath(
+                    args[0] as string,
+                    args[1] as string,
+                    args[2] as string,
+                    args.Length > 3 && args[3] is bool allow && allow,
+                    out resolved);
+            }
+            else
+            {
+                resolved = null;
+                result = false;
+            }
+
+            if (outIndex >= 0 && outIndex < args.Length)
+            {
+                args[outIndex] = resolved;
+            }
+
+            return result;
+        }
+
+        private static Array CreateEmptyArrayForReturnType(Type returnType)
+        {
+            var elementType = returnType?.IsArray == true
+                ? returnType.GetElementType()
+                : returnType?.GetGenericArguments().FirstOrDefault();
+            return Array.CreateInstance(elementType ?? typeof(object), 0);
+        }
+
+        private static object DefaultValue(Type type)
+        {
+            if (type == null || type == typeof(void) || !type.IsValueType)
+            {
+                return null;
+            }
+
+            return Activator.CreateInstance(type);
         }
 
         private static IEnumerable<FuseLegacyAssemblyManifest> DiscoverLegacyManifests(string modsRoot)
@@ -853,7 +1096,7 @@ namespace FUSE.Loading
 
         private sealed class HostedLegacyPlugin
         {
-            public HostedLegacyPlugin(FuseLegacyAssemblyManifest manifest, Type type, LegacyPluginBase plugin)
+            public HostedLegacyPlugin(FuseLegacyAssemblyManifest manifest, Type type, object plugin)
             {
                 Manifest = manifest;
                 Type = type;
@@ -862,7 +1105,53 @@ namespace FUSE.Loading
 
             public FuseLegacyAssemblyManifest Manifest { get; }
             public Type Type { get; }
-            public LegacyPluginBase Plugin { get; }
+            public object Plugin { get; }
+        }
+
+        private sealed class LegacyInterfaceProxy : RealProxy
+        {
+            private readonly Func<MethodInfo, object[], object> _invoke;
+
+            public LegacyInterfaceProxy(Type interfaceType, Func<MethodInfo, object[], object> invoke)
+                : base(interfaceType)
+            {
+                _invoke = invoke ?? throw new ArgumentNullException(nameof(invoke));
+            }
+
+            public override IMessage Invoke(IMessage msg)
+            {
+                var call = (IMethodCallMessage)msg;
+                var args = call.Args != null
+                    ? (object[])call.Args.Clone()
+                    : Array.Empty<object>();
+
+                try
+                {
+                    var method = call.MethodBase as MethodInfo;
+                    var returnValue = _invoke(method, args);
+                    var outArgs = GetOutArguments(method, args);
+                    return new ReturnMessage(returnValue, outArgs, outArgs.Length, call.LogicalCallContext, call);
+                }
+                catch (Exception ex)
+                {
+                    return new ReturnMessage(ex.GetBaseException(), call);
+                }
+            }
+
+            private static object[] GetOutArguments(MethodInfo method, object[] args)
+            {
+                var parameters = method?.GetParameters() ?? Array.Empty<ParameterInfo>();
+                var values = new List<object>();
+                foreach (var parameter in parameters)
+                {
+                    if (parameter.ParameterType.IsByRef && parameter.Position >= 0 && parameter.Position < args.Length)
+                    {
+                        values.Add(args[parameter.Position]);
+                    }
+                }
+
+                return values.ToArray();
+            }
         }
     }
 

--- a/FUSE/Patches/FuseAudioPatches.cs
+++ b/FUSE/Patches/FuseAudioPatches.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using AssetPack.Runtime;
 using HarmonyLib;
 using KeyValue.Runtime;
 using Model;
@@ -20,21 +21,80 @@ namespace FUSE.Patches
     [HarmonyPatch]
     public static class FusePrefabStoreWhistleDefinitionsPatch
     {
+        private static readonly FieldInfo StoresField = AccessTools.Field(typeof(PrefabStore), "_stores");
+        private static readonly HashSet<string> LoggedWhistleStoreFailures =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         public static MethodBase TargetMethod()
         {
             return AccessTools.Method(typeof(PrefabStore), "AllDefinitionInfosOfType")
                 ?.MakeGenericMethod(typeof(WhistleDefinition));
         }
 
-        public static void Postfix(ref IEnumerable<TypedContainerItem<WhistleDefinition>> __result)
+        public static bool Prefix(
+            PrefabStore __instance,
+            ref IEnumerable<TypedContainerItem<WhistleDefinition>> __result)
         {
-            if (!FuseAudioAPI.HasWhistles)
+            __result = SafeWhistleDefinitions(__instance);
+            return false;
+        }
+
+        internal static IEnumerable<TypedContainerItem<WhistleDefinition>> SafeWhistleDefinitions(PrefabStore prefabStore)
+        {
+            return EnumerateWhistleDefinitions(prefabStore)
+                .Concat(FuseAudioAPI.GetWhistleDefinitionItems());
+        }
+
+        private static IEnumerable<TypedContainerItem<WhistleDefinition>> EnumerateWhistleDefinitions(PrefabStore prefabStore)
+        {
+            if (prefabStore == null)
             {
-                return;
+                yield break;
             }
 
-            __result = (__result ?? Enumerable.Empty<TypedContainerItem<WhistleDefinition>>())
-                .Concat(FuseAudioAPI.GetWhistleDefinitionItems());
+            var stores = StoresField?.GetValue(prefabStore) as IEnumerable<AssetPackRuntimeStore>;
+            if (stores == null)
+            {
+                yield break;
+            }
+
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var store in stores)
+            {
+                Container container;
+                try
+                {
+                    container = store?.Container();
+                }
+                catch (Exception ex)
+                {
+                    var storeId = store?.Identifier ?? "<unknown>";
+                    if (LoggedWhistleStoreFailures.Add(storeId))
+                    {
+                        FuseLog.Warning(
+                            $"FUSE skipped whistle definitions from asset store '{storeId}' " +
+                            $"because its definitions could not be inspected: {ex.GetBaseException().Message}");
+                    }
+
+                    continue;
+                }
+
+                foreach (var item in container?.Objects ?? Enumerable.Empty<ContainerItem>())
+                {
+                    var definition = item?.Definition as WhistleDefinition;
+                    if (definition == null || string.IsNullOrEmpty(item.Identifier) || !seen.Add(item.Identifier))
+                    {
+                        continue;
+                    }
+
+                    yield return new TypedContainerItem<WhistleDefinition>
+                    {
+                        Identifier = item.Identifier,
+                        Metadata = item.Metadata,
+                        Definition = definition
+                    };
+                }
+            }
         }
     }
 
@@ -114,15 +174,116 @@ namespace FUSE.Patches
     [HarmonyPatch(typeof(UI.CarCustomizeWindow.CarCustomizeWindow), "BuildSoundTab")]
     public static class FuseCarCustomizeSoundTabPatch
     {
-        public static void Postfix(UIPanelBuilder builder, Car ____car)
+        public static bool Prefix(UIPanelBuilder builder, Car ____car)
         {
-            if (____car == null || ____car.Definition?.Components == null)
+            try
+            {
+                if (____car == null || ____car.Definition?.Components == null)
+                {
+                    return false;
+                }
+
+                AddWhistleDropdown(builder, ____car);
+                AddHornDropdown(builder, ____car);
+                AddBellDropdown(builder, ____car);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE suppressed an exception while building the locomotive customize sound tab", ex);
+            }
+
+            return false;
+        }
+
+        private static void AddWhistleDropdown(UIPanelBuilder builder, Car car)
+        {
+            var whistleComponent = car.Definition.Components.OfType<WhistleComponent>().FirstOrDefault();
+            if (whistleComponent == null)
             {
                 return;
             }
 
-            AddHornDropdown(builder, ____car);
-            AddBellDropdown(builder, ____car);
+            builder.AddSection("Whistle", section =>
+            {
+                try
+                {
+                    AddWhistleDropdownField(section, car, whistleComponent);
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception(
+                        $"FUSE skipped whistle customization UI for car '{car.id ?? "<unknown>"}' " +
+                        "so the customize window can still open",
+                        ex);
+                }
+            }, 0f);
+        }
+
+        private static void AddWhistleDropdownField(UIPanelBuilder builder, Car car, WhistleComponent whistleComponent)
+        {
+            var settings = WhistleCustomizationSettings.FromPropertyValue(ReadWhistleCustomizationValue(car)) ??
+                           new WhistleCustomizationSettings(whistleComponent.DefaultWhistleIdentifier);
+            var whistleItems = FusePrefabStoreWhistleDefinitionsPatch
+                .SafeWhistleDefinitions(TrainController.Shared?.PrefabStore as PrefabStore)
+                .Where(item => item != null && !string.IsNullOrWhiteSpace(item.Identifier))
+                .GroupBy(item => item.Identifier, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .OrderBy(item => DisplayNameForWhistle(item), StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var whistleIds = whistleItems.Select(item => item.Identifier).ToList();
+            var values = whistleItems.Select(DisplayNameForWhistle).ToList();
+            var currentIdentifier = settings.WhistleIdentifier ?? whistleComponent.DefaultWhistleIdentifier ?? string.Empty;
+            if (whistleIds.Count == 0 && !string.IsNullOrWhiteSpace(currentIdentifier))
+            {
+                whistleIds.Add(currentIdentifier);
+                values.Add(currentIdentifier);
+            }
+
+            var currentSelectedIndex = whistleIds.FindIndex(id =>
+                string.Equals(currentIdentifier, id, StringComparison.OrdinalIgnoreCase));
+            if (currentSelectedIndex < 0 && !string.IsNullOrWhiteSpace(currentIdentifier))
+            {
+                whistleIds.Insert(0, currentIdentifier);
+                values.Insert(0, currentIdentifier);
+                currentSelectedIndex = 0;
+            }
+
+            if (whistleIds.Count == 0)
+            {
+                return;
+            }
+
+            currentSelectedIndex = Math.Max(0, currentSelectedIndex);
+            builder.AddField("Whistle", builder.AddDropdown(values, currentSelectedIndex, index =>
+            {
+                if (index < 0 || index >= whistleIds.Count)
+                {
+                    return;
+                }
+
+                car.KeyValueObject[WhistleCustomizationSettings.ObjectKey] =
+                    new WhistleCustomizationSettings(whistleIds[index]).PropertyValue;
+            }));
+        }
+
+        private static Value ReadWhistleCustomizationValue(Car car)
+        {
+            try
+            {
+                return car?.KeyValueObject?[WhistleCustomizationSettings.ObjectKey] ?? Value.Null();
+            }
+            catch
+            {
+                return Value.Null();
+            }
+        }
+
+        private static string DisplayNameForWhistle(TypedContainerItem<WhistleDefinition> item)
+        {
+            return string.IsNullOrWhiteSpace(item?.Metadata?.Name)
+                ? item?.Identifier ?? string.Empty
+                : item.Metadata.Name;
         }
 
         private static void AddHornDropdown(UIPanelBuilder builder, Car car)

--- a/FUSE/Patches/FusePrefabStoreExternalStoresEditorMenuPatch.cs
+++ b/FUSE/Patches/FusePrefabStoreExternalStoresEditorMenuPatch.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AssetPack.Runtime;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using HarmonyLib;
+using Model.Database;
+
+namespace FUSE.Patches
+{
+    [HarmonyPatch(typeof(PrefabStore), "get_ExternalStores")]
+    internal static class FusePrefabStoreExternalStoresEditorMenuPatch
+    {
+        private static void Postfix(ref IEnumerable<AssetPackRuntimeStore> __result)
+        {
+            if (__result == null)
+            {
+                return;
+            }
+
+            try
+            {
+                __result = __result.Where(store => ShouldShowExternalStoreIdentifier(store?.Identifier));
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE failed to filter direct asset stores from the editor store menu", ex);
+            }
+        }
+
+        internal static bool ShouldShowExternalStoreIdentifier(string identifier)
+        {
+            return !FuseAssetPackRegistry.TryResolveDirectStoreBasePath(identifier, out _);
+        }
+    }
+}

--- a/FUSE/Patches/FuseProgressionDisabledDiagnosticPatches.cs
+++ b/FUSE/Patches/FuseProgressionDisabledDiagnosticPatches.cs
@@ -28,7 +28,7 @@ namespace FUSE.Patches
     {
         private static void Postfix(PassengerStop __instance, bool value)
         {
-            if (!FuseSettings.VerboseApplyReportDetails)
+            if (!FuseSettings.VerboseApplyReportDetails || !FuseSettings.ShowAdvancedHealthDetails)
             {
                 return;
             }
@@ -65,6 +65,7 @@ namespace FUSE.Patches
             }
             catch
             {
+                return "<unavailable>";
             }
 
             return "<unavailable>";
@@ -76,7 +77,7 @@ namespace FUSE.Patches
     {
         private static void Postfix(Industry __instance, bool value)
         {
-            if (!FuseSettings.VerboseApplyReportDetails)
+            if (!FuseSettings.VerboseApplyReportDetails || !FuseSettings.ShowAdvancedHealthDetails)
             {
                 return;
             }
@@ -117,7 +118,7 @@ namespace FUSE.Patches
     {
         private static void Postfix(IndustryComponent __instance, bool value)
         {
-            if (!FuseSettings.VerboseApplyReportDetails)
+            if (!FuseSettings.VerboseApplyReportDetails || !FuseSettings.ShowAdvancedHealthDetails)
             {
                 return;
             }

--- a/FUSE/Patches/FuseSceneryAssetManagerEditorMenuPatch.cs
+++ b/FUSE/Patches/FuseSceneryAssetManagerEditorMenuPatch.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using AssetPack.Runtime;
+using HarmonyLib;
+using Helpers;
+using Model.Database;
+using Model.Definition;
+using Model.Definition.Data;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+
+namespace FUSE.Patches
+{
+    [HarmonyPatch]
+    internal static class FuseSceneryAssetManagerEditorMenuPatch
+    {
+        private static readonly FieldInfo StoresField = AccessTools.Field(typeof(PrefabStore), "_stores");
+        private static readonly PropertyInfo PrefabStoreProperty = AccessTools.Property(typeof(SceneryAssetManager), "PrefabStore");
+        private static bool LoggedFilterSummary;
+
+        private static MethodInfo TargetMethod()
+        {
+            return AccessTools.Method(typeof(SceneryAssetManager), "GetSceneryDefinitionIdentifiers");
+        }
+
+        private static void Postfix(SceneryAssetManager __instance, ref List<string> __result)
+        {
+            if (__result == null || __result.Count == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                var prefabStore = PrefabStoreProperty?.GetValue(__instance, null) as PrefabStore;
+                var directOnly = ComputeDirectOnlySceneryIdentifiers(prefabStore);
+                var before = __result.Count;
+                __result = FilterDirectOnlyIdentifiersForEditorMenu(__result, directOnly);
+                var removed = before - __result.Count;
+                if (removed > 0 && !LoggedFilterSummary)
+                {
+                    LoggedFilterSummary = true;
+                    FuseLog.Info(
+                        $"FUSE filtered {removed} direct mod-folder scenery asset(s) out of the editor asset menu. " +
+                        "Install an asset pack normally if it should be available for editor placement.");
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE editor scenery asset menu filter failed softly; direct mod-folder assets may be visible: " +
+                    $"{ex.GetBaseException().Message}");
+            }
+        }
+
+        internal static List<string> FilterDirectOnlyIdentifiersForEditorMenu(
+            IEnumerable<string> identifiers,
+            ISet<string> directOnlyIdentifiers)
+        {
+            if (identifiers == null)
+            {
+                return new List<string>();
+            }
+
+            if (directOnlyIdentifiers == null || directOnlyIdentifiers.Count == 0)
+            {
+                return identifiers.ToList();
+            }
+
+            return identifiers
+                .Where(identifier => string.IsNullOrEmpty(identifier) || !directOnlyIdentifiers.Contains(identifier))
+                .ToList();
+        }
+
+        private static HashSet<string> ComputeDirectOnlySceneryIdentifiers(PrefabStore prefabStore)
+        {
+            var directIdentifiers = new HashSet<string>(StringComparer.Ordinal);
+            var installedIdentifiers = new HashSet<string>(StringComparer.Ordinal);
+            var stores = StoresField?.GetValue(prefabStore) as IEnumerable<AssetPackRuntimeStore>;
+            if (stores == null)
+            {
+                return directIdentifiers;
+            }
+
+            foreach (var store in stores)
+            {
+                if (store == null)
+                {
+                    continue;
+                }
+
+                Container container;
+                try
+                {
+                    container = store.Container();
+                }
+                catch
+                {
+                    continue;
+                }
+
+                var isDirectStore = FuseAssetPackRegistry.TryResolveDirectStoreBasePath(store.Identifier, out _);
+                foreach (var item in container?.Objects ?? Enumerable.Empty<ContainerItem>())
+                {
+                    if (item?.Definition is SceneryDefinition && !string.IsNullOrEmpty(item.Identifier))
+                    {
+                        if (isDirectStore)
+                        {
+                            directIdentifiers.Add(item.Identifier);
+                        }
+                        else
+                        {
+                            installedIdentifiers.Add(item.Identifier);
+                        }
+                    }
+                }
+            }
+
+            directIdentifiers.ExceptWith(installedIdentifiers);
+            return directIdentifiers;
+        }
+    }
+}

--- a/FUSE/Runtime/API/FusePassengerStopComponent.cs
+++ b/FUSE/Runtime/API/FusePassengerStopComponent.cs
@@ -180,7 +180,7 @@ namespace FUSE.Runtime.API
             var chosenDisabled = parentIndustry != null ? industryDisabled : componentDisabled;
             passengerStop.ProgressionDisabled = chosenDisabled;
 
-            if (FuseSettings.VerboseApplyReportDetails)
+            if (FuseSettings.VerboseApplyReportDetails && FuseSettings.ShowAdvancedHealthDetails)
             {
                 FuseLog.Info(
                     $"FUSE diag TryRefreshPassengerStop ProgressionDisabled decision id='{stopIdentifier}' " +
@@ -466,7 +466,7 @@ namespace FUSE.Runtime.API
             var previousValue = AllPassengerStopsField?.GetValue(null) as PassengerStop[];
             AllPassengerStopsField?.SetValue(null, stops);
 
-            if (FuseSettings.VerboseApplyReportDetails)
+            if (FuseSettings.VerboseApplyReportDetails && FuseSettings.ShowAdvancedHealthDetails)
             {
                 try
                 {


### PR DESCRIPTION
## 🔗 Related Issue

N/A - local regression report from Railroader/FUSE testing.

## 📝 Description of the Change

Fixes several FUSE regressions around legacy mod compatibility and editor usability.

- Restores legacy old-loader plugin hosting for mods compiled against the real `Railloader.Interchange.dll`, not only FUSE’s shim types. This lets packages such as `C_L_B.DKW` run their own startup/Harmony code instead of FUSE trying to recreate their behavior.
- Removes the attempted native DKW reconstruction path. FUSE now defers DKW splineys back to the legacy plugin host so DKW owns its own switch/spliney logic.
- Hardens the locomotive Customize sound tab. FUSE now builds the whistle/horn/bell sound UI defensively so missing or bad whistle entries cannot prevent the whole Customize window from opening.
- Filters direct `fuseasset://...` stores out of the base-game editor asset-pack picker while keeping those stores mounted for runtime asset resolution.
- Reduces passenger-stop progression diagnostic spam by requiring advanced health details in addition to verbose apply details.

## 🔄 Alternatives Considered

- Reimplementing DKW topology directly in FUSE was tried and rejected. DKW’s switch behavior belongs to the DKW plugin, and copying its logic is both brittle and inappropriate.
- Filtering only scenery identifiers was too narrow; the screenshot showed the base-game car editor listing `PrefabStore.ExternalStores`, so the filter moved to that source.
- Leaving the base-game Customize sound tab intact and only appending FUSE controls was insufficient because failures in the base whistle list could still abort the window.

## ⚠️ Possible Drawbacks

- The legacy plugin bridge uses runtime proxying for real `Railloader.Interchange` interfaces, so unsupported old-loader API calls may still need more bridge coverage later.
- Filtering `PrefabStore.ExternalStores` hides direct FUSE stores anywhere that property is used, not only the visible editor picker.
- The Customize sound tab is now replaced by FUSE’s guarded implementation for locomotives, so future base-game changes to that tab may need to be mirrored.

Changes are intended to be backwards compatible with existing saves.

## ✅ Verification Process

- Ran `dotnet test FUSE.Tests\FUSE.Tests.csproj -c Release` with Railroader/Unity managed references.
- Result: `732/732` tests passed.
- Ran Release deploy build with `EnableModDeploy=true`.
- Result: build succeeded with `0` warnings and `0` errors.
- Ran slopwatch dirty-change hook.
- Result: passed.
- Confirmed deployed DLL timestamp in `C:\Steam\steamapps\common\Railroader\Mods\FUSE\FUSE.dll`.

## 💡 Additional Information

This PR intentionally does not copy DKW implementation details into FUSE. The goal is to make FUSE correctly host and interoperate with legacy plugins so those mods can continue to own their specialized behavior.