### PR TITLE
fuse-legacy-compat-fixes

### DIFF
--- a/FUSE.Tests/Loading/FuseLegacyTextConverterTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyTextConverterTests.cs
@@ -1,0 +1,54 @@
+using FUSE.Loading;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public class FuseLegacyTextConverterTests
+    {
+        private static JObject Convert(JObject source)
+        {
+            var manifest = new FuseLegacyPackageManifest
+            {
+                PackageId = "test-pkg",
+                DisplayName = "Test Package",
+                Author = "tester",
+                Version = "1.0.0"
+            };
+            var root = FuseLegacyDataConverter.CreateSkeleton(manifest, "text-fragment");
+            FuseLegacyDataConverter.ConvertSource(source, root, manifest);
+            return root;
+        }
+
+        [Fact]
+        public void StringTextReplacement_BecomesMapLabelTextUpdate()
+        {
+            var root = Convert(new JObject
+            {
+                ["texts"] = new JObject
+                {
+                    ["Alarka Jct"] = "DeHart"
+                }
+            });
+
+            var label = (JObject)root["world"]["mapLabels"]["Alarka Jct"];
+            Assert.NotNull(label);
+            Assert.Equal("DeHart", (string)label["text"]);
+        }
+
+        [Fact]
+        public void NullTextReplacement_BecomesMapLabelRemoval()
+        {
+            var root = Convert(new JObject
+            {
+                ["texts"] = new JObject
+                {
+                    ["Old Label"] = JValue.CreateNull()
+                }
+            });
+
+            var removals = (JArray)root["world"]["removals"]["mapLabels"];
+            Assert.Contains("Old Label", removals.Values<string>());
+        }
+    }
+}

--- a/FUSE/Loading/FuseLegacyDataConverter.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.cs
@@ -837,6 +837,16 @@ namespace FUSE.Loading
                     {
                         ((JObject)root["world"]["mapLabels"])[label.Name] = ConvertLabel(label.Name, labelObject);
                     }
+                    else
+                    {
+                        var text = label.Value.ToString().Trim();
+                        if (!string.IsNullOrWhiteSpace(text))
+                        {
+                            ((JObject)root["world"]["mapLabels"])[label.Name] = ConvertLabel(
+                                label.Name,
+                                new JObject { ["text"] = text });
+                        }
+                    }
                 }
             }
 

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -155,14 +155,44 @@ namespace FUSE.Runtime.API
                 return (MapLabel)cached;
             }
 
-            return !string.IsNullOrWhiteSpace(id)
-                ? UnityEngine.Object.FindObjectsOfType<MapLabel>().FirstOrDefault(label => label.name == id)
-                : null;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return null;
+            }
+
+            var labels = UnityEngine.Object.FindObjectsOfType<MapLabel>(true)
+                .Where(label => label != null)
+                .ToArray();
+            var match = labels.FirstOrDefault(label => string.Equals(label.name, id, StringComparison.OrdinalIgnoreCase)) ??
+                        SingleMapLabel(labels, label => label.transform?.parent != null &&
+                                                       string.Equals(label.transform.parent.name, id, StringComparison.OrdinalIgnoreCase)) ??
+                        SingleMapLabel(labels, label => string.Equals(label.text, id, StringComparison.OrdinalIgnoreCase)) ??
+                        SingleMapLabel(labels, label =>
+                        {
+                            var text = label.GetComponentInChildren<TMP_Text>(true);
+                            return text != null && string.Equals(text.text, id, StringComparison.OrdinalIgnoreCase);
+                        });
+
+            if (match != null)
+            {
+                FuseMapLabelRuntimeIndex.Instance.Set(id, match);
+            }
+
+            return match;
         }
 
         public static IEnumerable<MapLabel> GetAllMapLabels()
         {
             return UnityEngine.Object.FindObjectsOfType<MapLabel>();
+        }
+
+        private static MapLabel SingleMapLabel(IEnumerable<MapLabel> labels, Func<MapLabel, bool> predicate)
+        {
+            var matches = labels
+                .Where(predicate)
+                .Take(2)
+                .ToArray();
+            return matches.Length == 1 ? matches[0] : null;
         }
 
         public static FuseMapLabel GetMapLabelDefinition(string id)

--- a/FUSE/Runtime/API/StationAPI.cs
+++ b/FUSE/Runtime/API/StationAPI.cs
@@ -91,15 +91,17 @@ namespace FUSE.Runtime.API
         }
 
         /// <summary>
-        /// Re-binds StationAgent.passengerStop on every FUSE-tracked station whose
-        /// stored definition references <paramref name="stop"/>'s identifier.
+        /// Re-binds StationAgent.passengerStop on every compatible station agent.
         ///
         /// FusePassengerStopComponent.RefreshPassengerStop destroys and recreates
         /// the PassengerStop on every GraphRebuilt. The depot's StationAgent
         /// keeps a Unity-null C# reference to the destroyed instance, so the
         /// vanilla StationWindow.Populate check `passengerStop != null` evaluates
         /// false and silently drops the Passengers tab. This helper is the
-        /// re-bind step the refresh path was missing.
+        /// re-bind step the refresh path was missing. Legacy packages sometimes
+        /// add only a passenger-stop component under an existing area/industry
+        /// and rely on the area's station agent for UI, so the fallback also
+        /// binds unambiguous area-local station agents that have no live stop.
         /// </summary>
         internal static int RebindStationAgentsForPassengerStop(PassengerStop stop)
         {
@@ -115,32 +117,22 @@ namespace FUSE.Runtime.API
             }
 
             var rebound = 0;
