### PR TITLE
1.0.0 prep: README polish + Info.json sync workflow

### DIFF
--- a/.github/workflows/sync-info-json.yml
+++ b/.github/workflows/sync-info-json.yml
@@ -1,0 +1,69 @@
+name: Sync Info.json to latest release
+
+# Keeps the source FUSE/Info.json "Version" field in step with the latest
+# published GitHub release. Skipped for GitHub pre-releases (incl. the
+# 0.x series treated as pre-release by release.yml) and for any tag that
+# isn't a plain v<MAJOR>.<MINOR>.<PATCH>. The release artifact itself is
+# already correctly stamped by the build (see InjectModVersionIntoInfoJson
+# in Directory.Build.targets); this workflow only updates the in-repo
+# manifest so the source-of-truth tracks the latest GA release.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    if: ${{ github.event.release.prerelease == false }}
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          # Default GITHUB_TOKEN can push back to main; branch protections
+          # that require PRs will block this and need a separate token.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Parse semantic version from release tag
+        id: version
+        shell: powershell
+        run: |
+          $tag = "${{ github.event.release.tag_name }}"
+          if ($tag -notmatch '^v(?<version>[0-9]+\.[0-9]+\.[0-9]+)$') {
+            Write-Host "Release tag '$tag' is not a 3-part GA semver; skipping sync."
+            "skip=true" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+          "version=$($Matches.version)" >> $env:GITHUB_OUTPUT
+          "skip=false" >> $env:GITHUB_OUTPUT
+
+      - name: Stamp FUSE/Info.json
+        if: steps.version.outputs.skip == 'false'
+        shell: powershell
+        run: |
+          .\scripts\stamp-info-version.ps1 -Path FUSE\Info.json -Version ${{ steps.version.outputs.version }}
+
+      - name: Commit and push
+        if: steps.version.outputs.skip == 'false'
+        shell: powershell
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          $status = git status --porcelain FUSE/Info.json
+          if (-not $status) {
+            Write-Host "FUSE/Info.json already at v${{ steps.version.outputs.version }}; nothing to commit."
+            exit 0
+          }
+
+          git add FUSE/Info.json
+          # [skip ci] keeps this metadata bump from re-running the full CI
+          # build matrix; the verify-stamping check is exercised on every
+          # other push so we don't lose coverage.
+          git commit -m "Sync FUSE/Info.json Version to ${{ steps.version.outputs.version }} [skip ci]"
+          git push origin main

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,11 +11,14 @@
 
   <!--
     Stamp the build-deployed Info.json with the real ModVersion. The source
-    Info.json keeps a sentinel "0.0.0" placeholder so debug builds without
-    -p:ModVersion=... stay obviously unversioned. The CI/release workflow passes
-    -p:ModVersion=<semver from tag> so the artifact carries the right version.
+    Info.json tracks the latest published release version, kept in sync by
+    .github/workflows/sync-info-json.yml. Local/CI debug builds without
+    -p:ModVersion=... skip stamping so the bin output mirrors source. The
+    release workflow passes -p:ModVersion=<semver from tag>, so the
+    published artifact always carries the right version regardless of what
+    the source manifest currently shows.
   -->
-  <Target Name="InjectModVersionIntoInfoJson" AfterTargets="AfterBuild" Condition="'$(ModVersion)' != '0.0.0'">
-    <Exec Command="powershell -NoProfile -Command &quot;$f = '$(TargetDir)Info.json'; if (Test-Path $f) { (Get-Content $f -Raw) -replace '0\.0\.0', '$(ModVersionCore)' | Set-Content $f -NoNewline }&quot;" />
+  <Target Name="InjectModVersionIntoInfoJson" AfterTargets="AfterBuild" Condition="'$(ModVersion)' != '0.0.0' AND Exists('$(TargetDir)Info.json')">
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)scripts\stamp-info-version.ps1&quot; -Path &quot;$(TargetDir)Info.json&quot; -Version $(ModVersionCore)" />
   </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # FUSE
 
-FUSE is a Unity Mod Manager modding layer for Railroader. It loads FUSE data packages for route extensions, asset packs, audio packs, track graph changes, world scenery, operations, progression data, and compatibility imports from the legacy AMM, Strange Customs, and RailLoader ecosystem.
-
-This repository is currently targeting a beta release.
+FUSE is a Unity Mod Manager modding layer for Railroader. It loads FUSE data packages — route extensions, asset packs, audio packs, track graph changes, world scenery, operations, and progression data — and provides drop-in compatibility for legacy Railloader, Strange Customs, ConfusingSupplements, For Your Convenience, and Alina's Map Mod packages.
 
 ## Supported Game Version
 
