### PR TITLE
Fix Customize tab

### DIFF
--- a/FUSE.Tests/Loading/FuseAssetCollisionRegistryFilesystemTests.cs
+++ b/FUSE.Tests/Loading/FuseAssetCollisionRegistryFilesystemTests.cs
@@ -9,8 +9,8 @@ namespace FUSE.Tests.Loading
     /// <summary>
     /// Integration tests that exercise the collision registry against
     /// real on-disk pack-folder structures. We synthesize a tiny mods
-    /// folder (Catalog.json + Definitions.json + a sentinel Bundle file
-    /// per pack), run the scan, and check the recorded collisions.
+    /// folder (Catalog.json + a sentinel Bundle file per pack), run
+    /// the scan, and check the recorded collisions.
     ///
     /// <para>These tests catch path-normalization regressions the
     /// in-memory-only tests miss — anything that depends on
@@ -231,7 +231,9 @@ namespace FUSE.Tests.Loading
             // Synthesize minimal pack contents. Discovery does not parse
             // these files for the leaf-name detection path; they just need
             // to exist so IsAssetPackFolder() (and our enumerator) would
-            // accept the folder as a valid pack.
+            // accept the folder as a valid pack. Definitions.json is
+            // included here because these tests model definition-bearing
+            // packs, but model-only packs are valid too.
             File.WriteAllText(
                 Path.Combine(folder, "Catalog.json"),
                 "{\"identifier\":\"" + Path.GetFileName(folder) + "\",\"name\":\"" + Path.GetFileName(folder) + "\",\"assets\":{}}");
@@ -244,8 +246,8 @@ namespace FUSE.Tests.Loading
         private static string[] EnumeratePackFolders(string modsRoot)
         {
             // Mirror FuseAssetPackRegistry.IsAssetPackFolder semantics:
-            // any directory that contains Catalog.json + Definitions.json
-            // + Bundle counts as a pack.
+            // any directory that contains Catalog.json + Bundle counts
+            // as a pack. Definitions.json is optional for model-only packs.
             return Directory
                 .EnumerateDirectories(modsRoot, "*", SearchOption.AllDirectories)
                 .Where(IsPackFolder)
@@ -255,7 +257,6 @@ namespace FUSE.Tests.Loading
         private static bool IsPackFolder(string folder)
         {
             return File.Exists(Path.Combine(folder, "Catalog.json")) &&
-                   File.Exists(Path.Combine(folder, "Definitions.json")) &&
                    File.Exists(Path.Combine(folder, "Bundle"));
         }
 

--- a/FUSE.Tests/Loading/FuseAssetPackDiscoveryOrderTests.cs
+++ b/FUSE.Tests/Loading/FuseAssetPackDiscoveryOrderTests.cs
@@ -58,11 +58,19 @@ namespace FUSE.Tests.Loading
         {
             var full = Path.Combine(_modsRoot, relative);
             Directory.CreateDirectory(full);
-            // Asset-pack discovery requires all three sentinel files to
-            // be present, mirroring what AssetPackRuntimeStore looks for.
+            // Definition-bearing packs include all three files.
             File.WriteAllText(Path.Combine(full, "Bundle"), "fake-bundle");
             File.WriteAllText(Path.Combine(full, "Catalog.json"), "{}");
             File.WriteAllText(Path.Combine(full, "Definitions.json"), "{}");
+            return full;
+        }
+
+        private string CreateModelOnlyPackFolder(string relative)
+        {
+            var full = Path.Combine(_modsRoot, relative);
+            Directory.CreateDirectory(full);
+            File.WriteAllText(Path.Combine(full, "Bundle"), "fake-bundle");
+            File.WriteAllText(Path.Combine(full, "Catalog.json"), "{}");
             return full;
         }
 
@@ -126,6 +134,22 @@ namespace FUSE.Tests.Loading
 
             Assert.Contains(Path.GetFullPath(pack1), folders);
             Assert.Contains(Path.GetFullPath(pack2), folders);
+        }
+
+        [Fact]
+        public void Discovery_yields_model_only_packs_without_definitions()
+        {
+            var modFolder = Path.Combine(_modsRoot, "WhistleModels");
+            Directory.CreateDirectory(modFolder);
+
+            var modelPack = CreateModelOnlyPackFolder(@"WhistleModels\TPPWhistleModels");
+
+            var folders = FuseAssetPackRegistry
+                .EnumerateFallbackAssetPackFolders(modFolder)
+                .Select(Path.GetFullPath)
+                .ToArray();
+
+            Assert.Contains(Path.GetFullPath(modelPack), folders);
         }
 
         [Fact]

