### PR TITLE
feat: live-game test harness for FUSE (TestBridge + TestCli + LiveHarness)

### DIFF
--- a/FUSE.Core/Bridge/BridgeIo.cs
+++ b/FUSE.Core/Bridge/BridgeIo.cs
@@ -29,6 +29,19 @@ namespace Fuse.Core.Bridge
         public static string HeartbeatPath(string gameModsDir) =>
             Path.Combine(gameModsDir, BridgeProtocol.BridgeModFolderName, BridgeProtocol.StateFileName);
 
+        /// <summary>The dev-only test bridge channel directory under a game Mods directory: <c>Mods/FUSE.TestBridge</c>.</summary>
+        public static string TestChannelDir(string gameModsDir) =>
+            Path.Combine(gameModsDir, BridgeProtocol.TestBridgeModFolderName);
+
+        public static string TestRequestPath(string gameModsDir, string requestId) =>
+            Path.Combine(TestChannelDir(gameModsDir), BridgeProtocol.TestRequestPrefix + requestId + ".json");
+
+        public static string TestResultPath(string gameModsDir, string requestId) =>
+            Path.Combine(TestChannelDir(gameModsDir), BridgeProtocol.TestResultPrefix + requestId + ".json");
+
+        public static string TestStatePath(string gameModsDir) =>
+            Path.Combine(TestChannelDir(gameModsDir), BridgeProtocol.TestStateFileName);
+
         public static void WriteAtomic(string path, object value)
         {
             var dir = Path.GetDirectoryName(path);

--- a/FUSE.Core/Bridge/BridgeProtocol.cs
+++ b/FUSE.Core/Bridge/BridgeProtocol.cs
@@ -19,6 +19,33 @@ namespace Fuse.Core.Bridge
 
         public const string ReloadCommand = "reload";
         public const string ReloadTerrainCommand = "reloadTerrain";
+
+        // --- Dev-only test bridge (FUSE.TestBridge mod) ---
+        // A point-to-point RPC channel: the driver (CLI) drops a request into the
+        // test bridge mod's own folder, the in-game mod executes it on the Unity
+        // main thread and writes a result alongside, plus a ~1s heartbeat.
+
+        /// <summary>The dev-only test bridge mod's folder under <c>Mods/</c>; request/result/heartbeat files live here.</summary>
+        public const string TestBridgeModFolderName = "FUSE.TestBridge";
+        // Per-request files (correlated by RequestId) so a slow/aborted request never clobbers the next.
+        public const string TestRequestPrefix = "test_request_";
+        public const string TestResultPrefix = "test_result_";
+        public const string TestRequestPattern = "test_request_*.json";
+        public const string TestStateFileName = "test_state.json";
+
+        // Test bridge verbs (TestRequest.Verb).
+        public const string TestVerbReload = "reload";
+        public const string TestVerbReloadTerrain = "reloadTerrain";
+        public const string TestVerbConsole = "console";
+        public const string TestVerbReport = "report";
+        public const string TestVerbScreenshot = "screenshot";
+        public const string TestVerbDump = "dump";
+        public const string TestVerbLoadSave = "loadSave";
+        public const string TestVerbSaves = "saves";
+        public const string TestVerbSave = "save";
+        public const string TestVerbUmm = "umm";
+        public const string TestVerbNewGame = "newGame";
+        public const string TestVerbCleanup = "cleanup";
     }
 
     /// <summary>Editor → game: "re-read packages from disk and re-apply".</summary>
@@ -48,5 +75,33 @@ namespace Fuse.Core.Bridge
         public int AppliedCount { get; set; }
         public bool Ok { get; set; }
         public string Error { get; set; }
+
+        /// <summary>Absolute path to the active FUSE.log (test bridge only; lets the driver tail it without a round trip).</summary>
+        public string LogPath { get; set; }
+    }
+
+    /// <summary>Driver → game: a single test-bridge RPC. <see cref="Verb"/> selects the action;
+    /// <see cref="CommandLine"/> carries the console command for <c>console</c>, <see cref="Arg"/> a generic argument.</summary>
+    public sealed class TestRequest
+    {
+        public int Schema { get; set; } = BridgeProtocol.Schema;
+        public string RequestId { get; set; }
+        public string Verb { get; set; }
+        public string CommandLine { get; set; }
+        public string Arg { get; set; }
+        public string Reason { get; set; }
+        public string IssuedUtc { get; set; }
+    }
+
+    /// <summary>Game → driver: the result of a single <see cref="TestRequest"/>, correlated by <see cref="RequestId"/>.</summary>
+    public sealed class TestResult
+    {
+        public int Schema { get; set; } = BridgeProtocol.Schema;
+        public string RequestId { get; set; }
+        public bool Ok { get; set; }
+        public string Text { get; set; }
+        public string Error { get; set; }
+        public string ArtifactPath { get; set; }
+        public string CompletedUtc { get; set; }
     }
 }

--- a/FUSE.LiveHarness.Tests/FUSE.LiveHarness.Tests.csproj
+++ b/FUSE.LiveHarness.Tests/FUSE.LiveHarness.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- xUnit v3 runs tests via an app-host executable, so the test project emits an exe. -->
+    <OutputType>Exe</OutputType>
+    <AssemblyName>FUSE.LiveHarness.Tests</AssemblyName>
+    <RootNamespace>Fuse.LiveHarness.Tests</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <!-- Pure file/string logic: no game/Unity DLLs, builds and runs with no GameDir (CI lane). -->
+    <FuseIsGameFree>true</FuseIsGameFree>
+    <!-- xUnit test methods are instance by convention. -->
+    <NoWarn>$(NoWarn);CA1822</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FUSE.LiveHarness\FUSE.LiveHarness.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/FUSE.LiveHarness.Tests/JsonDiffTests.cs
+++ b/FUSE.LiveHarness.Tests/JsonDiffTests.cs
@@ -1,0 +1,65 @@
+using Fuse.LiveHarness.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Fuse.LiveHarness.Tests;
+
+public class JsonDiffTests
+{
+    [Fact]
+    public void Identical_Trees_Have_No_Deltas()
+    {
+        var deltas = JsonDiff.Compare(
+            JToken.Parse("""{ "a": 1, "b": [1, 2] }"""),
+            JToken.Parse("""{ "a": 1, "b": [1, 2] }"""));
+
+        Assert.Empty(deltas);
+    }
+
+    [Fact]
+    public void Detects_Changed_Value_With_Json_Path()
+    {
+        var deltas = JsonDiff.Compare(
+            JToken.Parse("""{ "counts": { "nodes": 10 } }"""),
+            JToken.Parse("""{ "counts": { "nodes": 11 } }"""));
+
+        var delta = Assert.Single(deltas);
+        Assert.Equal(JsonDeltaKind.Changed, delta.Kind);
+        Assert.Equal("$.counts.nodes", delta.Path);
+        Assert.Equal("10", delta.Left);
+        Assert.Equal("11", delta.Right);
+    }
+
+    [Fact]
+    public void Detects_Added_And_Removed_Members()
+    {
+        var deltas = JsonDiff.Compare(
+            JToken.Parse("""{ "a": 1 }"""),
+            JToken.Parse("""{ "b": 2 }"""));
+
+        Assert.Contains(deltas, d => d.Kind == JsonDeltaKind.Removed && d.Path == "$.a");
+        Assert.Contains(deltas, d => d.Kind == JsonDeltaKind.Added && d.Path == "$.b");
+    }
+
+    [Fact]
+    public void Normalized_Then_Diffed_Ignores_Volatile_Fields_And_Array_Order()
+    {
+        var normalizer = new JsonNormalizer();
+        var baseline = normalizer.Normalize(JToken.Parse("""{ "createdLocal": "x", "items": ["a", "b"] }"""));
+        var current = normalizer.Normalize(JToken.Parse("""{ "createdLocal": "y", "items": ["b", "a"] }"""));
+
+        Assert.Empty(JsonDiff.Compare(baseline, current));
+    }
+
+    [Fact]
+    public void Catches_A_Coordinate_Regression_After_Normalization()
+    {
+        // The Bryson-style case: a scene-clone localPosition must not silently change.
+        var normalizer = new JsonNormalizer();
+        var baseline = normalizer.Normalize(JToken.Parse("""{ "localPosition": { "x": 12.3456, "y": 0.0, "z": -4.5 } }"""));
+        var current = normalizer.Normalize(JToken.Parse("""{ "localPosition": { "x": 0.0, "y": 0.0, "z": -4.5 } }"""));
+
+        var deltas = JsonDiff.Compare(baseline, current);
+        Assert.Contains(deltas, d => d.Path == "$.localPosition.x" && d.Kind == JsonDeltaKind.Changed);
+    }
+}

--- a/FUSE.LiveHarness.Tests/JsonNormalizerTests.cs
+++ b/FUSE.LiveHarness.Tests/JsonNormalizerTests.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using Fuse.LiveHarness.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Fuse.LiveHarness.Tests;
+
+public class JsonNormalizerTests
+{
+    [Fact]
+    public void Strips_Volatile_Keys_Recursively()
+    {
+        var normalizer = new JsonNormalizer();
+        var result = (JObject)normalizer.Normalize(JToken.Parse(
+            """{ "createdLocal": "2026-01-01", "counts": { "pid": 99, "nodes": 3 } }"""));
+
+        Assert.False(result.ContainsKey("createdLocal"));
+        Assert.False(((JObject)result["counts"]!).ContainsKey("pid"));
+        Assert.Equal(3, result["counts"]!["nodes"]!.Value<int>());
+    }
+
+    [Fact]
+    public void Rounds_Floats_To_Configured_Precision()
+    {
+        var normalizer = new JsonNormalizer(decimals: 2);
+        var result = normalizer.Normalize(JToken.Parse("""{ "x": 1.234567, "n": 10 }"""));
+
+        Assert.Equal(1.23, result["x"]!.Value<double>(), 5);
+        Assert.Equal(10, result["n"]!.Value<int>()); // integers untouched
+    }
+
+    [Fact]
+    public void Sorts_Object_Keys_Recursively()
+    {
+        var normalizer = new JsonNormalizer();
+        var result = (JObject)normalizer.Normalize(JToken.Parse("""{ "b": 1, "a": { "z": 1, "y": 2 } }"""));
+
+        Assert.Equal("a,b", string.Join(",", result.Properties().Select(p => p.Name)));
+        Assert.Equal("y,z", string.Join(",", ((JObject)result["a"]!).Properties().Select(p => p.Name)));
+    }
+
+    [Fact]
+    public void Sorts_Arrays_So_Reordering_Is_Not_Drift()
+    {
+        var normalizer = new JsonNormalizer();
+        var one = normalizer.Canonical("""{ "items": ["b", "a", "c"] }""");
+        var two = normalizer.Canonical("""{ "items": ["c", "b", "a"] }""");
+
+        Assert.Equal(one, two);
+    }
+
+    [Fact]
+    public void Array_Sorting_Can_Be_Disabled()
+    {
+        var normalizer = new JsonNormalizer(sortArrays: false);
+        var one = normalizer.Canonical("""{ "items": ["b", "a"] }""");
+        var two = normalizer.Canonical("""{ "items": ["a", "b"] }""");
+
+        Assert.NotEqual(one, two);
+    }
+}