@@ -15,7 +13,7 @@ FUSE logs its version report at startup in `FUSE.log`.
 
 ## Supported Package Types
 
-FUSE beta supports these package categories:
+FUSE supports these package categories:
 
 - Route/data packages with `*.fuse.json` files
 - Map tile overlays
@@ -28,10 +26,10 @@ FUSE beta supports these package categories:
 
 The FUSE JSON schema lives at `schemas/fuse-mod.schema.json`. The hand-written schema notes live at `schemas/FUSE_JSON_SCHEMA.md`.
 
-## Not Supported In This Beta
+## Not Supported
 
 - Full public in-game editor workflow
-- Multiplayer is compatibility-mode only for beta. FUSE does not sync package contents over the network; instead every host/client applies its own local package stack, matching the legacy RailLoader expectation that everyone has the same mods installed. Non-host clients log a warning the first time they apply runtime world changes. Servers that want strict client blocking can set `Settings.BlockNonHostMultiplayerClientWorldApply` to `true`.
+- Multiplayer is compatibility-mode only. FUSE does not sync package contents over the network; instead every host/client applies its own local package stack, matching the legacy Railloader expectation that everyone has the same mods installed. Non-host clients log a warning the first time they apply runtime world changes. Servers that want strict client blocking can set `Settings.BlockNonHostMultiplayerClientWorldApply` to `true`.
 - Arbitrary legacy script mods that are not data, asset, audio, or supported runtime component packages
 - Rolling stock and locomotive/car mods, except audio definitions that FUSE can import
 - Mid-session scene-path suppression re-enable
@@ -67,9 +65,9 @@ Do not mix legacy and converted FUSE copies of the same route unless you are del
 4. Restore the previous mod folders and save backup if needed.
 5. Start the game and verify the legacy stack or vanilla game loads normally.
 
-## Beta Support Policy
+## Support Policy
 
-When reporting a beta issue, include:
+When reporting an issue, include:
 
 - `FUSE.log`
 - `Player.log`
@@ -79,7 +77,7 @@ When reporting a beta issue, include:
 - The converter `conversion-report.json` and `conversion-report.md` for the affected package
 - Screenshots and the exact mod/package list
 
-The current supported test stack is the converted corpus under `C:\Railroader mods\Installed\Map` plus the asset packs required by those packages. Public support priority goes to issues reproducible with that stack or with a minimal converted package.
+Support priority goes to issues reproducible with a minimal converted package or against a documented legacy route covered by the converter.
 
 ## Runtime Diagnostics
 
@@ -104,7 +102,7 @@ Experimental commands:
 - `/fuse.reapply`
 - `/fuse.restore`
 
-Experimental commands should not be used during normal beta play unless testing recovery.
+Experimental commands should not be used during normal play unless testing recovery.
 
 ## Known Limitations
 

--- a/scripts/stamp-info-version.ps1
+++ b/scripts/stamp-info-version.ps1
@@ -1,0 +1,44 @@
+#requires -Version 5
+# Rewrites the "Version" field in a UMM Info.json file.
+#
+# Used by:
+#   - Directory.Build.targets (InjectModVersionIntoInfoJson) to stamp the
+#     bin-deployed copy with the MSBuild ModVersion property.
+#   - .github/workflows/sync-info-json.yml to sync the source manifest to
+#     the latest published GitHub release tag.
+#
+# The replacement is byte-faithful: only the version value changes;
+# whitespace, line endings, key order, and encoding are preserved.
+
+param(
+  [Parameter(Mandatory)][string]$Path,
+  [Parameter(Mandatory)][string]$Version
+)
+
+if (-not (Test-Path -LiteralPath $Path)) {
+  Write-Error "File not found: $Path"
+  exit 1
+}
+
+$resolved = (Resolve-Path -LiteralPath $Path).ProviderPath
+$content  = Get-Content -LiteralPath $resolved -Raw
+
+if ($content -notmatch '"Version"\s*:\s*"[^"]+"') {
+  Write-Error "No 'Version' field found in $resolved."
+  exit 1
+}
+
+# Lookbehind/lookahead so the surrounding quotes are preserved. The
+# literal '"Version"' anchor avoids accidental matches on neighboring
+# fields like ManagerVersion or GameVersion (their leading char is not
+# a quote).
+$updated = $content -replace '(?<="Version":\s*")[^"]+(?=")', $Version
+
+if ($content -eq $updated) {
+  Write-Host "$resolved already at Version=$Version; no change."
+  exit 0
+}
+
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText($resolved, $updated, $utf8NoBom)
+Write-Host "Stamped $resolved Version=$Version"


### PR DESCRIPTION
## 🔗 Related Issue