--- a/FUSE.Tests/Patches/FusePrefabStoreMaterialDefinitionsPatchTests.cs
+++ b/FUSE.Tests/Patches/FusePrefabStoreMaterialDefinitionsPatchTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FUSE.Patches;
+using HarmonyLib;
 using Model.Definition;
 using Model.Definition.Data;
 using Xunit;
@@ -11,11 +13,12 @@ namespace FUSE.Tests.Patches
     /// Direct-invocation tests for
     /// <see cref="FusePrefabStoreMaterialDefinitionsPatch.SanitizeMaterialDefinition"/>.
     ///
-    /// This patch wraps
-    /// <c>PrefabStore.AllDefinitionInfosOfType&lt;MaterialDefinition&gt;</c>
-    /// and replaces the returned enumeration with one that sanitises
-    /// each <see cref="MaterialDefinition"/> in flight, guaranteeing
-    /// that downstream consumers (notably
+    /// This sanitizer used to wrap
+    /// <c>PrefabStore.AllDefinitionInfosOfType&lt;MaterialDefinition&gt;</c>,
+    /// but that generic Harmony hook can corrupt other closed generic
+    /// enumerations on Mono's shared generic body. It now runs only
+    /// from non-generic direct-container paths, guaranteeing that
+    /// downstream consumers (notably
     /// <see cref="FuseAggregateLoadModelMaterialFieldPatch.TryGetFieldSafely"/>
     /// once the prefix hands control to it) never see a null
     /// <see cref="MaterialDefinition.Fields"/> list or a null
@@ -55,6 +58,15 @@ namespace FUSE.Tests.Patches
                 Identifier = identifier,
                 Definition = definition
             };
+
+        [Fact]
+        public void MaterialSanitizer_IsNotHarmonyPatched()
+        {
+            var attributes = typeof(FusePrefabStoreMaterialDefinitionsPatch)
+                .GetCustomAttributes(typeof(HarmonyPatch), inherit: false);
+
+            Assert.Empty(attributes.Cast<object>());
+        }
 
         // ---- guard paths ----
 

--- a/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
@@ -10,7 +10,9 @@ using Model.Database;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using FUSE.Infrastructure;
+using FUSE.Patches;
 using UnityEngine;
+using Model.Definition.Data;
 
 namespace FUSE.Loading
 {
@@ -357,6 +359,7 @@ namespace FUSE.Loading
                 var sourceText = File.ReadAllText(definitionsPath);
                 var sanitizedText = SanitizeDefinitionsJson(sourceText, removedByKind);
                 container = DeserializeContainerBypassingPostfix(sanitizedText, store?.Identifier);
+                SanitizeDeserializedDirectContainer(container);
                 RuntimeStoreContainerField?.SetValue(store, container);
 
                 if (removedByKind.Count > 0 && SanitizedDirectContainerWarnings.Add(store.Identifier))
@@ -408,6 +411,31 @@ namespace FUSE.Loading
             }
 
             return ContainerSerialization.Deserialize(text);
+        }
+
+        private static void SanitizeDeserializedDirectContainer(Container container)
+        {
+            if (container?.Objects == null)
+            {
+                return;
+            }
+
+            foreach (var item in container.Objects)
+            {
+                var material = item?.Definition as MaterialDefinition;
+                if (material == null)
+                {
+                    continue;
+                }
+
+                FusePrefabStoreMaterialDefinitionsPatch.SanitizeMaterialDefinition(
+                    new TypedContainerItem<MaterialDefinition>
+                    {
+                        Identifier = item.Identifier,
+                        Metadata = item.Metadata,
+                        Definition = material
+                    });
+            }
         }
     }
 }

--- a/FUSE/Loading/FuseAssetPackRegistry.Mounting.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.Mounting.cs
@@ -386,8 +386,7 @@ namespace FUSE.Loading
         private static bool IsAssetPackFolder(string folderPath)
         {
             return File.Exists(Path.Combine(folderPath, "Bundle")) &&
-                   File.Exists(Path.Combine(folderPath, "Catalog.json")) &&
-                   File.Exists(Path.Combine(folderPath, "Definitions.json"));
+                   File.Exists(Path.Combine(folderPath, "Catalog.json"));
         }
 
         private static int MountAssetPackFolder(string sourcePath)

