### PR TITLE
Fix scenery culling churn (#76) + reproducible scenery benchmark tool

### DIFF
--- a/FUSE.UnityTests/Assets/Tests/FuseSceneryCullingDebounceTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/FuseSceneryCullingDebounceTests.cs
@@ -1,0 +1,66 @@
+using FUSE.Patches;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FUSE.UnityTests
+{
+    /// <summary>
+    /// Deterministic EditMode tests for the issue #76 culling-debounce decision.
+    ///
+    /// The fix holds FUSE scenery resident within a distance deadband of the camera
+    /// (so the game's no-hysteresis ~1500m unload boundary can't thrash load/unload),
+    /// and releases it beyond the deadband so genuinely-distant scenery still culls.
+    /// The decision is extracted into the pure
+    /// <see cref="FuseSceneryCullingDebouncePatch.ShouldHoldResident"/> (reachable
+    /// here via FUSE's InternalsVisibleTo) so it can be asserted without a live game,
+    /// Harmony, a camera, or asset bundles — i.e. a fast regression guard that the
+    /// fix can't silently break (e.g. an inverted comparison would re-introduce the
+    /// pop, or pin everything forever).
+    /// </summary>
+    public class FuseSceneryCullingDebounceTests
+    {
+        private const float Deadband = FuseSceneryCullingDebouncePatch.UnloadDistance;
+
+        [Test]
+        public void WellInsideDeadband_HoldsResident()
+        {
+            Assert.IsTrue(
+                FuseSceneryCullingDebouncePatch.ShouldHoldResident(Vector3.zero, new Vector3(0f, 0f, Deadband * 0.5f)),
+                "Scenery within the deadband must be held resident to absorb boundary jitter (no flap).");
+        }
+
+        [Test]
+        public void WellBeyondDeadband_ReleasesForUnload()
+        {
+            Assert.IsFalse(
+                FuseSceneryCullingDebouncePatch.ShouldHoldResident(Vector3.zero, new Vector3(0f, 0f, Deadband * 2f)),
+                "Genuinely-distant scenery must be released so the game unloads it (culling still works).");
+        }
+
+        [Test]
+        public void JustInsideBoundary_Holds()
+        {
+            Assert.IsTrue(
+                FuseSceneryCullingDebouncePatch.ShouldHoldResident(Vector3.zero, new Vector3(0f, 0f, Deadband - 1f)));
+        }
+
+        [Test]
+        public void JustOutsideBoundary_Releases()
+        {
+            Assert.IsFalse(
+                FuseSceneryCullingDebouncePatch.ShouldHoldResident(Vector3.zero, new Vector3(0f, 0f, Deadband + 1f)));
+        }
+
+        [Test]
+        public void DecisionIsRelativeToCamera_NotAbsolutePosition()
+        {
+            // Distance is what matters, so the decision is floating-origin safe.
+            var camera = new Vector3(123456f, 78f, -98765f);
+            var near = camera + new Vector3(0f, 0f, 100f);
+            var far = camera + new Vector3(0f, 0f, Deadband + 100f);
+
+            Assert.IsTrue(FuseSceneryCullingDebouncePatch.ShouldHoldResident(camera, near));
+            Assert.IsFalse(FuseSceneryCullingDebouncePatch.ShouldHoldResident(camera, far));
+        }
+    }
+}

--- a/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
@@ -572,6 +572,24 @@ namespace FUSE.UnityTests
         }
 
         // -----------------------------------------------------------------
+        // SceneryAssetInstance — FuseSceneryBenchmark reads _wantsLoaded and
+        // _model to count in-flight scenery loads (settle detection); the
+        // scenery-animation patch also reflects _model. Issue #76 tooling.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void SceneryAssetInstance_wantsLoaded_InstanceField()
+        {
+            AssertField("Helpers.SceneryAssetInstance", "_wantsLoaded", InstanceNonPublic);
+        }
+
+        [Test]
+        public void SceneryAssetInstance_model_InstanceField()
+        {
+            AssertField("Helpers.SceneryAssetInstance", "_model", InstanceNonPublic);
+        }
+
+        // -----------------------------------------------------------------
         // Helpers
         // -----------------------------------------------------------------
 

--- a/FUSE/Info.json
+++ b/FUSE/Info.json
@@ -12,6 +12,7 @@
     "EnableExperimentalEarlyScenePathSuppression": false,
     "MirrorAssetPacksToLocalLow": false,
     "VerboseApplyReportDetails": false,
+    "EnableSceneryCullingDiagnostics": false,
     "BlockNonHostMultiplayerClientWorldApply": false,
     "ShowAdvancedHealthDetails": false,
     "ShowLegacyModsInUmm": true

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -12,6 +12,7 @@ namespace FUSE.Infrastructure
         public const bool DefaultMirrorInfoToPlayerLog = false;
         public const bool DefaultMirrorAssetPacksToLocalLow = false;
         public const bool DefaultVerboseApplyReportDetails = false;
+        public const bool DefaultEnableSceneryCullingDiagnostics = false;
         public const bool DefaultBlockNonHostMultiplayerClientWorldApply = false;
         public const bool DefaultShowAdvancedHealthDetails = false;
         public const bool DefaultShowTrackDebugOverlay = false;
@@ -40,6 +41,8 @@ namespace FUSE.Infrastructure
         public static bool MirrorAssetPacksToLocalLow { get; private set; } = DefaultMirrorAssetPacksToLocalLow;
 
         public static bool VerboseApplyReportDetails { get; private set; } = DefaultVerboseApplyReportDetails;
+
+        public static bool EnableSceneryCullingDiagnostics { get; private set; } = DefaultEnableSceneryCullingDiagnostics;
 
         public static bool BlockNonHostMultiplayerClientWorldApply { get; private set; } =
             DefaultBlockNonHostMultiplayerClientWorldApply;
@@ -74,6 +77,7 @@ namespace FUSE.Infrastructure
             MirrorInfoToPlayerLog = DefaultMirrorInfoToPlayerLog;
             MirrorAssetPacksToLocalLow = DefaultMirrorAssetPacksToLocalLow;
             VerboseApplyReportDetails = DefaultVerboseApplyReportDetails;
+            EnableSceneryCullingDiagnostics = DefaultEnableSceneryCullingDiagnostics;
             BlockNonHostMultiplayerClientWorldApply = DefaultBlockNonHostMultiplayerClientWorldApply;
             ShowAdvancedHealthDetails = DefaultShowAdvancedHealthDetails;
             ShowTrackDebugOverlay = DefaultShowTrackDebugOverlay;
@@ -108,6 +112,8 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, "MirrorAssetPacksToLocalLow", DefaultMirrorAssetPacksToLocalLow);
                 VerboseApplyReportDetails =
                     ReadBool(settings, "VerboseApplyReportDetails", DefaultVerboseApplyReportDetails);
+                EnableSceneryCullingDiagnostics =
+                    ReadBool(settings, "EnableSceneryCullingDiagnostics", DefaultEnableSceneryCullingDiagnostics);
                 BlockNonHostMultiplayerClientWorldApply =
                     ReadBool(settings, "BlockNonHostMultiplayerClientWorldApply", DefaultBlockNonHostMultiplayerClientWorldApply);
                 ShowAdvancedHealthDetails =
@@ -143,6 +149,7 @@ namespace FUSE.Infrastructure
                     $"MirrorInfoToPlayerLog={MirrorInfoToPlayerLog} " +
                     $"MirrorAssetPacksToLocalLow={MirrorAssetPacksToLocalLow} " +
                     $"VerboseApplyReportDetails={VerboseApplyReportDetails} " +
+                    $"EnableSceneryCullingDiagnostics={EnableSceneryCullingDiagnostics} " +
                     $"BlockNonHostMultiplayerClientWorldApply={BlockNonHostMultiplayerClientWorldApply} " +
                     $"ShowAdvancedHealthDetails={ShowAdvancedHealthDetails} " +
                     $"ShowTrackDebugOverlay={ShowTrackDebugOverlay} " +
