### PR TITLE
fix(schema): permit serializer-emitted fields in fuse-mod.schema.json

### DIFF
--- a/schemas/fuse-mod.schema.json
+++ b/schemas/fuse-mod.schema.json
@@ -432,6 +432,36 @@
                 },
                 "tags": {
                     "$ref": "#/$defs/stringArray"
+                },
+                "partial": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, this entry patches an existing runtime segment; the preserve* flags select which fields keep their current runtime value instead of being overwritten."
+                },
+                "preserveStyle": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "In a partial patch, keep the existing segment style instead of overwriting it."
+                },
+                "preserveTrackClass": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "In a partial patch, keep the existing trackClass instead of overwriting it."
+                },
+                "preserveSpeedLimit": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "In a partial patch, keep the existing speedLimit instead of overwriting it."
+                },
+                "preservePriority": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "In a partial patch, keep the existing priority instead of overwriting it."
+                },
+                "preserveGroupId": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "In a partial patch, keep the existing groupId instead of overwriting it."
                 }
             }
         },
@@ -729,6 +759,11 @@
                     "default": false,
                     "description": "When true, component entries patch existing runtime components and do not remove components omitted from this definition. Intended for compatibility-converted fragments."
                 },
+                "replaceComponents": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, components is the complete intended set for this industry and any pre-existing runtime sub-components not listed here are removed. Set by the legacy converter when a mod uses the \"$replace\" directive at the top of its source components dictionary."
+                },
                 "components": {
                     "allOf": [
                         {
@@ -750,13 +785,27 @@
             "allOf": [
                 {
                     "if": {
-                        "properties": {
-                            "partial": {
-                                "const": true
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "partial": {
+                                        "const": true
+                                    }
+                                },
+                                "required": [
+                                    "partial"
+                                ]
+                            },
+                            {
+                                "properties": {
+                                    "remove": {
+                                        "const": true
+                                    }
+                                },
+                                "required": [
+                                    "remove"
+                                ]
                             }
-                        },
-                        "required": [
-                            "partial"
                         ]
                     },
                     "else": {
@@ -768,6 +817,11 @@
                 }
             ],
             "properties": {
+                "remove": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, this entry is a deletion request for an existing runtime component rather than an add/update, and may omit type/name. Emitted by the legacy converter for the Strange Customs \"<name>\": null component-removal idiom."
+                },
                 "partial": {
                     "type": "boolean",
                     "default": false,
@@ -1113,6 +1167,28 @@
                         "y": 1,
                         "z": 1
                     }
+                },
+                "bridgeTrackEnabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether the rotating bridge carries a drivable track segment. Defaults to true."
+                },
+                "bridgeTrackGauge": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "default": 1.435,
+                    "description": "Gauge of the bridge track in meters. Defaults to 1.435 (standard gauge)."
+                },
+                "bridgeTrackLength": {
+                    "type": "number",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Length of the bridge track. Defaults to 0, in which case it is derived from the turntable radius."
+                },
+                "bridgeTrackYOffset": {
+                    "type": "number",
+                    "default": 0.08,
+                    "description": "Vertical offset applied to the bridge track. Defaults to 0.08."
                 },
                 "controllerType": {
                     "type": "string",
@@ -1635,6 +1711,10 @@
                 "center": {
                     "$ref": "#/$defs/vec3"
                 },
+                "rotation": {
+                    "$ref": "#/$defs/vec3",
+                    "description": "Always emitted by the serializer because every mask shares one model shape. Unused for circles; defaults to {0,0,0}."
+                },
                 "radius": {
                     "type": "number",
                     "exclusiveMinimum": 0
@@ -1724,6 +1804,14 @@
             "properties": {
                 "type": {
                     "const": "curve"
+                },
+                "center": {
+                    "$ref": "#/$defs/vec3",
+                    "description": "Always emitted by the serializer because every mask shares one model shape. Unused for curves (the path is defined by points); defaults to {0,0,0}."
+                },
+                "rotation": {
+                    "$ref": "#/$defs/vec3",
+                    "description": "Always emitted by the serializer because every mask shares one model shape. Unused for curves; defaults to {0,0,0}."
                 },
                 "width": {
                     "type": "number",


### PR DESCRIPTION
## 🔗 Related Issue

N/A — pre-existing schema/serializer drift discovered while preparing the Unity-free `FUSE.Core` serializer (`Fuse.Core.Serialization.FuseCoreSerializer`) for the external editor. Not introduced by that work; the shipping `FuseSerializer` already had it.

## 📝 Description of the Change

`schemas/fuse-mod.schema.json` was out of date relative to the serializer model. `FuseSerializer.GetSettings()` uses `DefaultValueHandling.Include` + `NullValueHandling.Ignore`, so the serializer **always emits non-nullable value-type model fields** (`bool`, `Vector3`, `int`/`float`) even at their defaults, and `FuseMigration.Normalize` fills null collections to empty. The schema uses `additionalProperties: false` throughout, so the serializer's *own output* failed validation.

Concretely: round-tripping the canonical example — `FuseSerializer.ToJson(FuseSerializer.FromJson(schemas/fuse-mod.example.json))` — and validating with `jsonschema.Draft202012Validator` produced **24 errors**, even though the hand-authored example validates at 0. `tools/json_lint.py` only validates the example (never serializer output), so this drift was invisible to CI and accumulated as the model grew.

This PR adds the real, currently-rejected fields to the schema (all changes **additive** — the existing example still validates):

- **`industry.replaceComponents`** (bool) — the `"$replace"` directive signal.
- **`industryComponent.remove`** (bool) — the Strange Customs `"<name>": null` component-removal idiom. Also extended the `type`/`name` `if/else` into an `anyOf` so a `remove: true` deletion may omit `type`/`name` (mirrors the existing `partial: true` exemption), completing the field's documented semantics.
- **`trackSegment`** — `partial` + `preserveStyle` / `preserveTrackClass` / `preserveSpeedLimit` / `preservePriority` / `preserveGroupId` (partial segment-patch flags).
- **`turntableVisuals`** — `bridgeTrackEnabled` / `bridgeTrackGauge` / `bridgeTrackLength` / `bridgeTrackYOffset`.
- **`mapMask`** — added `rotation` to the `circle` variant and `center` + `rotation` to the `curve` variant. The flat `FuseMapMask` shares one model shape, so `center`/`rotation` are always emitted regardless of mask type; the `oneOf` still discriminates uniquely on the `type` const.

## 🔄 Alternatives Considered

- **Apply only the three fields originally reported** (`replaceComponents`, `remove`, mask reconcile). Rejected: reproducing against the real serializer showed the model has since grown `FuseSegment.Partial`/`Preserve*` and `FuseTurntableVisuals.BridgeTrack*`, so a partial fix would still leave serializer output failing. Fixed the full actual error set instead.
- **Collapse the `mapMask` `oneOf` into one flat object** matching the C# class. Rejected: that loses the per-type validation value (circle requires `radius`, curve requires `points`, …). Kept the discriminated `oneOf` and just permitted the always-emitted `center`/`rotation`.
- **Change the serializer instead of the schema** (e.g. `[DefaultValue]`/`ShouldSerialize` to suppress the fields). Rejected: these are real model fields that belong in the published contract; the schema, not the serializer, was the stale artifact.

## ⚠️ Possible Drawbacks

- The schema is now slightly more permissive (six small field additions + two mask variants accept `center`/`rotation`). No previously-valid document becomes invalid; this is purely widening.
- Backwards compatible with existing saves — no data shape changed, only the schema that describes it.
- **Out of scope / noted, not fixed:** mask `maskName` serializes as an **integer** (no `StringEnumConverter`) but the schema types it `string`. The example doesn't exercise it, so it isn't part of the 24 errors; the correct fix (emit a string vs. accept an int) is a judgment call left for a follow-up.

## ✅ Verification Process

Reproduced and verified with the **real shipping serializer** (not a simulation): a throwaway `[Fact]` in `FUSE.Tests` round-tripped `schemas/fuse-mod.example.json` through `FuseSerializer`, and the output was validated with `jsonschema.Draft202012Validator` (the same validator `json_lint` uses).

- **Before:** serializer output → **24 errors** (12 `remove`, 7 `replaceComponents`, 2 `mapMasks`, 2 `trackSegments`, 1 `turntableVisuals`).
- **After:** serializer output → **0 errors**.
- `python tools/json_lint.py` → **all checks passed** (example still validates; schema is still a valid Draft 2020-12 document).
- Synthetic edge cases confirmed: `remove:true`/`partial:true` may omit `type`/`name` while a plain component still requires them; each mask `type` matches exactly one `oneOf` variant, and malformed masks (circle w/o radius, curve w/o points, unknown type) are still rejected.
- The throwaway test and scratch files were removed; the diff is the schema file only. No C# changed, so no runtime/test regressions.

## 💡 Additional Information

The `FUSE.Core`/`FuseCoreSerializer` library does not exist in this branch yet (forthcoming external-editor work), but it mirrors the same model + Json.NET settings, so this schema now covers both serializers. The companion prose doc `schemas/FUSE_JSON_SCHEMA.md` is a design overview (not a field-by-field reference) and was intentionally left unchanged.