-            foreach (var cached in FuseStationRuntimeIndex.Instance.Values)
+            var stopArea = stop.GetComponentInParent<Area>(true);
+            var stopIsOnlyPassengerStopInArea = IsOnlyPassengerStopInArea(stop, stopArea);
+            foreach (var agent in UnityEngine.Object.FindObjectsOfType<StationAgent>(true))
             {
-                var agent = cached as StationAgent;
                 if (agent == null)
                 {
                     continue;
                 }
 
-                var agentId = agent.name;
-                if (string.IsNullOrWhiteSpace(agentId))
-                {
-                    continue;
-                }
-
-                if (!FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.Station, agentId, out FuseStation definition) || definition == null)
-                {
-                    continue;
-                }
-
-                if (!string.Equals(definition.PassengerStopId, stopId, StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                var current = PassengerStopField.GetValue(agent) as PassengerStop;
+                var current = GetStationPassengerStop(agent);
                 if (ReferenceEquals(current, stop))
+                {
+                    continue;
+                }
+
+                if (!ShouldRebindStationAgent(agent, current, stopId, stopArea, stopIsOnlyPassengerStopInArea))
                 {
                     continue;
                 }
@@ -150,6 +142,96 @@ namespace FUSE.Runtime.API
             }
 
             return rebound;
+        }
+
+        private static bool ShouldRebindStationAgent(
+            StationAgent agent,
+            PassengerStop current,
+            string stopId,
+            Area stopArea,
+            bool stopIsOnlyPassengerStopInArea)
+        {
+            var agentId = agent.name;
+            if (!string.IsNullOrWhiteSpace(agentId) &&
+                FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.Station, agentId, out FuseStation definition) &&
+                definition != null)
+            {
+                return string.Equals(definition.PassengerStopId, stopId, StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (PassengerStopHasIdentifier(current, stopId))
+            {
+                return true;
+            }
+
+            if (current != null || stopArea == null || !stopIsOnlyPassengerStopInArea)
+            {
+                return false;
+            }
+
+            var agentArea = AreaField?.GetValue(agent) as Area;
+            return ReferenceEquals(agentArea, stopArea);
+        }
+
+        private static PassengerStop GetStationPassengerStop(StationAgent agent)
+        {
+            try
+            {
+                return PassengerStopField?.GetValue(agent) as PassengerStop;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception($"FUSE station rebinder could not read StationAgent.passengerStop for '{agent?.name ?? "<unknown>"}'.", ex);
+                return null;
+            }
+        }
+
+        private static bool PassengerStopHasIdentifier(PassengerStop stop, string stopId)
+        {
+            if (stop == null || string.IsNullOrWhiteSpace(stopId))
+            {
+                return false;
+            }
+
+            try
+            {
+                return string.Equals(stop.identifier, stopId, StringComparison.OrdinalIgnoreCase);
+            }
+            catch (MissingReferenceException)
+            {
+                return false;
+            }
+        }
+
+        private static bool IsOnlyPassengerStopInArea(PassengerStop stop, Area stopArea)
+        {
+            if (stop == null || stopArea == null)
+            {
+                return false;
+            }
+
+            var count = 0;
+            foreach (var candidate in PassengerStop.FindAll())
+            {
+                if (candidate == null)
+                {
+                    continue;
+                }
+
+                var candidateArea = candidate.GetComponentInParent<Area>(true);
+                if (!ReferenceEquals(candidateArea, stopArea))
+                {
+                    continue;
+                }
+
+                count++;
+                if (count > 1)
+                {
+                    return false;
+                }
+            }
+
+            return count == 1;
         }
 
         public static PassengerStop GetPassengerStop(string id)


### PR DESCRIPTION
## 🔗 Related Issue

N/A

## 📝 Description of the Change

This PR fixes two FUSE compatibility issues found with legacy map mods:

- Fixes custom passenger stations whose `PassengerStop` components load correctly but whose station agents do not show a Passenger tab.
  - FUSE now rebinds compatible `StationAgent.passengerStop` references after passenger stop refresh.
  - Exact FUSE station definitions still take priority.
  - For legacy area-only stations, FUSE only falls back to area-based binding when the area has one unambiguous passenger stop.

- Restores legacy `texts` map-label replacements.
  - String entries such as `"Alarka Jct": "DeHart"` are now converted into map-label updates instead of being ignored.
  - Runtime map-label lookup is more tolerant, matching existing labels by component name, parent name, current label text, or visible TMP text when the match is unique.

## 🔄 Alternatives Considered

Considered adding special handling for the DeHart/Alarka case, but the implemented fix preserves the broader legacy `texts` behavior so other mods with the same pattern work too.

## ⚠️ Possible Drawbacks

Area-based station-agent rebinding is intentionally conservative. Mods with multiple passenger stops in one area may still need explicit station definitions.

Map-label text matching only applies when the match is unique, which avoids replacing the wrong label but may leave ambiguous labels unchanged.

The changes are intended to be backward compatible with existing saves.

## ✅ Verification Process

- Built FUSE in Release successfully.
- Ran the FUSE test suite successfully: `728/728` passing.
- Ran slopwatch successfully.
- Deployed the updated `FUSE.dll` into the Railroader `Mods/FUSE` folder.
- Verified the reported cases against logs and legacy data shapes:
  - Ela-style passenger stops now have a path to rebind station agents.
  - Legacy `texts` entries like `Alarka Jct -> DeHart` are converted and applied.

## 💡 Additional Information

This PR is limited to passenger station tab rebinding and legacy map-label/text replacement compatibility.