--- a/FUSE/Patches/FuseAudioPatches.cs
+++ b/FUSE/Patches/FuseAudioPatches.cs
@@ -18,86 +18,6 @@ using UI.Builder;
 
 namespace FUSE.Patches
 {
-    [HarmonyPatch]
-    public static class FusePrefabStoreWhistleDefinitionsPatch
-    {
-        private static readonly FieldInfo StoresField = AccessTools.Field(typeof(PrefabStore), "_stores");
-        private static readonly HashSet<string> LoggedWhistleStoreFailures =
-            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        public static MethodBase TargetMethod()
-        {
-            return AccessTools.Method(typeof(PrefabStore), "AllDefinitionInfosOfType")
-                ?.MakeGenericMethod(typeof(WhistleDefinition));
-        }
-
-        public static bool Prefix(
-            PrefabStore __instance,
-            ref IEnumerable<TypedContainerItem<WhistleDefinition>> __result)
-        {
-            __result = SafeWhistleDefinitions(__instance);
-            return false;
-        }
-
-        internal static IEnumerable<TypedContainerItem<WhistleDefinition>> SafeWhistleDefinitions(PrefabStore prefabStore)
-        {
-            return EnumerateWhistleDefinitions(prefabStore)
-                .Concat(FuseAudioAPI.GetWhistleDefinitionItems());
-        }
-
-        private static IEnumerable<TypedContainerItem<WhistleDefinition>> EnumerateWhistleDefinitions(PrefabStore prefabStore)
-        {
-            if (prefabStore == null)
-            {
-                yield break;
-            }
-
-            var stores = StoresField?.GetValue(prefabStore) as IEnumerable<AssetPackRuntimeStore>;
-            if (stores == null)
-            {
-                yield break;
-            }
-
-            var seen = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var store in stores)
-            {
-                Container container;
-                try
-                {
-                    container = store?.Container();
-                }
-                catch (Exception ex)
-                {
-                    var storeId = store?.Identifier ?? "<unknown>";
-                    if (LoggedWhistleStoreFailures.Add(storeId))
-                    {
-                        FuseLog.Warning(
-                            $"FUSE skipped whistle definitions from asset store '{storeId}' " +
-                            $"because its definitions could not be inspected: {ex.GetBaseException().Message}");
-                    }
-
-                    continue;
-                }
-
-                foreach (var item in container?.Objects ?? Enumerable.Empty<ContainerItem>())
-                {
-                    var definition = item?.Definition as WhistleDefinition;
-                    if (definition == null || string.IsNullOrEmpty(item.Identifier) || !seen.Add(item.Identifier))
-                    {
-                        continue;
-                    }
-
-                    yield return new TypedContainerItem<WhistleDefinition>
-                    {
-                        Identifier = item.Identifier,
-                        Metadata = item.Metadata,
-                        Definition = definition
-                    };
-                }
-            }
-        }
-    }
-
     [HarmonyPatch(typeof(WhistleController), "Configure", new[] { typeof(WhistleCustomizationSettings) })]
     public static class FuseWhistleControllerConfigurePatch
     {
@@ -174,116 +94,15 @@ namespace FUSE.Patches
     [HarmonyPatch(typeof(UI.CarCustomizeWindow.CarCustomizeWindow), "BuildSoundTab")]
     public static class FuseCarCustomizeSoundTabPatch
     {
-        public static bool Prefix(UIPanelBuilder builder, Car ____car)
+        public static void Postfix(UIPanelBuilder builder, Car ____car)
         {
-            try
-            {
-                if (____car == null || ____car.Definition?.Components == null)
-                {
-                    return false;
-                }
-
-                AddWhistleDropdown(builder, ____car);
-                AddHornDropdown(builder, ____car);
-                AddBellDropdown(builder, ____car);
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception("FUSE suppressed an exception while building the locomotive customize sound tab", ex);
-            }
-
-            return false;
-        }
-
-        private static void AddWhistleDropdown(UIPanelBuilder builder, Car car)
-        {
-            var whistleComponent = car.Definition.Components.OfType<WhistleComponent>().FirstOrDefault();
-            if (whistleComponent == null)
+            if (____car == null || ____car.Definition?.Components == null)
             {
                 return;
             }
 
-            builder.AddSection("Whistle", section =>
-            {
-                try
-                {
-                    AddWhistleDropdownField(section, car, whistleComponent);
-                }
-                catch (Exception ex)
-                {
-                    FuseLog.Exception(
-                        $"FUSE skipped whistle customization UI for car '{car.id ?? "<unknown>"}' " +
-                        "so the customize window can still open",
-                        ex);
-                }
-            }, 0f);
-        }
-
-        private static void AddWhistleDropdownField(UIPanelBuilder builder, Car car, WhistleComponent whistleComponent)
-        {
-            var settings = WhistleCustomizationSettings.FromPropertyValue(ReadWhistleCustomizationValue(car)) ??
-                           new WhistleCustomizationSettings(whistleComponent.DefaultWhistleIdentifier);
-            var whistleItems = FusePrefabStoreWhistleDefinitionsPatch
-                .SafeWhistleDefinitions(TrainController.Shared?.PrefabStore as PrefabStore)
-                .Where(item => item != null && !string.IsNullOrWhiteSpace(item.Identifier))
-                .GroupBy(item => item.Identifier, StringComparer.OrdinalIgnoreCase)
-                .Select(group => group.First())
-                .OrderBy(item => DisplayNameForWhistle(item), StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-            var whistleIds = whistleItems.Select(item => item.Identifier).ToList();
-            var values = whistleItems.Select(DisplayNameForWhistle).ToList();
-            var currentIdentifier = settings.WhistleIdentifier ?? whistleComponent.DefaultWhistleIdentifier ?? string.Empty;
-            if (whistleIds.Count == 0 && !string.IsNullOrWhiteSpace(currentIdentifier))
-            {
-                whistleIds.Add(currentIdentifier);
-                values.Add(currentIdentifier);
-            }
-
-            var currentSelectedIndex = whistleIds.FindIndex(id =>
-                string.Equals(currentIdentifier, id, StringComparison.OrdinalIgnoreCase));
-            if (currentSelectedIndex < 0 && !string.IsNullOrWhiteSpace(currentIdentifier))
-            {
-                whistleIds.Insert(0, currentIdentifier);
-                values.Insert(0, currentIdentifier);
-                currentSelectedIndex = 0;
-            }
-
-            if (whistleIds.Count == 0)
-            {
-                return;
-            }
-
-            currentSelectedIndex = Math.Max(0, currentSelectedIndex);
-            builder.AddField("Whistle", builder.AddDropdown(values, currentSelectedIndex, index =>
-            {
-                if (index < 0 || index >= whistleIds.Count)
-                {
-                    return;
-                }
-
-                car.KeyValueObject[WhistleCustomizationSettings.ObjectKey] =
-                    new WhistleCustomizationSettings(whistleIds[index]).PropertyValue;
-            }));
-        }
-
-        private static Value ReadWhistleCustomizationValue(Car car)
-        {
-            try
-            {
-                return car?.KeyValueObject?[WhistleCustomizationSettings.ObjectKey] ?? Value.Null();
-            }
-            catch
-            {
-                return Value.Null();
-            }
-        }
-
-        private static string DisplayNameForWhistle(TypedContainerItem<WhistleDefinition> item)
-        {
-            return string.IsNullOrWhiteSpace(item?.Metadata?.Name)
-                ? item?.Identifier ?? string.Empty
-                : item.Metadata.Name;
+            AddHornDropdown(builder, ____car);
+            AddBellDropdown(builder, ____car);
         }
 
         private static void AddHornDropdown(UIPanelBuilder builder, Car car)
@@ -360,5 +179,6 @@ namespace FUSE.Patches
                 }));
             }, 0f);
         }