@@ -164,6 +171,7 @@ namespace FUSE.Infrastructure
                 MirrorInfoToPlayerLog = DefaultMirrorInfoToPlayerLog;
                 MirrorAssetPacksToLocalLow = DefaultMirrorAssetPacksToLocalLow;
                 VerboseApplyReportDetails = DefaultVerboseApplyReportDetails;
+                EnableSceneryCullingDiagnostics = DefaultEnableSceneryCullingDiagnostics;
                 BlockNonHostMultiplayerClientWorldApply = DefaultBlockNonHostMultiplayerClientWorldApply;
                 ShowAdvancedHealthDetails = DefaultShowAdvancedHealthDetails;
                 ShowTrackDebugOverlay = DefaultShowTrackDebugOverlay;
@@ -187,6 +195,21 @@ namespace FUSE.Infrastructure
             VerboseApplyReportDetails = enabled;
             SaveUserOverride(nameof(VerboseApplyReportDetails), enabled);
             FuseLog.Info($"FUSE setting changed: {nameof(VerboseApplyReportDetails)}={enabled}.");
+        }
+
+        public static void SetEnableSceneryCullingDiagnostics(bool enabled)
+        {
+            EnableSceneryCullingDiagnostics = enabled;
+            SaveUserOverride(nameof(EnableSceneryCullingDiagnostics), enabled);
+            FuseLog.Info($"FUSE setting changed: {nameof(EnableSceneryCullingDiagnostics)}={enabled}.");
+        }
+
+        // Transient (non-persisting) toggle used by FuseSceneryBenchmark to capture
+        // scenery churn counts during a run without writing a user override. The
+        // benchmark restores the prior value when the run finishes.
+        internal static void SetSceneryCullingDiagnosticsTransient(bool enabled)
+        {
+            EnableSceneryCullingDiagnostics = enabled;
         }
 
         public static void SetBlockNonHostMultiplayerClientWorldApply(bool enabled)
@@ -324,6 +347,8 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, nameof(EnableExperimentalEarlyScenePathSuppression), EnableExperimentalEarlyScenePathSuppression);
                 VerboseApplyReportDetails =
                     ReadBool(settings, nameof(VerboseApplyReportDetails), VerboseApplyReportDetails);
+                EnableSceneryCullingDiagnostics =
+                    ReadBool(settings, nameof(EnableSceneryCullingDiagnostics), EnableSceneryCullingDiagnostics);
                 BlockNonHostMultiplayerClientWorldApply =
                     ReadBool(settings, nameof(BlockNonHostMultiplayerClientWorldApply), BlockNonHostMultiplayerClientWorldApply);
                 ShowAdvancedHealthDetails =

--- a/FUSE/Interface/FuseHealthUi.AdvancedTab.cs
+++ b/FUSE/Interface/FuseHealthUi.AdvancedTab.cs
@@ -227,6 +227,44 @@ namespace FUSE.Interface
             }
             builder.Spacer(4f);
 
+            builder.AddSection("Performance Diagnostics");
+            AddSettingToggle(
+                builder,
+                "Scenery Cull Log",
+                FuseSettings.EnableSceneryCullingDiagnostics ? "logging all scenery (FUSE + vanilla) load/unload to FUSE.log" : "disabled",
+                FuseSettings.EnableSceneryCullingDiagnostics ? "Disable" : "Enable",
+                () =>
+                {
+                    FuseSettings.SetEnableSceneryCullingDiagnostics(!FuseSettings.EnableSceneryCullingDiagnostics);
+                    RebuildWindow();
+                });
+            AddWrappedField(
+                builder,
+                "Usage",
+                "Toggle on, teleport into the heavy scene, then off. Each scenery load/unload flip is written to FUSE.log as 'scenery-cull' (fuse=true|false). Hot, repeating flips on the same object during the test point at culling churn (issue #76).",
+                58f);
+            builder.Spacer(4f);
+
+            builder.AddSection("Scenery Load Benchmark");
+            AddWrappedField(
+                builder,
+                "How",
+                "Reproducible culling/streaming tests (issue #76), measured debounce off vs on. CORRIDOR teleports between Bryson and Sylva a few times, then drives the camera up and down the track between them at a set pace. SWEEP A/B is the quick local test (oscillates across the cull boundary at your current view). Be in the overview camera. Each run appends a summary to FUSE-scenery-benchmark.json and writes a per-frame CSV (FUSE-bench-*.csv: FPS, object counts, churn, load latency, memory); live progress prints to FUSE.log.",
+                120f);
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Run Corridor", () => RunAction("run corridor benchmark", FuseSceneryBenchmark.RunCorridor));
+                row.AddButtonCompact("Corridor A/B", () => RunAction("run corridor A/B benchmark", FuseSceneryBenchmark.RunCorridorAb));
+            }, 6f).Height(32f);
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Sweep A/B", () => RunAction("run sweep A/B benchmark", FuseSceneryBenchmark.RunSweepAb));
+                row.AddButtonCompact("Refresh", RebuildWindow);
+            }, 6f).Height(32f);
+            _lastBenchmarkStatus = FuseSceneryBenchmark.Status;
+            AddWrappedLabel(builder, "Benchmark: " + _lastBenchmarkStatus, 48f);
+            builder.Spacer(4f);
+
             builder.AddSection("Experimental");
             AddSettingToggle(
                 builder,

--- a/FUSE/Interface/FuseHealthUi.cs
+++ b/FUSE/Interface/FuseHealthUi.cs
@@ -39,6 +39,7 @@ namespace FUSE.Interface
         private UIPanel _panel;
         private Page _activePage = Page.Health;
         private Page _lastBuiltPage = Page.Health;
+        private string _lastBenchmarkStatus;
         private string _lastAction = "No runtime action has been run from this page.";
         private float _fpsElapsed;
         private int _fpsFrames;
@@ -104,6 +105,16 @@ namespace FUSE.Interface
             if (_button == null)
             {
                 TryInstallHudButton();
+            }
+
+            // Live-refresh the Advanced page while a benchmark reports progress (phase
+            // changes + final result) so the status updates without hitting Refresh.
+            // _lastBenchmarkStatus is set to the rendered value in BuildAdvancedContent,
+            // so this only rebuilds when the status actually changes.
+            if (_activePage == Page.Advanced && _window != null && _window.IsShown &&
+                FuseSceneryBenchmark.Status != _lastBenchmarkStatus)
+            {
+                RebuildWindow();
             }
         }
 