--- a/FUSE.LiveHarness/Bridge/BridgeClient.cs
+++ b/FUSE.LiveHarness/Bridge/BridgeClient.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Fuse.Core.Bridge;
+
+namespace Fuse.LiveHarness.Bridge;
+
+/// <summary>Bridge connection state derived from heartbeat freshness.</summary>
+public enum BridgeConnection
+{
+    Disconnected,
+    Stale,
+    Connected,
+}
+
+/// <summary>
+/// Client side of the FUSE.TestBridge channel. Each request is written to a unique
+/// <c>test_request_&lt;id&gt;.json</c> and the matching <c>test_result_&lt;id&gt;.json</c> is polled for, so a
+/// slow or aborted request never clobbers the next. Also reads the heartbeat and provides a
+/// settle-aware readiness wait. Shared by the CLI and the fixture runner.
+/// </summary>
+public sealed class BridgeClient
+{
+    private readonly string _modsDir;
+    private readonly int _timeoutSeconds;
+    private readonly int _pollMilliseconds;
+    private readonly double _staleSeconds;
+
+    public BridgeClient(string modsDir, int timeoutSeconds = 30, int pollMilliseconds = 100, double staleSeconds = 5.0)
+    {
+        _modsDir = modsDir;
+        _timeoutSeconds = timeoutSeconds;
+        _pollMilliseconds = pollMilliseconds;
+        _staleSeconds = staleSeconds;
+    }
+
+    public string ChannelDir => BridgeIo.TestChannelDir(_modsDir);
+
+    public bool ChannelExists => Directory.Exists(ChannelDir);
+
+    public BridgeState? ReadState() => BridgeIo.TryRead<BridgeState>(BridgeIo.TestStatePath(_modsDir));
+
+    public BridgeConnection Classify(BridgeState? state, DateTime nowUtc)
+    {
+        if (state?.HeartbeatUtc is null
+            || !DateTime.TryParse(state.HeartbeatUtc, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var beat))
+        {
+            return BridgeConnection.Disconnected;
+        }
+
+        return (nowUtc - beat.ToUniversalTime()).TotalSeconds <= _staleSeconds
+            ? BridgeConnection.Connected
+            : BridgeConnection.Stale;
+    }
+
+    public async Task<TestResult> SendAsync(TestRequest request, CancellationToken ct = default)
+    {
+        request.RequestId = Guid.NewGuid().ToString("N");
+        request.IssuedUtc = DateTime.UtcNow.ToString("o");
+        var requestPath = BridgeIo.TestRequestPath(_modsDir, request.RequestId);
+        var resultPath = BridgeIo.TestResultPath(_modsDir, request.RequestId);
+        BridgeIo.WriteAtomic(requestPath, request);
+
+        var deadline = DateTime.UtcNow.AddSeconds(_timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            var result = BridgeIo.TryRead<TestResult>(resultPath);
+            if (result is not null && string.Equals(result.RequestId, request.RequestId, StringComparison.Ordinal))
+            {
+                TryDelete(resultPath);
+                return result;
+            }
+
+            await Task.Delay(_pollMilliseconds, ct);
+        }
+
+        // Give up: remove our request so the bridge doesn't run dead work.
+        TryDelete(requestPath);
+        throw new TimeoutException($"No bridge result within {_timeoutSeconds}s for verb '{request.Verb}'.");
+    }
+
+    /// <summary>
+    /// Wait until the bridge is genuinely settled — connected, a map loaded, world-apply allowed, AND
+    /// the heartbeat has advanced several times without stalling. FUSE's post-load apply blocks the
+    /// single-threaded bridge (freezing the heartbeat), so requiring sustained fresh beats avoids the
+    /// "ready, then the next command times out because FUSE is still applying" trap.
+    /// </summary>
+    public async Task<bool> WaitReadyAsync(int requiredBeats = 3, CancellationToken ct = default)
+    {
+        var beats = new HashSet<string>(StringComparer.Ordinal);
+        var deadline = DateTime.UtcNow.AddSeconds(_timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            var state = ReadState();
+            if (state is not null
+                && Classify(state, DateTime.UtcNow) == BridgeConnection.Connected
+                && state.MapLoaded
+                && state.CanApply
+                && state.HeartbeatUtc is not null)
+            {
+                beats.Add(state.HeartbeatUtc);
+                if (beats.Count >= requiredBeats)
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                beats.Clear(); // a stall/disconnect resets the streak
+            }
+
+            await Task.Delay(_pollMilliseconds, ct);
+        }
+
+        return false;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+}

--- a/FUSE.LiveHarness/FUSE.LiveHarness.csproj
+++ b/FUSE.LiveHarness/FUSE.LiveHarness.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>FUSE.LiveHarness</AssemblyName>
+    <RootNamespace>Fuse.LiveHarness</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <!-- Pure net10 harness logic (bridge client, JSON normalize/diff, fixture runner);
+         no game/Unity DLLs. Shares the bridge DTOs from FUSE.Core. Sets its own version. -->
+    <FuseIsGameFree>true</FuseIsGameFree>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FUSE.Core\FUSE.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/FUSE.LiveHarness/Fixtures/FixtureManifest.cs
+++ b/FUSE.LiveHarness/Fixtures/FixtureManifest.cs
@@ -1,0 +1,29 @@
+namespace Fuse.LiveHarness.Fixtures;
+
+/// <summary>
+/// A live-harness fixture manifest (fixture.json): which save to load, the expected game version
+/// (a mismatch skips rather than fails), and which captures to golden-master.
+/// </summary>
+public sealed class FixtureManifest
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Expected game version; if set and the live game differs, the run is skipped (baselines are version-pinned).</summary>
+    public string GameVersion { get; set; } = string.Empty;
+
+    /// <summary>The save to load into the running session before capturing. Empty = use whatever is loaded.</summary>
+    public string SaveName { get; set; } = string.Empty;
+
+    public string MultiplayerRole { get; set; } = "host";
+
+    /// <summary>Reason string passed to reload (kept fixed so it does not perturb the captured report).</summary>
+    public string Reason { get; set; } = "fixture run";
+
+    /// <summary>Capture and golden-master the <c>/fuse.report json</c> output.</summary>
+    public bool CaptureReport { get; set; } = true;
+
+    /// <summary>Dump captures to golden-master. Valid: graph, runtimegraph, mandelas, progression.</summary>
+    public string[] Dumps { get; set; } = { "runtimegraph", "mandelas" };
+}

--- a/FUSE.LiveHarness/Fixtures/FixtureRunner.cs
+++ b/FUSE.LiveHarness/Fixtures/FixtureRunner.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Fuse.Core.Bridge;
+using Fuse.LiveHarness.Bridge;
+using Fuse.LiveHarness.Json;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Fuse.LiveHarness.Fixtures;
+
+/// <summary>Outcome of golden-mastering one capture (the report, or one dump) against its baseline.</summary>
+public sealed record CaptureResult(string Name, bool Ok, IReadOnlyList<JsonDelta> Deltas, string Note);
+
+/// <summary>Outcome of a whole fixture run.</summary>
+public sealed class FixtureRunResult
+{
+    public bool Success { get; private init; }
+
+    public bool WasSkipped { get; private init; }
+
+    public bool Updated { get; private init; }
+
+    public string? Message { get; private init; }
+
+    public IReadOnlyList<CaptureResult> Captures { get; private init; } = Array.Empty<CaptureResult>();
+
+    public static FixtureRunResult Error(string message) => new() { Success = false, Message = message };
+
+    public static FixtureRunResult Skipped(string message) => new() { Success = true, WasSkipped = true, Message = message };
+
+    public static FixtureRunResult Completed(IReadOnlyList<CaptureResult> captures, bool updated) => new()
+    {
+        Captures = captures,
+        Updated = updated,
+        Success = updated || captures.All(c => c.Ok),
+    };
+}
+
+/// <summary>
+/// Drives one fixture against the live game: load the fixture save, wait until ready, reload FUSE
+/// packages, capture the report + dumps, normalize, and either write baselines (<c>update</c>) or
+/// diff against the stored baselines. The capture/normalize/diff steps reuse the CI-tested
+/// <see cref="JsonNormalizer"/> and <see cref="JsonDiff"/>; only the orchestration needs the live game.
+/// </summary>
+public sealed class FixtureRunner
+{
+    private readonly BridgeClient _client;
+    private readonly JsonNormalizer _normalizer;
+
+    public FixtureRunner(BridgeClient client, JsonNormalizer? normalizer = null)
+    {
+        _client = client;
+        _normalizer = normalizer ?? new JsonNormalizer();
+    }
+
+    public async Task<FixtureRunResult> RunAsync(string fixtureDir, bool updateBaselines, CancellationToken ct = default)
+    {
+        var manifestPath = Path.Combine(fixtureDir, "fixture.json");
+        if (!File.Exists(manifestPath))
+        {
+            return FixtureRunResult.Error($"fixture.json not found in {fixtureDir}");
+        }
+
+        var manifest = JsonConvert.DeserializeObject<FixtureManifest>(File.ReadAllText(manifestPath))
+                       ?? new FixtureManifest();
+
+        var state = _client.ReadState();
+        if (state is null || _client.Classify(state, DateTime.UtcNow) != BridgeConnection.Connected)
+        {
+            return FixtureRunResult.Error("bridge not connected — is the game running with FUSE.TestBridge enabled?");
+        }
+
+        if (!string.IsNullOrEmpty(manifest.GameVersion)
+            && !string.Equals(manifest.GameVersion, state.GameVersion, StringComparison.Ordinal))
+        {
+            return FixtureRunResult.Skipped(
+                $"game version '{state.GameVersion}' != fixture '{manifest.GameVersion}'; baselines are version-pinned.");
+        }
+
+        if (!string.IsNullOrEmpty(manifest.SaveName))
+        {
+            await _client.SendAsync(new TestRequest { Verb = BridgeProtocol.TestVerbLoadSave, Arg = manifest.SaveName }, ct);
+            if (!await _client.WaitReadyAsync(ct: ct))
+            {
+                return FixtureRunResult.Error($"session not ready after loading save '{manifest.SaveName}'.");
+            }
+        }
+        else if (!await _client.WaitReadyAsync(ct: ct))
+        {
+            return FixtureRunResult.Error("no map loaded — load a save first or set saveName in the fixture.");
+        }
+
+        await _client.SendAsync(new TestRequest { Verb = BridgeProtocol.TestVerbReload, Reason = manifest.Reason }, ct);
+
+        var baselineDir = Path.Combine(fixtureDir, "baselines");
+        Directory.CreateDirectory(baselineDir);
+
+        var captures = new List<CaptureResult>();
+
+        if (manifest.CaptureReport)
+        {
+            var report = await _client.SendAsync(new TestRequest { Verb = BridgeProtocol.TestVerbReport, Arg = "json" }, ct);
+            captures.Add(Capture("report", report.Text ?? string.Empty, baselineDir, updateBaselines));
+        }
+
+        foreach (var dump in manifest.Dumps ?? Array.Empty<string>())
+        {
+            var result = await _client.SendAsync(new TestRequest { Verb = BridgeProtocol.TestVerbDump, Arg = dump }, ct);
+            var json = result.ArtifactPath is not null && File.Exists(result.ArtifactPath)
+                ? File.ReadAllText(result.ArtifactPath)
+                : result.Text ?? string.Empty;
+            captures.Add(Capture(dump, json, baselineDir, updateBaselines));
+        }
+
+        return FixtureRunResult.Completed(captures, updateBaselines);
+    }
+
+    private CaptureResult Capture(string name, string json, string baselineDir, bool update)
+    {
+        JToken current;
+        try
+        {
+            current = _normalizer.Normalize(JToken.Parse(string.IsNullOrWhiteSpace(json) ? "{}" : json));
+        }
+        catch (JsonException ex)
+        {
+            return new CaptureResult(name, false, Array.Empty<JsonDelta>(), $"could not parse capture: {ex.Message}");
+        }
+
+        var baselinePath = Path.Combine(baselineDir, name + ".json");
+        if (update || !File.Exists(baselinePath))
+        {
+            var existed = File.Exists(baselinePath);
+            File.WriteAllText(baselinePath, current.ToString(Formatting.Indented));
+            return new CaptureResult(name, true, Array.Empty<JsonDelta>(), existed ? "baseline updated" : "baseline created");
+        }
+
+        var baseline = _normalizer.Normalize(JToken.Parse(File.ReadAllText(baselinePath)));
+        var deltas = JsonDiff.Compare(baseline, current);
+        return new CaptureResult(name, deltas.Count == 0, deltas, deltas.Count == 0 ? "match" : $"{deltas.Count} delta(s)");
+    }
+}

--- a/FUSE.LiveHarness/Fixtures/FixtureRunner.cs
+++ b/FUSE.LiveHarness/Fixtures/FixtureRunner.cs
@@ -83,7 +83,12 @@ public sealed class FixtureRunner
 
         if (!string.IsNullOrEmpty(manifest.SaveName))
         {
-            await _client.SendAsync(new TestRequest { Verb = BridgeProtocol.TestVerbLoadSave, Arg = manifest.SaveName }, ct);
+            var load = await _client.SendAsync(new TestRequest { Verb = BridgeProtocol.TestVerbLoadSave, Arg = manifest.SaveName }, ct);
+            if (!load.Ok)
+            {
+                return FixtureRunResult.Error($"failed to load save '{manifest.SaveName}': {load.Error}");
+            }
+
             if (!await _client.WaitReadyAsync(ct: ct))
             {
                 return FixtureRunResult.Error($"session not ready after loading save '{manifest.SaveName}'.");
@@ -94,7 +99,11 @@ public sealed class FixtureRunner
             return FixtureRunResult.Error("no map loaded — load a save first or set saveName in the fixture.");
         }
 
-        await _client.SendAsync(new TestRequest { Verb = BridgeProtocol.TestVerbReload, Reason = manifest.Reason }, ct);
+        var reload = await _client.SendAsync(new TestRequest { Verb = BridgeProtocol.TestVerbReload, Reason = manifest.Reason }, ct);
+        if (!reload.Ok)
+        {
+            return FixtureRunResult.Error($"reload failed: {reload.Error}");
+        }
 
         var baselineDir = Path.Combine(fixtureDir, "baselines");
         Directory.CreateDirectory(baselineDir);
@@ -104,12 +113,20 @@ public sealed class FixtureRunner
         if (manifest.CaptureReport)
         {
             var report = await _client.SendAsync(new TestRequest { Verb = BridgeProtocol.TestVerbReport, Arg = "json" }, ct);
-            captures.Add(Capture("report", report.Text ?? string.Empty, baselineDir, updateBaselines));
+            captures.Add(report.Ok
+                ? Capture("report", report.Text ?? string.Empty, baselineDir, updateBaselines)
+                : new CaptureResult("report", false, Array.Empty<JsonDelta>(), $"request failed: {report.Error}"));
         }
 
         foreach (var dump in manifest.Dumps ?? Array.Empty<string>())
         {
             var result = await _client.SendAsync(new TestRequest { Verb = BridgeProtocol.TestVerbDump, Arg = dump }, ct);
+            if (!result.Ok)
+            {
+                captures.Add(new CaptureResult(dump, false, Array.Empty<JsonDelta>(), $"request failed: {result.Error}"));
+                continue;
+            }
+
             var json = result.ArtifactPath is not null && File.Exists(result.ArtifactPath)
                 ? File.ReadAllText(result.ArtifactPath)
                 : result.Text ?? string.Empty;
@@ -139,7 +156,16 @@ public sealed class FixtureRunner
             return new CaptureResult(name, true, Array.Empty<JsonDelta>(), existed ? "baseline updated" : "baseline created");
         }
 
-        var baseline = _normalizer.Normalize(JToken.Parse(File.ReadAllText(baselinePath)));
+        JToken baseline;
+        try
+        {
+            baseline = _normalizer.Normalize(JToken.Parse(File.ReadAllText(baselinePath)));
+        }
+        catch (JsonException ex)
+        {
+            return new CaptureResult(name, false, Array.Empty<JsonDelta>(), $"could not parse baseline: {ex.Message}");
+        }
+
         var deltas = JsonDiff.Compare(baseline, current);
         return new CaptureResult(name, deltas.Count == 0, deltas, deltas.Count == 0 ? "match" : $"{deltas.Count} delta(s)");
     }

