### PR TITLE
fix(loading): restore Customize options for library-framework asset packs

### DIFF
--- a/FUSE.Tests/Loading/FuseAssetPackSanitizerTests.cs
+++ b/FUSE.Tests/Loading/FuseAssetPackSanitizerTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Loading;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    /// <summary>
+    /// Covers <see cref="FuseAssetPackRegistry.FilterUnbindableComponents"/>, the resilient
+    /// retry filter that replaced the old static allow-list strip. The allow-list silently
+    /// deleted runtime-registered customization components (MaterialColorizerComponent,
+    /// DefaultLivelryComponent, ComponentGroup, ...), emptying the in-game Customize menu for
+    /// ~60 modded cars. These tests pin the new contract: only components that genuinely fail
+    /// to bind are dropped, and never their valid siblings or the whole pack. The bind check is
+    /// injected so the test stays hermetic (no game / library DLLs needed in CI).
+    /// </summary>
+    public class FuseAssetPackSanitizerTests
+    {
+        // Builds a Definitions.json-shaped document; each entry is one object's component-kind
+        // list. A null kind produces a component with no "kind" property.
+        private static string Definitions(params string[][] objectComponentKinds)
+        {
+            var objects = new JArray();
+            var i = 0;
+            foreach (var kinds in objectComponentKinds)
+            {
+                var components = new JArray(kinds.Select(k =>
+                    k == null ? new JObject() : new JObject { ["kind"] = k, ["name"] = k + "_inst" }));
+                objects.Add(new JObject
+                {
+                    ["identifier"] = "obj-" + i++,
+                    ["definition"] = new JObject { ["kind"] = "CarDefinition", ["components"] = components },
+                });
+            }
+
+            return new JObject { ["objects"] = objects }.ToString();
+        }
+
+        private static string[] ComponentKinds(string json, int objectIndex = 0)
+        {
+            var objects = (JArray)JObject.Parse(json)["objects"];
+            var components = (JArray)objects[objectIndex]["definition"]["components"];
+            return components.Select(c => (string)c["kind"]).ToArray();
+        }
+
+        // Simulates a missing defining library: the named kinds cannot bind, everything else can.
+        private static Func<JObject, bool> RejectKinds(params string[] unbindable)
+        {
+            var set = new HashSet<string>(unbindable, StringComparer.Ordinal);
+            return comp => comp["kind"] != null && !set.Contains((string)comp["kind"]);
+        }
+
+        [Fact]
+        public void AllBindable_ReturnsInputUnchanged_NoDrops()
+        {
+            var input = Definitions(new[] { "Bell", "MaterialColorizerComponent", "DefaultLivelryComponent" });
+            var dropped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            var result = FuseAssetPackRegistry.FilterUnbindableComponents(input, dropped, RejectKinds());
+
+            Assert.Same(input, result); // same reference == nothing rewritten
+            Assert.Empty(dropped);
+        }
+
+        [Fact]
+        public void UnbindableKind_Dropped_ValidSiblingsRetained()
+        {
+            var input = Definitions(new[] { "Bell", "BogusKind", "MaterialColorizerComponent" });
+            var dropped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            var result = FuseAssetPackRegistry.FilterUnbindableComponents(input, dropped, RejectKinds("BogusKind"));
+
+            Assert.Equal(new[] { "Bell", "MaterialColorizerComponent" }, ComponentKinds(result));
+            Assert.Single(dropped);
+            Assert.Equal(1, dropped["BogusKind"]);
+        }
+
+        [Fact]
+        public void PerObjectIsolation_BadComponentInOneObject_DoesNotAffectOthers()
+        {
+            var input = Definitions(
+                new[] { "Bell", "Headlight" },     // object 0 — all bindable
+                new[] { "BogusKind", "Whistle" }); // object 1 — one unbindable
+            var dropped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            var result = FuseAssetPackRegistry.FilterUnbindableComponents(input, dropped, RejectKinds("BogusKind"));
+
+            Assert.Equal(new[] { "Bell", "Headlight" }, ComponentKinds(result, 0));
+            Assert.Equal(new[] { "Whistle" }, ComponentKinds(result, 1));
+            Assert.Single(dropped);
+            Assert.Equal(1, dropped["BogusKind"]);
+        }
+
+        [Fact]
+        public void MultipleUnbindable_CountedByKind()
+        {
+            var input = Definitions(
+                new[] { "BogusKind", "Bell" },
+                new[] { "BogusKind", "OtherBogus" });
+            var dropped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            FuseAssetPackRegistry.FilterUnbindableComponents(input, dropped, RejectKinds("BogusKind", "OtherBogus"));
+
+            Assert.Equal(2, dropped["BogusKind"]);
+            Assert.Equal(1, dropped["OtherBogus"]);
+        }
+
+        [Fact]
+        public void ComponentWithoutKind_DroppedAsMissing()
+        {
+            var input = Definitions(new[] { (string)null, "Bell" });
+            var dropped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            var result = FuseAssetPackRegistry.FilterUnbindableComponents(input, dropped, RejectKinds());
+
+            Assert.Equal(new[] { "Bell" }, ComponentKinds(result));
+            Assert.Equal(1, dropped["<missing>"]);
+        }
+
+        [Fact]
+        public void NoObjectsArray_ReturnsInputUnchanged()
+        {
+            var input = "{\"notObjects\":1}";
+            var dropped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            var result = FuseAssetPackRegistry.FilterUnbindableComponents(input, dropped, RejectKinds("anything"));
+
+            Assert.Same(input, result);
+            Assert.Empty(dropped);
+        }
+
+        [Fact]
+        public void ObjectWithoutComponents_Ignored()
+        {
+            var input = "{\"objects\":[{\"identifier\":\"a\",\"definition\":{\"kind\":\"CarDefinition\"}}]}";
+            var dropped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            var result = FuseAssetPackRegistry.FilterUnbindableComponents(input, dropped, RejectKinds("anything"));
+
+            Assert.Same(input, result);
+            Assert.Empty(dropped);
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseLegacyAssetPackAliasTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyAssetPackAliasTests.cs
@@ -1,0 +1,52 @@
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    /// <summary>
+    /// Covers <see cref="FuseAssetPackRegistry.NormalizeLegacyAssetPackIdentifier"/>, which lets
+    /// legacy scheme-prefixed asset-pack references (e.g. an older "scheme://owner/pack" form)
+    /// collapse onto the base-game-native "owner/pack" aliases FUSE registers — without FUSE's
+    /// source naming any particular legacy scheme. Pins the two guarantees: FUSE's own
+    /// fuseasset:// scheme is preserved verbatim, and everything else is reduced to the
+    /// base-game form so existing content keeps resolving.
+    /// </summary>
+    public class FuseLegacyAssetPackAliasTests
+    {
+        [Theory]
+        // Base-game-native composite (the form the game's AssetReference uses); backslashes
+        // normalize to forward slashes. This is the Goldfinch case.
+        [InlineData("RLW RSP-4 Goldfinch Class\\rlw-g3-bc", "RLW RSP-4 Goldfinch Class/rlw-g3-bc")]
+        [InlineData("Owner/Pack", "Owner/Pack")]
+        // A legacy scheme-prefixed reference collapses onto the bare base-game form.
+        [InlineData("zsc://Owner/Pack", "Owner/Pack")]
+        [InlineData("zsc://Owner/SCAssetPacks/bulkhead1", "Owner/SCAssetPacks/bulkhead1")]
+        // Scheme handling is generic, not tied to any one legacy scheme name.
+        [InlineData("anything://Owner/Pack", "Owner/Pack")]
+        // Whitespace + trailing separators are trimmed.
+        [InlineData("  zsc://Owner/Pack/  ", "Owner/Pack")]
+        public void Normalizes_LegacyAndBareForms_ToBaseGameForm(string input, string expected)
+        {
+            Assert.Equal(expected, FuseAssetPackRegistry.NormalizeLegacyAssetPackIdentifier(input));
+        }
+
+        [Theory]
+        // FUSE's own direct-store scheme must be preserved verbatim so those identifiers
+        // keep resolving to themselves (never collapsed like a legacy scheme).
+        [InlineData("fuseasset://F:/SteamLibrary/Mods/Pack/sub", "fuseasset://F:/SteamLibrary/Mods/Pack/sub")]
+        [InlineData("FUSEASSET://Mixed/Case", "FUSEASSET://Mixed/Case")]
+        public void Preserves_FuseDirectStoreScheme(string input, string expected)
+        {
+            Assert.Equal(expected, FuseAssetPackRegistry.NormalizeLegacyAssetPackIdentifier(input));
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("   ", "")]
+        public void HandlesEmptyAndNull(string input, string expected)
+        {
+            Assert.Equal(expected, FuseAssetPackRegistry.NormalizeLegacyAssetPackIdentifier(input));
+        }
+    }
+}

--- a/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
@@ -357,8 +357,7 @@ namespace FUSE.Loading
 
                 var removedByKind = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
                 var sourceText = File.ReadAllText(definitionsPath);
-                var sanitizedText = SanitizeDefinitionsJson(sourceText, removedByKind);
-                container = DeserializeContainerBypassingPostfix(sanitizedText, store?.Identifier);
+                container = LoadResilientDirectContainer(sourceText, store?.Identifier, removedByKind);
                 SanitizeDeserializedDirectContainer(container);
                 RuntimeStoreContainerField?.SetValue(store, container);
 
@@ -368,8 +367,8 @@ namespace FUSE.Loading
                     var summary = string.Join(", ", removedByKind.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)
                         .Select(item => $"{item.Key}={item.Value}"));
                     FuseLog.Info(
-                        $"FUSE sanitized direct asset pack '{packId}' Definitions.json in memory by removing unsupported component kind(s): {summary}. " +
-                        "The source mod files were not modified.");
+                        $"FUSE dropped unbindable component(s) from direct asset pack '{packId}' Definitions.json in memory: {summary}. " +
+                        "Their defining library mod is likely missing or disabled; the source mod files were not modified.");
                 }
 
                 return true;
