### PR TITLE
docs(codeowners): note code-owner review is now enforced

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Members of the F-U-S-E-E org (https://github.com/F-U-S-E-E) review all changes.
-# Advisory only until branch protection is enabled (requires GitHub Team plan
-# on a private repo, or making the repo public).
+# Enforced by branch protection on `main`: every PR needs an approving review
+# from a code owner below before it can merge (Settings > Branches > main).
 * @Alex6511 @Hrogers-Rog


### PR DESCRIPTION
## 🔗 Related Issue

N/A — repository administration follow-up to enabling branch protection on `main`.

## 📝 Description of the Change

Branch protection is now live on `main` (require Code Owner review, require branches to be up to date with the base before merging, and required status checks `build` / `cs-lint` / `json-lint`).

The `.github/CODEOWNERS` header still carried a placeholder note written before protection was available:

> Advisory only until branch protection is enabled (requires GitHub Team plan on a private repo, or making the repo public).

That statement is no longer true. This PR rewrites the comment to describe the live enforcement instead. The owners rule itself — `* @Alex6511 @Hrogers-Rog` — is **unchanged**, so review routing is unaffected.

## 🔄 Alternatives Considered

Leaving the comment as-is — rejected because it now asserts the opposite of reality and would mislead anyone reading the file.

## ⚠️ Possible Drawbacks

None. Comment-only change; no impact on code ownership, CI, runtime behavior, or save compatibility.

## ✅ Verification Process

- Confirmed protection is live: `gh api repos/F-U-S-E-E/FuseDevelopmentGroup/branches/main/protection` reports `required_status_checks.strict = true`, contexts `build`/`cs-lint`/`json-lint`, and `required_pull_request_reviews.require_code_owner_reviews = true`.
- `git diff` confirms only the two comment lines changed; the `* @Alex6511 @Hrogers-Rog` ownership rule is untouched.

## 💡 Additional Information

This is the documentation tail of enabling branch protection now that the org is on the GitHub Team (paid) plan. The PR will itself exercise the new rules — it requires an org-member (Code Owner) approval, an up-to-date branch, and passing checks before it can merge.