--- a/FUSE.LiveHarness/Json/JsonDiff.cs
+++ b/FUSE.LiveHarness/Json/JsonDiff.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Fuse.LiveHarness.Json;
+
+public enum JsonDeltaKind
+{
+    Added,
+    Removed,
+    Changed,
+}
+
+/// <summary>A single difference between a baseline and a current value, keyed by JSON path.</summary>
+public sealed record JsonDelta(string Path, JsonDeltaKind Kind, string? Left, string? Right);
+
+/// <summary>
+/// Structural diff of two (normally already-normalized) JSON trees, producing path-keyed deltas
+/// so a failure points at exactly what drifted. Compare normalized trees from <see cref="JsonNormalizer"/>.
+/// </summary>
+public static class JsonDiff
+{
+    public static IReadOnlyList<JsonDelta> Compare(JToken baseline, JToken current)
+    {
+        var deltas = new List<JsonDelta>();
+        Walk("$", baseline, current, deltas);
+        return deltas;
+    }
+
+    private static void Walk(string path, JToken? left, JToken? right, List<JsonDelta> deltas)
+    {
+        if (left is null && right is null)
+        {
+            return;
+        }
+
+        if (left is null)
+        {
+            deltas.Add(new JsonDelta(path, JsonDeltaKind.Added, null, Short(right)));
+            return;
+        }
+
+        if (right is null)
+        {
+            deltas.Add(new JsonDelta(path, JsonDeltaKind.Removed, Short(left), null));
+            return;
+        }
+
+        if (left.Type != right.Type)
+        {
+            deltas.Add(new JsonDelta(path, JsonDeltaKind.Changed, Short(left), Short(right)));
+            return;
+        }
+
+        switch (left)
+        {
+            case JObject leftObject:
+                var rightObject = (JObject)right;
+                foreach (var name in leftObject.Properties().Select(p => p.Name)
+                             .Union(rightObject.Properties().Select(p => p.Name)))
+                {
+                    Walk($"{path}.{name}", leftObject[name], rightObject[name], deltas);
+                }
+
+                break;
+
+            case JArray leftArray:
+                var rightArray = (JArray)right;
+                var max = Math.Max(leftArray.Count, rightArray.Count);
+                for (var i = 0; i < max; i++)
+                {
+                    Walk($"{path}[{i}]", i < leftArray.Count ? leftArray[i] : null, i < rightArray.Count ? rightArray[i] : null, deltas);
+                }
+
+                break;
+
+            default:
+                if (!JToken.DeepEquals(left, right))
+                {
+                    deltas.Add(new JsonDelta(path, JsonDeltaKind.Changed, Short(left), Short(right)));
+                }
+
+                break;
+        }
+    }
+
+    private static string Short(JToken? token)
+    {
+        var text = token?.ToString(Formatting.None) ?? "null";
+        return text.Length > 120 ? string.Concat(text.AsSpan(0, 117), "...") : text;
+    }
+}

--- a/FUSE.LiveHarness/Json/JsonNormalizer.cs
+++ b/FUSE.LiveHarness/Json/JsonNormalizer.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Fuse.LiveHarness.Json;
+
+/// <summary>
+/// Canonicalizes a JSON tree so golden-master comparisons ignore non-deterministic noise:
+/// strips volatile keys (timestamps, pids, request ids), rounds floating-point values to a
+/// fixed precision (graph coordinates are live Transform reads that wobble in the last ulps),
+/// recursively sorts object keys (JSON object/Dictionary key order is not contractual), and —
+/// by default — sorts arrays by canonical content so reordering is not flagged as drift.
+/// </summary>
+public sealed class JsonNormalizer
+{
+    /// <summary>Per-run fields stripped before comparison (from the dump JSON and bridge state).</summary>
+    public static readonly string[] DefaultStripKeys =
+    {
+        "createdLocal", "pid", "heartbeatUtc", "lastReloadUtc", "lastRequestId", "issuedUtc", "completedUtc",
+    };
+
+    private readonly HashSet<string> _stripKeys;
+    private readonly int _decimals;
+    private readonly bool _sortArrays;
+
+    public JsonNormalizer(IEnumerable<string>? stripKeys = null, int decimals = 4, bool sortArrays = true)
+    {
+        _stripKeys = new HashSet<string>(stripKeys ?? DefaultStripKeys, StringComparer.OrdinalIgnoreCase);
+        _decimals = decimals;
+        _sortArrays = sortArrays;
+    }
+
+    public JToken Normalize(JToken token)
+    {
+        switch (token)
+        {
+            case JObject obj:
+                var normalizedObject = new JObject();
+                foreach (var property in obj.Properties()
+                             .Where(p => !_stripKeys.Contains(p.Name))
+                             .OrderBy(p => p.Name, StringComparer.Ordinal))
+                {
+                    normalizedObject.Add(property.Name, Normalize(property.Value));
+                }
+
+                return normalizedObject;
+
+            case JArray array:
+                var items = array.Select(Normalize).ToList();
+                if (_sortArrays)
+                {
+                    items.Sort((a, b) => string.CompareOrdinal(a.ToString(Formatting.None), b.ToString(Formatting.None)));
+                }
+
+                return new JArray(items);
+
+            case JValue value when value.Type == JTokenType.Float:
+                return new JValue(Math.Round(value.Value<double>(), _decimals));
+
+            default:
+                return token.DeepClone();
+        }
+    }
+
+    /// <summary>Normalize and render as stable, indented JSON (what gets stored as a baseline).</summary>
+    public string Canonical(JToken token) => Normalize(token).ToString(Formatting.Indented);
+
+    public string Canonical(string json) => Canonical(JToken.Parse(json));
+}

--- a/FUSE.TestBridge/FUSE.TestBridge.csproj
+++ b/FUSE.TestBridge/FUSE.TestBridge.csproj
@@ -1,0 +1,72 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Dev-only in-game test bridge: a point-to-point RPC channel the FUSE.TestCli
+       driver uses to reload packages, run /fuse.* commands, and read the load report
+       on the Unity main thread. net48 + Unity. Gated so it never affects a player
+       (Main.cs requires FUSE_TEST_BRIDGE=1 or Info.json "Enabled": true) and not
+       deployed unless EnableTestBridgeDeploy=true. Paths.user supplies $(GameDir). -->
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <AssemblyName>FUSE.TestBridge</AssemblyName>
+    <RootNamespace>FUSE.TestBridge</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <Platforms>AnyCPU</Platforms>
+    <NoWarn>$(NoWarn);0618</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GameDir Condition="'$(GameDir)' == ''">C:\Steam\steamapps\common\Railroader</GameDir>
+    <UnityManagedDir Condition="'$(UnityManagedDir)' == ''">$(GameDir)\Railroader_Data\Managed</UnityManagedDir>
+    <UnityModManagerDir Condition="'$(UnityModManagerDir)' == ''">$(UnityManagedDir)\UnityModManager</UnityModManagerDir>
+    <ModDeployDir Condition="'$(ModDeployDir)' == ''">$(GameDir)\Mods\FUSE.TestBridge</ModDeployDir>
+    <EnableTestBridgeDeploy Condition="'$(EnableTestBridgeDeploy)' == ''">false</EnableTestBridgeDeploy>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FUSE\FUSE.csproj" />
+    <ProjectReference Include="..\FUSE.Core\FUSE.Core.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <UnityModManagerAssemblyPath Condition="'$(UnityModManagerAssemblyPath)' == '' and Exists('$(UnityModManagerDir)\UnityModManagerNet.dll')">$(UnityModManagerDir)\UnityModManagerNet.dll</UnityModManagerAssemblyPath>
+    <UnityModManagerAssemblyPath Condition="'$(UnityModManagerAssemblyPath)' == '' and Exists('$(UnityModManagerDir)\UnityModManager.dll')">$(UnityModManagerDir)\UnityModManager.dll</UnityModManagerAssemblyPath>
+    <UnityModManagerReferenceName Condition="'$(UnityModManagerReferenceName)' == '' and Exists('$(UnityModManagerDir)\UnityModManagerNet.dll')">UnityModManagerNet</UnityModManagerReferenceName>
+    <UnityModManagerReferenceName Condition="'$(UnityModManagerReferenceName)' == '' and Exists('$(UnityModManagerDir)\UnityModManager.dll')">UnityModManager</UnityModManagerReferenceName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="$(UnityModManagerReferenceName)" Condition="Exists('$(UnityModManagerAssemblyPath)')">
+      <HintPath>$(UnityModManagerAssemblyPath)</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json" Condition="Exists('$(UnityManagedDir)\Newtonsoft.Json.dll')">
+      <HintPath>$(UnityManagedDir)\Newtonsoft.Json.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule" Condition="Exists('$(UnityManagedDir)\UnityEngine.CoreModule.dll')">
+      <HintPath>$(UnityManagedDir)\UnityEngine.CoreModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <Target Name="ValidateUnityReferences" BeforeTargets="ResolveReferences">
+    <Error Condition="!Exists('$(UnityModManagerAssemblyPath)')" Text="UnityModManagerNet.dll or UnityModManager.dll not found. Set UnityModManagerDir or GameDir (Paths.user)." />
+    <Error Condition="!Exists('$(UnityManagedDir)\UnityEngine.CoreModule.dll')" Text="UnityEngine.CoreModule.dll not found in the Railroader Managed folder." />
+  </Target>
+
+  <ItemGroup>
+    <Content Include="Info.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <Target Name="DeployFuseTestBridge" AfterTargets="Build" Condition="'$(EnableTestBridgeDeploy)' == 'true'">
+    <MakeDir Directories="$(ModDeployDir)" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)\Info.json" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="true" />
+    <!-- FUSE.Core.dll travels with the bridge (FUSE.dll is provided by the FUSE mod). -->
+    <Copy SourceFiles="$(TargetDir)FUSE.Core.dll" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="true" Condition="Exists('$(TargetDir)FUSE.Core.dll')" />
+  </Target>
+</Project>