@@ -385,16 +384,83 @@ namespace FUSE.Loading
         private static readonly HashSet<string> DeserializeBypassFallbackWarnings =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        private static Container LoadResilientDirectContainer(string sourceText, string storeIdentifier, IDictionary<string, int> droppedByKind)
+        {
+            // No reflection-based strict bypass available (rare): defer to the legacy
+            // deserialize path, which itself falls back to ContainerSerialization.Deserialize.
+            if (ContainerSerializerSettingsMethod == null)
+            {
+                return DeserializeContainerBypassingPostfix(sourceText, storeIdentifier);
+            }
+
+            try
+            {
+                // Happy path: with the defining library mods loaded, the game's
+                // JsonSubtypes converter binds every component kind — including the
+                // runtime-registered customization kinds (MaterialColorizerComponent,
+                // DefaultLivelryComponent, ComponentGroup, ...) the old static
+                // allow-list used to strip. The whole pack deserializes verbatim.
+                return BypassDeserialize(sourceText);
+            }
+            catch (Exception)
+            {
+                // A component kind could not be bound — almost always because the
+                // mod that defines it is absent or disabled. Drop ONLY the unbindable
+                // components (never the whole pack) and retry, so every bindable
+                // component still reaches the game. If the failure was not a component
+                // kind (so nothing is dropped), the retry throws again and the caller
+                // falls through to the game's native loader.
+                var filtered = FilterUnbindableComponents(sourceText, droppedByKind, CanBindComponent);
+                return BypassDeserialize(filtered);
+            }
+        }
+
+        /// <summary>
+        /// Deserializes a <see cref="Container"/> from Definitions.json text using the
+        /// same serializer settings the game's own loader uses, but WITHOUT routing
+        /// through the public <c>ContainerSerialization.Deserialize</c> (whose legacy
+        /// Harmony postfixes double-apply edits — see <see cref="ContainerSerializerSettingsMethod"/>).
+        /// Throws if any component kind cannot be bound.
+        /// </summary>
+        private static Container BypassDeserialize(string text)
+        {
+            var settings = (JsonSerializerSettings)ContainerSerializerSettingsMethod.Invoke(null, null);
+            var container = JsonConvert.DeserializeObject<Container>(text, settings);
+            container?.Awake();
+            return container;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> when the supplied component JSON binds to a concrete
+        /// <see cref="Model.Definition.Component"/> subtype under the game's live JsonSubtypes
+        /// registry (which loaded mods extend at runtime). Used only on the resilient retry
+        /// path to single out the components whose defining mod is missing.
+        /// </summary>
+        private static bool CanBindComponent(JObject componentJson)
+        {
+            if (componentJson == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                var settings = (JsonSerializerSettings)ContainerSerializerSettingsMethod.Invoke(null, null);
+                return JsonConvert.DeserializeObject<Model.Definition.Component>(componentJson.ToString(), settings) != null;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
         private static Container DeserializeContainerBypassingPostfix(string text, string storeIdentifier)
         {
             if (ContainerSerializerSettingsMethod != null)
             {
                 try
                 {
-                    var settings = (JsonSerializerSettings)ContainerSerializerSettingsMethod.Invoke(null, null);
-                    var container = JsonConvert.DeserializeObject<Container>(text, settings);
-                    container?.Awake();
-                    return container;
+                    return BypassDeserialize(text);
                 }
                 catch (Exception ex)
                 {

--- a/FUSE/Loading/FuseAssetPackRegistry.LegacyAlias.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.LegacyAlias.cs
@@ -90,8 +90,17 @@ namespace FUSE.Loading
             var relative = GetRelativePath(packagePath, assetPackFolder).Replace(Path.DirectorySeparatorChar, '/');
             if (!string.IsNullOrWhiteSpace(packageId) && !string.IsNullOrWhiteSpace(relative))
             {
-                AddLegacyAssetPackAlias(aliases, $"zsc://{packageId}/{relative}", resolved);
-                AddLegacyAssetPackAlias(aliases, $"zsc://{Path.GetFileName(packagePath)}/{relative}", resolved);
+                // Register the base-game-native "<owner>/<pack-relative-path>" reference
+                // form, keyed by both the declared package id and the on-disk folder name.
+                // The game composes an AssetReference's pack identifier this way (e.g.
+                // "RLW RSP-4 Goldfinch Class/rlw-g3-bc"), and the declared id often differs
+                // from the folder (hyphen vs space, etc.), so registering both lets a pack's
+                // own components (PrefabModelComponent sub-prefabs, ComponentGroup parts, ...)
+                // resolve to this direct store instead of a literal, non-existent bundle path.
+                // Older scheme-prefixed references collapse onto these same keys via
+                // NormalizeLegacyAssetPackIdentifier, so existing content keeps resolving.
+                AddLegacyAssetPackAlias(aliases, $"{packageId}/{relative}", resolved);
+                AddLegacyAssetPackAlias(aliases, $"{Path.GetFileName(packagePath)}/{relative}", resolved);
             }
 
             RegisterCatalogAliases(aliases, assetPackFolder, resolved);
@@ -139,9 +148,28 @@ namespace FUSE.Loading
             }
         }
 
-        private static string NormalizeLegacyAssetPackIdentifier(string identifier)
+        internal static string NormalizeLegacyAssetPackIdentifier(string identifier)
         {
-            return (identifier ?? string.Empty).Trim().Replace('\\', '/').TrimEnd('/');
+            var normalized = (identifier ?? string.Empty).Trim().Replace('\\', '/').TrimEnd('/');
+
+            // Preserve FUSE's own direct-store scheme verbatim — those identifiers must
+            // keep resolving to themselves.
+            if (normalized.Length == 0 ||
+                normalized.StartsWith(DirectStorePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return normalized;
+            }
+
+            // Tolerate older "<scheme>://<owner>/<pack>" asset-pack references (legacy
+            // loaders mounted packs under a scheme-prefixed identifier) WITHOUT binding FUSE
+            // to any specific legacy scheme name: drop a leading "<scheme>://" so the
+            // reference collapses onto the base-game-native "<owner>/<pack>" aliases. This
+            // keeps existing scheme-prefixed content resolving while FUSE's own source
+            // references only its own scheme and the base-game form.
+            var schemeIndex = normalized.IndexOf("://", StringComparison.Ordinal);
+            return schemeIndex >= 0
+                ? normalized.Substring(schemeIndex + 3)
+                : normalized;
         }
     }
 }

--- a/FUSE/Loading/FuseAssetPackRegistry.Mounting.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.Mounting.cs
@@ -422,19 +422,19 @@ namespace FUSE.Loading
                     Directory.CreateDirectory(destinationDirectory);
                 }
 
-                copiedCount += CopyAssetPackFileIfChanged(sourcePath, sourceFile, destinationFile);
+                copiedCount += CopyAssetPackFileIfChanged(sourceFile, destinationFile);
             }
 
             return copiedCount;
         }
 