--- a/FUSE/Interface/FuseSceneryBenchmark.cs
+++ b/FUSE/Interface/FuseSceneryBenchmark.cs
@@ -1,0 +1,893 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using FUSE.Infrastructure;
+using FUSE.Patches;
+using Helpers;
+using Model.Ops;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Track;
+using UnityEngine;
+using UnityEngine.Profiling;
+
+namespace FUSE.Interface
+{
+    /// <summary>
+    /// Scenario-driven, automated, reproducible camera benchmark for issue #76 and
+    /// general culling/streaming debugging.
+    ///
+    /// A <see cref="Scenario"/> is just a named camera-movement coroutine. The
+    /// generic runner wraps any scenario: it resets the FUSE churn counters, runs the
+    /// movement (sampling peak in-flight loads), then records one JSON row of churn +
+    /// timing to FUSE-scenery-benchmark.json. "A/B" runs the scenario twice, forcing
+    /// the debounce off then on via
+    /// <see cref="FuseSceneryCullingDebouncePatch.BenchmarkDebounceOverride"/> (a
+    /// benchmark-only override, not a user setting) — the churn delta is the signal.
+    ///
+    /// Built-in scenarios:
+    ///  - "sweep": jump to your current view, then oscillate the camera across the
+    ///    ~1500m cull boundary (quick, local churn test).
+    ///  - "corridor": teleport between Bryson and Sylva a few times, then drive the
+    ///    camera up and down the track between them at a set pace (realistic streaming
+    ///    exercise). Endpoints resolve from the game's PassengerStops by name; the
+    ///    drive uses the public Track.Graph to walk the rails.
+    ///
+    /// All movement uses the proven public camera APIs (CameraSelector.JumpToPoint /
+    /// MoveStrategyToPoint) — no game-internal reflection.
+    /// </summary>
+    internal static class FuseSceneryBenchmark
+    {
+        // Sweep scenario.
+        private const float ColdOffsetMeters = 8000f;
+        private const float SweepDistanceMeters = 2500f;
+        private const float SweepCycleSeconds = 4f;
+        private const float SweepDurationSeconds = 16f;
+        private const float ColdTimeoutSeconds = 30f;
+        private const float TargetTimeoutSeconds = 60f;
+        private const float SettleConfirmSeconds = 0.5f;
+
+        // Corridor scenario.
+        private const string CorridorFromName = "Bryson";
+        private const string CorridorToName = "Sylva";
+        private const int TeleportCycles = 3;
+        private const int RoundTrips = 2;
+        private const float PaceMetersPerSec = 350f;
+        private const float DwellSeconds = 3f;
+        private const float DwellTimeoutSeconds = 30f;
+        private const float LegTimeoutSeconds = 120f;
+
+        private static readonly SceneryLoadStateReader LoadState = new SceneryLoadStateReader();
+
+        private static bool _running;
+        private static string _status = "idle";
+
+        internal static string Status => _status;
+        internal static bool IsRunning => _running;
+
+        // ---- Entry points (Advanced panel) ----
+
+        internal static string RunCorridor() => StartScenario(BuildCorridorScenario(), ab: false);
+
+        internal static string RunCorridorAb() => StartScenario(BuildCorridorScenario(), ab: true);
+
+        internal static string RunSweepAb() => StartScenario(BuildSweepScenario(), ab: true);
+
+        private static string StartScenario(Scenario scenario, bool ab)
+        {
+            if (_running)
+            {
+                return _status = "Benchmark already running.";
+            }
+
+            if (scenario == null)
+            {
+                return _status; // builder already set a reason
+            }
+
+            if (!LoadState.Available)
+            {
+                return _status = "Cannot read SceneryAssetInstance load state (game layout changed). Benchmark unavailable.";
+            }
+
+            if (CameraSelector.shared == null)
+            {
+                return _status = "No camera available — load a map first.";
+            }
+
+            BenchmarkRunner.Instance.StartCoroutine(ab ? RunAbRoutine(scenario) : RunSingleRoutine(scenario));
+            return _status = $"{scenario.Name} {(ab ? "A/B " : string.Empty)}started — watch the status line / FUSE.log.";
+        }
+
+        // ---- Scenario definitions ----
+
+        private sealed class Scenario
+        {
+            public string Name;
+            public Func<IEnumerator> Movement;
+        }
+
+        private static Scenario BuildSweepScenario()
+        {
+            var cam = Camera.main;
+            if (cam == null)
+            {
+                _status = "No active camera. Switch to the overview camera and try again.";
+                return null;
+            }
+
+            var target = WorldTransformer.WorldToGame(cam.transform.position);
+            var rotation = cam.transform.rotation;
+            var cold = target + new Vector3(ColdOffsetMeters, 0f, 0f);
+            return new Scenario { Name = "sweep", Movement = () => SweepMovement(target, cold, rotation) };
+        }
+
+        private static Scenario BuildCorridorScenario()
+        {
+            return new Scenario { Name = "corridor", Movement = CorridorMovement };
+        }
+
+        // ---- Generic A/B harness ----
+
+        private static IEnumerator RunSingleRoutine(Scenario scenario)
+        {
+            _running = true;
+            yield return RunScenarioOnce(scenario, null, "single", null);
+            _running = false;
+        }
+
+        private static IEnumerator RunAbRoutine(Scenario scenario)
+        {
+            _running = true;
+            JObject baseline = null;
+            JObject fixedRun = null;
+            yield return RunScenarioOnce(scenario, false, "baseline-no-debounce", r => baseline = r);
+            yield return RunScenarioOnce(scenario, true, "fix-debounce", r => fixedRun = r);
+            _running = false;
+
+            if (baseline != null && fixedRun != null)
+            {
+                _status =
+                    $"{scenario.Name} A/B — churn base {baseline.Value<long>("fuseLoads")}L/{baseline.Value<long>("fuseUnloads")}U " +
+                    $"vs fix {fixedRun.Value<long>("fuseLoads")}L/{fixedRun.Value<long>("fuseUnloads")}U " +
+                    $"(held {fixedRun.Value<long>("suppressedUnloads")}). " +
+                    $"minFps base={baseline.Value<double>("minFps"):0} fix={fixedRun.Value<double>("minFps"):0}. " +
+                    $"duration base={baseline.Value<double>("durationMs"):0}ms fix={fixedRun.Value<double>("durationMs"):0}ms.";
+                FuseLog.Info("FUSE benchmark A/B: " + _status);
+            }
+        }
+
+        // try/finally (no catch around yields) guarantees the overrides are cleared.
+        private static IEnumerator RunScenarioOnce(Scenario scenario, bool? debounceOverride, string label, Action<JObject> onResult)
+        {
+            var prevDiagnostics = FuseSettings.EnableSceneryCullingDiagnostics;
+            JObject result = null;
+            RunSampler sampler = null;
+            try
+            {
+                FuseSettings.SetSceneryCullingDiagnosticsTransient(true);
+                FuseSceneryCullingDebouncePatch.BenchmarkDebounceOverride = debounceOverride;
+                FuseSceneryCullingDiagnosticPatch.ResetCounters();
+                FuseSceneryCullingDebouncePatch.ResetSuppressedUnloads();
+
+                // Parallel per-frame sampler -> time-series CSV (FPS, counts, churn,
+                // load latency, memory). Runs as its own coroutine so it samples even
+                // while the movement is inside a nested wait.
+                sampler = new RunSampler(scenario.Name, label);
+                BenchmarkRunner.Instance.StartCoroutine(sampler.Loop());
+
+                var startTime = Time.realtimeSinceStartup;
+                var movement = scenario.Movement();
+                while (true)
+                {
+                    bool advanced;
+                    try
+                    {
+                        advanced = movement.MoveNext();
+                    }
+                    catch (Exception ex)
+                    {
+                        FuseLog.Exception($"FUSE benchmark scenario '{scenario.Name}' movement failed", ex);
+                        break;
+                    }
+
+                    if (!advanced)
+                    {
+                        break;
+                    }
+
+                    yield return movement.Current;
+                }
+
+                var durationMs = Math.Round((Time.realtimeSinceStartup - startTime) * 1000f, 0);
+                result = new JObject
+                {
+                    ["timestampLocal"] = DateTime.Now.ToString("O"),
+                    ["scenario"] = scenario.Name,
+                    ["label"] = label,
+                    ["buildConfiguration"] = BuildConfiguration,
+                    ["debounce"] = debounceOverride.HasValue
+                        ? (debounceOverride.Value ? "forced-on" : "forced-off")
+                        : "default-on",
+                    ["deadbandMeters"] = FuseSceneryCullingDebouncePatch.UnloadDistance,
+                    ["durationMs"] = durationMs,
+                    ["peakInFlight"] = sampler.PeakInFlight,
+                    ["avgFps"] = Math.Round(sampler.AvgFps, 1),
+                    ["minFps"] = Math.Round(sampler.MinFps, 1),
+                    ["fuseLoads"] = FuseSceneryCullingDiagnosticPatch.FuseLoads,
+                    ["fuseUnloads"] = FuseSceneryCullingDiagnosticPatch.FuseUnloads,
+                    ["vanillaLoads"] = FuseSceneryCullingDiagnosticPatch.VanillaLoads,
+                    ["vanillaUnloads"] = FuseSceneryCullingDiagnosticPatch.VanillaUnloads,
+                    ["suppressedUnloads"] = FuseSceneryCullingDebouncePatch.SuppressedUnloads,
+                    ["csv"] = sampler.FileName
+                };
+                AppendResult(result);
+                _status =
+                    $"[{scenario.Name}/{label}] done {durationMs:0}ms; loads={FuseSceneryCullingDiagnosticPatch.FuseLoads} " +
+                    $"unloads={FuseSceneryCullingDiagnosticPatch.FuseUnloads} suppressed={FuseSceneryCullingDebouncePatch.SuppressedUnloads} " +
+                    $"minFps={sampler.MinFps:0} peak={sampler.PeakInFlight}. CSV: {sampler.FileName}";
+                FuseLog.Info("FUSE benchmark " + _status);
+            }
+            finally
+            {
+                sampler?.Finish();
+                FuseSceneryCullingDebouncePatch.BenchmarkDebounceOverride = null;
+                FuseSettings.SetSceneryCullingDiagnosticsTransient(prevDiagnostics);
+                onResult?.Invoke(result);
+            }
+        }
+
+        // ---- Scenario: sweep ----
+
+        private static IEnumerator SweepMovement(Vector3 target, Vector3 cold, Quaternion rotation)
+        {
+            _status = "[sweep] cooling — jumping away…";
+            Teleport(cold, rotation);
+            yield return WaitForLoadAndSettle(ColdTimeoutSeconds, null);
+            for (var i = 0; i < 30; i++)
+            {
+                yield return null;
+            }
+
+            _status = "[sweep] cold-loading — jumping to target…";
+            Teleport(target, rotation);
+            yield return WaitForLoadAndSettle(TargetTimeoutSeconds, null);
+
+            // Measure only the sweep flaps: reset here so the harness's end-snapshot
+            // reflects boundary churn, not the one-time cold load.
+            FuseSceneryCullingDiagnosticPatch.ResetCounters();
+            FuseSceneryCullingDebouncePatch.ResetSuppressedUnloads();
+
+            _status = "[sweep] sweeping — measuring churn…";
+            var sweepFar = target + new Vector3(SweepDistanceMeters, 0f, 0f);
+            var start = Time.realtimeSinceStartup;
+            while (Time.realtimeSinceStartup - start < SweepDurationSeconds)
+            {
+                var elapsed = Time.realtimeSinceStartup - start;
+                var phase = 0.5f * (1f - Mathf.Cos(elapsed / SweepCycleSeconds * 2f * Mathf.PI));
+                MoveStrategy(Vector3.Lerp(target, sweepFar, phase), rotation);
+                yield return null;
+            }
+
+            MoveStrategy(target, rotation);
+        }
+
+        // ---- Scenario: corridor ----
+
+        private static IEnumerator CorridorMovement()
+        {
+            var from = ResolveStop(CorridorFromName);
+            var to = ResolveStop(CorridorToName);
+            if (from == null || to == null)
+            {
+                _status = $"corridor: could not find '{CorridorFromName}' and/or '{CorridorToName}' stations.";
+                FuseLog.Warning("FUSE benchmark " + _status);
+                yield break;
+            }
+
+            var fromPos = from.CenterPoint;
+            var toPos = to.CenterPoint;
+            var rotation = Camera.main != null ? Camera.main.transform.rotation : Quaternion.identity;
+
+            // Phase 1: teleport back and forth a few times.
+            for (var cycle = 0; cycle < TeleportCycles; cycle++)
+            {
+                _status = $"corridor: teleport {cycle + 1}/{TeleportCycles} → {CorridorFromName}";
+                Teleport(fromPos, rotation);
+                yield return WaitForLoadAndSettle(DwellTimeoutSeconds, null);
+                yield return new WaitForSecondsRealtime(DwellSeconds);
+
+                _status = $"corridor: teleport {cycle + 1}/{TeleportCycles} → {CorridorToName}";
+                Teleport(toPos, rotation);
+                yield return WaitForLoadAndSettle(DwellTimeoutSeconds, null);
+                yield return new WaitForSecondsRealtime(DwellSeconds);
+            }
+
+            // Phase 2: A* a route along the rails between the stations, then drive up
+            // and down it. (LocationByMoving alone wanders into yard dead-ends at
+            // switches — A* picks the correct branches.)
+            var route = BuildTrackRoute(fromPos, toPos);
+            if (route == null || route.Count < 2)
+            {
+                _status = $"corridor: no track route {CorridorFromName}→{CorridorToName} found — teleport phase only.";
+                FuseLog.Warning("FUSE benchmark " + _status);
+                yield break;
+            }
+
+            FuseLog.Info($"FUSE benchmark corridor route resolved: {route.Count} points.");
+            var reverse = new List<Vector3>(route);
+            reverse.Reverse();
+            for (var trip = 0; trip < RoundTrips; trip++)
+            {
+                _status = $"corridor: track run {trip + 1}/{RoundTrips} → {CorridorToName}";
+                yield return DrivePolyline(route, rotation);
+
+                _status = $"corridor: track run {trip + 1}/{RoundTrips} → {CorridorFromName}";
+                yield return DrivePolyline(reverse, rotation);
+            }
+        }
+
+        // Builds a game-coord polyline along the rails between two points by A* over
+        // the track-node graph (edge weight = segment length). null if disconnected.
+        private static List<Vector3> BuildTrackRoute(Vector3 fromGamePos, Vector3 toGamePos)
+        {
+            var graph = Graph.Shared;
+            if (graph == null)
+            {
+                return null;
+            }
+
+            var start = NearestNode(graph, fromGamePos);
+            var goal = NearestNode(graph, toGamePos);
+            if (start == null || goal == null)
+            {
+                return null;
+            }
+
+            // Sanity log: if these distances are large, node positions and station
+            // CenterPoints are in different coordinate spaces (would need adjusting).
+            FuseLog.Info(
+                $"FUSE benchmark corridor A*: nearest node {(NodePos(start) - fromGamePos).magnitude:0}m from {CorridorFromName}, " +
+                $"{(NodePos(goal) - toGamePos).magnitude:0}m from {CorridorToName}.");
+
+            var nodePath = AStarNodePath(graph, start, goal);
+            if (nodePath == null)
+            {
+                return null;
+            }
+
+            var points = new List<Vector3>(nodePath.Count + 2) { fromGamePos };
+            foreach (var node in nodePath)
+            {
+                points.Add(NodePos(node));
+            }
+
+            points.Add(toGamePos);
+            return points;
+        }
+
+        private static TrackNode NearestNode(Graph graph, Vector3 gamePos)
+        {
+            TrackNode best = null;
+            var bestSqr = float.MaxValue;
+            foreach (var node in graph.Nodes)
+            {
+                if (node == null)
+                {
+                    continue;
+                }
+
+                var sqr = (NodePos(node) - gamePos).sqrMagnitude;
+                if (sqr < bestSqr)
+                {
+                    bestSqr = sqr;
+                    best = node;
+                }
+            }
+
+            return best;
+        }
+
+        private static Vector3 NodePos(TrackNode node) => node.transform.localPosition;
+
+        // Standard A*: segments are edges weighted by length, heuristic is the
+        // straight-line distance to the goal node.
+        private static List<TrackNode> AStarNodePath(Graph graph, TrackNode start, TrackNode goal)
+        {
+            var goalPos = NodePos(goal);
+            var open = new List<TrackNode> { start };
+            var cameFrom = new Dictionary<TrackNode, TrackNode>();
+            var gScore = new Dictionary<TrackNode, float> { [start] = 0f };
+            var fScore = new Dictionary<TrackNode, float> { [start] = (NodePos(start) - goalPos).magnitude };
+            var closed = new HashSet<TrackNode>();
+            var guard = 0;
+
+            while (open.Count > 0 && guard++ < 500000)
+            {
+                var currentIndex = 0;
+                var current = open[0];
+                for (var i = 1; i < open.Count; i++)
+                {
+                    if (Score(fScore, open[i]) < Score(fScore, current))
+                    {
+                        current = open[i];
+                        currentIndex = i;
+                    }
+                }
+
+                if (current == goal)
+                {
+                    return Reconstruct(cameFrom, current);
+                }
+
+                open.RemoveAt(currentIndex);
+                closed.Add(current);
+
+                foreach (var segment in graph.SegmentsConnectedTo(current))
+                {
+                    if (segment == null)
+                    {
+                        continue;
+                    }
+
+                    var neighbor = segment.GetOtherNode(current);
+                    if (neighbor == null || neighbor == current || closed.Contains(neighbor))
+                    {
+                        continue;
+                    }
+
+                    var tentative = Score(gScore, current) + Mathf.Max(segment.GetLength(), 0.01f);
+                    if (tentative < Score(gScore, neighbor))
+                    {
+                        cameFrom[neighbor] = current;
+                        gScore[neighbor] = tentative;
+                        fScore[neighbor] = tentative + (NodePos(neighbor) - goalPos).magnitude;
+                        if (!open.Contains(neighbor))
+                        {
+                            open.Add(neighbor);
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static float Score(Dictionary<TrackNode, float> scores, TrackNode node) =>
+            scores.TryGetValue(node, out var value) ? value : float.MaxValue;
+
+        private static List<TrackNode> Reconstruct(Dictionary<TrackNode, TrackNode> cameFrom, TrackNode current)
+        {
+            var path = new List<TrackNode> { current };
+            while (cameFrom.TryGetValue(current, out var previous))
+            {
+                current = previous;
+                path.Add(current);
+            }
+
+            path.Reverse();
+            return path;
+        }
+
+        // Glides the camera along a game-coord polyline at PaceMetersPerSec.
+        private static IEnumerator DrivePolyline(List<Vector3> points, Quaternion rotation)
+        {
+            var legStart = Time.realtimeSinceStartup;
+            for (var i = 0; i < points.Count - 1; i++)
+            {
+                var a = points[i];
+                var b = points[i + 1];
+                var length = Vector3.Distance(a, b);
+                if (length < 0.01f)
+                {
+                    continue;
+                }
+
+                var traveled = 0f;
+                while (traveled < length)
+                {
+                    traveled += PaceMetersPerSec * Time.deltaTime;
+                    MoveStrategy(Vector3.Lerp(a, b, Mathf.Clamp01(traveled / length)), rotation);
+                    if (Time.realtimeSinceStartup - legStart > LegTimeoutSeconds)
+                    {
+                        yield break;
+                    }
+
+                    yield return null;
+                }
+            }
+        }
+
+        private static PassengerStop ResolveStop(string name)
+        {
+            try
+            {
+                foreach (var stop in PassengerStop.FindAll())
+                {
+                    if (stop == null)
+                    {
+                        continue;
+                    }
+
+                    var timetable = stop.TimetableName;
+                    var id = stop.identifier;
+                    if ((timetable != null && timetable.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0) ||
+                        (id != null && id.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0))
+                    {
+                        return stop;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE benchmark could not enumerate passenger stops", ex);
+            }
+
+            return null;
+        }
+
+        // ---- Camera ----
+
+        // Real teleport (selects the Strategy camera + loads), for jumps.
+        private static void Teleport(Vector3 gamePosition, Quaternion rotation)
+        {
+            try
+            {
+                CameraSelector.shared?.JumpToPoint(gamePosition, rotation, CameraSelector.CameraIdentifier.Strategy);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE benchmark teleport failed", ex);
+            }
+        }
+
+        // Instant per-frame move of the already-selected Strategy camera, for sweeps
+        // and track drives.
+        private static void MoveStrategy(Vector3 gamePosition, Quaternion rotation)
+        {
+            try
+            {
+                CameraSelector.shared?.MoveStrategyToPoint(WorldTransformer.GameToWorld(gamePosition), rotation);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE benchmark camera move failed", ex);
+            }
+        }
+
+        // ---- Settle detection ----
+
+        private static IEnumerator WaitForLoadAndSettle(float timeoutSeconds, Action<int> onPoll)
+        {
+            var start = Time.realtimeSinceStartup;
+            var loadingStarted = false;
+            var firstZeroTime = -1f;
+            while (Time.realtimeSinceStartup - start < timeoutSeconds)
+            {
+                var inFlight = CountInFlight();
+                onPoll?.Invoke(inFlight);
+
+                if (inFlight > 0)
+                {
+                    loadingStarted = true;
+                    firstZeroTime = -1f;
+                }
+                else if (loadingStarted)
+                {
+                    if (firstZeroTime < 0f)
+                    {
+                        firstZeroTime = Time.realtimeSinceStartup;
+                    }
+
+                    if (Time.realtimeSinceStartup - firstZeroTime >= SettleConfirmSeconds)
+                    {
+                        yield break;
+                    }
+                }
+
+                yield return null;
+            }
+        }
+
+        private static int CountInFlight()
+        {
+            var instances = UnityEngine.Object.FindObjectsOfType<SceneryAssetInstance>();
+            var count = 0;
+            foreach (var instance in instances)
+            {
+                if (instance == null)
+                {
+                    continue;
+                }
+
+                if (!LoadState.GetWantsLoaded(instance))
+                {
+                    continue;
+                }
+
+                if (LoadState.GetModel(instance) == null)
+                {
+                    count++; // wants to be loaded but the model isn't present yet
+                }
+            }
+
+            return count;
+        }
+
+        // ---- Output ----
+
+        private static string ResultsPath => Path.Combine(Application.persistentDataPath, "FUSE-scenery-benchmark.json");
+
+        private static void AppendResult(JObject result)
+        {
+            try
+            {
+                var history = File.Exists(ResultsPath)
+                    ? JArray.Parse(File.ReadAllText(ResultsPath))
+                    : new JArray();
+                history.Add(result);
+                File.WriteAllText(ResultsPath, history.ToString(Formatting.Indented));
+                FuseLog.Info($"FUSE benchmark result appended to '{ResultsPath}'.");
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE benchmark could not write results", ex);
+            }
+        }
+
+        private static string BuildConfiguration
+        {
+            get
+            {
+#if DEBUG
+                return "Debug";
+#else
+                return "Release";
+#endif
+            }
+        }
+
+        // Small reflection holder for SceneryAssetInstance's private load-state fields
+        // (used to count in-flight loads). Cached once.
+        private sealed class SceneryLoadStateReader
+        {
+            private readonly System.Reflection.FieldInfo _wantsLoaded =
+                typeof(SceneryAssetInstance).GetField("_wantsLoaded", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+            private readonly System.Reflection.FieldInfo _model =
+                typeof(SceneryAssetInstance).GetField("_model", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+            public bool Available => _wantsLoaded != null && _model != null;
+
+            public bool GetWantsLoaded(SceneryAssetInstance instance) => _wantsLoaded.GetValue(instance) is bool b && b;
+
+            public GameObject GetModel(SceneryAssetInstance instance) => _model.GetValue(instance) as GameObject;
+        }
+
+        // Parallel per-frame sampler that writes a time-series performance CSV for a
+        // run: FPS, frame time, scenery in-flight/loaded counts, churn deltas, sampled
+        // per-object load latency, and memory — tagged with the current phase. Runs as
+        // its own coroutine so it keeps sampling even while the movement is in a
+        // nested wait. Sampling is throttled to 4 Hz to limit its own overhead.
+        private sealed class RunSampler
+        {
+            private const float SampleIntervalSeconds = 0.25f;
+
+            private readonly string _fileName;
+            private readonly float _startTime;
+            private readonly Dictionary<int, float> _loadStart = new Dictionary<int, float>();
+            private StreamWriter _writer;
+            private bool _active = true;
+            private float _lastSampleTime;
+            private int _framesSinceSample;
+            private long _lastLoads;
+            private long _lastUnloads;
+            private long _lastSuppressed;
+            private float _fpsSum;
+            private float _fpsMin = float.MaxValue;
+            private int _fpsCount;
+
+            internal int PeakInFlight { get; private set; }
+            internal float AvgFps => _fpsCount > 0 ? _fpsSum / _fpsCount : 0f;
+            internal float MinFps => _fpsCount > 0 ? _fpsMin : 0f;
+            internal string FileName => _fileName;
+
+            internal RunSampler(string scenario, string label)
+            {
+                _startTime = Time.realtimeSinceStartup;
+                _lastSampleTime = _startTime;
+                _fileName = $"FUSE-bench-{Sanitize(scenario)}-{Sanitize(label)}-{DateTime.Now:yyyyMMdd-HHmmss}.csv";
+                try
+                {
+                    var path = Path.Combine(Application.persistentDataPath, _fileName);
+                    _writer = new StreamWriter(path, false) { AutoFlush = true };
+                    _writer.WriteLine(
+                        "elapsedSec,fps,frameMs,inFlight,loaded,loadsDelta,unloadsDelta,suppressedDelta," +
+                        "loadsCompleted,avgLoadMs,maxLoadMs,managedMB,unityMB,phase");
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception("FUSE benchmark could not open CSV", ex);
+                    _writer = null;
+                }
+            }
+
+            internal IEnumerator Loop()
+            {
+                while (_active)
+                {
+                    try
+                    {
+                        Frame();
+                    }
+                    catch (Exception ex)
+                    {
+                        FuseLog.Exception("FUSE benchmark sampler frame failed", ex);
+                    }
+
+                    yield return null;
+                }
+            }
+
+            internal void Finish()
+            {
+                _active = false;
+                try
+                {
+                    _writer?.Flush();
+                    _writer?.Dispose();
+                }
+                catch
+                {
+                }
+
+                _writer = null;
+            }
+
+            private void Frame()
+            {
+                _framesSinceSample++;
+                var now = Time.realtimeSinceStartup;
+                if (now - _lastSampleTime < SampleIntervalSeconds)
+                {
+                    return;
+                }
+
+                var intervalElapsed = Mathf.Max(now - _lastSampleTime, 0.0001f);
+                var fps = _framesSinceSample / intervalElapsed;
+                var frameMs = 1000f / Mathf.Max(fps, 0.01f);
+                _fpsSum += fps;
+                _fpsCount++;
+                if (fps < _fpsMin)
+                {
+                    _fpsMin = fps;
+                }
+
+                int inFlight = 0, loaded = 0, completed = 0;
+                float latencySum = 0f, latencyMax = 0f;
+                var instances = UnityEngine.Object.FindObjectsOfType<SceneryAssetInstance>();
+                foreach (var instance in instances)
+                {
+                    if (instance == null || !LoadState.GetWantsLoaded(instance))
+                    {
+                        continue;
+                    }
+
+                    var id = instance.GetInstanceID();
+                    if (LoadState.GetModel(instance) == null)
+                    {
+                        inFlight++;
+                        if (!_loadStart.ContainsKey(id))
+                        {
+                            _loadStart[id] = now;
+                        }
+                    }
+                    else
+                    {
+                        loaded++;
+                        if (_loadStart.TryGetValue(id, out var startedAt))
+                        {
+                            var latency = (now - startedAt) * 1000f;
+                            latencySum += latency;
+                            if (latency > latencyMax)
+                            {
+                                latencyMax = latency;
+                            }
+
+                            completed++;
+                            _loadStart.Remove(id);
+                        }
+                    }
+                }
+
+                if (inFlight > PeakInFlight)
+                {
+                    PeakInFlight = inFlight;
+                }
+
+                var totalLoads = FuseSceneryCullingDiagnosticPatch.FuseLoads + FuseSceneryCullingDiagnosticPatch.VanillaLoads;
+                var totalUnloads = FuseSceneryCullingDiagnosticPatch.FuseUnloads + FuseSceneryCullingDiagnosticPatch.VanillaUnloads;
+                var suppressed = FuseSceneryCullingDebouncePatch.SuppressedUnloads;
+                var loadsDelta = totalLoads - _lastLoads;
+                var unloadsDelta = totalUnloads - _lastUnloads;
+                var suppressedDelta = suppressed - _lastSuppressed;
+                _lastLoads = totalLoads;
+                _lastUnloads = totalUnloads;
+                _lastSuppressed = suppressed;
+
+                var managedMb = GC.GetTotalMemory(false) / 1048576f;
+                var unityMb = SafeUnityMemory() / 1048576f;
+                var avgLoadMs = completed > 0 ? latencySum / completed : 0f;
+
+                _writer?.WriteLine(
+                    $"{now - _startTime:0.00},{fps:0.0},{frameMs:0.0},{inFlight},{loaded}," +
+                    $"{loadsDelta},{unloadsDelta},{suppressedDelta},{completed},{avgLoadMs:0},{latencyMax:0}," +
+                    $"{managedMb:0.0},{unityMb:0.0},\"{CsvPhase()}\"");
+
+                _lastSampleTime = now;
+                _framesSinceSample = 0;
+            }
+
+            private static long SafeUnityMemory()
+            {
+                try
+                {
+                    return Profiler.GetTotalAllocatedMemoryLong();
+                }
+                catch
+                {
+                    return 0L;
+                }
+            }
+
+            private static string CsvPhase()
+            {
+                var status = _status ?? string.Empty;
+                return status.Replace('"', '\'').Replace('\n', ' ').Replace('\r', ' ');
+            }
+
+            private static string Sanitize(string value)
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    return "x";
+                }
+
+                var chars = value.ToCharArray();
+                for (var i = 0; i < chars.Length; i++)
+                {
+                    var c = chars[i];
+                    if (!char.IsLetterOrDigit(c) && c != '-' && c != '_')
+                    {
+                        chars[i] = '-';
+                    }
+                }
+
+                return new string(chars);
+            }
+        }
+
+        // Persistent host so the benchmark coroutine survives the Health panel being
+        // rebuilt or closed mid-run.
+        private sealed class BenchmarkRunner : MonoBehaviour
+        {
+            private static BenchmarkRunner _instance;
+
+            internal static BenchmarkRunner Instance
+            {
+                get
+                {
+                    if (_instance == null)
+                    {
+                        var host = new GameObject("FUSE.SceneryBenchmark");
+                        DontDestroyOnLoad(host);
+                        _instance = host.AddComponent<BenchmarkRunner>();
+                    }
+
+                    return _instance;
+                }
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseSceneryCullingDebouncePatch.cs
+++ b/FUSE/Patches/FuseSceneryCullingDebouncePatch.cs
@@ -1,0 +1,134 @@
+using System;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Helpers;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Issue #76 fix: adds a distance deadband (hysteresis) to scenery model
+    /// unloading for FUSE-owned scenery, killing the boundary load/unload flap.
+    ///
+    /// The game culls scenery with no hysteresis. Distance bands {100, 1000, 1500}m
+    /// drive <c>SetLoaded(distanceBand &lt;= 2)</c>, so a model unloads the instant its
+    /// culling sphere crosses band 3 (&gt;1500m) and reloads (async asset-bundle load +
+    /// Instantiate) when it returns. During a teleport / camera-settle the reference
+    /// point swings across that boundary repeatedly, so clusters of FUSE scenery flap
+    /// load/unload many times in seconds — the popping, and a big share of the slow
+    /// settle (each object reloads ~8-16x instead of once).
+    ///
+    /// This prefix only acts when the game wants to UNLOAD (band &gt;= 3). It measures
+    /// the real distance from the active camera to the instance: while the object is
+    /// inside <see cref="UnloadDistance"/> it clamps the band to 2 (the game's own
+    /// "resident but renderers-off" state) so boundary jitter between ~1500m and the
+    /// deadband edge can't thrash load/unload; once the object is genuinely beyond
+    /// the deadband it lets band 3 through and the game unloads it normally. The
+    /// resident working set is therefore bounded to a radius around the camera — it
+    /// still culls, it just doesn't flap.
+    ///
+    /// A distance test is used rather than a time-based grace because
+    /// <c>CullingSphereStateChanged</c> is event / world-shift driven (not called
+    /// every frame), so a timed grace never reliably expires and ends up pinning
+    /// everything. The distance check is correct on every individual call regardless
+    /// of cadence, and needs no per-instance state.
+    ///
+    /// Scoped to FUSE scenery (<see cref="FUSE.Runtime.API.SceneryAPI.FuseSceneryMarker"/>)
+    /// so vanilla culling is untouched. Always active on this branch (no runtime
+    /// toggle). Runs alongside the diagnostic postfix on the same method: in-deadband
+    /// objects are clamped (so they log no UNLOAD), genuinely-far objects pass band 3
+    /// through (so the postfix logs <c>scenery-cull UNLOAD fuse=True</c>) — that is the
+    /// signal that culling is still happening.
+    /// </summary>
+    [HarmonyPatch(typeof(SceneryAssetInstance), "CullingSphereStateChanged")]
+    internal static class FuseSceneryCullingDebouncePatch
+    {
+        // Vanilla: SetLoaded(distanceBand <= 2). Bands 0-2 keep the model resident
+        // (band 0-1 render, band 2 resident-but-invisible); band 3 unloads. Holding
+        // an object at band 2 is a no-op visually but skips the destroy + reload.
+        private const int ResidentBandCeiling = 2;
+
+        // Deadband outer edge. Band 3 begins ~1500m out (the SceneryDistanceBands
+        // ceiling); we keep FUSE scenery resident until it is this far so jitter near
+        // 1500m can't flap, then allow the unload. Squared to avoid a sqrt per call.
+        internal const float UnloadDistance = 3000f;
+        private const float UnloadDistanceSqr = UnloadDistance * UnloadDistance;
+
+        // Benchmark-only override (NOT a user setting): null = normal always-on
+        // behavior; false = force the debounce OFF for an A/B baseline pass; true =
+        // force ON. Set transiently by FuseSceneryBenchmark and cleared after a run.
+        internal static bool? BenchmarkDebounceOverride;
+
+        // Cached camera (the culler's distance reference is the active camera). Cheap
+        // to reuse; re-fetched only when it goes null (scene swap / teardown).
+        private static Camera _camera;
+
+        private static long _suppressedUnloads;
+
+        /// <summary>Unloads suppressed (objects held resident) since the last reset.</summary>
+        internal static long SuppressedUnloads => _suppressedUnloads;
+
+        internal static void ResetSuppressedUnloads() => _suppressedUnloads = 0;
+
+        /// <summary>
+        /// Pure debounce decision: should a band-3 FUSE scenery object be held
+        /// resident (true) rather than unloaded (false)? True while it is inside the
+        /// <see cref="UnloadDistance"/> deadband of the camera. Extracted for
+        /// deterministic unit testing (see FUSE.UnityTests).
+        /// </summary>
+        internal static bool ShouldHoldResident(Vector3 cameraPos, Vector3 objectPos)
+        {
+            return (cameraPos - objectPos).sqrMagnitude < UnloadDistanceSqr;
+        }
+
+        private static void Prefix(SceneryAssetInstance __instance, ref int distanceBand)
+        {
+            // Only the unload band is in scope; in-range bands keep vanilla behavior.
+            // BenchmarkDebounceOverride == false forces a baseline (no-debounce) pass.
+            if (distanceBand <= ResidentBandCeiling || __instance == null || BenchmarkDebounceOverride == false)
+            {
+                return;
+            }
+
+            try
+            {
+                if (__instance.GetComponent<FUSE.Runtime.API.SceneryAPI.FuseSceneryMarker>() == null)
+                {
+                    return; // FUSE-owned scenery only; vanilla culls normally.
+                }
+
+                if (_camera == null)
+                {
+                    _camera = Camera.main;
+                }
+
+                if (_camera == null)
+                {
+                    return; // No reference to measure against: let the game unload.
+                }
+
+                // transform.position and the camera are in the same (floating-origin
+                // shifted) space, so the delta is correct regardless of world shifts.
+                if (!ShouldHoldResident(_camera.transform.position, __instance.transform.position))
+                {
+                    return; // Genuinely far: let band 3 through so the game unloads it.
+                }
+
+                // Inside the deadband: hold it resident so the ~1500m boundary can't
+                // thrash load/unload.
+                distanceBand = ResidentBandCeiling;
+                _suppressedUnloads++;
+                if (FuseSettings.EnableSceneryCullingDiagnostics && _suppressedUnloads % 1000 == 0)
+                {
+                    FuseLog.Info(
+                        $"FUSE diag scenery-debounce active: suppressedUnloads={_suppressedUnloads} " +
+                        $"(holding FUSE scenery resident within {UnloadDistance:0}m).");
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE scenery unload debounce prefix failed", ex);
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseSceneryCullingDiagnosticPatch.cs
+++ b/FUSE/Patches/FuseSceneryCullingDiagnosticPatch.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Runtime.CompilerServices;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Helpers;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Diagnostic Harmony patch for issue #76 (asset/scenery culling churn that
+    /// may be caused by FUSE). Vanilla
+    /// <c>SceneryAssetInstance.CullingSphereStateChanged(isVisible, distanceBand)</c>
+    /// calls <c>SetLoaded(distanceBand &lt;= 2)</c> every time the culler reports a
+    /// new band, so a model loads when the band drops to &lt;= 2 and unloads when it
+    /// rises above 2. If FUSE re-enables scene paths, reloads components, or
+    /// rebuilds containers more often than Railloader did, the culler gets extra
+    /// chances to unload/reload scenery — visible as "popping".
+    ///
+    /// This patch logs the load/unload <em>transitions</em> for all scenery,
+    /// tagging each line <c>fuse=true</c> (carries a
+    /// <see cref="FUSE.Runtime.API.SceneryAPI.FuseSceneryMarker"/>) or
+    /// <c>fuse=false</c> (vanilla), so we can confirm whether those events are hot
+    /// and line up with the popping — including base-game structures like the
+    /// roundhouse that FUSE never marks.
+    /// We log threshold crossings rather than every raw call: a model only pops
+    /// when <c>SetLoaded</c> actually flips, so repeated same-state callbacks (e.g.
+    /// band 3 -&gt; 4 while flying away, both unloaded) are deduplicated to keep the
+    /// signal readable. Each line carries a per-object flip count plus session
+    /// totals; if a handful of objects rack up dozens of flips during a teleport,
+    /// that is the smoking gun.
+    ///
+    /// Gated behind <see cref="FuseSettings.EnableSceneryCullingDiagnostics"/>
+    /// (default off) because the culler fires constantly during play. When the
+    /// flag is off the postfix returns on the first line, so it costs nothing in
+    /// normal sessions; toggle it on from the FUSE Health → Advanced page right
+    /// before a stress test and off afterwards.
+    /// </summary>
+    [HarmonyPatch(typeof(SceneryAssetInstance), "CullingSphereStateChanged")]
+    internal static class FuseSceneryCullingDiagnosticPatch
+    {
+        // Vanilla: SetLoaded(distanceBand <= 2). Keep in one place so the log's
+        // notion of "loaded" stays in lock-step with the game's.
+        private const int LoadedBandThreshold = 2;
+
+        // Per-instance last-known loaded state + flip counter. Weak keys so
+        // destroyed scenery is collected without us pinning it; the Unity culling
+        // callback is main-thread only, so no locking is required.
+        private static readonly ConditionalWeakTable<SceneryAssetInstance, CullState> States =
+            new ConditionalWeakTable<SceneryAssetInstance, CullState>();
+
+        private static readonly ConditionalWeakTable<SceneryAssetInstance, CullState>.CreateValueCallback CreateState =
+            _ => new CullState();
+
+        private static long _fuseLoads;
+        private static long _fuseUnloads;
+        private static long _vanillaLoads;
+        private static long _vanillaUnloads;
+
+        // Snapshot accessors for FuseSceneryBenchmark. These tallies only increment
+        // while the cull log is enabled (the Postfix early-returns otherwise), so the
+        // benchmark transiently enables it for the duration of a run.
+        internal static long FuseLoads => _fuseLoads;
+        internal static long FuseUnloads => _fuseUnloads;
+        internal static long VanillaLoads => _vanillaLoads;
+        internal static long VanillaUnloads => _vanillaUnloads;
+
+        internal static void ResetCounters()
+        {
+            _fuseLoads = 0;
+            _fuseUnloads = 0;
+            _vanillaLoads = 0;
+            _vanillaUnloads = 0;
+        }
+
+        private static void Postfix(SceneryAssetInstance __instance, bool isVisible, int distanceBand)
+        {
+            if (!FuseSettings.EnableSceneryCullingDiagnostics || __instance == null)
+            {
+                return;
+            }
+
+            try
+            {
+                // Log BOTH FUSE-owned and vanilla scenery, tagged via fuse=. The
+                // churn hypothesis is about the game's culler in general, and the
+                // structures that visibly pop (e.g. the roundhouse) are usually
+                // base-game scenery with no FUSE marker, so a FUSE-only filter
+                // would miss them.
+                var marker = __instance.GetComponent<FUSE.Runtime.API.SceneryAPI.FuseSceneryMarker>();
+                var isFuse = marker != null;
+
+                var loaded = distanceBand <= LoadedBandThreshold;
+                var state = States.GetValue(__instance, CreateState);
+                if (state.HasObservation && state.Loaded == loaded)
+                {
+                    // No load/unload transition -> no pop -> nothing to report.
+                    return;
+                }
+
+                var isFirst = !state.HasObservation;
+                if (!isFirst)
+                {
+                    state.FlipCount++;
+                }
+
+                state.HasObservation = true;
+                state.Loaded = loaded;
+
+                string verb;
+                if (loaded)
+                {
+                    if (isFuse) { _fuseLoads++; } else { _vanillaLoads++; }
+                    verb = isFirst ? "INIT-LOAD" : "LOAD";
+                }
+                else
+                {
+                    if (isFuse) { _fuseUnloads++; } else { _vanillaUnloads++; }
+                    verb = isFirst ? "INIT-UNLOAD" : "UNLOAD";
+                }
+
+                var loads = isFuse ? _fuseLoads : _vanillaLoads;
+                var unloads = isFuse ? _fuseUnloads : _vanillaUnloads;
+                var id = isFuse ? (marker.Id ?? "<null>") : (__instance.identifier ?? "<null>");
+
+                FuseLog.Info(
+                    $"FUSE diag scenery-cull {verb} fuse={isFuse} id='{id}' name='{__instance.name ?? "<null>"}' " +
+                    $"band={distanceBand} visible={isVisible} flips={state.FlipCount} " +
+                    $"loads={loads} unloads={unloads} frame={Time.frameCount}.");
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE diag scenery-cull postfix failed", ex);
+            }
+        }
+
+        private sealed class CullState
+        {
+            public bool HasObservation;
+            public bool Loaded;
+            public int FlipCount;
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue

#76 — Asset/Scenery culling issues (popping + slow load) possibly related to FUSE.

## 📝 Description of the Change

**Root cause.** The game culls scenery by distance band with no hysteresis: a model unloads once it passes the ~1500 m band and reloads when it comes back. During camera movement, clusters of FUSE scenery sitting near that boundary flap load↔unload repeatedly — a diagnostic capture during a Sylva→Bryson teleport showed ~700 objects flipping **11–16×** in seconds, each flip a model destroy + async asset reload. That is the popping, and a large share of the wasted load work.

This PR adds three things:

1. **`FuseSceneryCullingDebouncePatch` (the fix).** A Harmony prefix on `SceneryAssetInstance.CullingSphereStateChanged` that adds a **distance deadband** for FUSE-owned scenery only: while an object is within 3 km of the camera it's held in the game's own "resident, renderers-off" band-2 state instead of unloading, so boundary jitter can't thrash; beyond the deadband the real band passes through and the game unloads it normally (culling still works). Scoped via the existing `FuseSceneryMarker`, always-on (no user setting). The decision is a pure `ShouldHoldResident(camera, object)` for unit testing.

2. **`FuseSceneryCullingDiagnosticPatch` (how we found/verified it).** An opt-in postfix logger (`EnableSceneryCullingDiagnostics`, default off) that records scenery load/unload transitions to `FUSE.log`, tagged FUSE vs vanilla, with per-object flip counts.

3. **`FuseSceneryBenchmark` (a reusable test tool).** A scenario-driven, reproducible in-game A/B benchmark on the Health → Advanced page. It scripts camera movement — a local **"sweep"** across the cull boundary, and a **"corridor"** that teleports Bryson↔Sylva then **A\*-routes the track** between them and drives the camera along it — forces the debounce off vs on, and records churn plus a **per-frame CSV** (FPS, in-flight/loaded counts, object load latency, memory) for analysis. The Advanced page auto-refreshes while a run reports progress.

## 🔄 Alternatives Considered

- **Time-grace debounce** (hold N seconds after wanting to unload): implemented first, but the cull callback is event/world-shift-driven (not per-frame), so the grace never reliably expired and it pinned everything. Replaced with the stateless distance deadband.
- **Pin all FUSE scenery loaded / enlarge the definition cull radius:** simpler but blunt (unbounded memory, or never culls). The deadband keeps a bounded working set and still culls beyond it.
- **A user toggle for the debounce:** intentionally omitted at the maintainer's request — it's always on; A/B is done via the benchmark's internal override or a build swap.

## ⚠️ Possible Drawbacks

- **Memory:** holding scenery resident in the deadband trades memory for no-churn. The corridor CSV showed Unity allocation growing over a long traversal (loads outpacing unloads ~2:1). `UnloadDistance` (3 km) is a one-line tunable if the trade needs adjusting.
- **Scope:** the fix targets *churn*, not first-load *throughput*. The benchmark confirms a separate remaining bottleneck — a one-time asset-load stall when a large batch loads at once (1 fps / multi-second per-object latency on teleport-in). That's a follow-up, not addressed here.
- **Reflection:** the benchmark reads two private `SceneryAssetInstance` fields by name (`_wantsLoaded`, `_model`); both are covered by the reflection-surface canary test so a future game rename fails CI loudly.
- **Save/multiplayer compatibility:** none affected — culling is client-local visual state; no save format or sync changes. The only persisted addition is the opt-in `EnableSceneryCullingDiagnostics` flag (default off).

## ✅ Verification Process

- `dotnet build FUSE/FUSE.csproj` → **0 warnings / 0 errors**; `dotnet test FUSE.Tests` → **1170 passing**.
- New deterministic EditMode test (`FuseSceneryCullingDebounceTests`) covers the deadband decision (hold inside, release beyond, boundary).
- **In-game A/B (sweep):** boundary-sweep cull churn dropped from **712 unloads → 0** (debounce off vs on), with the deadband reporting 712 suppressed.
- **In-game (corridor):** A\* routed correctly (nearest nodes 17 m / 45 m from the stations), full ~7-min drive captured to CSV; steady-state drive is smooth and the fix held 7,464 would-be-unloads. The CSV isolates the remaining slowness as asset-load throughput (distinct from churn).

## 💡 Additional Information

- The diagnostic and benchmark are both opt-in/manual and have no effect in normal play (the diagnostic early-returns when off; the benchmark only runs on a button press).
- The benchmark is intentionally general (scenario abstraction) so it can be reused for future culling/streaming/perf investigations, not just this issue.
- Suggested follow-ups: an A/B corridor run to quantify the memory↔churn trade, optionally lowering the deadband to ~2 km, and a load-throttle for the batch-load stalls.
