### PR TITLE
Progressions need love too

### DIFF
--- a/FUSE.Tests/Loading/FuseLegacyProgressionConverterTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyProgressionConverterTests.cs
@@ -1,0 +1,58 @@
+using FUSE.Authoring.Serialization;
+using FUSE.Loading;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public class FuseLegacyProgressionConverterTests
+    {
+        private static JObject Convert(JObject source)
+        {
+            var manifest = new FuseLegacyPackageManifest
+            {
+                PackageId = "test-pkg",
+                DisplayName = "Test Package",
+                Author = "tester",
+                Version = "1.0.0"
+            };
+            var root = FuseLegacyDataConverter.CreateSkeleton(manifest, "progression-fragment");
+            FuseLegacyDataConverter.ConvertSource(source, root, manifest);
+            return root;
+        }
+
+        [Fact]
+        public void EmptyDeliveryPhase_BecomesFreePhaseInsteadOfBeingRemoved()
+        {
+            var root = Convert(new JObject
+            {
+                ["progressions"] = new JObject
+                {
+                    ["ewh"] = new JObject
+                    {
+                        ["sections"] = new JObject
+                        {
+                            ["AP-AR-W-SAWMILL"] = new JObject
+                            {
+                                ["displayName"] = "Whittier Sawmill",
+                                ["deliveryPhases"] = new JArray(new JObject()),
+                                ["enableFeaturesOnUnlock"] = new JObject
+                                {
+                                    ["AR-Whittier-Sawmill"] = true
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            var phase = (JObject)root["progression"]["progressions"]["ewh"]["sections"]["AP-AR-W-SAWMILL"]["deliveryPhases"][0];
+            Assert.Equal(0, (int)phase["cost"]);
+
+            var definition = FuseSerializer.FromJson(root.ToString());
+            var section = definition.Progression.Progressions["ewh"].Sections["AP-AR-W-SAWMILL"];
+            Assert.Single(section.DeliveryPhases);
+            Assert.Equal(0, section.DeliveryPhases[0].Cost);
+        }
+    }
+}

--- a/FUSE/Loading/FuseLegacyDataConverter.Progression.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.Progression.cs
@@ -97,6 +97,12 @@ namespace FUSE.Loading
                 }
                 else
                 {
+                    if (string.Equals(targetKey, "deliveryPhases", StringComparison.OrdinalIgnoreCase))
+                    {
+                        result[targetKey] = NormalizeDeliveryPhases(property.Value);
+                        continue;
+                    }
+
                     // We deliberately do NOT pre-collapse boolean-dictionary
                     // fields here (the SC convention: <c>{ "foo": true,
                     // "bar": false }</c> on tracksEnable / tracksAvail /
@@ -134,6 +140,35 @@ namespace FUSE.Loading
             }
 
             return CleanObject(result);
+        }
+
+        private static JToken NormalizeDeliveryPhases(JToken value)
+        {
+            if (!(value is JArray array))
+            {
+                return NormalizeProgressionValue(value);
+            }
+
+            var result = new JArray();
+            foreach (var item in array)
+            {
+                var normalized = NormalizeProgressionValue(item);
+                if (normalized is JObject phase && !phase.HasValues)
+                {
+                    // Legacy progressions use `{}` as a valid free phase:
+                    // zero cost, no deliveries. The generic cleaner treats an
+                    // empty object as absent, which collapses `[{}]` into zero
+                    // phases and crashes the vanilla milestones UI.
+                    phase["cost"] = 0;
+                }
+
+                if (normalized != null && normalized.Type != JTokenType.Null)
+                {
+                    result.Add(normalized);
+                }
+            }
+
+            return result;
         }
 
         private static string NormalizeProgressionKey(string key)

--- a/FUSE/Patches/FuseGoalsPanelGameModePatch.cs
+++ b/FUSE/Patches/FuseGoalsPanelGameModePatch.cs
@@ -1,0 +1,26 @@
+using System;
+using FUSE.Infrastructure;
+using Game.Events;
+using HarmonyLib;
+using UI.Builder;
+using UI.Common;
+using UI.CompanyWindow;
+
+namespace FUSE.Patches
+{
+    [HarmonyPatch(typeof(GoalsPanelBuilder), nameof(GoalsPanelBuilder.Build))]
+    internal static class FuseGoalsPanelGameModePatch
+    {
+        private static void Postfix(UIPanelBuilder builder, UIState<string> selectedItem)
+        {
+            try
+            {
+                builder.RebuildOnEvent<GameModeDidChange>();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE failed to attach Milestones panel game-mode rebuild observer.", ex);
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseTagDestinationAreaColorPatch.cs
+++ b/FUSE/Patches/FuseTagDestinationAreaColorPatch.cs
@@ -1,0 +1,99 @@
+using System;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Helpers;
+using Model;
+using Model.Ops;
+using UI.Tags;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    [HarmonyPatch(typeof(TagController), "UpdateTag")]
+    internal static class FuseTagDestinationAreaColorPatch
+    {
+        private static void Postfix(Car car, TagCallout tagCallout, OpsController opsController)
+        {
+            try
+            {
+                if (car == null || tagCallout?.colorImages == null || opsController == null)
+                {
+                    return;
+                }
+
+                string destinationName;
+                bool isAtDestination;
+                Vector3 destinationPosition;
+                OpsCarPosition destination;
+                if (!opsController.TryGetDestinationInfo(
+                        car,
+                        out destinationName,
+                        out isAtDestination,
+                        out destinationPosition,
+                        out destination))
+                {
+                    return;
+                }
+
+                var destinationArea = opsController.AreaForCarPosition(destination);
+                if (!IsTransparent(destinationArea?.tagColor ?? default(Color)))
+                {
+                    return;
+                }
+
+                var fallbackArea = FindNearestVisibleArea(opsController, destinationPosition, destinationArea);
+                if (fallbackArea == null)
+                {
+                    return;
+                }
+
+                var color = fallbackArea.tagColor;
+                if (isAtDestination)
+                {
+                    color *= 0.5f;
+                }
+
+                foreach (var image in tagCallout.colorImages)
+                {
+                    if (image != null)
+                    {
+                        image.color = color;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE failed to apply fallback destination area color to car tag.", ex);
+            }
+        }
+
+        private static Area FindNearestVisibleArea(OpsController opsController, Vector3 destinationPosition, Area excludedArea)
+        {
+            Area nearestArea = null;
+            var nearestDistance = float.MaxValue;
+
+            foreach (var area in opsController.Areas)
+            {
+                if (area == null || area == excludedArea || IsTransparent(area.tagColor))
+                {
+                    continue;
+                }
+
+                var areaPosition = WorldTransformer.WorldToGame(area.transform.position);
+                var distance = Vector3.Distance(destinationPosition, areaPosition) - area.radius;
+                if (distance <= nearestDistance)
+                {
+                    nearestArea = area;
+                    nearestDistance = distance;
+                }
+            }
+
+            return nearestArea;
+        }
+
+        private static bool IsTransparent(Color color)
+        {
+            return color.a <= 0.001f;
+        }
+    }
+}

--- a/FUSE/Runtime/API/ProgressionAPI.Diagnostics.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.Diagnostics.cs
@@ -129,8 +129,192 @@ namespace FUSE.Runtime.API
                     prerequisiteSectionIds = ListSectionIds(section.prerequisiteSections),
                     enableFeaturesOnUnlock = ListFeatureIds(section.enableFeaturesOnUnlock),
                     deliveryPhaseCount = section.deliveryPhases?.Length ?? 0,
+                    deliveryPhases = BuildSectionDeliveryPhasePayloads(section),
                 })
                 .ToArray();
+        }
+
+        private static object[] BuildSectionDeliveryPhasePayloads(Section section)
+        {
+            if (section?.deliveryPhases == null || section.deliveryPhases.Length == 0)
+            {
+                return Array.Empty<object>();
+            }
+
+            return section.deliveryPhases
+                .Select((phase, phaseIndex) =>
+                {
+                    var component = phase?.industryComponent;
+                    var receivedCounts = ReadProgressionReceivedCounts(component);
+                    var spans = (component?.TrackSpans ?? Enumerable.Empty<TrackSpan>())
+                        .Where(span => span != null)
+                        .ToArray();
+
+                    return (object)new
+                    {
+                        index = phaseIndex,
+                        cost = phase?.cost ?? 0,
+                        industryComponentId = component != null ? component.Identifier : null,
+                        industryComponentProgressionDisabled = component != null ? (bool?)component.ProgressionDisabled : null,
+                        industryComponentActiveInHierarchy = component != null ? (bool?)component.gameObject.activeInHierarchy : null,
+                        trackSpanCount = spans.Length,
+                        trackSpans = spans
+                            .Select(span => new
+                            {
+                                id = span.id ?? span.name,
+                                lowerSegmentId = span.lower?.segment?.id,
+                                upperSegmentId = span.upper?.segment?.id,
+                            })
+                            .ToArray(),
+                        deliveries = BuildDeliveryPayloads(section, phase, phaseIndex, receivedCounts),
+                        carsAtComponent = BuildProgressionComponentCarPayloads(component),
+                    };
+                })
+                .ToArray();
+        }
+
+        private static object[] BuildDeliveryPayloads(
+            Section section,
+            Section.DeliveryPhase phase,
+            int phaseIndex,
+            Dictionary<string, int> receivedCounts)
+        {
+            if (phase?.deliveries == null || phase.deliveries.Length == 0)
+            {
+                return Array.Empty<object>();
+            }
+
+            return phase.deliveries
+                .Select((delivery, deliveryIndex) =>
+                {
+                    var tag = ProgressionDeliveryTag(section, phaseIndex, deliveryIndex);
+                    var receivedCount = 0;
+                    receivedCounts?.TryGetValue(tag, out receivedCount);
+                    var load = delivery?.load;
+                    return (object)new
+                    {
+                        index = deliveryIndex,
+                        tag,
+                        carTypeFilter = delivery?.carTypeFilter?.ToString(),
+                        count = delivery?.count ?? 0,
+                        receivedCount,
+                        loadId = load != null ? load.id : null,
+                        loadName = load != null ? load.description : null,
+                        loadUnits = load != null ? load.units.ToString() : null,
+                        loadImportable = load != null ? (bool?)load.importable : null,
+                        loadNominalQuantityPerCar = load != null ? (float?)load.NominalQuantityPerCarLoad : null,
+                        direction = delivery?.direction.ToString(),
+                    };
+                })
+                .ToArray();
+        }
+
+        private static string ProgressionDeliveryTag(Section section, int phaseIndex, int deliveryIndex)
+        {
+            return $"{section?.identifier ?? string.Empty}.{phaseIndex}.{deliveryIndex}";
+        }
+
+        private static Dictionary<string, int> ReadProgressionReceivedCounts(ProgressionIndustryComponent component)
+        {
+            var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            if (component == null)
+            {
+                return counts;
+            }
+
+            try
+            {
+                var field = typeof(ProgressionIndustryComponent).GetField("_keyValueObject", BindingFlags.Instance | BindingFlags.NonPublic);
+                var keyValueObject = field?.GetValue(component) as IKeyValueObject;
+                if (keyValueObject == null)
+                {
+                    return counts;
+                }
+
+                var value = keyValueObject["indRecv"];
+                if (value.Type != KeyValue.Runtime.ValueType.Dictionary)
+                {
+                    return counts;
+                }
+
+                foreach (var pair in value.DictionaryValue)
+                {
+                    if (!string.IsNullOrWhiteSpace(pair.Key))
+                    {
+                        counts[pair.Key] = pair.Value.IntValue;
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return counts;
+        }
+
+        private static object[] BuildProgressionComponentCarPayloads(ProgressionIndustryComponent component)
+        {
+            var ops = OpsController.Shared;
+            if (component == null || ops == null)
+            {
+                return Array.Empty<object>();
+            }
+
+            try
+            {
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                return ops.CarsAtPosition(component)
+                    .Where(car => car != null && seen.Add(car.id ?? string.Empty))
+                    .OrderBy(car => car.DisplayName ?? car.id ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                    .Select(car =>
+                    {
+                        var waybill = car.Waybill;
+                        return (object)new
+                        {
+                            id = car.id,
+                            displayName = car.DisplayName,
+                            carType = car.CarType,
+                            componentCarTypeAccepted = component.carTypeFilter?.Matches(car.CarType) ?? false,
+                            velocity = car.velocity,
+                            waybillDestinationId = waybill != null ? waybill.Value.Destination.Identifier : null,
+                            waybillTag = waybill != null ? waybill.Value.Tag : null,
+                            waybillCompleted = waybill != null ? (bool?)waybill.Value.Completed : null,
+                            loads = BuildCarLoadPayloads(car),
+                        };
+                    })
+                    .ToArray();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception($"FUSE progression dump payload cars for component '{component.Identifier}' failed", ex);
+                return Array.Empty<object>();
+            }
+        }
+
+        private static object[] BuildCarLoadPayloads(Car car)
+        {
+            if (car?.Definition?.LoadSlots == null)
+            {
+                return Array.Empty<object>();
+            }
+
+            var loads = new List<object>();
+            for (var slotIndex = 0; slotIndex < car.Definition.LoadSlots.Count; slotIndex++)
+            {
+                var slot = car.Definition.LoadSlots[slotIndex];
+                var loadInfo = car.GetLoadInfo(slotIndex);
+                loads.Add(new
+                {
+                    slot = slotIndex,
+                    loadId = loadInfo != null ? loadInfo.Value.LoadId : null,
+                    quantity = loadInfo != null ? (float?)loadInfo.Value.Quantity : null,
+                    maximumCapacity = slot?.MaximumCapacity,
+                    loadUnits = slot?.LoadUnits.ToString(),
+                    requiredLoadIdentifier = slot?.RequiredLoadIdentifier,
+                });
+            }
+
+            return loads.ToArray();
         }
 
         // Build the union of groups referenced by a MapFeature with

--- a/FUSE/Runtime/API/ProgressionAPI.FeatureState.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.FeatureState.cs
@@ -309,6 +309,7 @@ namespace FUSE.Runtime.API
             // time using the (then-reliable) IsSandbox, so no pre-fill is
             // required for correctness.
             var initialized = InitializeMissingMapFeatureStates(manager);
+            var inferredIndustryIncludes = InferMapFeatureIndustryIncludes(manager, reason);
             var forcedFeatureState = ForceApplyCurrentMapFeatureState(manager, reason);
             var restoredTrackGroups = RestoreDisabledTrackGroups(manager, reason);
             var finalisedOrphans = RevokeTransientlyPreEnabledOrphanGroups(manager, reason);
@@ -316,7 +317,8 @@ namespace FUSE.Runtime.API
                 $"FUSE refreshed progression runtime state package='<all>' operation='refresh progression state' " +
                 $"kind='map features' id='<all>' reason='{reason ?? "unspecified"}' " +
                 $"currentProgressionRefreshed={invokedCurrentProgression} initializedFeatureStates={initialized} " +
-                $"forcedFeatureState={forcedFeatureState} restoredDisabledTrackGroups={restoredTrackGroups} " +
+                $"inferredIndustryIncludes={inferredIndustryIncludes} forcedFeatureState={forcedFeatureState} " +
+                $"restoredDisabledTrackGroups={restoredTrackGroups} " +
                 $"finalisedOrphanTrackGroups={finalisedOrphans}.");
 
             if (FuseSettings.VerboseApplyReportDetails)

--- a/FUSE/Runtime/API/ProgressionAPI.FeatureState.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.FeatureState.cs
@@ -279,25 +279,7 @@ namespace FUSE.Runtime.API
             RefreshMapFeatureManager(manager);
             RefreshProgressionManager();
 
-            var invokedCurrentProgression = false;
-            try
-            {
-                var progressionManager = UnityEngine.Object.FindObjectOfType<ProgressionManager>();
-                var current = progressionManager != null
-                    ? ManagerCurrentProgressionField?.GetValue(progressionManager) as Progression
-                    : null;
-                if (current != null && ProgressionUpdateSectionStatesMethod != null)
-                {
-                    ProgressionUpdateSectionStatesMethod.Invoke(current, Array.Empty<object>());
-                    invokedCurrentProgression = true;
-                }
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Warning(
-                    $"FUSE progression refresh package='<all>' operation='refresh progression state' " +
-                    $"kind='progression' id='<current>' reason='{reason ?? "unspecified"}' message='{ex.Message}'.");
-            }
+            var invokedCurrentProgressionBeforeFeatureState = TryRefreshCurrentProgression(reason, "before map feature replay");
 
             // NOTE: InitializeMissingMapFeatureStates now intentionally returns 0
             // and writes nothing — it remains only as a diagnostic logger. Writing
@@ -311,12 +293,15 @@ namespace FUSE.Runtime.API
             var initialized = InitializeMissingMapFeatureStates(manager);
             var inferredIndustryIncludes = InferMapFeatureIndustryIncludes(manager, reason);
             var forcedFeatureState = ForceApplyCurrentMapFeatureState(manager, reason);
+            var invokedCurrentProgressionAfterFeatureState = TryRefreshCurrentProgression(reason, "after map feature replay");
             var restoredTrackGroups = RestoreDisabledTrackGroups(manager, reason);
             var finalisedOrphans = RevokeTransientlyPreEnabledOrphanGroups(manager, reason);
             FuseLog.Info(
                 $"FUSE refreshed progression runtime state package='<all>' operation='refresh progression state' " +
                 $"kind='map features' id='<all>' reason='{reason ?? "unspecified"}' " +
-                $"currentProgressionRefreshed={invokedCurrentProgression} initializedFeatureStates={initialized} " +
+                $"currentProgressionRefreshedBeforeFeatureState={invokedCurrentProgressionBeforeFeatureState} " +
+                $"currentProgressionRefreshedAfterFeatureState={invokedCurrentProgressionAfterFeatureState} " +
+                $"initializedFeatureStates={initialized} " +
                 $"inferredIndustryIncludes={inferredIndustryIncludes} forcedFeatureState={forcedFeatureState} " +
                 $"restoredDisabledTrackGroups={restoredTrackGroups} " +
                 $"finalisedOrphanTrackGroups={finalisedOrphans}.");
@@ -325,6 +310,31 @@ namespace FUSE.Runtime.API
             {
                 DumpProgressionStateForDiagnostics(manager, reason);
             }
+        }
+
+        private static bool TryRefreshCurrentProgression(string reason, string stage)
+        {
+            try
+            {
+                var progressionManager = UnityEngine.Object.FindObjectOfType<ProgressionManager>();
+                var current = progressionManager != null
+                    ? ManagerCurrentProgressionField?.GetValue(progressionManager) as Progression
+                    : null;
+                if (current != null && ProgressionUpdateSectionStatesMethod != null)
+                {
+                    ProgressionUpdateSectionStatesMethod.Invoke(current, Array.Empty<object>());
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE progression refresh package='<all>' operation='refresh progression state' " +
+                    $"kind='progression' id='<current>' stage='{stage ?? "unspecified"}' " +
+                    $"reason='{reason ?? "unspecified"}' message='{ex.Message}'.");
+            }
+
+            return false;
         }
     }
 }

--- a/FUSE/Runtime/API/ProgressionAPI.MapFeatureManager.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.MapFeatureManager.cs
@@ -381,6 +381,429 @@ namespace FUSE.Runtime.API
             return unavailabled;
         }
 
+        private static int InferMapFeatureIndustryIncludes(MapFeatureManager manager, string reason)
+        {
+            if (manager == null)
+            {
+                return 0;
+            }
+
+            var features = (manager.AvailableFeatures ?? Enumerable.Empty<MapFeature>())
+                .Where(feature => feature != null && !string.IsNullOrWhiteSpace(feature.identifier))
+                .ToArray();
+            if (features.Length == 0)
+            {
+                return 0;
+            }
+
+            var trackGroupOwners = BuildTrackGroupOwnerMap(features);
+            var changed = 0;
+            foreach (var industry in UnityEngine.Object.FindObjectsOfType<Industry>(true))
+            {
+                if (industry == null || string.IsNullOrWhiteSpace(industry.identifier))
+                {
+                    continue;
+                }
+
+                var trackGroups = CollectIndustryTrackGroups(industry);
+                var feature = InferFeatureFromTrackGroups(trackGroupOwners, trackGroups, industry, reason);
+                var basis = "track-groups";
+                if (feature == null)
+                {
+                    feature = InferFeatureFromScenery(features, industry, reason);
+                    basis = "scenery";
+                }
+
+                if (feature == null || !CanAddInferredIndustryInclude(feature, industry))
+                {
+                    continue;
+                }
+
+                if (AddInferredIndustryInclude(feature, industry))
+                {
+                    changed++;
+                    FuseLog.Info(
+                        $"FUSE inferred progression industry include feature='{feature.identifier}' " +
+                        $"industry='{industry.identifier}' basis='{basis}' " +
+                        $"trackGroups=[{string.Join(",", trackGroups.OrderBy(group => group).ToArray())}] " +
+                        $"reason='{reason ?? "unspecified"}'.");
+                }
+            }
+
+            return changed;
+        }
+
+        private static Dictionary<string, List<MapFeature>> BuildTrackGroupOwnerMap(IEnumerable<MapFeature> features)
+        {
+            var owners = new Dictionary<string, List<MapFeature>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var feature in features ?? Enumerable.Empty<MapFeature>())
+            {
+                if (feature == null)
+                {
+                    continue;
+                }
+
+                foreach (var groupId in FeatureTrackGroups(feature))
+                {
+                    if (!owners.TryGetValue(groupId, out var groupOwners))
+                    {
+                        groupOwners = new List<MapFeature>();
+                        owners[groupId] = groupOwners;
+                    }
+
+                    if (!groupOwners.Any(existing => SameFeature(existing, feature)))
+                    {
+                        groupOwners.Add(feature);
+                    }
+                }
+            }
+
+            return owners;
+        }
+
+        private static MapFeature InferFeatureFromTrackGroups(
+            Dictionary<string, List<MapFeature>> trackGroupOwners,
+            HashSet<string> trackGroups,
+            Industry industry,
+            string reason)
+        {
+            if (trackGroupOwners == null || trackGroups == null || trackGroups.Count == 0)
+            {
+                return null;
+            }
+
+            var owners = new List<MapFeature>();
+            foreach (var groupId in trackGroups)
+            {
+                if (!trackGroupOwners.TryGetValue(groupId, out var groupOwners))
+                {
+                    continue;
+                }
+
+                foreach (var owner in groupOwners)
+                {
+                    if (owner != null && !owners.Any(existing => SameFeature(existing, owner)))
+                    {
+                        owners.Add(owner);
+                    }
+                }
+            }
+
+            if (owners.Count == 1)
+            {
+                return owners[0];
+            }
+
+            if (owners.Count > 1 && FuseSettings.VerboseApplyReportDetails)
+            {
+                FuseLog.Info(
+                    $"FUSE skipped progression industry inference industry='{industry?.identifier ?? "<unknown>"}' " +
+                    $"reason='{reason ?? "unspecified"}' message='track spans are claimed by multiple features' " +
+                    $"features=[{string.Join(",", owners.Select(feature => feature.identifier).OrderBy(id => id).ToArray())}] " +
+                    $"trackGroups=[{string.Join(",", trackGroups.OrderBy(group => group).ToArray())}].");
+            }
+
+            return null;
+        }
+
+        private static MapFeature InferFeatureFromScenery(IEnumerable<MapFeature> features, Industry industry, string reason)
+        {
+            if (industry == null || !industry.usesContract)
+            {
+                return null;
+            }
+
+            var aliases = BuildIndustrySearchAliases(industry);
+            if (aliases.Count == 0)
+            {
+                return null;
+            }
+
+            var matches = new List<MapFeature>();
+            foreach (var feature in features ?? Enumerable.Empty<MapFeature>())
+            {
+                if (feature == null)
+                {
+                    continue;
+                }
+
+                var sceneryKey = BuildFeatureScenerySearchKey(feature);
+                if (string.IsNullOrWhiteSpace(sceneryKey))
+                {
+                    continue;
+                }
+
+                if (aliases.Any(alias => sceneryKey.Contains(alias)))
+                {
+                    matches.Add(feature);
+                }
+            }
+
+            if (matches.Count == 1)
+            {
+                return matches[0];
+            }
+
+            if (matches.Count > 1 && FuseSettings.VerboseApplyReportDetails)
+            {
+                FuseLog.Info(
+                    $"FUSE skipped progression industry scenery inference industry='{industry.identifier}' " +
+                    $"reason='{reason ?? "unspecified"}' message='industry name matched multiple feature scenery paths' " +
+                    $"features=[{string.Join(",", matches.Select(feature => feature.identifier).OrderBy(id => id).ToArray())}].");
+            }
+
+            return null;
+        }
+
+        private static bool CanAddInferredIndustryInclude(MapFeature feature, Industry industry)
+        {
+            if (feature == null || industry == null)
+            {
+                return false;
+            }
+
+            if ((feature.unlockExcludeIndustries ?? Array.Empty<Industry>()).Any(existing => SameIndustry(existing, industry)))
+            {
+                return false;
+            }
+
+            if ((feature.unlockIncludeIndustries ?? Array.Empty<Industry>()).Any(existing => SameIndustry(existing, industry)))
+            {
+                return false;
+            }
+
+            return !FeatureAreasContainIndustry(feature, industry);
+        }
+
+        private static bool AddInferredIndustryInclude(MapFeature feature, Industry industry)
+        {
+            var existing = feature.unlockIncludeIndustries ?? Array.Empty<Industry>();
+            if (existing.Any(candidate => SameIndustry(candidate, industry)))
+            {
+                return false;
+            }
+
+            var merged = existing
+                .Where(candidate => candidate != null)
+                .Concat(new[] { industry })
+                .GroupBy(candidate => string.IsNullOrWhiteSpace(candidate.identifier) ? candidate.GetInstanceID().ToString() : candidate.identifier,
+                    StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .ToArray();
+            feature.unlockIncludeIndustries = merged;
+            return true;
+        }
+
+        private static bool FeatureAreasContainIndustry(MapFeature feature, Industry industry)
+        {
+            foreach (var area in feature.areasEnableOnUnlock ?? Array.Empty<Area>())
+            {
+                if (area == null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if ((area.Industries ?? Enumerable.Empty<Industry>()).Any(candidate => SameIndustry(candidate, industry)))
+                    {
+                        return true;
+                    }
+                }
+                catch
+                {
+                    // Best effort only; a feature's explicit include/exclude lists still apply above.
+                }
+            }
+
+            return false;
+        }
+
+        private static HashSet<string> CollectIndustryTrackGroups(Industry industry)
+        {
+            var groups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (industry == null)
+            {
+                return groups;
+            }
+
+            IndustryComponent[] components;
+            try
+            {
+                components = industry.GetComponentsInChildren<IndustryComponent>(true) ?? Array.Empty<IndustryComponent>();
+            }
+            catch
+            {
+                return groups;
+            }
+
+            foreach (var component in components)
+            {
+                if (component == null)
+                {
+                    continue;
+                }
+
+                IEnumerable<TrackSpan> spans;
+                try
+                {
+                    spans = component.TrackSpans ?? Enumerable.Empty<TrackSpan>();
+                }
+                catch
+                {
+                    continue;
+                }
+
+                foreach (var span in spans)
+                {
+                    AddTrackSpanGroupIds(span, groups);
+                }
+            }
+
+            return groups;
+        }
+
+        private static void AddTrackSpanGroupIds(TrackSpan span, ISet<string> groups)
+        {
+            if (span == null || groups == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var upper = span.upper;
+                if (upper.HasValue)
+                {
+                    AddTrackSegmentGroupId(upper.Value.segment, groups);
+                }
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                var lower = span.lower;
+                if (lower.HasValue)
+                {
+                    AddTrackSegmentGroupId(lower.Value.segment, groups);
+                }
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                foreach (var segment in span.GetSegments() ?? Enumerable.Empty<TrackSegment>())
+                {
+                    AddTrackSegmentGroupId(segment, groups);
+                }
+            }
+            catch
+            {
+                // Invalid spans should not block the rest of the inference pass.
+            }
+        }
+
+        private static void AddTrackSegmentGroupId(TrackSegment segment, ISet<string> groups)
+        {
+            if (segment == null || string.IsNullOrWhiteSpace(segment.groupId))
+            {
+                return;
+            }
+
+            groups.Add(segment.groupId);
+        }
+
+        private static List<string> BuildIndustrySearchAliases(Industry industry)
+        {
+            var aliases = new List<string>();
+            AddSearchAlias(aliases, industry?.identifier);
+            AddSearchAlias(aliases, industry?.name);
+            return aliases;
+        }
+
+        private static void AddSearchAlias(List<string> aliases, string value)
+        {
+            var compact = CompactSearchKey(value);
+            if (compact.Length < 8 || aliases.Contains(compact))
+            {
+                return;
+            }
+
+            aliases.Add(compact);
+        }
+
+        private static string BuildFeatureScenerySearchKey(MapFeature feature)
+        {
+            if (feature == null)
+            {
+                return string.Empty;
+            }
+
+            var parts = new List<string>();
+            foreach (var gameObject in feature.gameObjectsEnableOnUnlock ?? Array.Empty<GameObject>())
+            {
+                if (gameObject == null)
+                {
+                    continue;
+                }
+
+                parts.Add(gameObject.name);
+                parts.Add(GetGameObjectPath(gameObject));
+            }
+
+            return CompactSearchKey(string.Join(" ", parts.ToArray()));
+        }
+
+        private static string CompactSearchKey(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            var chars = new char[value.Length];
+            var count = 0;
+            foreach (var ch in value)
+            {
+                if (!char.IsLetterOrDigit(ch))
+                {
+                    continue;
+                }
+
+                chars[count++] = char.ToLowerInvariant(ch);
+            }
+
+            return count == 0 ? string.Empty : new string(chars, 0, count);
+        }
+
+        private static bool SameFeature(MapFeature left, MapFeature right)
+        {
+            if (left == null || right == null)
+            {
+                return false;
+            }
+
+            return left == right ||
+                   (!string.IsNullOrWhiteSpace(left.identifier) &&
+                    string.Equals(left.identifier, right.identifier, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static bool SameIndustry(Industry left, Industry right)
+        {
+            if (left == null || right == null)
+            {
+                return false;
+            }
+
+            return left == right ||
+                   (!string.IsNullOrWhiteSpace(left.identifier) &&
+                    string.Equals(left.identifier, right.identifier, StringComparison.OrdinalIgnoreCase));
+        }
+
         private static bool IsFeatureEnabled(MapFeature feature, IDictionary<string, bool> states)
         {
             if (feature == null || string.IsNullOrWhiteSpace(feature.identifier))

--- a/FUSE/Runtime/API/ProgressionAPI.MapFeatureManager.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.MapFeatureManager.cs
@@ -562,6 +562,19 @@ namespace FUSE.Runtime.API
                 return false;
             }
 
+            if (IsProgressionOnlyIndustry(industry))
+            {
+                if (FuseSettings.VerboseApplyReportDetails)
+                {
+                    FuseLog.Info(
+                        $"FUSE skipped progression industry inference industry='{industry.identifier}' " +
+                        $"feature='{feature.identifier}' reason='industry is progression-only; " +
+                        "active delivery phases are gated by Progression.UpdateSectionStates instead'.");
+                }
+
+                return false;
+            }
+
             if ((feature.unlockExcludeIndustries ?? Array.Empty<Industry>()).Any(existing => SameIndustry(existing, industry)))
             {
                 return false;
@@ -573,6 +586,27 @@ namespace FUSE.Runtime.API
             }
 
             return !FeatureAreasContainIndustry(feature, industry);
+        }
+
+        private static bool IsProgressionOnlyIndustry(Industry industry)
+        {
+            if (industry == null)
+            {
+                return false;
+            }
+
+            IndustryComponent[] components;
+            try
+            {
+                components = industry.GetComponentsInChildren<IndustryComponent>(true) ?? Array.Empty<IndustryComponent>();
+            }
+            catch
+            {
+                return false;
+            }
+
+            return components.Length > 0 &&
+                   components.All(component => component == null || component is ProgressionIndustryComponent);
         }
 
         private static bool AddInferredIndustryInclude(MapFeature feature, Industry industry)

--- a/FUSE/Runtime/API/ProgressionAPI.Resolution.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.Resolution.cs
@@ -336,11 +336,48 @@ namespace FUSE.Runtime.API
                 return resolved;
             }
 
-            return UnityEngine.Object.FindObjectsOfType<Transform>(true)
-                .FirstOrDefault(transform =>
-                    string.Equals(transform.name, path, StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(GetScenePath(transform), path, StringComparison.OrdinalIgnoreCase))
-                ?.gameObject;
+            var normalized = NormalizeScenePath(path);
+            var transforms = UnityEngine.Object.FindObjectsOfType<Transform>(true);
+            var exact = transforms.FirstOrDefault(transform =>
+                string.Equals(transform.name, path, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(NormalizeScenePath(GetScenePath(transform)), normalized, StringComparison.OrdinalIgnoreCase));
+            if (exact != null)
+            {
+                return exact.gameObject;
+            }
+
+            if (normalized.IndexOf('/') < 0)
+            {
+                return null;
+            }
+
+            var suffix = "/" + normalized.TrimStart('/');
+            var suffixMatches = transforms
+                .Where(transform => NormalizeScenePath(GetScenePath(transform)).EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                .Take(2)
+                .ToArray();
+            if (suffixMatches.Length == 1)
+            {
+                FuseLog.Info(
+                    $"FUSE resolved shortened scene path '{path}' to '{GetScenePath(suffixMatches[0])}'.");
+                return suffixMatches[0].gameObject;
+            }
+
+            if (suffixMatches.Length > 1)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not resolve shortened scene path '{path}' because multiple scene objects match that suffix.");
+            }
+
+            return null;
+        }
+
+        private static string NormalizeScenePath(string path)
+        {
+            return (path ?? string.Empty)
+                .Trim()
+                .Replace('\\', '/')
+                .Trim('/');
         }
 
         private static bool ComponentMatchesId(IndustryComponent component, string id)


### PR DESCRIPTION
## 🔗 Related Issue

N/A - fixes found during in-game progression testing with Appalachian Railway / legacy converted mods.

## 📝 Description of the Change

This fixes several progression compatibility issues caused by legacy map/progression data not carrying all of the relationships the base game expects.

Legacy `deliveryPhases: [ {} ]` entries are now preserved as valid free phases instead of being cleaned into an empty phase list. This prevents free milestones from showing as `0/0 Phases Complete` or breaking progression UI logic.

Map feature scene-object resolution now supports unique suffix matching for shortened legacy paths. This lets paths such as `Whittier Saw Mill Culled/Saw Mill` bind to the actual scene object under `World/Large Scenery/...`.

FUSE also now infers missing runtime `unlockIncludeIndustries` entries when a map feature clearly owns an industry’s track groups or matching scenery. This fixes cases where the milestone/track/scenery were locked, but the Locations tab still showed the industry and allowed contracts for something that did not exist yet.

## 🔄 Alternatives Considered

Manually patching individual legacy mods was considered, but that would only fix one package at a time.

Patching the Locations UI directly was also avoided because the real game state issue is `Industry.ProgressionDisabled`, which affects contracts, ticking, and ops behavior beyond just the UI.

## ⚠️ Possible Drawbacks

Industry inference is intentionally conservative, but it is still a runtime heuristic. If multiple features appear to own the same industry, FUSE skips the inference rather than guessing.

The change is backwards compatible with existing saves. It does not alter save data or mod files; inferred industry includes are applied at runtime before the base game reapplies map feature state.

## ✅ Verification Process

Built and deployed FUSE successfully:

`dotnet build .\FUSE\FUSE.csproj -c Release -p:GameDir="C:\Steam\steamapps\common\Railroader" -p:UnityManagedDir="C:\Steam\steamapps\common\Railroader\Railroader_Data\Managed" -p:EnableModDeploy=true`

Ran the full test suite successfully:

`dotnet test .\FUSE.Tests\FUSE.Tests.csproj -c Release -p:GameDir="C:\Steam\steamapps\common\Railroader" -p:UnityManagedDir="C:\Steam\steamapps\common\Railroader\Railroader_Data\Managed"`

Result: `735` passed, `0` failed.

## 💡 Additional Information

The runtime log now reports `inferredIndustryIncludes` during progression refresh, which should help diagnose future cases where a feature locks scenery/track but did not explicitly list the affected industry.