--- a/FUSE.TestBridge/FuseTestBridgeBehaviour.cs
+++ b/FUSE.TestBridge/FuseTestBridgeBehaviour.cs
@@ -1,0 +1,417 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using Fuse.Core.Bridge;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using FUSE.Testing;
+using UnityEngine;
+
+namespace FUSE.TestBridge
+{
+    /// <summary>
+    /// Persistent (DontDestroyOnLoad) host for the dev-only test bridge. A
+    /// <see cref="FileSystemWatcher"/> on this mod's own folder detects driver-written
+    /// <c>test_request_&lt;id&gt;.json</c> files; each is read and executed on the Unity main thread in
+    /// <see cref="Update"/> (the only place FUSE/Unity calls are legal), then a
+    /// <c>test_result_&lt;id&gt;.json</c> is written and the request file deleted. Per-request files mean a
+    /// slow or aborted request never clobbers the next. A ~1s heartbeat to <c>test_state.json</c> lets the
+    /// driver see liveness/readiness (and the FUSE.log path) without a round trip.
+    ///
+    /// The watcher fires on a thread-pool thread and only flags work; all execution is on the main
+    /// thread. The <c>screenshot</c> verb is deferred — Unity writes the PNG a frame later, so its result
+    /// is held until the file exists.
+    /// </summary>
+    public sealed class FuseTestBridgeBehaviour : MonoBehaviour
+    {
+        private const float ScreenshotTimeoutSeconds = 15f;
+
+        private string _channelDir;
+        private string _statePath;
+        private FileSystemWatcher _watcher;
+        private readonly object _lock = new object();
+        private bool _pending;
+        private float _heartbeatTimer;
+        private int _pid;
+
+        private string _lastRequestId;
+        private string _lastCompletedUtc;
+        private bool _lastOk = true;
+        private string _lastError;
+        private int _lastAppliedCount;
+
+        // Deferred screenshot completion (the PNG appears a frame or two after the capture call).
+        private string _pendingScreenshotRequestId;
+        private string _pendingScreenshotRequestPath;
+        private string _pendingScreenshotPath;
+        private float _pendingScreenshotElapsed;
+
+        public void Configure(string modPath)
+        {
+            _channelDir = modPath;
+            _statePath = Path.Combine(modPath, BridgeProtocol.TestStateFileName);
+            _pid = Process.GetCurrentProcess().Id; // invariant; resolve once (avoids leaking a Process handle per heartbeat)
+
+            CleanStaleChannelFiles();
+            SetupWatcher();
+            WriteHeartbeat();
+        }
+
+        // Remove leftover request/result files from a previous game session so we start clean.
+        private void CleanStaleChannelFiles()
+        {
+            try
+            {
+                foreach (var file in Directory.GetFiles(_channelDir, BridgeProtocol.TestRequestPattern))
+                {
+                    TryDelete(file);
+                }
+
+                foreach (var file in Directory.GetFiles(_channelDir, BridgeProtocol.TestResultPrefix + "*.json"))
+                {
+                    TryDelete(file);
+                }
+            }
+            catch (Exception ex)
+            {
+                Main.ModEntry?.Logger.Warning("FUSE.TestBridge stale-file cleanup failed: " + ex.Message);
+            }
+        }
+
+        private void SetupWatcher()
+        {
+            try
+            {
+                _watcher = new FileSystemWatcher(_channelDir, BridgeProtocol.TestRequestPattern)
+                {
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.CreationTime,
+                };
+                _watcher.Changed += OnRequestEvent;
+                _watcher.Created += OnRequestEvent;
+                _watcher.Renamed += OnRequestRenamed;
+                _watcher.Error += OnWatcherError;
+                _watcher.EnableRaisingEvents = true;
+            }
+            catch (Exception ex)
+            {
+                Main.ModEntry?.Logger.Warning("FUSE.TestBridge watcher setup failed: " + ex.Message);
+            }
+        }
+
+        // The watcher's internal buffer can overflow; when it does the Error event fires and delivery
+        // can stop. Log it and re-arm so request delivery survives.
+        private void OnWatcherError(object sender, ErrorEventArgs e)
+        {
+            Main.ModEntry?.Logger.Warning("FUSE.TestBridge watcher error (re-arming): " + e.GetException()?.Message);
+            try
+            {
+                _watcher?.Dispose();
+            }
+            catch
+            {
+                // ignore
+            }
+
+            SetupWatcher();
+        }
+
+        private void OnRequestEvent(object sender, FileSystemEventArgs e) => Flag();
+
+        private void OnRequestRenamed(object sender, RenamedEventArgs e) => Flag();
+
+        private void Flag()
+        {
+            lock (_lock)
+            {
+                _pending = true;
+            }
+        }
+
+        private void Update()
+        {
+            // While a screenshot is in flight, finish it before accepting new work.
+            if (_pendingScreenshotRequestId != null)
+            {
+                AdvancePendingScreenshot();
+            }
+            else
+            {
+                bool pending;
+                lock (_lock)
+                {
+                    pending = _pending;
+                    _pending = false;
+                }
+
+                if (pending)
+                {
+                    ProcessOldestRequest();
+                }
+            }
+
+            _heartbeatTimer += Time.unscaledDeltaTime;
+            if (_heartbeatTimer >= 1f)
+            {
+                _heartbeatTimer = 0f;
+                WriteHeartbeat();
+            }
+        }
+
+        private void ProcessOldestRequest()
+        {
+            string[] files;
+            try
+            {
+                files = Directory.GetFiles(_channelDir, BridgeProtocol.TestRequestPattern);
+            }
+            catch
+            {
+                return;
+            }
+
+            if (files.Length == 0)
+            {
+                return;
+            }
+
+            Array.Sort(files, (a, b) => File.GetLastWriteTimeUtc(a).CompareTo(File.GetLastWriteTimeUtc(b)));
+            var requestPath = files[0];
+            var request = BridgeIo.TryRead<TestRequest>(requestPath);
+
+            if (request == null || string.IsNullOrEmpty(request.RequestId))
+            {
+                TryDelete(requestPath);
+            }
+            else if (string.Equals(request.Verb, BridgeProtocol.TestVerbScreenshot, StringComparison.Ordinal))
+            {
+                BeginScreenshot(request, requestPath);
+                return; // hold further processing until the screenshot completes
+            }
+            else
+            {
+                CompleteRequest(Execute(request), requestPath);
+            }
+
+            // Re-arm so any remaining queued requests are processed on subsequent frames.
+            if (files.Length > 1)
+            {
+                Flag();
+            }
+        }
+
+        private TestResult Execute(TestRequest request)
+        {
+            var result = new TestResult
+            {
+                RequestId = request.RequestId,
+                CompletedUtc = DateTime.UtcNow.ToString("o"),
+                Ok = true,
+            };
+
+            try
+            {
+                var reason = string.IsNullOrWhiteSpace(request.Reason) ? "test-bridge" : request.Reason;
+                switch (request.Verb)
+                {
+                    case BridgeProtocol.TestVerbReload:
+                        _lastAppliedCount = FuseTestApi.Reload(reason);
+                        result.Text = _lastAppliedCount.ToString();
+                        break;
+                    case BridgeProtocol.TestVerbReloadTerrain:
+                        result.Text = FuseTestApi.ReloadTerrain(reason) ? "true" : "false";
+                        break;
+                    case BridgeProtocol.TestVerbReport:
+                        result.Text = string.Equals(request.Arg, "detail", StringComparison.OrdinalIgnoreCase)
+                            ? FuseTestApi.GetLoadReportDetail()
+                            : FuseTestApi.GetLoadReportJson();
+                        break;
+                    case BridgeProtocol.TestVerbConsole:
+                        result.Text = FuseTestApi.RunConsoleCommand(request.CommandLine);
+                        break;
+                    case BridgeProtocol.TestVerbDump:
+                        result.Text = FuseTestApi.Dump(request.Arg, out var dumpArtifact);
+                        result.ArtifactPath = dumpArtifact;
+                        break;
+                    case BridgeProtocol.TestVerbLoadSave:
+                        result.Text = FuseTestApi.LoadSave(request.Arg);
+                        break;
+                    case BridgeProtocol.TestVerbSaves:
+                        result.Text = FuseTestApi.ListSaves();
+                        break;
+                    case BridgeProtocol.TestVerbSave:
+                        result.Text = FuseTestApi.SaveGame(request.Arg);
+                        break;
+                    case BridgeProtocol.TestVerbUmm:
+                        result.Text = FuseTestApi.SetUmmWindow(
+                            string.Equals(request.Arg, "open", StringComparison.OrdinalIgnoreCase));
+                        break;
+                    case BridgeProtocol.TestVerbNewGame:
+                        result.Text = FuseTestApi.NewGame(request.Arg);
+                        break;
+                    case BridgeProtocol.TestVerbCleanup:
+                        result.Text = FuseTestApi.Cleanup();
+                        break;
+                    default:
+                        result.Ok = false;
+                        result.Error = $"Unknown verb '{request.Verb}'.";
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                result.Ok = false;
+                result.Error = ex.GetBaseException().Message;
+                Main.ModEntry?.Logger.Error($"FUSE.TestBridge verb '{request.Verb}' failed: " + ex);
+            }
+
+            return result;
+        }
+
+        private void BeginScreenshot(TestRequest request, string requestPath)
+        {
+            try
+            {
+                _pendingScreenshotPath = FuseTestApi.CaptureScreenshot(request.Arg);
+                _pendingScreenshotRequestId = request.RequestId;
+                _pendingScreenshotRequestPath = requestPath;
+                _pendingScreenshotElapsed = 0f;
+            }
+            catch (Exception ex)
+            {
+                Main.ModEntry?.Logger.Error("FUSE.TestBridge screenshot failed: " + ex);
+                CompleteRequest(
+                    new TestResult
+                    {
+                        RequestId = request.RequestId,
+                        CompletedUtc = DateTime.UtcNow.ToString("o"),
+                        Ok = false,
+                        Error = ex.GetBaseException().Message,
+                    },
+                    requestPath);
+            }
+        }
+
+        private void AdvancePendingScreenshot()
+        {
+            _pendingScreenshotElapsed += Time.unscaledDeltaTime;
+
+            var exists = false;
+            try
+            {
+                exists = File.Exists(_pendingScreenshotPath);
+            }
+            catch
+            {
+                // treat as not-yet-present
+            }
+
+            if (exists)
+            {
+                CompleteScreenshot(new TestResult
+                {
+                    RequestId = _pendingScreenshotRequestId,
+                    CompletedUtc = DateTime.UtcNow.ToString("o"),
+                    Ok = true,
+                    Text = _pendingScreenshotPath,
+                    ArtifactPath = _pendingScreenshotPath,
+                });
+            }
+            else if (_pendingScreenshotElapsed >= ScreenshotTimeoutSeconds)
+            {
+                CompleteScreenshot(new TestResult
+                {
+                    RequestId = _pendingScreenshotRequestId,
+                    CompletedUtc = DateTime.UtcNow.ToString("o"),
+                    Ok = false,
+                    Error = $"Screenshot file did not appear within {ScreenshotTimeoutSeconds}s: {_pendingScreenshotPath}",
+                });
+            }
+        }
+
+        private void CompleteScreenshot(TestResult result)
+        {
+            var requestPath = _pendingScreenshotRequestPath;
+            _pendingScreenshotRequestId = null;
+            _pendingScreenshotRequestPath = null;
+            _pendingScreenshotPath = null;
+            _pendingScreenshotElapsed = 0f;
+            CompleteRequest(result, requestPath);
+            Flag(); // process anything queued behind the screenshot
+        }
+
+        private void CompleteRequest(TestResult result, string requestPath)
+        {
+            _lastRequestId = result.RequestId;
+            _lastCompletedUtc = result.CompletedUtc;
+            _lastOk = result.Ok;
+            _lastError = result.Error;
+
+            try
+            {
+                BridgeIo.WriteAtomic(Path.Combine(_channelDir, BridgeProtocol.TestResultPrefix + result.RequestId + ".json"), result);
+            }
+            catch (Exception ex)
+            {
+                Main.ModEntry?.Logger.Error("FUSE.TestBridge failed to write result: " + ex);
+            }
+
+            TryDelete(requestPath);
+            WriteHeartbeat();
+        }
+
+        private void WriteHeartbeat()
+        {
+            try
+            {
+                var state = new BridgeState
+                {
+                    Pid = _pid,
+                    GameVersion = Application.version,
+                    FuseVersion = string.Empty,
+                    HeartbeatUtc = DateTime.UtcNow.ToString("o"),
+                    MapLoaded = FuseTestApi.IsMapLoaded(),
+                    CanApply = FuseLiveReloadApi.CanApplyWorldMutations("test-bridge heartbeat"),
+                    MultiplayerRole = FuseLiveReloadApi.DescribeMultiplayer("test-bridge heartbeat"),
+                    LastRequestId = _lastRequestId,
+                    LastReloadUtc = _lastCompletedUtc,
+                    AppliedCount = _lastAppliedCount,
+                    Ok = _lastOk,
+                    Error = _lastError,
+                    LogPath = FuseLog.LogFilePath,
+                };
+                BridgeIo.WriteAtomic(_statePath, state);
+            }
+            catch (Exception ex)
+            {
+                Main.ModEntry?.Logger.Warning("FUSE.TestBridge heartbeat write failed: " + ex.Message);
+            }
+        }
+
+        private static void TryDelete(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+
+        private void OnDestroy()
+        {
+            try
+            {
+                _watcher?.Dispose();
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+}

--- a/FUSE.TestBridge/FuseTestBridgeBehaviour.cs
+++ b/FUSE.TestBridge/FuseTestBridgeBehaviour.cs
@@ -288,6 +288,7 @@ namespace FUSE.TestBridge
                         Error = ex.GetBaseException().Message,
                     },
                     requestPath);
+                Flag(); // re-arm: ProcessOldestRequest returned early, so pick up anything queued behind this
             }
         }
 

--- a/FUSE.TestBridge/FuseTestBridgeHost.cs
+++ b/FUSE.TestBridge/FuseTestBridgeHost.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+namespace FUSE.TestBridge
+{
+    /// <summary>Creates the persistent test bridge MonoBehaviour once (DontDestroyOnLoad).</summary>
+    public static class FuseTestBridgeHost
+    {
+        private static GameObject _host;
+
+        public static void Ensure(string modPath)
+        {
+            if (_host != null)
+            {
+                return;
+            }
+
+            _host = new GameObject("FUSE Test Bridge");
+            Object.DontDestroyOnLoad(_host);
+            var behaviour = _host.AddComponent<FuseTestBridgeBehaviour>();
+            behaviour.Configure(modPath);
+        }
+    }
+}

--- a/FUSE.TestBridge/Info.json
+++ b/FUSE.TestBridge/Info.json
@@ -1,0 +1,13 @@
+{
+  "Id": "FUSE.TestBridge",
+  "DisplayName": "FUSE Test Bridge (dev only)",
+  "Author": "FUSE Team",
+  "Version": "0.1.0",
+  "ManagerVersion": "0.27.10",
+  "GameVersion": "2025.1",
+  "AssemblyName": "FUSE.TestBridge.dll",
+  "EntryMethod": "FUSE.TestBridge.Main.Load",
+  "Requirements": ["FUSE"],
+  "LoadAfter": ["FUSE"],
+  "Enabled": false
+}

--- a/FUSE.TestBridge/Main.cs
+++ b/FUSE.TestBridge/Main.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using Newtonsoft.Json;
+using UnityModManagerNet;
+
+namespace FUSE.TestBridge
+{
+    /// <summary>
+    /// UMM entry point for the optional, dev-only test bridge. It stays inert unless
+    /// explicitly enabled — either the environment variable <c>FUSE_TEST_BRIDGE=1</c> or
+    /// <c>"Enabled": true</c> in this mod's Info.json — so it can never affect a player
+    /// even if the DLL lands in their Mods folder. A normal build also never deploys it
+    /// (EnableTestBridgeDeploy defaults false).
+    /// </summary>
+    public static class Main
+    {
+        public static UnityModManager.ModEntry ModEntry { get; private set; }
+
+        public static bool Load(UnityModManager.ModEntry modEntry)
+        {
+            ModEntry = modEntry;
+            try
+            {
+                if (!IsEnabled(modEntry))
+                {
+                    modEntry.Logger.Log(
+                        "FUSE.TestBridge present but disabled. Set FUSE_TEST_BRIDGE=1 or \"Enabled\": true " +
+                        "in its Info.json to enable (dev only).");
+                    return true;
+                }
+
+                FuseTestBridgeHost.Ensure(modEntry.Path);
+                modEntry.Logger.Log("FUSE.TestBridge enabled; watching its folder for test requests.");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                modEntry.Logger.Error("FUSE.TestBridge failed to load: " + ex);
+                return false;
+            }
+        }
+
+        private static bool IsEnabled(UnityModManager.ModEntry modEntry)
+        {
+            if (string.Equals(Environment.GetEnvironmentVariable("FUSE_TEST_BRIDGE"), "1", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            try
+            {
+                var infoPath = Path.Combine(modEntry.Path, "Info.json");
+                if (File.Exists(infoPath))
+                {
+                    var info = JsonConvert.DeserializeObject<EnableFlag>(File.ReadAllText(infoPath));
+                    return info != null && info.Enabled;
+                }
+            }
+            catch
+            {
+                // A malformed or locked Info.json just leaves the bridge disabled.
+            }
+
+            return false;
+        }
+
+        // Newtonsoft matches the JSON "Enabled" field to this property by name
+        // (case-insensitive); other Info.json fields are ignored.
+        private sealed class EnableFlag
+        {
+            public bool Enabled { get; set; }
+        }
+    }
+}

--- a/FUSE.TestBridge/README.md
+++ b/FUSE.TestBridge/README.md
@@ -1,0 +1,91 @@
+# FUSE.TestBridge (dev-only)
+
+A point-to-point RPC channel for driving the **live** Railroader game to test FUSE —
+reload packages, run `/fuse.*` console commands, and read the load report from outside
+the game. It is the in-game half; [`FUSE.TestCli`](../FUSE.TestCli) is the driver Claude
+(or you) invokes from a shell.
+
+This mod is **dev-only** and triple-gated so it can never affect a player:
+
+1. A normal build does not deploy it (`EnableTestBridgeDeploy` defaults `false`).
+2. Its `Info.json` ships `"Enabled": false`.
+3. The host refuses to spawn unless `FUSE_TEST_BRIDGE=1` **or** `Info.json "Enabled": true`.
+
+## How it works
+
+The `FUSE.TestBridge` MonoBehaviour (DontDestroyOnLoad) watches its own
+`Mods/FUSE.TestBridge/` folder for `test_request_<id>.json` files. On the Unity **main
+thread** (in `Update()`) it executes each via the public `FUSE.Testing.FuseTestApi` facade
+and writes `test_result_<id>.json` (correlated by `RequestId`), then deletes the request.
+Per-request files mean a slow or aborted request never clobbers the next. It also writes a
+~1s heartbeat to `test_state.json` (`pid`, `gameVersion`, `mapLoaded`, `canApply`, log path).
+
+All IO reuses the atomic, camelCase `Fuse.Core.Bridge` protocol shared with the editor's
+live-reload bridge, so the net48 game and the net10 CLI exchange the exact same DTOs.
+
+Verbs: `reload`, `reloadTerrain`, `report` (`json`/`detail`), `console` (any `/fuse.*`),
+`dump` (graph/runtimegraph/mandelas/progression), `screenshot`, `loadSave`, `save`, `saves`,
+`umm` (open/close overlay), `newGame` (fresh sandbox), `cleanup` (delete test saves).
+
+## Enable it
+
+Deploy the mod into your Railroader install (worktrees pass `GameDir` explicitly — see
+[the build note](../README.md#local-development)):
+
+```powershell
+dotnet build FUSE.TestBridge/FUSE.TestBridge.csproj -c Debug `
+  -p:GameDir=F:\SteamLibrary\steamapps\common\Railroader `
+  -p:EnableTestBridgeDeploy=true
+```
+
+Then enable it (pick one) and launch the game:
+
+```powershell
+$env:FUSE_TEST_BRIDGE = "1"     # session-scoped, or set "Enabled": true in the deployed Info.json
+```
+
+Check `UnityModManager`'s log for `FUSE.TestBridge enabled; watching its folder for test requests.`
+
+## Drive it
+
+```powershell
+$env:FUSE_GAME_MODS = "F:\SteamLibrary\steamapps\common\Railroader\Mods"
+
+dotnet run --project FUSE.TestCli -- status                  # connection + mapLoaded + canApply (no round trip)
+dotnet run --project FUSE.TestCli -- newgame clean           # fresh sandbox from the menu; deletes old fuse-test-* saves
+dotnet run --project FUSE.TestCli -- ready                   # block until connected, mapLoaded, and FUSE has settled
+dotnet run --project FUSE.TestCli -- save fuse-test-clean    # persist the clean baseline
+dotnet run --project FUSE.TestCli -- reload "my change"      # re-read + re-apply; prints applied count
+dotnet run --project FUSE.TestCli -- report json
+dotnet run --project FUSE.TestCli -- dump runtimegraph       # writes the dump JSON; prints its path
+dotnet run --project FUSE.TestCli -- umm close               # hide the mod-manager overlay
+dotnet run --project FUSE.TestCli -- screenshot before-fix   # prints the saved PNG path
+dotnet run --project FUSE.TestCli -- tail-log 200            # last 200 lines of FUSE.log (no round trip)
+dotnet run --project FUSE.TestCli -- load fuse-test-clean    # reset to the baseline (cold-boot or in-session swap)
+dotnet run --project FUSE.TestCli -- run-fixture example     # golden-master a fixture (see tests/live/fixtures)
+```
+
+`status`, `tail-log`, and `ready` read local files directly (no round trip). `ready` waits
+until the heartbeat is steadily beating, so a heavy post-load apply has finished before the
+next command runs. `load` cold-boots from the main menu, or swaps saves in-session when a
+map is already loaded.
+
+## Test saves
+
+Harness-created saves use the reserved `fuse-test-` prefix. `cleanup` (and the cleanup step
+of `newgame`) **only ever delete saves with that prefix** — your real saves are never
+touched. Typical loop: `newgame clean` → `ready` → `save fuse-test-clean` once; then reset to
+that clean baseline any time with `load fuse-test-clean`, or `newgame` again for a fresh one
+(which removes the previous `fuse-test-*`).
+
+## Status / roadmap
+
+Implemented: the interactive driver (reload, console, report, status), screenshots, log
+tailing, dump capture, save + load (cold-boot from the menu and in-session swap), fresh-sandbox
+`newGame` with prefixed-save cleanup, the UMM overlay toggle, a settle-aware `ready`,
+per-request files (no clobbering), and the golden-master regression harness (`FUSE.LiveHarness`
++ `run-fixture`, with normalize/diff covered by `FUSE.LiveHarness.Tests`).
+
+Deferred (optional): a localhost HTTP transport for lower-latency interactive loops — the
+file channel covers every verb, so this is only worth adding if the loop feels sluggish.
+See the project plan.

--- a/FUSE.TestCli/FUSE.TestCli.csproj
+++ b/FUSE.TestCli/FUSE.TestCli.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>FUSE.TestCli</AssemblyName>
+    <RootNamespace>Fuse.TestCli</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <!-- Dev-only driver Claude invokes via Bash: no game/Unity DLLs; shares the bridge
+         DTOs from FUSE.Core (net10.0 TFM). Sets its own version, not the net48 mod stamp. -->
+    <FuseIsGameFree>true</FuseIsGameFree>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FUSE.Core\FUSE.Core.csproj" />
+    <ProjectReference Include="..\FUSE.LiveHarness\FUSE.LiveHarness.csproj" />
+  </ItemGroup>
+</Project>

--- a/FUSE.TestCli/Program.cs
+++ b/FUSE.TestCli/Program.cs
@@ -1,0 +1,375 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using Fuse.Core.Bridge;
+using Fuse.LiveHarness.Bridge;
+using Fuse.LiveHarness.Fixtures;
+
+namespace Fuse.TestCli;
+
+/// <summary>
+/// Dev-only command-line driver for the in-game <c>FUSE.TestBridge</c> mod. It uses the shared
+/// <see cref="BridgeClient"/> to write a <see cref="TestRequest"/>, poll for the correlated
+/// <see cref="TestResult"/>, and print it (errors to stderr, non-zero exit). Claude calls this via the
+/// Bash tool to drive FUSE against a live game session.
+///
+/// The game Mods directory comes from <c>--mods &lt;dir&gt;</c> or the <c>FUSE_GAME_MODS</c> env var.
+/// </summary>
+internal static class Program
+{
+    private static async Task<int> Main(string[] args)
+    {
+        try
+        {
+            return await RunAsync(args);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("fuse-test: " + ex.Message);
+            return 1;
+        }
+    }
+
+    private static async Task<int> RunAsync(string[] args)
+    {
+        if (args.Length == 0 || IsHelp(args[0]))
+        {
+            PrintUsage();
+            return args.Length == 0 ? 2 : 0;
+        }
+
+        var options = Options.Parse(args);
+        var client = new BridgeClient(options.ModsDir, options.TimeoutSeconds, options.PollMilliseconds, options.StaleSeconds);
+
+        // Local commands (read files directly / orchestrate) — no single round trip.
+        switch (options.Command)
+        {
+            case "status":
+                return Status(client);
+            case "tail-log":
+                return TailLog(client, options.Positional);
+            case "ready":
+                return await client.WaitReadyAsync() ? Ok("ready") : Fail(
+                    $"not ready within {options.TimeoutSeconds}s (need connected + mapLoaded + canApply, settled).");
+            case "run-fixture":
+                return await RunFixtureAsync(options);
+        }
+
+        var request = options.Command switch
+        {
+            "reload" => new TestRequest { Verb = BridgeProtocol.TestVerbReload, Reason = options.Positional ?? "fuse-test reload" },
+            "reload-terrain" => new TestRequest { Verb = BridgeProtocol.TestVerbReloadTerrain, Reason = options.Positional ?? "fuse-test reload-terrain" },
+            "report" => new TestRequest { Verb = BridgeProtocol.TestVerbReport, Arg = options.Positional ?? "json" },
+            "query" => new TestRequest { Verb = BridgeProtocol.TestVerbConsole, CommandLine = options.Positional },
+            "dump" => new TestRequest { Verb = BridgeProtocol.TestVerbDump, Arg = options.Positional },
+            "screenshot" => new TestRequest { Verb = BridgeProtocol.TestVerbScreenshot, Arg = options.Positional },
+            "load" => new TestRequest { Verb = BridgeProtocol.TestVerbLoadSave, Arg = options.Positional },
+            "saves" => new TestRequest { Verb = BridgeProtocol.TestVerbSaves },
+            "save" => new TestRequest { Verb = BridgeProtocol.TestVerbSave, Arg = options.Positional },
+            "umm" => new TestRequest { Verb = BridgeProtocol.TestVerbUmm, Arg = options.Positional ?? "close" },
+            "newgame" => new TestRequest { Verb = BridgeProtocol.TestVerbNewGame, Arg = options.Positional },
+            "cleanup" => new TestRequest { Verb = BridgeProtocol.TestVerbCleanup },
+            _ => null,
+        };
+
+        if (request is null)
+        {
+            return Fail($"unknown command '{options.Command}'. Run with --help.");
+        }
+
+        if (options.Command == "query" && string.IsNullOrWhiteSpace(request.CommandLine))
+        {
+            return Fail("'query' needs a console command, e.g. query \"/fuse.report json\".");
+        }
+
+        if (options.Command == "dump" && string.IsNullOrWhiteSpace(request.Arg))
+        {
+            return Fail("'dump' needs a target: graph | runtimegraph | mandelas | progression.");
+        }
+
+        if (options.Command == "load" && string.IsNullOrWhiteSpace(request.Arg))
+        {
+            return Fail("'load' needs a save name. Use 'saves' to list available saves.");
+        }
+
+        if (options.Command == "save" && string.IsNullOrWhiteSpace(request.Arg))
+        {
+            return Fail("'save' needs a name, e.g. save \"fuse-test-baseline\".");
+        }
+
+        return await SendAndPrintAsync(client, request);
+    }
+
+    private static async Task<int> SendAndPrintAsync(BridgeClient client, TestRequest request)
+    {
+        TestResult result;
+        try
+        {
+            result = await client.SendAsync(request);
+        }
+        catch (TimeoutException ex)
+        {
+            return Fail(ex.Message + " Is the game running with FUSE.TestBridge enabled, and (for session verbs) a map loaded?");
+        }
+
+        if (!result.Ok)
+        {
+            return Fail(result.Error ?? "command failed.");
+        }
+
+        if (!string.IsNullOrEmpty(result.Text))
+        {
+            Console.WriteLine(result.Text);
+        }
+
+        if (!string.IsNullOrEmpty(result.ArtifactPath))
+        {
+            Console.Error.WriteLine("artifact: " + result.ArtifactPath);
+        }
+
+        return 0;
+    }
+
+    private static int Status(BridgeClient client)
+    {
+        var state = client.ReadState();
+        if (state is null)
+        {
+            Console.WriteLine(
+                $"disconnected — no heartbeat in {client.ChannelDir}. " +
+                "Is the game running with FUSE.TestBridge enabled (FUSE_TEST_BRIDGE=1)?");
+            return 1;
+        }
+
+        var connection = client.Classify(state, DateTime.UtcNow);
+        Console.WriteLine($"connection  : {connection}");
+        Console.WriteLine($"pid         : {state.Pid}");
+        Console.WriteLine($"gameVersion : {state.GameVersion}");
+        Console.WriteLine($"mapLoaded   : {state.MapLoaded}");
+        Console.WriteLine($"canApply    : {state.CanApply}");
+        Console.WriteLine($"mpRole      : {state.MultiplayerRole}");
+        Console.WriteLine($"heartbeatUtc: {state.HeartbeatUtc}");
+        Console.WriteLine($"lastReload  : {state.LastReloadUtc} (applied={state.AppliedCount}, ok={state.Ok})");
+        if (!string.IsNullOrEmpty(state.Error))
+        {
+            Console.WriteLine($"lastError   : {state.Error}");
+        }
+
+        return connection == BridgeConnection.Connected ? 0 : 1;
+    }
+
+    private static int TailLog(BridgeClient client, string? positional)
+    {
+        var logPath = client.ReadState()?.LogPath;
+        if (string.IsNullOrEmpty(logPath) || !File.Exists(logPath))
+        {
+            return Fail($"no FUSE.log available (heartbeat LogPath='{logPath}'). Is the game running with FUSE.TestBridge enabled?");
+        }
+
+        var lines = 200;
+        if (!string.IsNullOrWhiteSpace(positional)
+            && int.TryParse(positional, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            && parsed > 0)
+        {
+            lines = parsed;
+        }
+
+        foreach (var line in ReadLastLines(logPath, lines))
+        {
+            Console.WriteLine(line);
+        }
+
+        return 0;
+    }
+
+    private static LinkedList<string> ReadLastLines(string path, int count)
+    {
+        // Open shared so we never fight the game's appender or its startup log rotation.
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream);
+        var tail = new LinkedList<string>();
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            tail.AddLast(line);
+            if (tail.Count > count)
+            {
+                tail.RemoveFirst();
+            }
+        }
+
+        return tail;
+    }
+
+    private static async Task<int> RunFixtureAsync(Options options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Positional))
+        {
+            return Fail("run-fixture needs a fixture id or directory.");
+        }
+
+        var fixtureDir = ResolveFixtureDir(options.Positional);
+        if (!Directory.Exists(fixtureDir))
+        {
+            return Fail($"fixture directory not found: {fixtureDir}");
+        }
+
+        // Fixture ops — reload especially — can take minutes on large installs; give generous headroom.
+        var client = new BridgeClient(options.ModsDir, Math.Max(options.TimeoutSeconds, 300), options.PollMilliseconds, options.StaleSeconds);
+        var result = await new FixtureRunner(client).RunAsync(fixtureDir, options.Update);
+
+        if (result.WasSkipped)
+        {
+            Console.WriteLine("SKIP: " + result.Message);
+            return 0;
+        }
+
+        if (result.Captures.Count == 0 && result.Message is not null)
+        {
+            return Fail(result.Message);
+        }
+
+        foreach (var capture in result.Captures)
+        {
+            Console.WriteLine($"{(capture.Ok ? "ok  " : "FAIL")} {capture.Name}: {capture.Note}");
+            foreach (var delta in capture.Deltas.Take(50))
+            {
+                Console.WriteLine($"     {delta.Kind} {delta.Path}: {delta.Left} -> {delta.Right}");
+            }
+        }
+
+        if (result.Updated)
+        {
+            Console.WriteLine("(baselines written — review and commit them)");
+        }
+
+        return result.Success ? 0 : 1;
+    }
+
+    private static string ResolveFixtureDir(string idOrDir)
+    {
+        if (Directory.Exists(idOrDir))
+        {
+            return idOrDir;
+        }
+
+        var root = Environment.GetEnvironmentVariable("FUSE_FIXTURES_DIR")
+            ?? Path.Combine(Directory.GetCurrentDirectory(), "tests", "live", "fixtures");
+        return Path.Combine(root, idOrDir);
+    }
+
+    private static int Ok(string message)
+    {
+        Console.WriteLine(message);
+        return 0;
+    }
+
+    private static int Fail(string message)
+    {
+        Console.Error.WriteLine("fuse-test: " + message);
+        return 1;
+    }
+
+    private static bool IsHelp(string arg) => arg is "-h" or "--help" or "help" or "/?";
+
+    private static void PrintUsage()
+    {
+        Console.WriteLine(
+@"fuse-test — drive the live Railroader game via the FUSE.TestBridge mod.
+
+Usage:
+  dotnet run --project FUSE.TestCli -- <command> [args] [--mods <dir>] [--timeout <sec>] [--poll <ms>]
+
+Commands:
+  status                      Read the bridge heartbeat (connection, mapLoaded, canApply). No round trip.
+  ready                       Wait until connected, a map is loaded, and FUSE has settled (heartbeat steady).
+  reload [reason]             Re-read FUSE packages from disk and re-apply. Prints the applied count.
+  reload-terrain [reason]     Rebuild terrain via the game's MapManager.
+  report [json|detail]        Print the FUSE load report (default: json).
+  query ""<console command>""   Run a /fuse.* command, e.g. query ""/fuse.report json"".
+  dump <which>                Write a dump JSON and print its path. which: graph | runtimegraph | mandelas | progression.
+  screenshot [name]           Capture a screenshot; prints the saved PNG path.
+  umm [open|close]            Open/close the Unity Mod Manager overlay (default close) so it doesn't block screenshots.
+  tail-log [n]                Print the last n lines of FUSE.log (default 200). No round trip.
+  newgame [name]              Start a fresh sandbox game from the menu (deletes old fuse-test-* saves first).
+  load <save>                 Load a save (cold-boot from the menu, or in-session swap when a map is loaded).
+  save <name>                 Save the running session (host). Test saves should start with 'fuse-test-'.
+  saves                       List available save names.
+  cleanup                     Delete the harness's fuse-test-* saves (never touches your real saves).
+  run-fixture <id> [--update] Load the fixture's save, reload, capture, and golden-master diff (--update writes baselines).
+
+The game Mods directory comes from --mods or the FUSE_GAME_MODS environment variable.");
+    }
+
+    private sealed class Options
+    {
+        public string Command { get; private set; } = string.Empty;
+        public string? Positional { get; private set; }
+        public string ModsDir { get; private set; } = string.Empty;
+        public int TimeoutSeconds { get; private set; } = 30;
+        public int PollMilliseconds { get; private set; } = 100;
+        public double StaleSeconds { get; private set; } = 5.0;
+        public bool Update { get; private set; }
+
+        public static Options Parse(string[] args)
+        {
+            var options = new Options();
+            var positionals = new List<string>();
+            for (var i = 0; i < args.Length; i++)
+            {
+                switch (args[i])
+                {
+                    case "--mods":
+                        options.ModsDir = Next(args, ref i);
+                        break;
+                    case "--timeout":
+                        options.TimeoutSeconds = int.Parse(Next(args, ref i), CultureInfo.InvariantCulture);
+                        break;
+                    case "--poll":
+                        options.PollMilliseconds = int.Parse(Next(args, ref i), CultureInfo.InvariantCulture);
+                        break;
+                    case "--update":
+                        options.Update = true;
+                        break;
+                    default:
+                        positionals.Add(args[i]);
+                        break;
+                }
+            }
+
+            if (positionals.Count > 0)
+            {
+                options.Command = positionals[0];
+            }
+
+            if (positionals.Count > 1)
+            {
+                options.Positional = string.Join(" ", positionals.GetRange(1, positionals.Count - 1));
+            }
+
+            if (string.IsNullOrEmpty(options.ModsDir))
+            {
+                options.ModsDir = Environment.GetEnvironmentVariable("FUSE_GAME_MODS") ?? string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(options.ModsDir))
+            {
+                throw new InvalidOperationException("No game Mods directory. Pass --mods <dir> or set FUSE_GAME_MODS.");
+            }
+
+            return options;
+        }
+
+        private static string Next(string[] args, ref int i)
+        {
+            if (i + 1 >= args.Length)
+            {
+                throw new InvalidOperationException($"Missing value for {args[i]}.");
+            }
+
+            return args[++i];
+        }
+    }
+}

--- a/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
@@ -609,6 +609,18 @@ namespace FUSE.UnityTests
             return type;
         }
 
+        // -----------------------------------------------------------------
+        // MenuManager — FuseTestApi.LoadSave (dev-only test bridge) reflects
+        // the private StartGameSinglePlayer(GameSetup) to cold-boot a save
+        // from the main menu, mirroring what the Load Game menu UI does.
+        // -----------------------------------------------------------------
+
+        [Test]
+        public void MenuManager_StartGameSinglePlayer_InstanceMethod()
+        {
+            AssertMethod("UI.Menu.MenuManager", "StartGameSinglePlayer", InstanceNonPublic);
+        }
+
         private static void AssertField(string typeFullName, string memberName, BindingFlags flags)
         {
             var type = RequireType(typeFullName);

--- a/FUSE.slnx
+++ b/FUSE.slnx
@@ -6,6 +6,10 @@
   <Project Path="FUSE.ExternalEditor/FUSE.ExternalEditor.csproj" />
   <Project Path="FUSE.ExternalEditor.UiTests/FUSE.ExternalEditor.UiTests.csproj" />
   <Project Path="FUSE.LiveBridge/FUSE.LiveBridge.csproj" />
+  <Project Path="FUSE.TestBridge/FUSE.TestBridge.csproj" />
+  <Project Path="FUSE.TestCli/FUSE.TestCli.csproj" />
+  <Project Path="FUSE.LiveHarness/FUSE.LiveHarness.csproj" />
+  <Project Path="FUSE.LiveHarness.Tests/FUSE.LiveHarness.Tests.csproj" />
   <Project Path="FUSE.Tests/FUSE.Tests.csproj" />
   <Project Path="FUSE/FUSE.csproj" />
 </Solution>

--- a/FUSE/Testing/FuseTestApi.cs
+++ b/FUSE/Testing/FuseTestApi.cs
@@ -111,6 +111,20 @@ namespace FUSE.Testing
             var stem = SanitizeStem(name);
             var absolutePath = Path.Combine(dir, stem + ".png");
 
+            // Remove any stale same-named file so the host's File.Exists poll observes the NEW
+            // capture, not a prior one (Unity writes the PNG a frame later).
+            try
+            {
+                if (File.Exists(absolutePath))
+                {
+                    File.Delete(absolutePath);
+                }
+            }
+            catch
+            {
+                // best-effort; if it can't be removed the host times out rather than returning stale data
+            }
+
             var screenCapture = Type.GetType("UnityEngine.ScreenCapture, UnityEngine.ScreenCaptureModule")
                 ?? Type.GetType("UnityEngine.ScreenCapture, UnityEngine.CoreModule");
             var capture = screenCapture?.GetMethod("CaptureScreenshot", new[] { typeof(string) });

--- a/FUSE/Testing/FuseTestApi.cs
+++ b/FUSE/Testing/FuseTestApi.cs
@@ -1,0 +1,402 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using FUSE.Interface.Console;
+using FUSE.Loading;
+using FUSE.Runtime.Lifecycle;
+using Game.Persistence;
+using Game.State;
+using Track;
+using UI.Console;
+using UnityEngine;
+
+namespace FUSE.Testing
+{
+    /// <summary>
+    /// Public, dev-facing facade the optional <c>FUSE.TestBridge</c> mod calls to drive
+    /// FUSE for automated live-game testing. It re-exposes the reload entry points, the
+    /// structured load report, and the <c>/fuse.*</c> console commands — several of which
+    /// live on <c>internal</c> types that a separate mod assembly cannot reach. This mirrors
+    /// the existing <see cref="FuseLiveReloadApi"/> precedent: a thin public seam inside the
+    /// FUSE assembly rather than widening internals to the mod.
+    ///
+    /// Every method assumes the Unity main thread; the test bridge host guarantees that by
+    /// only invoking this from its <c>Update()</c> pump.
+    /// </summary>
+    public static class FuseTestApi
+    {
+        private static readonly char[] WhitespaceSeparators = { ' ', '\t' };
+
+        private static readonly Dictionary<string, (string Command, string File)> DumpTargets =
+            new Dictionary<string, (string, string)>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["graph"] = ("/fuse.dumpgraph", "FUSE-original-graph.json"),
+                ["runtimegraph"] = ("/fuse.dumpruntimegraph", "FUSE-runtime-graph.json"),
+                ["mandelas"] = ("/fuse.dumpmandelas", "FUSE-mandelas.json"),
+                ["progression"] = ("/fuse.dumpprogression", "FUSE-progression.json"),
+            };
+
+        private static readonly Type[] StartGameSinglePlayerParams = { typeof(GameSetup) };
+
+        // Reserved prefix for harness-created saves. Cleanup ONLY ever deletes saves with this
+        // prefix — never the user's real saves. Defined here so FUSE.dll keeps no FUSE.Core dependency.
+        private const string TestSavePrefix = "fuse-test-";
+
+        private static Dictionary<string, IConsoleCommand> _commandsByName;
+
+        /// <summary>Re-read every FUSE package from disk and re-apply to the running world. Returns the number of definitions applied.</summary>
+        public static int Reload(string reason) => FuseLiveReloadApi.ReloadAllFromDisk(reason);
+
+        /// <summary>Rebuild terrain via the game's MapManager. Returns whether the rebuild ran.</summary>
+        public static bool ReloadTerrain(string reason) => FuseRuntimeReloadService.ReloadTerrain(reason);
+
+        /// <summary>The last FUSE map-load report as machine-readable JSON (re-snapshots registries on demand).</summary>
+        public static string GetLoadReportJson() => FuseLoadReport.GetLastJsonReport();
+
+        /// <summary>The last FUSE map-load report as human-readable text.</summary>
+        public static string GetLoadReportDetail() => FuseLoadReport.GetLastDetailReport();
+
+        /// <summary>Whether a map is loaded and the runtime track graph is populated.</summary>
+        public static bool IsMapLoaded()
+        {
+            try
+            {
+                return Graph.Shared != null && Graph.Shared.HasPopulatedCollections;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Run a FUSE console command by its full command line (e.g. <c>/fuse.report json</c>) and
+        /// return the same text the in-game console would show. Reuses the exact
+        /// <see cref="IConsoleCommand"/> instances FUSE registers with the game, so every
+        /// <c>/fuse.*</c> command is drivable without re-implementing any of them.
+        /// </summary>
+        public static string RunConsoleCommand(string commandLine)
+        {
+            if (string.IsNullOrWhiteSpace(commandLine))
+            {
+                return "FUSE test bridge: empty console command.";
+            }
+
+            var tokens = commandLine.Split(WhitespaceSeparators, StringSplitOptions.RemoveEmptyEntries);
+            var commands = Commands();
+            if (!commands.TryGetValue(Normalize(tokens[0]), out var command))
+            {
+                var known = string.Join(", ", commands.Keys.OrderBy(k => k, StringComparer.Ordinal));
+                return $"FUSE test bridge: unknown console command '{tokens[0]}'. Known: {known}.";
+            }
+
+            // The game passes components[0] == the command name; the commands scan the
+            // remaining tokens for flags/args. Pass the full token array unchanged.
+            return command.Execute(tokens) ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Capture a screenshot to <c>persistentDataPath/FUSE-test-shots/&lt;name&gt;.png</c> and return the
+        /// absolute path. Unity writes the PNG asynchronously (ready on a later frame), so the test bridge
+        /// host waits for the file to exist before reporting completion. ScreenCapture is resolved by
+        /// reflection so FUSE keeps no compile-time dependency on the screen-capture module.
+        /// </summary>
+        public static string CaptureScreenshot(string name)
+        {
+            var dir = Path.Combine(Application.persistentDataPath, "FUSE-test-shots");
+            Directory.CreateDirectory(dir);
+
+            var stem = SanitizeStem(name);
+            var absolutePath = Path.Combine(dir, stem + ".png");
+
+            var screenCapture = Type.GetType("UnityEngine.ScreenCapture, UnityEngine.ScreenCaptureModule")
+                ?? Type.GetType("UnityEngine.ScreenCapture, UnityEngine.CoreModule");
+            var capture = screenCapture?.GetMethod("CaptureScreenshot", new[] { typeof(string) });
+            if (capture == null)
+            {
+                throw new InvalidOperationException("UnityEngine.ScreenCapture.CaptureScreenshot(string) could not be resolved.");
+            }
+
+            // Pass an ABSOLUTE path: Unity resolves a *relative* screenshot path against the
+            // executable's working directory (the game root), not persistentDataPath, so a
+            // relative path lands somewhere the host isn't watching (or fails to create the subdir).
+            capture.Invoke(null, new object[] { absolutePath });
+            return absolutePath;
+        }
+
+        /// <summary>
+        /// Run one of FUSE's dump console commands (<c>graph</c>, <c>runtimegraph</c>, <c>mandelas</c>,
+        /// <c>progression</c>), returning its summary text and the absolute path of the JSON file it wrote.
+        /// </summary>
+        public static string Dump(string which, out string artifactPath)
+        {
+            artifactPath = null;
+            if (string.IsNullOrWhiteSpace(which) || !DumpTargets.TryGetValue(which.Trim(), out var target))
+            {
+                return $"FUSE test bridge: unknown dump '{which}'. Known: {string.Join(", ", DumpTargets.Keys)}.";
+            }
+
+            var summary = RunConsoleCommand(target.Command);
+            artifactPath = Path.Combine(FuseConsoleCommands.GetRailroaderRootFolder(), target.File);
+            return summary;
+        }
+
+        /// <summary>
+        /// Load a save into the running session by name. This is the in-session loader — it swaps
+        /// the current world for another save on the same map; it does NOT boot from the main menu.
+        /// Host-only and requires a session already loaded. The actual load proceeds over subsequent
+        /// frames; poll <see cref="IsMapLoaded"/>/the load report for completion.
+        /// </summary>
+        public static string LoadSave(string saveName)
+        {
+            if (string.IsNullOrWhiteSpace(saveName))
+            {
+                return "FUSE test bridge: loadSave needs a save name.";
+            }
+
+            var name = saveName.Trim();
+
+            // In a running session: swap to another save on the same map (host-only).
+            if (IsMapLoaded())
+            {
+                if (StateManager.Shared == null)
+                {
+                    return "FUSE test bridge: no active session state.";
+                }
+
+                if (!StateManager.IsHost)
+                {
+                    return "FUSE test bridge: loadSave is host-only.";
+                }
+
+                StateManager.Shared.SaveManager.Load(name);
+                return $"Loading save '{name}' into the running session.";
+            }
+
+            // At the main menu: cold-boot the save exactly as the Load Game menu does.
+            return ColdBootSave(name);
+        }
+
+        // Drives the same entry point the Load Game menu uses:
+        // MenuManager.StartGameSinglePlayer(new GameSetup(saveName)). The method is private,
+        // so it is reflected by name (canaried in RailroaderReflectionSurfaceTests); the load
+        // proceeds asynchronously — poll IsMapLoaded()/the load report for completion.
+        private static string ColdBootSave(string name)
+        {
+            var menu = UnityEngine.Object.FindObjectOfType<UI.Menu.MenuManager>();
+            if (menu == null)
+            {
+                return "FUSE test bridge: not in a session and the main menu (MenuManager) is not present — " +
+                       "wait for the main menu, then retry.";
+            }
+
+            var start = typeof(UI.Menu.MenuManager).GetMethod(
+                "StartGameSinglePlayer",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                types: StartGameSinglePlayerParams,
+                modifiers: null);
+            if (start == null)
+            {
+                return "FUSE test bridge: UI.Menu.MenuManager.StartGameSinglePlayer(GameSetup) not found (game changed).";
+            }
+
+            start.Invoke(menu, new object[] { new GameSetup(name) });
+            return $"Booting save '{name}' from the main menu.";
+        }
+
+        /// <summary>List the available save names on disk (newest first).</summary>
+        public static string ListSaves()
+        {
+            var infos = WorldStore.FindSaveInfos();
+            return infos == null || infos.Count == 0
+                ? "(no saves found)"
+                : string.Join(Environment.NewLine, infos.Select(info => info.Name));
+        }
+
+        /// <summary>Save the running session to a named save (host-only). Lets a test snapshot a known state for reuse.</summary>
+        public static string SaveGame(string saveName)
+        {
+            if (string.IsNullOrWhiteSpace(saveName))
+            {
+                return "FUSE test bridge: save needs a name.";
+            }
+
+            if (!IsMapLoaded() || StateManager.Shared == null)
+            {
+                return "FUSE test bridge: save requires a running session.";
+            }
+
+            if (!StateManager.IsHost)
+            {
+                return "FUSE test bridge: save is host-only.";
+            }
+
+            var name = saveName.Trim();
+            StateManager.Shared.SaveManager.Save(name);
+            return $"Saved session as '{name}'.";
+        }
+
+        /// <summary>Open or close the Unity Mod Manager overlay window so it doesn't block screenshots.</summary>
+        public static string SetUmmWindow(bool open)
+        {
+            // Reflected, not referenced: UMM's UI derives from MonoBehaviour in the monolithic
+            // UnityEngine assembly, which FUSE does not reference (it uses the split modules), so a
+            // direct compile-time call won't resolve. Reflection sidesteps that and stays graceful.
+            var uiType = AppDomain.CurrentDomain.GetAssemblies()
+                .Select(assembly => assembly.GetType("UnityModManagerNet.UnityModManager+UI", throwOnError: false))
+                .FirstOrDefault(type => type != null);
+            var instance = uiType?.GetProperty("Instance", BindingFlags.Static | BindingFlags.Public)?.GetValue(null);
+            if (instance == null)
+            {
+                return "FUSE test bridge: UMM UI instance not available.";
+            }
+
+            var toggle = uiType.GetMethod("ToggleWindow", new[] { typeof(bool) });
+            if (toggle == null)
+            {
+                return "FUSE test bridge: UMM UI.ToggleWindow(bool) not found.";
+            }
+
+            toggle.Invoke(instance, new object[] { open });
+            return open ? "UMM window opened." : "UMM window closed.";
+        }
+
+        /// <summary>
+        /// Start a fresh sandbox game from the main menu, first deleting prior harness test saves
+        /// (only those named with the reserved <c>fuse-test-</c> prefix — never the user's real saves).
+        /// Requires the main menu (MenuManager); the new session's save name carries the test prefix.
+        /// </summary>
+        public static string NewGame(string name)
+        {
+            var saveName = NormalizeTestSaveName(name);
+            var removed = CleanupTestSaves(saveName);
+
+            var menu = UnityEngine.Object.FindObjectOfType<UI.Menu.MenuManager>();
+            if (menu == null)
+            {
+                return "FUSE test bridge: newGame requires the main menu (quit to the menu first).";
+            }
+
+            var start = typeof(UI.Menu.MenuManager).GetMethod(
+                "StartGameSinglePlayer",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                types: StartGameSinglePlayerParams,
+                modifiers: null);
+            if (start == null)
+            {
+                return "FUSE test bridge: UI.Menu.MenuManager.StartGameSinglePlayer(GameSetup) not found (game changed).";
+            }
+
+            var setup = new GameSetup(saveName, new NewGameSetup("FUSE Test", "FUSE", GameMode.Sandbox, null, null));
+            start.Invoke(menu, new object[] { setup });
+            return $"Starting fresh sandbox game '{saveName}' (removed {removed} old test save(s)).";
+        }
+
+        /// <summary>Delete harness test saves (names starting with the reserved <c>fuse-test-</c> prefix). Never touches other saves.</summary>
+        public static string Cleanup()
+        {
+            var removed = CleanupTestSaves(null);
+            return $"Removed {removed} test save(s).";
+        }
+
+        private static int CleanupTestSaves(string keepName)
+        {
+            var infos = WorldStore.FindSaveInfos();
+            if (infos == null)
+            {
+                return 0;
+            }
+
+            var removed = 0;
+            foreach (var info in infos)
+            {
+                var saveName = info.Name;
+                if (string.IsNullOrEmpty(saveName)
+                    || !saveName.StartsWith(TestSavePrefix, StringComparison.Ordinal)
+                    || string.Equals(saveName, keepName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    WorldStore.Clear(saveName);
+                    removed++;
+                }
+                catch
+                {
+                    // skip a save we couldn't delete
+                }
+            }
+
+            return removed;
+        }
+
+        private static string NormalizeTestSaveName(string name)
+        {
+            var trimmed = string.IsNullOrWhiteSpace(name) ? "clean" : name.Trim();
+            return trimmed.StartsWith(TestSavePrefix, StringComparison.Ordinal)
+                ? trimmed
+                : TestSavePrefix + trimmed;
+        }
+
+        private static string SanitizeStem(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return "shot";
+            }
+
+            var stem = name.Trim();
+            foreach (var invalid in Path.GetInvalidFileNameChars())
+            {
+                stem = stem.Replace(invalid, '_');
+            }
+
+            return stem.Length == 0 ? "shot" : stem;
+        }
+
+        private static Dictionary<string, IConsoleCommand> Commands()
+        {
+            if (_commandsByName != null)
+            {
+                return _commandsByName;
+            }
+
+            var map = new Dictionary<string, IConsoleCommand>(StringComparer.OrdinalIgnoreCase);
+            foreach (var command in FuseConsoleCommands.CreateAll())
+            {
+                var name = Normalize(GetCommandName(command));
+                if (!string.IsNullOrEmpty(name))
+                {
+                    map[name] = command;
+                }
+            }
+
+            _commandsByName = map;
+            return _commandsByName;
+        }
+
+        // Read the [ConsoleCommand("/fuse.xxx", ...)] verb off each command via attribute
+        // data so we don't depend on the game attribute's property names.
+        private static string GetCommandName(IConsoleCommand command)
+        {
+            foreach (var data in CustomAttributeData.GetCustomAttributes(command.GetType()))
+            {
+                if (data.AttributeType.FullName == "UI.Console.ConsoleCommandAttribute"
+                    && data.ConstructorArguments.Count > 0)
+                {
+                    return data.ConstructorArguments[0].Value as string;
+                }
+            }
+
+            return null;
+        }
+
+        private static string Normalize(string name) => name?.TrimStart('/').Trim();
+    }
+}

--- a/tests/live/fixtures/README.md
+++ b/tests/live/fixtures/README.md
@@ -9,7 +9,7 @@ in CI.)
 
 ## Layout
 
-```
+```text
 tests/live/fixtures/<id>/
   fixture.json            # the manifest (see example/)
   packages/               # optional: the *.FUSE package stack this fixture expects (provision into Mods/)
@@ -30,6 +30,7 @@ diffs the live capture against it and fails on any delta, pointing at the exact 
 | `id` | Fixture identifier (matches the folder name). |
 | `gameVersion` | Expected `Application.version`; a mismatch **skips** (baselines are version-pinned). |
 | `saveName` | Save to load into the running session before capturing (empty = use the loaded session). |
+| `multiplayerRole` | Expected role; informational/reserved. Runs assume single-player host (the harness requires `canApply`). |
 | `reason` | Reason passed to reload (kept fixed so it does not perturb the report). |
 | `captureReport` | Capture + diff `/fuse.report json`. |
 | `dumps` | Dump captures to diff: any of `graph`, `runtimegraph`, `mandelas`, `progression`. |

--- a/tests/live/fixtures/README.md
+++ b/tests/live/fixtures/README.md
@@ -1,0 +1,50 @@
+# Live-harness fixtures
+
+Each fixture is a folder describing a repeatable golden-master check against a **live**
+Railroader session, driven by `FUSE.TestCli run-fixture <id>` (which uses
+`FUSE.LiveHarness`). The live run is a **local dev gate** — it needs a licensed game
+install, the fixture's save, and the `FUSE.TestBridge` mod enabled. It is *not* a CI
+gate. (The harness's own normalize/diff logic **is** covered by `FUSE.LiveHarness.Tests`
+in CI.)
+
+## Layout
+
+```
+tests/live/fixtures/<id>/
+  fixture.json            # the manifest (see example/)
+  packages/               # optional: the *.FUSE package stack this fixture expects (provision into Mods/)
+  save/<name>.shortsave   # optional: the known save (or document where to get it)
+  baselines/              # generated golden-master JSON (committed, reviewed like code)
+    report.json
+    runtimegraph.json
+    mandelas.json
+```
+
+`baselines/` is written by the first `--update` run and then committed. A normal run
+diffs the live capture against it and fails on any delta, pointing at the exact JSON path.
+
+## fixture.json
+
+| Field | Meaning |
+|---|---|
+| `id` | Fixture identifier (matches the folder name). |
+| `gameVersion` | Expected `Application.version`; a mismatch **skips** (baselines are version-pinned). |
+| `saveName` | Save to load into the running session before capturing (empty = use the loaded session). |
+| `reason` | Reason passed to reload (kept fixed so it does not perturb the report). |
+| `captureReport` | Capture + diff `/fuse.report json`. |
+| `dumps` | Dump captures to diff: any of `graph`, `runtimegraph`, `mandelas`, `progression`. |
+
+## Running
+
+```powershell
+$env:FUSE_GAME_MODS = "F:\SteamLibrary\steamapps\common\Railroader\Mods"
+# 1. Launch the game with FUSE.TestBridge enabled and get into any session (host).
+# 2. First time — capture baselines, then review/commit them:
+dotnet run --project FUSE.TestCli -- run-fixture <id> --update
+# 3. Thereafter — diff against the committed baselines (non-zero exit on drift):
+dotnet run --project FUSE.TestCli -- run-fixture <id>
+```
+
+Captured JSON is normalized before comparison (volatile timestamps/ids stripped, floats
+rounded, object keys and arrays sorted) so only meaningful drift surfaces. See
+`FUSE.LiveHarness/Json/JsonNormalizer.cs`.

--- a/tests/live/fixtures/example/fixture.json
+++ b/tests/live/fixtures/example/fixture.json
@@ -1,0 +1,10 @@
+{
+  "id": "example",
+  "description": "Template fixture. Create the clean save once with 'fuse-test newgame clean' + 'fuse-test save fuse-test-clean', then capture baselines with: fuse-test run-fixture example --update. Copy this folder for new fixtures.",
+  "gameVersion": "2025.1.0",
+  "saveName": "fuse-test-clean",
+  "multiplayerRole": "host",
+  "reason": "fixture run",
+  "captureReport": true,
+  "dumps": ["runtimegraph", "mandelas"]
+}


### PR DESCRIPTION
## 🔗 Related Issue

Relates to #16 (in-game golden-master / live test harness).

## 📝 Description of the Change

Today FUSE can only be tested against a live game by hand: launch Railroader, load a save, type `/fuse.*` console commands, and eyeball the results. The fast automated suites (`FUSE.Tests` xUnit, `FUSE.UnityTests` EditMode) deliberately can't drive a real map load or a real shipped scene. This PR adds a **dev-only bridge** that lets an external driver (a shell, CI, or an AI agent) drive a live session end to end.

**Architecture** — a thin RPC over a file channel, reusing the same `Fuse.Core.Bridge` atomic-JSON protocol the external editor's live-reload bridge already uses:

- **`FUSE/Testing/FuseTestApi.cs`** — a public facade inside the FUSE assembly. FUSE's reload/report/console surface is `internal`, so a separate mod can't call it; this facade re-exposes exactly the test verbs (mirroring the existing `FuseLiveReloadApi` pattern). It also adds save/load (cold-boot from the main menu **and** in-session swap), fresh-sandbox new game, screenshots, and the Unity Mod Manager overlay toggle. Game internals are reached through reverse-engineered reflection / public game APIs, as the rest of FUSE does.
- **`FUSE.TestBridge/`** — an optional, dev-only UMM mod. A `DontDestroyOnLoad` MonoBehaviour watches its own folder for `test_request_<id>.json` files and executes each on the Unity main thread (the only place game/Unity calls are legal), writing a correlated `test_result_<id>.json` plus a ~1s heartbeat. Per-request files mean a slow or aborted request never clobbers the next.
- **`FUSE.TestCli/`** — a net10 shell driver: one verb per command, results to stdout.
- **`FUSE.LiveHarness/` (+ `FUSE.LiveHarness.Tests/`)** — a net10 library with the bridge client, a settle-aware readiness wait, a JSON normalizer + differ, and a fixture runner for golden-master regression. The normalize/diff logic is unit-tested.
- **`FUSE.Core/Bridge`** — extended with per-request `TestRequest`/`TestResult` DTOs and path helpers, shared verbatim between the net48 game and the net10 driver.
- **`tests/live/fixtures/`** — fixture layout + example manifest.

The bridge is **triple-gated** so it can never affect a player: not deployed by a normal build (`EnableTestBridgeDeploy` defaults false), `Info.json` ships `Enabled: false`, and the host refuses to spawn unless `FUSE_TEST_BRIDGE=1` (or `Info.json "Enabled": true`).

## 🔄 Alternatives Considered

- **An MCP server** was the original framing. Dropped: an agent already has a shell, so a separate MCP process is unnecessary ceremony, and the in-game work is identical either way. A thin CLI over the file channel is simpler; an MCP wrapper can be added later over the same bridge.
- **Off-the-shelf Unity MCP / Editor automation** — these drive the Unity *Editor* with a project open; Railroader is a shipped build, so they don't apply.
- **In-session-only save loading** — the first cut only swapped saves in a running session; added menu cold-boot and fresh-sandbox new game so the loop is fully unattended.
- **A single request/result file** — clobbered when a slow command timed out and the next overwrote it; switched to per-request files.
- **Localhost HTTP transport** — deferred; the file channel covers every verb. Worth adding only if the interactive loop feels sluggish.

## ⚠️ Possible Drawbacks

- Dev-only tooling; never ships to players (triple-gated, not in the mod zip). Changes no gameplay or save behavior.
- The live run is a **local dev gate**, not CI (needs a licensed install, assets, and the bridge enabled). The harness's own normalize/diff logic *is* CI-tested.
- On a very large mod stack, `reload` can take minutes (it re-reads + re-applies every package); the CLI exposes `--timeout` and the fixture runner uses a generous default.
- **Save compatibility:** unaffected. The harness uses the game's own save APIs and only ever deletes its own `fuse-test-`-prefixed saves.

## ✅ Verification Process

- **Builds:** full solution builds clean (0 errors); new code adds no analyzer warnings.
- **Unit tests:** `FUSE.LiveHarness.Tests` 10/10 (normalizer + differ, CI-able); existing `FUSE.Tests` 1170/1170 still pass.
- **Reflection canary:** added a `RailroaderReflectionSurfaceTests` entry for the one game member reached by name (`MenuManager.StartGameSinglePlayer`).
- **Live, against a real session** (Railroader 2025.1.0, 200+ mods): deployed the bridge and drove the full loop from a shell — `newgame` → settle-aware `ready` → `report json` returned in **0.29s as the first post-ready command** (the case that previously timed out) → `reload` (applied 158) → `dump runtimegraph` (9005 nodes) → `save` / `umm close` / `screenshot` (verified the captured PNG). A fresh sandbox reported `faults 0 | conflicts 0 | orphans 0`.
- **Cleanup safety:** confirmed `newgame`/`cleanup` removed only the `fuse-test-`-prefixed save and left real saves (`mod testing`, `Hickory & Western Railway`, `SANDBOX`) intact.

## 💡 Additional Information

- Harness-created saves use a reserved `fuse-test-` prefix; deletion is hard-gated to that prefix. Typical loop: `newgame clean` → `ready` → `save fuse-test-clean`, then reset with `load fuse-test-clean` or a fresh `newgame`.
- See `FUSE.TestBridge/README.md` for enable + usage and `tests/live/fixtures/README.md` for the golden-master flow.