-        private static int CopyAssetPackFileIfChanged(string assetPackRoot, string sourceFile, string destinationFile)
+        private static int CopyAssetPackFileIfChanged(string sourceFile, string destinationFile)
         {
-            if (string.Equals(Path.GetFileName(sourceFile), "Definitions.json", StringComparison.OrdinalIgnoreCase))
-            {
-                return CopySanitizedDefinitionsFile(assetPackRoot, sourceFile, destinationFile);
-            }
-
+            // Definitions.json is copied verbatim like any other pack file. FUSE no
+            // longer pre-strips "unsupported" component kinds here: the game's native
+            // loader (which reads these mirrored files) binds every kind its loaded mods
+            // register, and the default direct-store path quarantines only genuinely
+            // unbindable components at load time (see TryLoadSanitizedDirectContainer).
             if (!NeedsCopy(sourceFile, destinationFile))
             {
                 return 0;

--- a/FUSE/Loading/FuseAssetPackRegistry.Sanitization.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.Sanitization.cs
@@ -1,65 +1,33 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using AssetPack.Runtime;
-using HarmonyLib;
-using Model.Definition;
-using Model.Database;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using FUSE.Infrastructure;
-using UnityEngine;
 
 namespace FUSE.Loading
 {
     internal static partial class FuseAssetPackRegistry
     {
-
-        private static int CopySanitizedDefinitionsFile(string assetPackRoot, string sourceFile, string destinationFile)
-        {
-            string outputText;
-            var removedByKind = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-            try
-            {
-                outputText = SanitizeDefinitionsJson(File.ReadAllText(sourceFile), removedByKind);
-            }
-            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
-            {
-                FuseLog.Exception(
-                    $"FUSE could not sanitize asset pack Definitions.json '{sourceFile}'; copying original file", ex);
-                if (!NeedsCopy(sourceFile, destinationFile))
-                {
-                    return 0;
-                }
-
-                File.Copy(sourceFile, destinationFile, true);
-                File.SetLastWriteTimeUtc(destinationFile, File.GetLastWriteTimeUtc(sourceFile));
-                return 1;
-            }
-
-            if (removedByKind.Count > 0)
-            {
-                var packId = Path.GetFileName(assetPackRoot);
-                var summary = string.Join(", ", removedByKind.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)
-                    .Select(item => $"{item.Key}={item.Value}"));
-                FuseLog.Info(
-                    $"FUSE sanitized asset pack '{packId}' Definitions.json by removing unsupported component kind(s): {summary}. " +
-                    "The source mod files were not modified.");
-            }
-
-            if (File.Exists(destinationFile) && string.Equals(File.ReadAllText(destinationFile), outputText, StringComparison.Ordinal))
-            {
-                return 0;
-            }
-
-            File.WriteAllText(destinationFile, outputText);
-            File.SetLastWriteTimeUtc(destinationFile, File.GetLastWriteTimeUtc(sourceFile));
-            return 1;
-        }
-
-        private static string SanitizeDefinitionsJson(string sourceText, Dictionary<string, int> removedByKind)
+        /// <summary>
+        /// Returns <paramref name="sourceText"/> (an asset pack's Definitions.json) with
+        /// only the components that fail <paramref name="canBind"/> removed from each
+        /// object's <c>definition.components</c> array, recording every removed
+        /// <c>kind</c> in <paramref name="droppedByKind"/>. When nothing is removed the
+        /// original text is returned unchanged (preserving formatting).
+        ///
+        /// This is the resilient retry path's filter. FUSE no longer pre-strips by a
+        /// hardcoded allow-list of base-game component kinds — that silently deleted the
+        /// runtime-registered customization kinds (MaterialColorizerComponent,
+        /// DefaultLivelryComponent, ComponentGroup, ...) library mods add, emptying the
+        /// in-game Customize menu. Instead the loader deserializes verbatim and only falls
+        /// back here when a kind genuinely cannot bind (its defining mod is absent),
+        /// dropping that one component rather than the whole pack.
+        ///
+        /// The bind check is injected so this method is hermetically unit-testable without
+        /// the game's component types.
+        /// </summary>
+        internal static string FilterUnbindableComponents(
+            string sourceText, IDictionary<string, int> droppedByKind, Func<JObject, bool> canBind)
         {
             var root = JObject.Parse(sourceText);
             var objects = root["objects"] as JArray;
@@ -68,6 +36,7 @@ namespace FUSE.Loading
                 return sourceText;
             }
 
+            var removedAny = false;
             foreach (var objectToken in objects.OfType<JObject>())
             {
                 var components = objectToken["definition"]?["components"] as JArray;
@@ -79,21 +48,22 @@ namespace FUSE.Loading
                 for (var index = components.Count - 1; index >= 0; index--)
                 {
                     var component = components[index] as JObject;
-                    var kind = GetStringProperty(component, "kind");
-                    if (!string.IsNullOrWhiteSpace(kind) && SupportedDefinitionComponentKinds.Contains(kind))
+                    if (component != null && canBind(component))
                     {
                         continue;
                     }
 
-                    components.RemoveAt(index);
+                    var kind = GetStringProperty(component, "kind");
                     var key = string.IsNullOrWhiteSpace(kind) ? "<missing>" : kind;
-                    removedByKind[key] = removedByKind.TryGetValue(key, out var count) ? count + 1 : 1;
+                    droppedByKind[key] = droppedByKind.TryGetValue(key, out var count) ? count + 1 : 1;
+                    components.RemoveAt(index);
+                    removedAny = true;
                 }
             }
 
-            return removedByKind.Count == 0
-                ? sourceText
-                : root.ToString(Newtonsoft.Json.Formatting.Indented);
+            return removedAny
+                ? root.ToString(Formatting.Indented)
+                : sourceText;
         }
 
         private static string GetStringProperty(JObject obj, string propertyName)

--- a/FUSE/Loading/FuseAssetPackRegistry.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.cs
@@ -19,41 +19,6 @@ namespace FUSE.Loading
         private const string FuseAssetPacksProperty = "FuseAssetPacks";
         private const string DirectStorePrefix = "fuseasset://";
 
-        private static readonly HashSet<string> SupportedDefinitionComponentKinds =
-            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            {
-                "AggregateLoadModel",
-                "Bell",
-                "PrefabControl",
-                "FireboxEffect",
-                "Chuff",
-                "ClassLight",
-                "Colorizer",
-                "Compressor",
-                "CylinderCock",
-                "Decal",
-                "DetailModel",
-                "DieselExhaust",
-                "Dynamo",
-                "Gauge",
-                "Headlight",
-                "Horn",
-                "Ladder",
-                "LightFixture",
-                "LoadAnimation",
-                "LoadModel",
-                "LoadTarget",
-                "MapMask",
-                "RectangleMapMask",
-                "CircleMapMask",
-                "MarkerLight",
-                "RadialControl",
-                "Seat",
-                "ToggleAnimation",
-                "ToggleControl",
-                "Whistle"
-            };
-
         private static bool _mountComplete;
         private static readonly Dictionary<string, string> MountedAssetPackSourcesById =
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
## 🔗 Related Issue

No tracked issue — reported during in-game testing: the Customize menu showed no options for cars built on the "Library of Stuff" customization framework (repro: RLW RSP-4 Goldfinch Class with LegosLibraryOfStuff + LegosLogosAndDeco installed).

## 📝 Description of the Change

Two related fixes to the direct-store asset-pack loader, both surfaced by the same report (empty Customize menu for affected rolling stock).

**1. Stop stripping runtime-registered component kinds (`9528e81`)**

The direct-store loader pre-filtered every pack's `Definitions.json` against a hardcoded allow-list of base-game component kinds (`SupportedDefinitionComponentKinds`), deleting any component whose `kind` wasn't on the list. Library mods register additional component kinds at runtime (colorizers, liveries, component groups, …), so those were silently removed before the game built the car — leaving the Customize menu empty.

Replaced the allow-list strip with a resilient load: deserialize each pack verbatim (every kind the running game can bind is kept) and, only if a deserialize fails, quarantine the individual components that genuinely cannot bind — never the whole pack. The opt-in LocalLow mirror path copies `Definitions.json` verbatim for the same reason. The hardcoded kind allow-list is removed.

**2. Resolve base-game-native asset-pack identifiers (`aaeefac`)**

With (1) in place, options appeared and liveries/colors applied, but `ComponentGroup` toggles (Side Ladders, Name Plate, …) did nothing. Root cause: those toggles activate sub-prefabs spawned by `PrefabModelComponent`, which loads its asset by the base-game `owner/pack` identifier (the mod's declared id + the pack's catalog identifier). FUSE only aliased the leaf name, the catalog identifier, and a hardcoded legacy URI-scheme form — not the bare `owner/pack` composite. When a mod's declared id differed from its on-disk folder name (hyphen vs space in the repro), the composite resolved to a non-existent bundle path and the asset bundle failed to load.

Registered the base-game-native `owner/pack` alias (keyed by both declared id and folder name), and made identifier normalization strip a leading `<scheme>://` generically (FUSE's own scheme preserved). The composite now resolves to the correct mounted store, and the hardcoded legacy-scheme literal is removed from the source while existing scheme-prefixed references still resolve to the same store.

## 🔄 Alternatives Considered

- **Fix 1:** extend the static allow-list with the missing kinds — rejected as brittle (every new framework/kind re-triggers the bug; the test install already had several unlisted kinds). The resilient approach is self-maintaining.
- **Fix 2:** keep the hardcoded legacy scheme and just add the composite alias — rejected because it embeds a legacy loader's URI scheme in FUSE's source; the generic scheme-strip removes that while preserving compatibility.

## ⚠️ Possible Drawbacks

- Both changes touch the direct-store loader used by **every** mounted asset pack, so blast radius is real. Mitigations: the happy path deserializes the same JSON the native loader would (proven behavior, minus the over-strip); new logic runs only on the rare bind-failure path; the existing `Container()` prefix still falls back to the native loader; and the legacy-scheme alias mapping is 1:1 with the keys it replaced.
- **Saves:** no save-format change. Saved component-group toggle states (stored in the car's `KeyValueObject`) will now actually take effect — the intended behavior.
- The opt-in `MirrorAssetPacksToLocalLow` path now mirrors `Definitions.json` verbatim instead of pre-stripping; the game's native loader binds it, consistent with the default direct-store path.

## ✅ Verification Process

- **Unit:** 752 tests pass (`dotnet test`, net48), incl. new hermetic tests — `FuseAssetPackSanitizerTests` (only-unbindable components dropped; valid siblings + per-object isolation preserved) and `FuseLegacyAssetPackAliasTests` (base-native + legacy-scheme normalization; FUSE scheme preserved). Build is 0 warnings / 0 errors.
- **In-game (manual):** with the repro mod set, the Customize menu now lists and applies liveries/colors, and the Side Ladders / Name Plate component-group toggles switch their parts. The `Failed to load asset bundle … rlw-4-6-2-g3-bc-lad/np` errors are gone.
- **Regression:** 24+ installed packs reference assets via the legacy scheme form; the replacement aliasing is 1:1 with the prior keys (covered by the normalization tests), so those packs resolve identically.

## 💡 Additional Information

- Branched from `origin/main` at `eb380b2`. No public API changes, no new dependencies.