No tracked issue — direct prep work for the 1.0.0 public release.

## 📝 Description of the Change

Two independent pieces of 1.0.0 prep work bundled into one commit:

### README polish

- Drop the "targeting a beta release" line and "Beta" qualifiers from headings (`Not Supported`, `Support Policy`), the multiplayer note, and the experimental-commands warning.
- Correct the legacy-ecosystem list in the intro: now lists Railloader, Strange Customs, ConfusingSupplements, For Your Convenience, and Alina's Map Mod (was partial and used `RailLoader` casing — the actual namespace is `Railloader`).
- Remove a maintainer-personal `C:\Railroader mods\Installed\Map` path from the support policy and reword to a generalized statement.

### Info.json auto-sync workflow

The goal is to keep `FUSE/Info.json`'s `Version` field in step with the latest published GA release tag, so the in-repo manifest matches reality instead of sitting at `0.0.0`.

- **`.github/workflows/sync-info-json.yml`** — runs on `release: published`. Skips GitHub pre-releases (which include the entire 0.x series per [release.yml:47](.github/workflows/release.yml)). Parses `v<MAJOR>.<MINOR>.<PATCH>`, rewrites the source manifest, commits to `main` with `[skip ci]`.
- **`scripts/stamp-info-version.ps1`** — single source of truth for the version-rewriting regex. Called by both the new workflow and the existing MSBuild stamping target. Uses lookbehind/lookahead on the literal `"Version"` field so neighbors like `ManagerVersion` and `GameVersion` are not touched. Byte-faithful: only the value characters change; line endings, encoding, key order, and trailing newline are preserved.
- **`Directory.Build.targets`** — `InjectModVersionIntoInfoJson` switches from a literal `'0\.0\.0'` swap to the generic regex via the shared script. **This is required**, not optional: once the workflow first runs and the source manifest moves off `0.0.0`, the old literal regex would no-op and the CI verify-stamping step ([ci.yml:69-74](.github/workflows/ci.yml)) would fail. The new approach is strictly backward compatible (still stamps correctly when source is still `0.0.0`).

## 🔄 Alternatives Considered

- **PR-back vs direct push to main.** Direct push is simpler and matches "automatically update." Trade-off: branch protection requiring PRs would block this — flagged below.
- **Leave the sentinel design and not update source manifest.** This would have avoided the build-target change, but the user explicitly asked for the source manifest to track the latest release.
- **Inline the regex in both consumers.** Less DRY; the regex is non-trivial (lookbehind/lookahead, neighbor-field-safe), so a shared script is preferable.
- **Workflow runner.** `windows-latest` chosen over `ubuntu-latest` so the PowerShell script can be shared with the MSBuild target without porting. Spin-up time is irrelevant for a once-per-release job.

## ⚠️ Possible Drawbacks

- **Branch protection on `main`.** If `main` is configured to require PRs, the default `GITHUB_TOKEN` push from the sync workflow will be rejected. The fix is either to exempt `github-actions[bot]` or to switch the workflow to `peter-evans/create-pull-request`. Worth a 30-second check before merging.
- **No-op until v1.0.0 ships.** The workflow correctly skips all of the 0.x series (treated as pre-release by `release.yml`), so the source manifest stays at `0.0.0` until the first GA tag.
- **No save-file impact**, no runtime behavior change, no API change.

## ✅ Verification Process

The regex / stamping script was exercised locally against the current `FUSE/Info.json`:

- **Neighbor-field safety:** the lookbehind anchor `"Version":\s*"` does not match `"ManagerVersion": "0.27.10"` or `"GameVersion": "2025.1"` (suffix of those identifiers is `rVersion"` / `eVersion"`, not `"Version"`).
- **Byte faithfulness:** initial file (547 bytes, CRLF, no BOM, trailing newline) round-trips identically when stamping `0.0.0 → 1.0.0`. First bytes `{ \r \n` and last bytes `} \r \n` are preserved.
- **Idempotency:** re-running with the same version prints "already at Version=X.Y.Z; no change." and does not rewrite the file; subsequent run with a new version stamps correctly.

What I did **not** verify:
- A full release-tag → workflow → commit-to-main round trip (would require cutting a real release).
- That `main` branch protections do not block the workflow's push (see drawback above).

## 💡 Additional Information

- The `[skip ci]` marker on the sync commit suppresses re-running the full CI matrix on a metadata-only bump. The stamping verification still runs on every other push, so coverage of that target is not lost.
- README also still shows `Current converter version: 0.2.0` and `Current FUSE schema version: 1.0` — left as-is per request; not part of this PR.
- `docs/CHANGELOG.md` still says `## Unreleased Beta` — explicitly deferred per request; not part of this PR.