### PR TITLE
Detect legacy Railloader install at startup and warn user

### DIFF
--- a/FUSE/Compatibility/FuseLegacyInstallDetector.cs
+++ b/FUSE/Compatibility/FuseLegacyInstallDetector.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using FUSE.Infrastructure;
+using UnityEngine;
+
+namespace FUSE.Compatibility
+{
+    // Detects when the legacy Railloader install is left in place alongside
+    // FUSE. The bad state is Railloader.dll and/or Railloader.Interchange.dll
+    // sitting in Railroader_Data\Managed\: Unity's assembly loader resolves
+    // them before FuseLegacySupportAssemblyShim's AssemblyResolve hook fires,
+    // so legacy mod IL binds to the real old-loader types instead of FUSE's
+    // shim types. FUSE's plugin host then silently rejects those plugin types
+    // because their base type isn't the shim Railloader.PluginBase.
+    internal static class FuseLegacyInstallDetector
+    {
+        private const string LegacyRailloaderDll = "Railloader.dll";
+        private const string LegacyInterchangeDll = "Railloader.Interchange.dll";
+
+        internal static IReadOnlyList<string> DetectConflictingFiles()
+        {
+            var results = new List<string>();
+            ProbeManagedDirectory(results);
+            ProbeLoadedAssemblies(results);
+            return results;
+        }
+
+        private static void ProbeManagedDirectory(List<string> results)
+        {
+            try
+            {
+                var dataPath = Application.dataPath;
+                if (string.IsNullOrWhiteSpace(dataPath))
+                {
+                    return;
+                }
+
+                var managedDir = Path.Combine(dataPath, "Managed");
+                AddIfFileExists(results, Path.Combine(managedDir, LegacyRailloaderDll));
+                AddIfFileExists(results, Path.Combine(managedDir, LegacyInterchangeDll));
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE legacy install detector could not probe the Managed directory: "
+                    + ex.GetBaseException().Message);
+            }
+        }
+
+        private static void ProbeLoadedAssemblies(List<string> results)
+        {
+            Assembly shimAssembly;
+            try
+            {
+                shimAssembly = typeof(Railloader.IModDefinition).Assembly;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE legacy install detector could not resolve the shim assembly reference; "
+                    + "loaded-assembly probe will be skipped: " + ex.GetBaseException().Message);
+                return;
+            }
+
+            Assembly[] assemblies;
+            try
+            {
+                assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE legacy install detector could not enumerate loaded assemblies: "
+                    + ex.GetBaseException().Message);
+                return;
+            }
+
+            foreach (var assembly in assemblies)
+            {
+                if (assembly == null || ReferenceEquals(assembly, shimAssembly))
+                {
+                    continue;
+                }
+
+                string assemblyName;
+                try
+                {
+                    assemblyName = assembly.GetName().Name;
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (!IsLegacyLoaderAssemblyName(assemblyName))
+                {
+                    continue;
+                }
+
+                string location = null;
+                try
+                {
+                    if (!assembly.IsDynamic)
+                    {
+                        location = assembly.Location;
+                    }
+                }
+                catch
+                {
+                    location = null;
+                }
+
+                AddUnique(
+                    results,
+                    string.IsNullOrWhiteSpace(location)
+                        ? assemblyName + " (loaded, location unavailable)"
+                        : location);
+            }
+        }
+
+        private static bool IsLegacyLoaderAssemblyName(string assemblyName)
+        {
+            if (string.IsNullOrWhiteSpace(assemblyName))
+            {
+                return false;
+            }
+
+            // Railloader.Injector is the Doorstop-style native-side hook that
+            // ships with the standard FUSE-compatible install — it is NOT the
+            // legacy managed loader API and must not be flagged as a conflict.
+            if (assemblyName.Equals("Railloader.Injector", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return assemblyName.StartsWith("Railloader", StringComparison.OrdinalIgnoreCase) ||
+                   assemblyName.Equals("StrangeCustoms", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static void AddIfFileExists(List<string> results, string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    AddUnique(results, path);
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE legacy install detector could not test path '{path}': "
+                    + ex.GetBaseException().Message);
+            }
+        }
+
+        private static void AddUnique(List<string> results, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return;
+            }
+
+            foreach (var existing in results)
+            {
+                if (string.Equals(existing, value, StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+            }
+
+            results.Add(value);
+        }
+    }
+}

--- a/FUSE/FusePlugin.cs
+++ b/FUSE/FusePlugin.cs
@@ -57,6 +57,7 @@ namespace FUSE
             try
             {
                 FuseLegacySupportAssemblyShim.Initialize();
+                WarnIfLegacyRailloaderInstallPresent();
                 LogStartupVersions(modEntry);
                 FuseSettings.Load(modEntry);
                 FuseAssetPackRegistry.MountAllAvailableAssetPacks();
@@ -118,6 +119,27 @@ namespace FUSE
             {
                 FuseLog.Exception($"FUSE startup version report failed", ex);
             }
+        }
+
+        private static void WarnIfLegacyRailloaderInstallPresent()
+        {
+            // Detection runs after the AssemblyResolve shim is wired so the
+            // loaded-assembly probe can identify a real Railloader assembly
+            // by exclusion from the shim assembly identity.
+            var conflicts = FuseLegacyInstallDetector.DetectConflictingFiles();
+            if (conflicts.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var path in conflicts)
+            {
+                FuseLog.Error(
+                    "FUSE detected a conflicting legacy Railloader file: " + path +
+                    ". Delete this file and restart Railroader.");
+            }
+
+            FuseLegacyInstallAlert.Ensure(conflicts);
         }
 
         private static string ReadInfoJsonString(string infoPath, string propertyName)

--- a/FUSE/Interface/FuseLegacyInstallAlert.cs
+++ b/FUSE/Interface/FuseLegacyInstallAlert.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Infrastructure;
+using UnityEngine;
+
+namespace FUSE.Interface
+{
+    // Full-screen blocking modal that warns the user when FUSE detects a
+    // conflicting legacy Railloader install at startup (see
+    // FuseLegacyInstallDetector). OnGUI is used because the game's Window
+    // primitive (ProgrammaticWindowCreator) is null until a map is loaded;
+    // OnGUI is the only UI surface that's alive from the splash screen
+    // onward, which is when the user most needs to see this.
+    internal sealed class FuseLegacyInstallAlert : MonoBehaviour
+    {
+        private const float DialogWidth = 720f;
+        private const float DialogHeight = 460f;
+
+        private static GameObject _host;
+        private static FuseLegacyInstallAlert _instance;
+        private static bool _dismissed;
+
+        private IReadOnlyList<string> _conflicts = Array.Empty<string>();
+        private Vector2 _scrollPosition;
+        private Texture2D _dimTexture;
+        private GUIStyle _titleStyle;
+        private GUIStyle _bodyStyle;
+        private GUIStyle _pathStyle;
+        private GUIStyle _instructionStyle;
+        private bool _stylesReady;
+        private bool _renderFailureLogged;
+
+        internal static void Ensure(IReadOnlyList<string> conflicts)
+        {
+            if (conflicts == null || conflicts.Count == 0)
+            {
+                return;
+            }
+
+            if (_host != null)
+            {
+                if (_instance != null)
+                {
+                    _instance._conflicts = conflicts;
+                }
+                return;
+            }
+
+            _host = new GameObject("FUSE Legacy Install Alert");
+            DontDestroyOnLoad(_host);
+            _host.hideFlags = HideFlags.HideAndDontSave;
+            _instance = _host.AddComponent<FuseLegacyInstallAlert>();
+            _instance._conflicts = conflicts;
+            FuseLog.Info("FUSE legacy install alert displayed at startup.");
+        }
+
+        private void OnGUI()
+        {
+            if (_dismissed || _conflicts == null || _conflicts.Count == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                EnsureStyles();
+                DrawDim();
+                DrawDialog();
+            }
+            catch (Exception ex)
+            {
+                if (!_renderFailureLogged)
+                {
+                    _renderFailureLogged = true;
+                    FuseLog.Warning(
+                        "FUSE legacy install alert OnGUI failed; alert will not render this session: "
+                        + ex.GetBaseException().Message);
+                }
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_dimTexture != null)
+            {
+                Destroy(_dimTexture);
+                _dimTexture = null;
+            }
+        }
+
+        private void EnsureStyles()
+        {
+            if (_stylesReady)
+            {
+                return;
+            }
+
+            _dimTexture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+            _dimTexture.SetPixel(0, 0, new Color(0f, 0f, 0f, 0.85f));
+            _dimTexture.Apply();
+
+            _titleStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 22,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleCenter
+            };
+            _titleStyle.normal.textColor = new Color(1f, 0.35f, 0.35f);
+
+            _bodyStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 14,
+                wordWrap = true
+            };
+            _bodyStyle.normal.textColor = Color.white;
+
+            _pathStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 13,
+                wordWrap = true
+            };
+            _pathStyle.normal.textColor = new Color(1f, 0.85f, 0.5f);
+
+            _instructionStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 14,
+                wordWrap = true,
+                fontStyle = FontStyle.Bold
+            };
+            _instructionStyle.normal.textColor = Color.white;
+
+            _stylesReady = true;
+        }
+
+        private void DrawDim()
+        {
+            GUI.depth = -1000;
+            GUI.DrawTexture(new Rect(0f, 0f, Screen.width, Screen.height), _dimTexture);
+        }
+
+        private void DrawDialog()
+        {
+            var width = Mathf.Min(DialogWidth, Screen.width - 40f);
+            var height = Mathf.Min(DialogHeight, Screen.height - 40f);
+            var rect = new Rect(
+                (Screen.width - width) * 0.5f,
+                (Screen.height - height) * 0.5f,
+                width,
+                height);
+
+            GUI.Box(rect, GUIContent.none);
+            GUILayout.BeginArea(new Rect(rect.x + 16f, rect.y + 16f, rect.width - 32f, rect.height - 32f));
+
+            GUILayout.Label("FUSE Cannot Run Safely", _titleStyle);
+            GUILayout.Space(8f);
+            GUILayout.Label(
+                "FUSE found leftover files from the legacy Railloader mod loader in this " +
+                "Railroader install. While these files are present, mods bind to the old " +
+                "loader's types instead of FUSE's compatibility shim and will not load " +
+                "correctly. You may see mods do nothing after loading a save.",
+                _bodyStyle);
+            GUILayout.Space(8f);
+            GUILayout.Label("Conflicting files:", _instructionStyle);
+
+            var listHeight = Mathf.Max(60f, rect.height - 300f);
+            _scrollPosition = GUILayout.BeginScrollView(_scrollPosition, GUILayout.Height(listHeight));
+            foreach (var path in _conflicts)
+            {
+                GUILayout.Label(path ?? string.Empty, _pathStyle);
+            }
+            GUILayout.EndScrollView();
+
+            GUILayout.Space(8f);
+            GUILayout.Label(
+                "Quit the game, delete the files listed above, then restart Railroader.",
+                _instructionStyle);
+            GUILayout.Space(8f);
+
+            GUILayout.BeginHorizontal();
+            if (GUILayout.Button("Copy Paths", GUILayout.Width(160f), GUILayout.Height(28f)))
+            {
+                CopyConflictsToClipboard();
+            }
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("I Understand", GUILayout.Width(160f), GUILayout.Height(28f)))
+            {
+                _dismissed = true;
+                FuseLog.Info("FUSE legacy install alert dismissed by user.");
+            }
+            GUILayout.EndHorizontal();
+
+            GUILayout.EndArea();
+        }
+
+        private void CopyConflictsToClipboard()
+        {
+            try
+            {
+                GUIUtility.systemCopyBuffer = string.Join(Environment.NewLine, _conflicts);
+                FuseLog.Info("FUSE legacy install alert copied conflicting paths to clipboard.");
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE legacy install alert could not copy paths to clipboard: "
+                    + ex.GetBaseException().Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue

No tracking issue — addresses the recurring "DKW (and other legacy mods) silently doesn't load" support reports caused by leftover `Railloader.Interchange.dll` in `Railroader_Data\Managed\`.

## 📝 Description of the Change

When users install FUSE without first deleting the legacy Railloader files from `Railroader_Data\Managed\`, Unity's assembly loader resolves the real `Railloader` / `Railloader.Interchange` DLLs before `FuseLegacySupportAssemblyShim`'s `AssemblyResolve` hook ever fires. Legacy mod IL (e.g. DKW) then binds to the real old-loader `Railloader.PluginBase` rather than FUSE's shim version, and `FuseLegacyAssemblyHost` silently rejects the plugin type because its base type isn't the shim one. The user only discovers the breakage after loading a save and noticing mods are inert.

This PR adds startup detection plus a blocking user-facing warning so the bad state is caught before the player ever loads in.

Three new pieces:

- **`FUSE/Compatibility/FuseLegacyInstallDetector.cs`** — disk probe of `<Application.dataPath>/Managed/` for `Railloader.dll` and `Railloader.Interchange.dll`, plus a loaded-assembly probe that scans `AppDomain.CurrentDomain.GetAssemblies()` for any assembly whose name starts with `Railloader` (or equals `StrangeCustoms`) that isn't the FUSE shim assembly. `Railloader.Injector` (the Doorstop-style native hook that ships with the normal FUSE-compatible install) is explicitly excluded so it's never flagged as a false positive. Every I/O and reflection call is wrapped in try/catch; detection itself can never block FUSE init.

- **`FUSE/Interface/FuseLegacyInstallAlert.cs`** — full-screen `OnGUI` modal on a `DontDestroyOnLoad` MonoBehaviour, modeled on the existing `FuseTrackDebugOverlay` pattern. Renders a dimmed background, a red "FUSE Cannot Run Safely" title, an explanation, the list of conflicting paths, instructions to quit and delete the files, and two buttons: **Copy Paths** (writes the paths to `GUIUtility.systemCopyBuffer`) and **I Understand** (dismisses the modal). `OnGUI` was chosen because the game's `ProgrammaticWindowCreator` (used by `FuseHealthUi` / `FuseOrphanedCarWindow`) is null until a map is loaded, so a `Window`-based modal cannot render at the splash / main-menu screen where the user most needs to see this.

- **`FUSE/FusePlugin.cs`** — calls `WarnIfLegacyRailloaderInstallPresent()` immediately after `FuseLegacySupportAssemblyShim.Initialize()`. If detection returns any paths, each is logged via `FuseLog.Error` and the alert is `Ensure`-d. FUSE then continues normal initialization; per the design discussion the modal is acknowledge-and-dismiss, not a hard FUSE shutdown.

## 🔄 Alternatives Considered

- **Game-native `Window` via `WindowCreatorHelper`** — would look more native but `ProgrammaticWindowCreator` is unavailable at the main menu (confirmed via the existing "creator not available yet" log paths in `FuseHealthUi.EnsureWindow` and `FuseOrphanedCarWindow.ShowOnce`), so it can't render at the moment we most want to surface this error. Skipped.
- **Toast.Present()** — works main-menu-and-later but is transient and non-interactive, so there's no acknowledgement gesture. Skipped.
- **Quit-on-acknowledge button** — considered for safety, but per the design discussion the user preferred a simple dismiss model so they can still poke around the FUSE Health UI even with the conflict present.

## ⚠️ Possible Drawbacks

- The `OnGUI` modal is cosmetically less polished than the game's own Window system. For an error/setup-issue dialog this is arguably the right look ("system warning, not game content").
- Dismissing the modal does NOT actually fix anything — FUSE still runs in the broken state until the user deletes the files. Documented in the body text and instructions inside the modal.
- The loaded-assembly probe excludes `Railloader.Injector` by name. If a future legacy install ships a differently-named injector-style DLL, the probe wouldn't false-positive on it but also wouldn't catch it. Disk probe covers the canonical case (`Railloader.dll`, `Railloader.Interchange.dll`).
- No save-compat concerns — this is startup detection only.

## ✅ Verification Process

- `dotnet build FUSE/FUSE.csproj` — clean, 0 warnings, 0 errors.
- `dotnet test FUSE.Tests/FUSE.Tests.csproj` — 734 passed / 0 failed.

Manual verification (to be run in-game by the author against an actual install):

1. **Clean install (negative path)**: no `Railloader.dll` / `Railloader.Interchange.dll` in `Managed\` → no modal, no `FuseLog.Error` lines about conflicts, FUSE loads as today.
2. **Disk conflict (positive path)**: drop a non-empty file named `Railloader.Interchange.dll` into `Railroader_Data\Managed\` → modal renders over splash + main menu, `FUSE.log` has `[ERROR]` line for the file path, **Copy Paths** populates the clipboard, **I Understand** dismisses.
3. **Detection failure safety**: a thrown exception inside the detector still lets FUSE finish loading; the alert just doesn't appear.

## 💡 Additional Information

The detector's predicate for the loaded-assembly probe deliberately mirrors `FuseLegacySupportAssemblyShim.IsLegacyLoaderAssembly` (same `StartsWith("Railloader") || Equals("StrangeCustoms")` rule) so detection and the AssemblyResolve shim agree on what "a legacy loader assembly" means. Both should be updated together if the rule ever evolves.