+
     }
 }

--- a/FUSE/Patches/FusePrefabStoreMaterialDefinitionsPatch.cs
+++ b/FUSE/Patches/FusePrefabStoreMaterialDefinitionsPatch.cs
@@ -1,52 +1,29 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using AssetPack.Runtime;
-using HarmonyLib;
 using Model.Definition;
 using Model.Definition.Data;
-using Model.Database;
 using FUSE.Infrastructure;
-using FUSE.Loading;
 
 namespace FUSE.Patches
 {
 
-    [HarmonyPatch]
     internal static class FusePrefabStoreMaterialDefinitionsPatch
     {
         private static readonly HashSet<string> WarnedNullFieldLists = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private static readonly HashSet<string> WarnedNullFieldPairs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        private static MethodInfo TargetMethod()
-        {
-            return AccessTools.Method(typeof(PrefabStore), "AllDefinitionInfosOfType")
-                ?.MakeGenericMethod(typeof(MaterialDefinition));
-        }
-
-        private static void Postfix(ref IEnumerable<TypedContainerItem<MaterialDefinition>> __result)
-        {
-            __result = SanitizeMaterialDefinitions(__result);
-        }
-
-        private static IEnumerable<TypedContainerItem<MaterialDefinition>> SanitizeMaterialDefinitions(
-            IEnumerable<TypedContainerItem<MaterialDefinition>> items)
-        {
-            foreach (var item in items ?? Enumerable.Empty<TypedContainerItem<MaterialDefinition>>())
-            {
-                SanitizeMaterialDefinition(item);
-                yield return item;
-            }
-        }
-
         /// <summary>
         /// Pure-data sanitizer for a single
         /// <see cref="MaterialDefinition"/>: guarantees a non-null
         /// <see cref="MaterialDefinition.Fields"/> list and drops any
-        /// null entries inside it. Internal so the body unit tests
-        /// in FUSE.Tests can call it directly with crafted shapes
-        /// the upstream PrefabStore enumeration can produce
+        /// null entries inside it. This helper is deliberately not a
+        /// Harmony patch: patching
+        /// <c>PrefabStore.AllDefinitionInfosOfType&lt;T&gt;</c> for a
+        /// closed generic type can still corrupt other closed forms on
+        /// Mono's shared generic body, including the vanilla whistle
+        /// picker in the locomotive customize window. Internal so the
+        /// body unit tests in FUSE.Tests can call it directly with
+        /// crafted shapes the upstream PrefabStore enumeration can produce
         /// (null definition, null Fields list, mixed null/valid
         /// FieldPairs). Each fixup is logged at most once per
         /// material identifier so a single corrupted asset doesn't


### PR DESCRIPTION
## 🔗 Related Issue

No linked issue.

## 📝 Description of the Change

Fixes the locomotive Customize window regression caused by FUSE patching `PrefabStore.AllDefinitionInfosOfType<T>()` on a closed generic type.

The failing in-game stack showed vanilla `CarCustomizeWindow.BuildSoundTabWhistle()` crashing while materializing `AllDefinitionInfosOfType<WhistleDefinition>()`. The root cause was not a missing/default whistle selection. FUSE had a material-definition sanitizer patched onto `AllDefinitionInfosOfType<MaterialDefinition>()`, and Mono/Harmony can share generic method bodies in a way that corrupts other closed generic uses.

This change removes that generic Harmony patch entirely. Material cleanup is still preserved, but it now runs after FUSE deserializes direct asset-pack containers by walking concrete `ContainerItem` objects instead of patching the generic PrefabStore enumeration.

Also keeps the earlier cleanup that removes the manual whistle-panel workaround/default-whistle patch and restores the vanilla Customize sound tab flow, with FUSE only adding its horn/bell sections afterward.

Model-only asset packs are now discovered when they contain `Bundle` + `Catalog.json`, even if they do not have `Definitions.json`, which allows packs like `TPPWhistleModels` to be mounted without copying or modifying their contents.

## 🔄 Alternatives Considered

Considered keeping a whistle fallback/default selection patch, but that was treating a symptom. The panel was failing before selection/default logic, during vanilla whistle-definition enumeration.

Considered keeping the material sanitizer as a closed generic Harmony patch, but that is the unsafe part. Moving cleanup to direct container sanitization keeps the intended protection without touching shared generic PrefabStore code.

## ⚠️ Possible Drawbacks

Material definition cleanup now applies through FUSE direct-container loading instead of a global PrefabStore enumeration hook. That is intentional, but malformed material definitions coming from a non-FUSE/non-direct path would rely on the existing downstream hardening instead.

Model-only packs without `Definitions.json` now get mounted as direct stores with an empty container. This should be compatible, but it can slightly increase the number of registered asset-pack stores.

Changes are backward compatible with existing saves.

## ✅ Verification Process

Built and deployed FUSE to the Railroader Mods folder:

`dotnet build .\FUSE\FUSE.csproj -c Release -p:GameDir="C:\Steam\steamapps\common\Railroader" -p:UnityManagedDir="C:\Steam\steamapps\common\Railroader\Railroader_Data\Managed" -p:EnableModDeploy=true`

Result: build succeeded with 0 warnings and 0 errors.

Ran the FUSE test suite:

`dotnet test .\FUSE.Tests\FUSE.Tests.csproj -c Release --no-build -p:GameDir="C:\Steam\steamapps\common\Railroader" -p:UnityManagedDir="C:\Steam\steamapps\common\Railroader\Railroader_Data\Managed"`

Result: 734 passed, 0 failed.

Confirmed the deployed DLL timestamp updated in:

`C:\Steam\steamapps\common\Railroader\Mods\FUSE\FUSE.dll`

## 💡 Additional Information

The important diagnostic clue was the in-game exception:

`ArrayTypeMismatchException` inside `List<T>.AddEnumerable()` while vanilla was calling `AllDefinitionInfosOfType<WhistleDefinition>().ToList()`.

That pointed to generic enumerable corruption, not a missing whistle asset or bad saved whistle id.