### PR TITLE
test(editor): de-flake mod-catalog traversal test with private temp parent

### DIFF
--- a/FUSE.Tests/Editor/FuseEditorModCatalogTests.cs
+++ b/FUSE.Tests/Editor/FuseEditorModCatalogTests.cs
@@ -13,11 +13,20 @@ namespace FUSE.Tests.Editor
     /// </summary>
     public sealed class FuseEditorModCatalogTests : IDisposable
     {
+        // Private parent dir, unique to this fixture instance. _modsRoot
+        // is nested one level inside it so the parent's only child is
+        // "mods" — this keeps the sibling-count assertions in
+        // CreateNewMod_rejects_traversal_id_without_writing_outside_root
+        // deterministic. (If _modsRoot lived directly under the shared
+        // system temp dir, parallel test collections creating their own
+        // temp dirs there would race the count.)
+        private readonly string _root;
         private readonly string _modsRoot;
 
         public FuseEditorModCatalogTests()
         {
-            _modsRoot = Path.Combine(Path.GetTempPath(), "FuseEditorModCatalogTests-" + Guid.NewGuid().ToString("N"));
+            _root = Path.Combine(Path.GetTempPath(), "FuseEditorModCatalogTests-" + Guid.NewGuid().ToString("N"));
+            _modsRoot = Path.Combine(_root, "mods");
             Directory.CreateDirectory(_modsRoot);
         }
 
@@ -25,9 +34,9 @@ namespace FUSE.Tests.Editor
         {
             try
             {
-                if (Directory.Exists(_modsRoot))
+                if (Directory.Exists(_root))
                 {
-                    Directory.Delete(_modsRoot, recursive: true);
+                    Directory.Delete(_root, recursive: true);
                 }
             }
             catch
@@ -222,6 +231,9 @@ namespace FUSE.Tests.Editor
             // empty-id gate), and the containment guard is the backstop.
             // Nothing must be created OUTSIDE the mods root, and the
             // sibling count of the root's parent must be unchanged.
+            // The parent here is the fixture's private _root (whose only
+            // child is "mods"), so the count is unperturbed by parallel
+            // test collections and the assertions are deterministic.
             var parent = Directory.GetParent(_modsRoot);
             var before = parent.GetDirectories().Length;
 


### PR DESCRIPTION
## 🔗 Related Issue

Flaky CI failure observed on PR #77's build job: `Assert.Equal() Failure: Expected: 378, Actual: 379`, which then passed on rerun with no code change.

## 📝 Description of the Change

`FuseEditorModCatalogTests` is a pure-filesystem test class. Its fixture constructor created `_modsRoot` directly under the shared system temp dir:

```csharp
_modsRoot = Path.Combine(Path.GetTempPath(), "FuseEditorModCatalogTests-" + Guid.NewGuid().ToString("N"));
```

The test `CreateNewMod_rejects_traversal_id_without_writing_outside_root` then asserts on `Directory.GetParent(_modsRoot).GetDirectories().Length` — i.e. the sibling count of `Path.GetTempPath()` **itself** (hundreds of dirs). Because xUnit runs test collections in parallel, other test classes' constructors (and this one's) create sibling temp dirs under that same shared parent, **racing the count** between the `before` snapshot and the assertions. That non-determinism is the entire cause of the flake — the security behavior under test was always correct (`CreateNewMod` properly returns `null` for `..`).

The fix gives the fixture a **private parent directory** so the sibling-count assertions become deterministic:

- New `_root = Path.Combine(Path.GetTempPath(), "FuseEditorModCatalogTests-<guid>")`.
- `_modsRoot = Path.Combine(_root, "mods")` — nested one level inside `_root`.
- The constructor creates `_modsRoot` (which materializes `_root` along the way).
- `Dispose` now deletes `_root` recursively.

`Directory.GetParent(_modsRoot)` is now the private `_root`, whose only child is `mods`, so no other process or parallel test can perturb the count. A comment was added explaining the invariant.

## 🔄 Alternatives Considered

- **Disable parallelization** for the collection (`[Collection]` / `DisableTestParallelization`) — slower CI and treats the symptom, not the cause.
- **Assert on `_modsRoot`'s own child count instead of the parent's** — would change the meaning of the test (it specifically guards that nothing is written *beside* the root, i.e. a sibling). Isolating the parent preserves the original intent exactly.

## ⚠️ Possible Drawbacks

None expected. The other tests operate relative to `_modsRoot`, so nesting it one level deeper is transparent to them. No production code changes; backward compatibility and saves are unaffected.

## ✅ Verification Process

- `dotnet test FUSE.Tests/FUSE.Tests.csproj -p:GameDir="…\Railroader" --filter "FullyQualifiedName~FuseEditorModCatalogTests"` → **31/31 passed**.
- Full suite (all collections run in parallel — the exact concurrency scenario that triggered the flake): `dotnet test FUSE.Tests/FUSE.Tests.csproj -p:GameDir="…\Railroader"` → **1150/1150 passed**, 0 failed.
- Build is clean; the only warnings are pre-existing CA analyzer notices in `FUSE.Converter`/`FUSE.Editor`, unrelated to this change.

## 💡 Additional Information

Single-file, test-only change. The fragile sibling-count assertion is now backed by an isolated parent directory rather than the shared system temp dir.
