### PR TITLE
perf(scenery/map-load): batch-load throttle + cut redundant map-load work (#76 follow-up)

### DIFF
--- a/FUSE.Tests/Infrastructure/FuseTerrainRefreshScopeTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseTerrainRefreshScopeTests.cs
@@ -1,0 +1,104 @@
+using FUSE.Infrastructure;
+using UnityEngine;
+using Xunit;
+
+namespace FUSE.Tests.Infrastructure
+{
+    /// <summary>
+    /// Tests for the map-load terrain-refresh coordinator: the scope that lets the
+    /// single trailing terrain rebuild absorb per-object mask refreshes (#3) and
+    /// accumulates the footprint FUSE touched for optional targeted invalidation (#4).
+    /// The depth/reset/union semantics are what the lifecycle and MapAPI rely on, so a
+    /// regression here would either leak deferral state across loads or mis-scope the
+    /// targeted rebuild. Each test fully opens and closes the scope so the shared
+    /// static state can't bleed between cases.
+    /// </summary>
+    public class FuseTerrainRefreshScopeTests
+    {
+        [Fact]
+        public void Begin_OpensDeferral_DisposeCloses()
+        {
+            Assert.False(FuseTerrainRefreshScope.IsDeferringMaskRefresh);
+
+            var token = FuseTerrainRefreshScope.Begin();
+            Assert.True(FuseTerrainRefreshScope.IsDeferringMaskRefresh);
+
+            token.Dispose();
+            Assert.False(FuseTerrainRefreshScope.IsDeferringMaskRefresh);
+        }
+
+        [Fact]
+        public void NestedScopes_StayOpenUntilOutermostCloses()
+        {
+            var outer = FuseTerrainRefreshScope.Begin();
+            var inner = FuseTerrainRefreshScope.Begin();
+            Assert.True(FuseTerrainRefreshScope.IsDeferringMaskRefresh);
+
+            inner.Dispose();
+            Assert.True(FuseTerrainRefreshScope.IsDeferringMaskRefresh); // still open: outer holds it
+
+            outer.Dispose();
+            Assert.False(FuseTerrainRefreshScope.IsDeferringMaskRefresh);
+        }
+
+        [Fact]
+        public void Dispose_IsIdempotent()
+        {
+            var token = FuseTerrainRefreshScope.Begin();
+            token.Dispose();
+            token.Dispose(); // must not double-decrement into a negative/leaked depth
+            Assert.False(FuseTerrainRefreshScope.IsDeferringMaskRefresh);
+
+            // A fresh scope still opens cleanly after a double-dispose.
+            var next = FuseTerrainRefreshScope.Begin();
+            Assert.True(FuseTerrainRefreshScope.IsDeferringMaskRefresh);
+            next.Dispose();
+            Assert.False(FuseTerrainRefreshScope.IsDeferringMaskRefresh);
+        }
+
+        [Fact]
+        public void NoteDeferredRefresh_AccumulatesCallsAndComponents()
+        {
+            var token = FuseTerrainRefreshScope.Begin();
+            FuseTerrainRefreshScope.NoteDeferredRefresh(0);
+            FuseTerrainRefreshScope.NoteDeferredRefresh(3);
+
+            Assert.Equal(2, FuseTerrainRefreshScope.DeferredRefreshCalls);
+            Assert.Equal(3, FuseTerrainRefreshScope.DeferredMaskComponents);
+            token.Dispose();
+        }
+
+        [Fact]
+        public void Begin_Outermost_ResetsCountersAndBounds()
+        {
+            var first = FuseTerrainRefreshScope.Begin();
+            FuseTerrainRefreshScope.NoteDeferredRefresh(5);
+            FuseTerrainRefreshScope.RecordBounds(new Bounds(new Vector3(10f, 0f, 10f), Vector3.one));
+            first.Dispose();
+
+            // A brand-new outermost scope starts clean.
+            var second = FuseTerrainRefreshScope.Begin();
+            Assert.Equal(0, FuseTerrainRefreshScope.DeferredRefreshCalls);
+            Assert.Equal(0, FuseTerrainRefreshScope.DeferredMaskComponents);
+            Assert.False(FuseTerrainRefreshScope.TryGetAccumulatedBounds(out _));
+            second.Dispose();
+        }
+
+        [Fact]
+        public void RecordBounds_UnionsFootprints()
+        {
+            var token = FuseTerrainRefreshScope.Begin();
+
+            Assert.False(FuseTerrainRefreshScope.TryGetAccumulatedBounds(out _));
+
+            FuseTerrainRefreshScope.RecordBounds(new Bounds(new Vector3(0f, 0f, 0f), new Vector3(2f, 2f, 2f)));
+            FuseTerrainRefreshScope.RecordBounds(new Bounds(new Vector3(100f, 0f, 0f), new Vector3(2f, 2f, 2f)));
+
+            Assert.True(FuseTerrainRefreshScope.TryGetAccumulatedBounds(out var union));
+            // Union must span both footprints on X (1 .. 101).
+            Assert.True(union.min.x <= -1f + 0.001f);
+            Assert.True(union.max.x >= 101f - 0.001f);
+            token.Dispose();
+        }
+    }
+}

--- a/FUSE.Tests/Infrastructure/FuseTerrainRefreshScopeTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseTerrainRefreshScopeTests.cs
@@ -100,5 +100,45 @@ namespace FUSE.Tests.Infrastructure
             Assert.True(union.max.x >= 101f - 0.001f);
             token.Dispose();
         }
+
+        [Fact]
+        public void BoundsComplete_TrueOnlyWithBoundsAndNoIncompleteFlag()
+        {
+            var token = FuseTerrainRefreshScope.Begin();
+            Assert.False(FuseTerrainRefreshScope.BoundsComplete); // nothing recorded yet
+
+            FuseTerrainRefreshScope.RecordBounds(new Bounds(Vector3.zero, Vector3.one));
+            Assert.True(FuseTerrainRefreshScope.BoundsComplete); // bounds present, not flagged
+            token.Dispose();
+        }
+
+        [Fact]
+        public void MarkBoundsIncomplete_ForcesIncomplete_EvenWhenSomeBoundsRecorded()
+        {
+            var token = FuseTerrainRefreshScope.Begin();
+            FuseTerrainRefreshScope.RecordBounds(new Bounds(Vector3.zero, Vector3.one));
+            FuseTerrainRefreshScope.MarkBoundsIncomplete();
+
+            // The footprint is still readable, but it's known-incomplete, so targeted
+            // invalidation must NOT trust it (the reload falls back to a full rebuild).
+            Assert.True(FuseTerrainRefreshScope.TryGetAccumulatedBounds(out _));
+            Assert.False(FuseTerrainRefreshScope.BoundsComplete);
+            token.Dispose();
+        }
+
+        [Fact]
+        public void Begin_Outermost_ResetsIncompleteFlag()
+        {
+            var first = FuseTerrainRefreshScope.Begin();
+            FuseTerrainRefreshScope.RecordBounds(new Bounds(Vector3.zero, Vector3.one));
+            FuseTerrainRefreshScope.MarkBoundsIncomplete();
+            Assert.False(FuseTerrainRefreshScope.BoundsComplete);
+            first.Dispose();
+
+            var second = FuseTerrainRefreshScope.Begin();
+            FuseTerrainRefreshScope.RecordBounds(new Bounds(Vector3.zero, Vector3.one));
+            Assert.True(FuseTerrainRefreshScope.BoundsComplete); // incomplete flag cleared on a fresh scope
+            second.Dispose();
+        }
     }
 }

--- a/FUSE.Tests/Patches/FuseSceneryLoadBudgetTests.cs
+++ b/FUSE.Tests/Patches/FuseSceneryLoadBudgetTests.cs
@@ -1,0 +1,106 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    /// <summary>
+    /// Deterministic tests for the issue #76 scenery load-throttle budget — the pure,
+    /// Unity-free core of <see cref="FuseSceneryLoadThrottlePatch"/>. The throttle caps
+    /// how many FUSE scenery loads START per frame so the teleport-in Instantiate burst
+    /// can't drop the frame rate to ~1&#160;fps; these guard the per-frame ceiling and
+    /// the frame-reset semantics the prefix and the pump both depend on (an off-by-one
+    /// or a missed reset would either stall loading or defeat the throttle).
+    /// </summary>
+    public class FuseSceneryLoadBudgetTests
+    {
+        [Fact]
+        public void TryConsume_AllowsUpToTheCeiling_ThenDefers()
+        {
+            var budget = new FuseSceneryLoadBudget(3);
+            budget.BeginFrame(1);
+
+            Assert.True(budget.TryConsume());
+            Assert.True(budget.TryConsume());
+            Assert.True(budget.TryConsume());
+            Assert.False(budget.TryConsume()); // 4th in the same frame is deferred.
+            Assert.Equal(0, budget.Remaining);
+            Assert.Equal(3, budget.StartedThisFrame);
+        }
+
+        [Fact]
+        public void BeginFrame_ResetsTheCounterOnANewFrame()
+        {
+            var budget = new FuseSceneryLoadBudget(2);
+            budget.BeginFrame(10);
+            Assert.True(budget.TryConsume());
+            Assert.True(budget.TryConsume());
+            Assert.False(budget.TryConsume());
+
+            budget.BeginFrame(11); // next frame: full budget again.
+            Assert.Equal(2, budget.Remaining);
+            Assert.True(budget.TryConsume());
+            Assert.True(budget.TryConsume());
+            Assert.False(budget.TryConsume());
+        }
+
+        [Fact]
+        public void BeginFrame_SameFrameDoesNotReset()
+        {
+            // The prefix and the pump both call BeginFrame within one frame; the second
+            // call must not refill the budget or the per-frame cap is meaningless.
+            var budget = new FuseSceneryLoadBudget(2);
+            budget.BeginFrame(5);
+            Assert.True(budget.TryConsume());
+
+            budget.BeginFrame(5); // same frame again.
+            Assert.Equal(1, budget.StartedThisFrame);
+            Assert.True(budget.TryConsume());
+            Assert.False(budget.TryConsume());
+        }
+
+        [Fact]
+        public void Remaining_NeverGoesNegative()
+        {
+            var budget = new FuseSceneryLoadBudget(1);
+            budget.BeginFrame(0);
+            Assert.True(budget.TryConsume());
+            Assert.False(budget.TryConsume());
+            Assert.Equal(0, budget.Remaining);
+        }
+
+        [Fact]
+        public void Constructor_ClampsCeilingToAtLeastOne()
+        {
+            // A zero/negative ceiling would stall scenery loading entirely; clamp it so
+            // a misconfigured tunable degrades to "load one per frame", not "never".
+            var budget = new FuseSceneryLoadBudget(0);
+            Assert.Equal(1, budget.MaxPerFrame);
+            budget.BeginFrame(1);
+            Assert.True(budget.TryConsume());
+            Assert.False(budget.TryConsume());
+        }
+
+        [Fact]
+        public void Reset_ClearsFrameStateSoTheNextBeginFrameStartsFresh()
+        {
+            var budget = new FuseSceneryLoadBudget(2);
+            budget.BeginFrame(7);
+            Assert.True(budget.TryConsume());
+
+            budget.Reset();
+            budget.BeginFrame(7); // same frame index, but state was cleared.
+            Assert.Equal(0, budget.StartedThisFrame);
+            Assert.Equal(2, budget.Remaining);
+        }
+
+        [Theory]
+        [InlineData(0, 8, true)]
+        [InlineData(7, 8, true)]
+        [InlineData(8, 8, false)]
+        [InlineData(9, 8, false)]
+        public void ShouldStartLoadNow_MatchesTheCeilingComparison(int startedThisFrame, int maxPerFrame, bool expected)
+        {
+            Assert.Equal(expected, FuseSceneryLoadThrottlePatch.ShouldStartLoadNow(startedThisFrame, maxPerFrame));
+        }
+    }
+}

--- a/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
@@ -251,6 +251,26 @@ namespace FUSE.UnityTests
         }
 
         [Test]
+        public void MapManager_InvalidateBounds_InstanceMethod()
+        {
+            // FuseRuntimeReloadService's opt-in targeted terrain invalidation
+            // (EnableTargetedTerrainInvalidation) invokes the private
+            // Invalidate(Bounds) overload to re-bake only the tiles FUSE
+            // touched instead of a full RebuildAll. A rename detaches the
+            // fast path and it silently falls back to the full rebuild — this
+            // canary surfaces that so the fast path can be re-bound.
+            var type = RequireType("Map.Runtime.MapManager");
+            var method = type.GetMethod(
+                "Invalidate",
+                InstanceNonPublic,
+                null,
+                new[] { typeof(UnityEngine.Bounds) },
+                null);
+            Assert.NotNull(method,
+                "Map.Runtime.MapManager.Invalidate(Bounds) not found — targeted terrain invalidation will always fall back to the full rebuild.");
+        }
+
+        [Test]
         public void MapManager_Instance_StaticPublicProperty()
         {
             AssertProperty("Map.Runtime.MapManager", "Instance", BindingFlags.Static | BindingFlags.Public);

--- a/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
@@ -574,7 +574,9 @@ namespace FUSE.UnityTests
         // -----------------------------------------------------------------
         // SceneryAssetInstance — FuseSceneryBenchmark reads _wantsLoaded and
         // _model to count in-flight scenery loads (settle detection); the
-        // scenery-animation patch also reflects _model. Issue #76 tooling.
+        // scenery-animation patch also reflects _model. The load throttle
+        // (FuseSceneryLoadThrottlePatch) reads _wantsLoaded and re-drives the
+        // private SetLoaded(bool) from its pump. Issue #76 tooling.
         // -----------------------------------------------------------------
 
         [Test]
@@ -587,6 +589,15 @@ namespace FUSE.UnityTests
         public void SceneryAssetInstance_model_InstanceField()
         {
             AssertField("Helpers.SceneryAssetInstance", "_model", InstanceNonPublic);
+        }
+
+        [Test]
+        public void SceneryAssetInstance_SetLoaded_InstanceMethod()
+        {
+            // FuseSceneryLoadThrottlePatch both Harmony-patches and reflectively
+            // re-invokes this private method to release deferred loads from its
+            // pump; a rename detaches the patch AND breaks the pump's re-drive.
+            AssertMethod("Helpers.SceneryAssetInstance", "SetLoaded", InstanceNonPublic);
         }
 
         // -----------------------------------------------------------------

--- a/FUSE/FusePlugin.cs
+++ b/FUSE/FusePlugin.cs
@@ -215,6 +215,7 @@ namespace FUSE
                 _lifecycle = null;
             }
 
+            FuseSceneryLoadThrottlePatch.Shutdown();
             FuseLegacyAssemblyHost.Shutdown();
             FuseLegacySupportAssemblyShim.Shutdown();
             FuseRuntimeRebindService.Shutdown();

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -13,6 +13,7 @@ namespace FUSE.Infrastructure
         public const bool DefaultMirrorAssetPacksToLocalLow = false;
         public const bool DefaultVerboseApplyReportDetails = false;
         public const bool DefaultEnableSceneryCullingDiagnostics = false;
+        public const bool DefaultEnableTargetedTerrainInvalidation = false;
         public const bool DefaultBlockNonHostMultiplayerClientWorldApply = false;
         public const bool DefaultShowAdvancedHealthDetails = false;
         public const bool DefaultShowTrackDebugOverlay = false;
@@ -43,6 +44,13 @@ namespace FUSE.Infrastructure
         public static bool VerboseApplyReportDetails { get; private set; } = DefaultVerboseApplyReportDetails;
 
         public static bool EnableSceneryCullingDiagnostics { get; private set; } = DefaultEnableSceneryCullingDiagnostics;
+
+        // Experimental (issue #76 follow-up): when on, the post-apply terrain rebuild
+        // is narrowed to the tiles FUSE actually touched (MapManager.Invalidate) instead
+        // of a full MapManager.RebuildAll teardown+reload. Big load-time win but timing-
+        // sensitive (masks load async); default OFF until validated in-game. Falls back
+        // to the full rebuild whenever no footprint was captured.
+        public static bool EnableTargetedTerrainInvalidation { get; private set; } = DefaultEnableTargetedTerrainInvalidation;
 
         public static bool BlockNonHostMultiplayerClientWorldApply { get; private set; } =
             DefaultBlockNonHostMultiplayerClientWorldApply;
@@ -78,6 +86,7 @@ namespace FUSE.Infrastructure
             MirrorAssetPacksToLocalLow = DefaultMirrorAssetPacksToLocalLow;
             VerboseApplyReportDetails = DefaultVerboseApplyReportDetails;
             EnableSceneryCullingDiagnostics = DefaultEnableSceneryCullingDiagnostics;
+            EnableTargetedTerrainInvalidation = DefaultEnableTargetedTerrainInvalidation;
             BlockNonHostMultiplayerClientWorldApply = DefaultBlockNonHostMultiplayerClientWorldApply;
             ShowAdvancedHealthDetails = DefaultShowAdvancedHealthDetails;
             ShowTrackDebugOverlay = DefaultShowTrackDebugOverlay;
@@ -114,6 +123,8 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, "VerboseApplyReportDetails", DefaultVerboseApplyReportDetails);
                 EnableSceneryCullingDiagnostics =
                     ReadBool(settings, "EnableSceneryCullingDiagnostics", DefaultEnableSceneryCullingDiagnostics);
+                EnableTargetedTerrainInvalidation =
+                    ReadBool(settings, "EnableTargetedTerrainInvalidation", DefaultEnableTargetedTerrainInvalidation);
                 BlockNonHostMultiplayerClientWorldApply =
                     ReadBool(settings, "BlockNonHostMultiplayerClientWorldApply", DefaultBlockNonHostMultiplayerClientWorldApply);
                 ShowAdvancedHealthDetails =
@@ -150,6 +161,7 @@ namespace FUSE.Infrastructure
                     $"MirrorAssetPacksToLocalLow={MirrorAssetPacksToLocalLow} " +
                     $"VerboseApplyReportDetails={VerboseApplyReportDetails} " +
                     $"EnableSceneryCullingDiagnostics={EnableSceneryCullingDiagnostics} " +
+                    $"EnableTargetedTerrainInvalidation={EnableTargetedTerrainInvalidation} " +
                     $"BlockNonHostMultiplayerClientWorldApply={BlockNonHostMultiplayerClientWorldApply} " +
                     $"ShowAdvancedHealthDetails={ShowAdvancedHealthDetails} " +
                     $"ShowTrackDebugOverlay={ShowTrackDebugOverlay} " +
@@ -172,6 +184,7 @@ namespace FUSE.Infrastructure
                 MirrorAssetPacksToLocalLow = DefaultMirrorAssetPacksToLocalLow;
                 VerboseApplyReportDetails = DefaultVerboseApplyReportDetails;
                 EnableSceneryCullingDiagnostics = DefaultEnableSceneryCullingDiagnostics;
+                EnableTargetedTerrainInvalidation = DefaultEnableTargetedTerrainInvalidation;
                 BlockNonHostMultiplayerClientWorldApply = DefaultBlockNonHostMultiplayerClientWorldApply;
                 ShowAdvancedHealthDetails = DefaultShowAdvancedHealthDetails;
                 ShowTrackDebugOverlay = DefaultShowTrackDebugOverlay;
@@ -210,6 +223,15 @@ namespace FUSE.Infrastructure
         internal static void SetSceneryCullingDiagnosticsTransient(bool enabled)
         {
             EnableSceneryCullingDiagnostics = enabled;
+        }
+
+        public static void SetEnableTargetedTerrainInvalidation(bool enabled)
+        {
+            EnableTargetedTerrainInvalidation = enabled;
+            SaveUserOverride(nameof(EnableTargetedTerrainInvalidation), enabled);
+            FuseLog.Warning(
+                $"FUSE experimental setting changed: {nameof(EnableTargetedTerrainInvalidation)}={enabled}. " +
+                "Takes effect on the next map load / terrain reload.");
         }
 
         public static void SetBlockNonHostMultiplayerClientWorldApply(bool enabled)
@@ -349,6 +371,8 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, nameof(VerboseApplyReportDetails), VerboseApplyReportDetails);
                 EnableSceneryCullingDiagnostics =
                     ReadBool(settings, nameof(EnableSceneryCullingDiagnostics), EnableSceneryCullingDiagnostics);
+                EnableTargetedTerrainInvalidation =
+                    ReadBool(settings, nameof(EnableTargetedTerrainInvalidation), EnableTargetedTerrainInvalidation);
                 BlockNonHostMultiplayerClientWorldApply =
                     ReadBool(settings, nameof(BlockNonHostMultiplayerClientWorldApply), BlockNonHostMultiplayerClientWorldApply);
                 ShowAdvancedHealthDetails =

--- a/FUSE/Infrastructure/FuseTerrainRefreshScope.cs
+++ b/FUSE/Infrastructure/FuseTerrainRefreshScope.cs
@@ -1,0 +1,118 @@
+using System;
+using UnityEngine;
+
+namespace FUSE.Infrastructure
+{
+    /// <summary>
+    /// Coordinates map-mask refresh and terrain re-bake during a bulk apply that the
+    /// caller guarantees is followed by exactly one terrain rebuild
+    /// (<c>FuseRuntimeReloadService.ReloadTerrain</c> at the end of
+    /// <c>FuseLifecycle.OnMapDidLoad</c>).
+    ///
+    /// Two optimizations hang off an active scope:
+    ///  1. <b>Mask-refresh deferral (#3).</b> Per-object
+    ///     <c>MapAPI.RefreshAttachedMapMasks</c> calls made during the apply are
+    ///     skipped — the single trailing terrain rebuild re-evaluates every live mask
+    ///     component at once, so the per-object <c>GetComponentsInChildren</c> +
+    ///     modifier churn is redundant. (Outside a scope — e.g. a runtime
+    ///     single-object API call with no trailing rebuild — the per-object refresh
+    ///     still runs, so behavior there is unchanged.)
+    ///  2. <b>Bounds accumulation (#4, opt-in).</b> The world-space footprints touched
+    ///     during apply are unioned so the trailing rebuild can optionally be narrowed
+    ///     to just those tiles instead of tearing down and re-streaming the whole map.
+    ///
+    /// The scope is a simple main-thread depth counter (apply is single-threaded);
+    /// dispose the token returned by <see cref="Begin"/> in a finally to close it.
+    /// </summary>
+    internal static class FuseTerrainRefreshScope
+    {
+        private static int _depth;
+        private static int _deferredRefreshCalls;
+        private static int _deferredMaskComponents;
+        private static bool _haveBounds;
+        private static Bounds _bounds;
+
+        /// <summary>True while a bulk-apply scope is open (mask refresh is deferred).</summary>
+        internal static bool IsDeferringMaskRefresh => _depth > 0;
+
+        /// <summary>RefreshAttachedMapMasks calls deferred during the current/last scope.</summary>
+        internal static int DeferredRefreshCalls => _deferredRefreshCalls;
+
+        /// <summary>Mask components deferred during the current/last scope.</summary>
+        internal static int DeferredMaskComponents => _deferredMaskComponents;
+
+        /// <summary>
+        /// Opens a deferral scope. The outermost <see cref="Begin"/> resets the
+        /// deferral counters and accumulated bounds; nested calls just increase depth.
+        /// Always dispose the returned token (use a <c>using</c> / finally).
+        /// </summary>
+        internal static IDisposable Begin()
+        {
+            if (_depth == 0)
+            {
+                _deferredRefreshCalls = 0;
+                _deferredMaskComponents = 0;
+                _haveBounds = false;
+                _bounds = default(Bounds);
+            }
+
+            _depth++;
+            return new Token();
+        }
+
+        /// <summary>Records that a per-object mask refresh of <paramref name="maskComponentCount"/> components was deferred.</summary>
+        internal static void NoteDeferredRefresh(int maskComponentCount)
+        {
+            _deferredRefreshCalls++;
+            if (maskComponentCount > 0)
+            {
+                _deferredMaskComponents += maskComponentCount;
+            }
+        }
+
+        /// <summary>Unions <paramref name="worldBounds"/> into the accumulated footprint (#4).</summary>
+        internal static void RecordBounds(Bounds worldBounds)
+        {
+            if (_haveBounds)
+            {
+                _bounds.Encapsulate(worldBounds);
+            }
+            else
+            {
+                _bounds = worldBounds;
+                _haveBounds = true;
+            }
+        }
+
+        /// <summary>Returns the accumulated world-space footprint touched during apply, if any (#4).</summary>
+        internal static bool TryGetAccumulatedBounds(out Bounds worldBounds)
+        {
+            worldBounds = _bounds;
+            return _haveBounds;
+        }
+
+        private static void End()
+        {
+            if (_depth > 0)
+            {
+                _depth--;
+            }
+        }
+
+        private sealed class Token : IDisposable
+        {
+            private bool _disposed;
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                End();
+            }
+        }
+    }
+}

--- a/FUSE/Infrastructure/FuseTerrainRefreshScope.cs
+++ b/FUSE/Infrastructure/FuseTerrainRefreshScope.cs
@@ -30,6 +30,7 @@ namespace FUSE.Infrastructure
         private static int _deferredRefreshCalls;
         private static int _deferredMaskComponents;
         private static bool _haveBounds;
+        private static bool _boundsIncomplete;
         private static Bounds _bounds;
 
         /// <summary>True while a bulk-apply scope is open (mask refresh is deferred).</summary>
@@ -40,6 +41,15 @@ namespace FUSE.Infrastructure
 
         /// <summary>Mask components deferred during the current/last scope.</summary>
         internal static int DeferredMaskComponents => _deferredMaskComponents;
+
+        /// <summary>
+        /// True only when an accurate footprint was captured for <em>every</em> deferred
+        /// object — i.e. some bounds were recorded and nothing was flagged unbounded.
+        /// Targeted terrain invalidation may run only when this holds; otherwise the
+        /// trailing reload must do a full rebuild, since narrowing to a footprint that
+        /// doesn't actually cover a mask would leave dark, uncut terrain.
+        /// </summary>
+        internal static bool BoundsComplete => _haveBounds && !_boundsIncomplete;
 
         /// <summary>
         /// Opens a deferral scope. The outermost <see cref="Begin"/> resets the
@@ -53,6 +63,7 @@ namespace FUSE.Infrastructure
                 _deferredRefreshCalls = 0;
                 _deferredMaskComponents = 0;
                 _haveBounds = false;
+                _boundsIncomplete = false;
                 _bounds = default(Bounds);
             }
 
@@ -82,6 +93,16 @@ namespace FUSE.Infrastructure
                 _bounds = worldBounds;
                 _haveBounds = true;
             }
+        }
+
+        /// <summary>
+        /// Flags that a deferred object's footprint could not be measured accurately
+        /// (e.g. its model/masks haven't streamed in yet). Forces the trailing reload
+        /// back to a full rebuild — see <see cref="BoundsComplete"/>.
+        /// </summary>
+        internal static void MarkBoundsIncomplete()
+        {
+            _boundsIncomplete = true;
         }
 
         /// <summary>Returns the accumulated world-space footprint touched during apply, if any (#4).</summary>

--- a/FUSE/Interface/FuseHealthUi.AdvancedTab.cs
+++ b/FUSE/Interface/FuseHealthUi.AdvancedTab.cs
@@ -291,7 +291,7 @@ namespace FUSE.Interface
             AddWrappedField(
                 builder,
                 "Terrain Rebuild",
-                "EXPERIMENTAL. After applying packages, FUSE re-bakes terrain so placed map-masks cut in. Off = full MapManager.RebuildAll (re-streams the whole map; safe). On = invalidate only the tiles FUSE touched (much faster, but if a mask's footprint is missed you'll see dark uncut terrain patches). Validate on your maps before relying on it; check FUSE.log for 'terrain reload (targeted invalidation)'.",
+                "EXPERIMENTAL. After applying packages, FUSE re-bakes terrain so placed map-masks cut in. Off = full MapManager.RebuildAll (re-streams the whole map; safe). On = invalidate only the tiles FUSE touched, BUT only when their footprint can be measured accurately; if any mask can't be bounded (e.g. scenery still streaming in at apply time) it safely falls back to the full rebuild rather than risk dark uncut terrain. Check FUSE.log for 'terrain reload (targeted invalidation)' vs '(full rebuild)'.",
                 120f);
             AddWrappedField(
                 builder,

--- a/FUSE/Interface/FuseHealthUi.AdvancedTab.cs
+++ b/FUSE/Interface/FuseHealthUi.AdvancedTab.cs
@@ -249,16 +249,18 @@ namespace FUSE.Interface
             AddWrappedField(
                 builder,
                 "How",
-                "Reproducible culling/streaming tests (issue #76), measured debounce off vs on. CORRIDOR teleports between Bryson and Sylva a few times, then drives the camera up and down the track between them at a set pace. SWEEP A/B is the quick local test (oscillates across the cull boundary at your current view). Be in the overview camera. Each run appends a summary to FUSE-scenery-benchmark.json and writes a per-frame CSV (FUSE-bench-*.csv: FPS, object counts, churn, load latency, memory); live progress prints to FUSE.log.",
-                120f);
+                "Reproducible culling/streaming tests (issue #76). CORRIDOR teleports between Bryson and Sylva a few times, then drives the camera up and down the track between them at a set pace. SWEEP A/B is the quick local test (oscillates across the cull boundary at your current view). The DEBOUNCE A/B (Corridor/Sweep A/B) toggles culling hysteresis off vs on (churn). The THROTTLE A/B toggles the per-frame load cap off vs on (batch-load stall) — compare minFps and maxLoadMs. Be in the overview camera. Each run appends a summary to FUSE-scenery-benchmark.json and writes a per-frame CSV (FUSE-bench-*.csv: FPS, object counts, churn, defer/release, load latency, memory); live progress prints to FUSE.log.",
+                150f);
             builder.HStack(row =>
             {
                 row.AddButtonCompact("Run Corridor", () => RunAction("run corridor benchmark", FuseSceneryBenchmark.RunCorridor));
-                row.AddButtonCompact("Corridor A/B", () => RunAction("run corridor A/B benchmark", FuseSceneryBenchmark.RunCorridorAb));
+                row.AddButtonCompact("Corridor A/B", () => RunAction("run corridor debounce A/B benchmark", FuseSceneryBenchmark.RunCorridorAb));
+                row.AddButtonCompact("Sweep A/B", () => RunAction("run sweep debounce A/B benchmark", FuseSceneryBenchmark.RunSweepAb));
             }, 6f).Height(32f);
             builder.HStack(row =>
             {
-                row.AddButtonCompact("Sweep A/B", () => RunAction("run sweep A/B benchmark", FuseSceneryBenchmark.RunSweepAb));
+                row.AddButtonCompact("Corridor Throttle A/B", () => RunAction("run corridor throttle A/B benchmark", FuseSceneryBenchmark.RunCorridorThrottleAb));
+                row.AddButtonCompact("Sweep Throttle A/B", () => RunAction("run sweep throttle A/B benchmark", FuseSceneryBenchmark.RunSweepThrottleAb));
                 row.AddButtonCompact("Refresh", RebuildWindow);
             }, 6f).Height(32f);
             _lastBenchmarkStatus = FuseSceneryBenchmark.Status;

--- a/FUSE/Interface/FuseHealthUi.AdvancedTab.cs
+++ b/FUSE/Interface/FuseHealthUi.AdvancedTab.cs
@@ -278,6 +278,21 @@ namespace FUSE.Interface
                     FuseSettings.SetEnableExperimentalEarlyScenePathSuppression(!FuseSettings.EnableExperimentalEarlyScenePathSuppression);
                     RebuildWindow();
                 });
+            AddSettingToggle(
+                builder,
+                "Targeted Terrain Rebuild",
+                FuseSettings.EnableTargetedTerrainInvalidation ? "enabled next map load" : "disabled (full terrain rebuild)",
+                FuseSettings.EnableTargetedTerrainInvalidation ? "Disable" : "Enable",
+                () =>
+                {
+                    FuseSettings.SetEnableTargetedTerrainInvalidation(!FuseSettings.EnableTargetedTerrainInvalidation);
+                    RebuildWindow();
+                });
+            AddWrappedField(
+                builder,
+                "Terrain Rebuild",
+                "EXPERIMENTAL. After applying packages, FUSE re-bakes terrain so placed map-masks cut in. Off = full MapManager.RebuildAll (re-streams the whole map; safe). On = invalidate only the tiles FUSE touched (much faster, but if a mask's footprint is missed you'll see dark uncut terrain patches). Validate on your maps before relying on it; check FUSE.log for 'terrain reload (targeted invalidation)'.",
+                120f);
             AddWrappedField(
                 builder,
                 "Inspector Roadmap",

--- a/FUSE/Interface/FuseSceneryBenchmark.cs
+++ b/FUSE/Interface/FuseSceneryBenchmark.cs
@@ -830,6 +830,16 @@ namespace FUSE.Interface
                 _runMaxLoadMs = 0f;
                 _loadStart.Clear();
                 PeakInFlight = 0;
+
+                // Rebase the per-sample delta baselines too: the caller (SweepMovement)
+                // zeroes the global churn/throttle counters at this same boundary, so
+                // without this the next CSV row would report large NEGATIVE deltas
+                // (small post-reset counter minus the stale pre-reset baseline).
+                _lastLoads = FuseSceneryCullingDiagnosticPatch.FuseLoads + FuseSceneryCullingDiagnosticPatch.VanillaLoads;
+                _lastUnloads = FuseSceneryCullingDiagnosticPatch.FuseUnloads + FuseSceneryCullingDiagnosticPatch.VanillaUnloads;
+                _lastSuppressed = FuseSceneryCullingDebouncePatch.SuppressedUnloads;
+                _lastDeferred = FuseSceneryLoadThrottlePatch.DeferredLoads;
+                _lastReleased = FuseSceneryLoadThrottlePatch.ReleasedLoads;
             }
 
             private void Frame()

--- a/FUSE/Interface/FuseSceneryBenchmark.cs
+++ b/FUSE/Interface/FuseSceneryBenchmark.cs
@@ -63,6 +63,11 @@ namespace FUSE.Interface
         private static bool _running;
         private static string _status = "idle";
 
+        // The sampler for the run currently in progress, so a scenario's movement can
+        // reset the per-run latency/load window at a measurement boundary (e.g. the
+        // sweep resets after the one-time cold load). Set while a run is active.
+        private static RunSampler _activeSampler;
+
         internal static string Status => _status;
         internal static bool IsRunning => _running;
 
@@ -217,6 +222,7 @@ namespace FUSE.Interface
                 // load latency, memory). Runs as its own coroutine so it samples even
                 // while the movement is inside a nested wait.
                 sampler = new RunSampler(scenario.Name, label);
+                _activeSampler = sampler;
                 BenchmarkRunner.Instance.StartCoroutine(sampler.Loop());
 
                 var startTime = Time.realtimeSinceStartup;
@@ -285,6 +291,7 @@ namespace FUSE.Interface
             finally
             {
                 sampler?.Finish();
+                _activeSampler = null;
                 FuseSceneryCullingDebouncePatch.BenchmarkDebounceOverride = null;
                 FuseSceneryLoadThrottlePatch.BenchmarkThrottleOverride = null;
                 FuseSettings.SetSceneryCullingDiagnosticsTransient(prevDiagnostics);
@@ -308,10 +315,14 @@ namespace FUSE.Interface
             Teleport(target, rotation);
             yield return WaitForLoadAndSettle(TargetTimeoutSeconds, null);
 
-            // Measure only the sweep flaps: reset here so the harness's end-snapshot
-            // reflects boundary churn, not the one-time cold load.
+            // Measure only the sweep flaps: reset ALL benchmarked counters here — churn,
+            // throttle (deferred/released/peak-queue), and the sampler's per-run latency/
+            // load window — so the end-snapshot and CSV reflect boundary churn, not the
+            // one-time cold load that just finished.
             FuseSceneryCullingDiagnosticPatch.ResetCounters();
             FuseSceneryCullingDebouncePatch.ResetSuppressedUnloads();
+            FuseSceneryLoadThrottlePatch.ResetStats();
+            _activeSampler?.ResetLatencyWindow();
 
             _status = "[sweep] sweeping — measuring churn…";
             var sweepFar = target + new Vector3(SweepDistanceMeters, 0f, 0f);
@@ -806,6 +817,19 @@ namespace FUSE.Interface
                 }
 
                 _writer = null;
+            }
+
+            // Resets the per-run latency/load aggregates so a scenario can measure only
+            // the phase after a boundary (the sweep's post-cold-load oscillation), not
+            // the one-time cold load. CSV rows keep streaming; only the run-level
+            // PeakInFlight / Avg / MaxLoadMs reported in the JSON summary restart.
+            internal void ResetLatencyWindow()
+            {
+                _runLatencySum = 0f;
+                _runLatencyCount = 0;
+                _runMaxLoadMs = 0f;
+                _loadStart.Clear();
+                PeakInFlight = 0;
             }
 
             private void Frame()

--- a/FUSE/Interface/FuseSceneryBenchmark.cs
+++ b/FUSE/Interface/FuseSceneryBenchmark.cs
@@ -68,13 +68,25 @@ namespace FUSE.Interface
 
         // ---- Entry points (Advanced panel) ----
 
-        internal static string RunCorridor() => StartScenario(BuildCorridorScenario(), ab: false);
+        internal static string RunCorridor() => StartScenario(BuildCorridorScenario(), AbMode.Single);
 
-        internal static string RunCorridorAb() => StartScenario(BuildCorridorScenario(), ab: true);
+        internal static string RunCorridorAb() => StartScenario(BuildCorridorScenario(), AbMode.Debounce);
 
-        internal static string RunSweepAb() => StartScenario(BuildSweepScenario(), ab: true);
+        internal static string RunSweepAb() => StartScenario(BuildSweepScenario(), AbMode.Debounce);
 
-        private static string StartScenario(Scenario scenario, bool ab)
+        internal static string RunCorridorThrottleAb() => StartScenario(BuildCorridorScenario(), AbMode.Throttle);
+
+        internal static string RunSweepThrottleAb() => StartScenario(BuildSweepScenario(), AbMode.Throttle);
+
+        // Which lever (if any) an A/B run toggles between its baseline and fix passes.
+        private enum AbMode
+        {
+            Single,
+            Debounce,
+            Throttle
+        }
+
+        private static string StartScenario(Scenario scenario, AbMode mode)
         {
             if (_running)
             {
@@ -96,8 +108,11 @@ namespace FUSE.Interface
                 return _status = "No camera available — load a map first.";
             }
 
-            BenchmarkRunner.Instance.StartCoroutine(ab ? RunAbRoutine(scenario) : RunSingleRoutine(scenario));
-            return _status = $"{scenario.Name} {(ab ? "A/B " : string.Empty)}started — watch the status line / FUSE.log.";
+            var routine = mode == AbMode.Single ? RunSingleRoutine(scenario) : RunAbRoutine(scenario, mode);
+            BenchmarkRunner.Instance.StartCoroutine(routine);
+            var suffix = mode == AbMode.Single ? string.Empty
+                : mode == AbMode.Throttle ? "throttle A/B " : "A/B ";
+            return _status = $"{scenario.Name} {suffix}started — watch the status line / FUSE.log.";
         }
 
         // ---- Scenario definitions ----
@@ -133,33 +148,58 @@ namespace FUSE.Interface
         private static IEnumerator RunSingleRoutine(Scenario scenario)
         {
             _running = true;
-            yield return RunScenarioOnce(scenario, null, "single", null);
+            yield return RunScenarioOnce(scenario, null, null, "single", null);
             _running = false;
         }
 
-        private static IEnumerator RunAbRoutine(Scenario scenario)
+        private static IEnumerator RunAbRoutine(Scenario scenario, AbMode mode)
         {
             _running = true;
             JObject baseline = null;
             JObject fixedRun = null;
-            yield return RunScenarioOnce(scenario, false, "baseline-no-debounce", r => baseline = r);
-            yield return RunScenarioOnce(scenario, true, "fix-debounce", r => fixedRun = r);
+            if (mode == AbMode.Throttle)
+            {
+                // Debounce stays default-on; toggle only the load throttle so the delta
+                // isolates batch-load throughput from churn.
+                yield return RunScenarioOnce(scenario, null, false, "baseline-no-throttle", r => baseline = r);
+                yield return RunScenarioOnce(scenario, null, true, "fix-throttle", r => fixedRun = r);
+            }
+            else
+            {
+                yield return RunScenarioOnce(scenario, false, null, "baseline-no-debounce", r => baseline = r);
+                yield return RunScenarioOnce(scenario, true, null, "fix-debounce", r => fixedRun = r);
+            }
+
             _running = false;
 
             if (baseline != null && fixedRun != null)
             {
-                _status =
-                    $"{scenario.Name} A/B — churn base {baseline.Value<long>("fuseLoads")}L/{baseline.Value<long>("fuseUnloads")}U " +
-                    $"vs fix {fixedRun.Value<long>("fuseLoads")}L/{fixedRun.Value<long>("fuseUnloads")}U " +
-                    $"(held {fixedRun.Value<long>("suppressedUnloads")}). " +
-                    $"minFps base={baseline.Value<double>("minFps"):0} fix={fixedRun.Value<double>("minFps"):0}. " +
-                    $"duration base={baseline.Value<double>("durationMs"):0}ms fix={fixedRun.Value<double>("durationMs"):0}ms.";
+                if (mode == AbMode.Throttle)
+                {
+                    _status =
+                        $"{scenario.Name} throttle A/B — minFps base={baseline.Value<double>("minFps"):0} fix={fixedRun.Value<double>("minFps"):0}; " +
+                        $"peakInFlight base={baseline.Value<long>("peakInFlight")} fix={fixedRun.Value<long>("peakInFlight")}; " +
+                        $"maxLoadMs base={baseline.Value<double>("maxLoadMs"):0} fix={fixedRun.Value<double>("maxLoadMs"):0} " +
+                        $"(deferred {fixedRun.Value<long>("deferredLoads")}, peakQueue {fixedRun.Value<int>("peakQueueDepth")}). " +
+                        $"duration base={baseline.Value<double>("durationMs"):0}ms fix={fixedRun.Value<double>("durationMs"):0}ms.";
+                }
+                else
+                {
+                    _status =
+                        $"{scenario.Name} A/B — churn base {baseline.Value<long>("fuseLoads")}L/{baseline.Value<long>("fuseUnloads")}U " +
+                        $"vs fix {fixedRun.Value<long>("fuseLoads")}L/{fixedRun.Value<long>("fuseUnloads")}U " +
+                        $"(held {fixedRun.Value<long>("suppressedUnloads")}). " +
+                        $"minFps base={baseline.Value<double>("minFps"):0} fix={fixedRun.Value<double>("minFps"):0}. " +
+                        $"duration base={baseline.Value<double>("durationMs"):0}ms fix={fixedRun.Value<double>("durationMs"):0}ms.";
+                }
+
                 FuseLog.Info("FUSE benchmark A/B: " + _status);
             }
         }
 
         // try/finally (no catch around yields) guarantees the overrides are cleared.
-        private static IEnumerator RunScenarioOnce(Scenario scenario, bool? debounceOverride, string label, Action<JObject> onResult)
+        private static IEnumerator RunScenarioOnce(
+            Scenario scenario, bool? debounceOverride, bool? throttleOverride, string label, Action<JObject> onResult)
         {
             var prevDiagnostics = FuseSettings.EnableSceneryCullingDiagnostics;
             JObject result = null;
@@ -168,8 +208,10 @@ namespace FUSE.Interface
             {
                 FuseSettings.SetSceneryCullingDiagnosticsTransient(true);
                 FuseSceneryCullingDebouncePatch.BenchmarkDebounceOverride = debounceOverride;
+                FuseSceneryLoadThrottlePatch.BenchmarkThrottleOverride = throttleOverride;
                 FuseSceneryCullingDiagnosticPatch.ResetCounters();
                 FuseSceneryCullingDebouncePatch.ResetSuppressedUnloads();
+                FuseSceneryLoadThrottlePatch.ResetStats();
 
                 // Parallel per-frame sampler -> time-series CSV (FPS, counts, churn,
                 // load latency, memory). Runs as its own coroutine so it samples even
@@ -220,19 +262,31 @@ namespace FUSE.Interface
                     ["vanillaLoads"] = FuseSceneryCullingDiagnosticPatch.VanillaLoads,
                     ["vanillaUnloads"] = FuseSceneryCullingDiagnosticPatch.VanillaUnloads,
                     ["suppressedUnloads"] = FuseSceneryCullingDebouncePatch.SuppressedUnloads,
+                    ["throttle"] = throttleOverride.HasValue
+                        ? (throttleOverride.Value ? "forced-on" : "forced-off")
+                        : "default-on",
+                    ["maxLoadsPerFrame"] = FuseSceneryLoadThrottlePatch.MaxLoadsPerFrame,
+                    ["deferredLoads"] = FuseSceneryLoadThrottlePatch.DeferredLoads,
+                    ["releasedLoads"] = FuseSceneryLoadThrottlePatch.ReleasedLoads,
+                    ["droppedStaleLoads"] = FuseSceneryLoadThrottlePatch.DroppedStaleLoads,
+                    ["peakQueueDepth"] = FuseSceneryLoadThrottlePatch.PeakQueueDepth,
+                    ["avgLoadMs"] = Math.Round(sampler.AvgLoadMs, 0),
+                    ["maxLoadMs"] = Math.Round(sampler.MaxLoadMs, 0),
                     ["csv"] = sampler.FileName
                 };
                 AppendResult(result);
                 _status =
                     $"[{scenario.Name}/{label}] done {durationMs:0}ms; loads={FuseSceneryCullingDiagnosticPatch.FuseLoads} " +
                     $"unloads={FuseSceneryCullingDiagnosticPatch.FuseUnloads} suppressed={FuseSceneryCullingDebouncePatch.SuppressedUnloads} " +
-                    $"minFps={sampler.MinFps:0} peak={sampler.PeakInFlight}. CSV: {sampler.FileName}";
+                    $"deferred={FuseSceneryLoadThrottlePatch.DeferredLoads} peakQueue={FuseSceneryLoadThrottlePatch.PeakQueueDepth} " +
+                    $"minFps={sampler.MinFps:0} peak={sampler.PeakInFlight} maxLoadMs={sampler.MaxLoadMs:0}. CSV: {sampler.FileName}";
                 FuseLog.Info("FUSE benchmark " + _status);
             }
             finally
             {
                 sampler?.Finish();
                 FuseSceneryCullingDebouncePatch.BenchmarkDebounceOverride = null;
+                FuseSceneryLoadThrottlePatch.BenchmarkThrottleOverride = null;
                 FuseSettings.SetSceneryCullingDiagnosticsTransient(prevDiagnostics);
                 onResult?.Invoke(result);
             }
@@ -684,13 +738,22 @@ namespace FUSE.Interface
             private long _lastLoads;
             private long _lastUnloads;
             private long _lastSuppressed;
+            private long _lastDeferred;
+            private long _lastReleased;
             private float _fpsSum;
             private float _fpsMin = float.MaxValue;
             private int _fpsCount;
+            private float _runLatencySum;
+            private int _runLatencyCount;
+            private float _runMaxLoadMs;
 
             internal int PeakInFlight { get; private set; }
             internal float AvgFps => _fpsCount > 0 ? _fpsSum / _fpsCount : 0f;
             internal float MinFps => _fpsCount > 0 ? _fpsMin : 0f;
+            // Run-level per-object load latency (load start -> model present), the key
+            // batch-load-throughput signal the throttle targets.
+            internal float AvgLoadMs => _runLatencyCount > 0 ? _runLatencySum / _runLatencyCount : 0f;
+            internal float MaxLoadMs => _runMaxLoadMs;
             internal string FileName => _fileName;
 
             internal RunSampler(string scenario, string label)
@@ -704,7 +767,7 @@ namespace FUSE.Interface
                     _writer = new StreamWriter(path, false) { AutoFlush = true };
                     _writer.WriteLine(
                         "elapsedSec,fps,frameMs,inFlight,loaded,loadsDelta,unloadsDelta,suppressedDelta," +
-                        "loadsCompleted,avgLoadMs,maxLoadMs,managedMB,unityMB,phase");
+                        "deferredDelta,releasedDelta,queueDepth,loadsCompleted,avgLoadMs,maxLoadMs,managedMB,unityMB,phase");
                 }
                 catch (Exception ex)
                 {
@@ -806,15 +869,29 @@ namespace FUSE.Interface
                     PeakInFlight = inFlight;
                 }
 
+                // Run-level latency aggregates feed the JSON summary / throttle A/B.
+                _runLatencySum += latencySum;
+                _runLatencyCount += completed;
+                if (latencyMax > _runMaxLoadMs)
+                {
+                    _runMaxLoadMs = latencyMax;
+                }
+
                 var totalLoads = FuseSceneryCullingDiagnosticPatch.FuseLoads + FuseSceneryCullingDiagnosticPatch.VanillaLoads;
                 var totalUnloads = FuseSceneryCullingDiagnosticPatch.FuseUnloads + FuseSceneryCullingDiagnosticPatch.VanillaUnloads;
                 var suppressed = FuseSceneryCullingDebouncePatch.SuppressedUnloads;
+                var deferred = FuseSceneryLoadThrottlePatch.DeferredLoads;
+                var released = FuseSceneryLoadThrottlePatch.ReleasedLoads;
                 var loadsDelta = totalLoads - _lastLoads;
                 var unloadsDelta = totalUnloads - _lastUnloads;
                 var suppressedDelta = suppressed - _lastSuppressed;
+                var deferredDelta = deferred - _lastDeferred;
+                var releasedDelta = released - _lastReleased;
                 _lastLoads = totalLoads;
                 _lastUnloads = totalUnloads;
                 _lastSuppressed = suppressed;
+                _lastDeferred = deferred;
+                _lastReleased = released;
 
                 var managedMb = GC.GetTotalMemory(false) / 1048576f;
                 var unityMb = SafeUnityMemory() / 1048576f;
@@ -822,7 +899,8 @@ namespace FUSE.Interface
 
                 _writer?.WriteLine(
                     $"{now - _startTime:0.00},{fps:0.0},{frameMs:0.0},{inFlight},{loaded}," +
-                    $"{loadsDelta},{unloadsDelta},{suppressedDelta},{completed},{avgLoadMs:0},{latencyMax:0}," +
+                    $"{loadsDelta},{unloadsDelta},{suppressedDelta},{deferredDelta},{releasedDelta}," +
+                    $"{FuseSceneryLoadThrottlePatch.QueueDepth},{completed},{avgLoadMs:0},{latencyMax:0}," +
                     $"{managedMb:0.0},{unityMb:0.0},\"{CsvPhase()}\"");
 
                 _lastSampleTime = now;

--- a/FUSE/Patches/FuseSceneryLoadBudget.cs
+++ b/FUSE/Patches/FuseSceneryLoadBudget.cs
@@ -1,0 +1,73 @@
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Unity-free, single-thread per-frame "load starts" budget used by
+    /// <see cref="FuseSceneryLoadThrottlePatch"/> to bound how many FUSE scenery
+    /// models may begin loading in a single frame.
+    ///
+    /// The counter resets the first time <see cref="BeginFrame"/> is called with a
+    /// new frame index, so any number of callers within the same frame (the cull
+    /// callback and the throttle pump) share one budget. Pulled out of the patch so
+    /// the frame-reset / ceiling logic can be asserted in plain unit tests without a
+    /// live game, Harmony, or a Unity frame loop (see FUSE.Tests).
+    /// </summary>
+    internal sealed class FuseSceneryLoadBudget
+    {
+        private readonly int _maxPerFrame;
+        private int _frame;
+        private bool _hasFrame;
+        private int _startedThisFrame;
+
+        internal FuseSceneryLoadBudget(int maxPerFrame)
+        {
+            // A ceiling below 1 would stall loading entirely; clamp defensively.
+            _maxPerFrame = maxPerFrame < 1 ? 1 : maxPerFrame;
+        }
+
+        internal int MaxPerFrame => _maxPerFrame;
+
+        internal int StartedThisFrame => _startedThisFrame;
+
+        /// <summary>Slots still available this frame (never negative).</summary>
+        internal int Remaining => _startedThisFrame >= _maxPerFrame ? 0 : _maxPerFrame - _startedThisFrame;
+
+        /// <summary>
+        /// Advance the budget to <paramref name="frame"/>. The starts counter resets
+        /// on the first call of each new frame and is a no-op on repeat calls within
+        /// the same frame, so the prefix and the pump can both call it freely.
+        /// </summary>
+        internal void BeginFrame(int frame)
+        {
+            if (!_hasFrame || frame != _frame)
+            {
+                _frame = frame;
+                _hasFrame = true;
+                _startedThisFrame = 0;
+            }
+        }
+
+        /// <summary>
+        /// Consume one slot if the per-frame ceiling has not been reached. Returns
+        /// true (and increments the counter) when a load may start now, false when it
+        /// must be deferred to a later frame.
+        /// </summary>
+        internal bool TryConsume()
+        {
+            if (_startedThisFrame >= _maxPerFrame)
+            {
+                return false;
+            }
+
+            _startedThisFrame++;
+            return true;
+        }
+
+        /// <summary>Forget all frame state (used when tearing the throttle down).</summary>
+        internal void Reset()
+        {
+            _hasFrame = false;
+            _frame = 0;
+            _startedThisFrame = 0;
+        }
+    }
+}

--- a/FUSE/Patches/FuseSceneryLoadThrottlePatch.cs
+++ b/FUSE/Patches/FuseSceneryLoadThrottlePatch.cs
@@ -170,8 +170,12 @@ namespace FUSE.Patches
                     return true; // under budget — start the load this frame.
                 }
 
-                Enqueue(__instance);
+                // Create the pump BEFORE recording the pending id: if EnsurePump threw
+                // after Enqueue, the catch below fails open (this load proceeds) but the
+                // stale PendingIds entry would block every future SetLoaded(true) for
+                // this object with nothing draining it.
                 EnsurePump();
+                Enqueue(__instance);
                 return false; // over budget — defer to the pump.
             }
             catch (Exception ex)

--- a/FUSE/Patches/FuseSceneryLoadThrottlePatch.cs
+++ b/FUSE/Patches/FuseSceneryLoadThrottlePatch.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Helpers;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Issue #76 follow-up: smooths the one-time asset-load stall when a large batch
+    /// of FUSE scenery loads at once (e.g. teleport-in), the bottleneck the culling
+    /// debounce (<see cref="FuseSceneryCullingDebouncePatch"/>) deliberately left out
+    /// of scope.
+    ///
+    /// The game loads a scenery model in <c>SceneryAssetInstance.SetLoaded(true)</c>:
+    /// it awaits an async asset-bundle load and then, on the main thread, runs
+    /// <c>Object.Instantiate</c> + component setup. When a whole region crosses into
+    /// the load band in the same settle (a teleport, or the debounce widening the
+    /// resident set to its 3&#160;km deadband), hundreds of those continuations resume
+    /// together and the per-frame Instantiate burst drops the frame rate to ~1&#160;fps
+    /// with multi-second per-object latency.
+    ///
+    /// This prefix throttles how many FUSE scenery loads may <em>start</em> per frame
+    /// (<see cref="MaxLoadsPerFrame"/>). Over-budget loads are deferred into a queue
+    /// and released a few per frame by a persistent pump
+    /// (<see cref="FuseSceneryLoadThrottlePump"/>). Staggering the starts staggers the
+    /// completions, so the Instantiate work spreads across frames instead of spiking.
+    /// A pump is required because <c>CullingSphereStateChanged</c> is event/world-shift
+    /// driven (not per-frame), so a deferred object would otherwise never be revisited
+    /// — the same cadence constraint the debounce patch documents.
+    ///
+    /// Scope and safety:
+    ///  - FUSE-owned scenery only (<see cref="FUSE.Runtime.API.SceneryAPI.FuseSceneryMarker"/>);
+    ///    vanilla loading is untouched.
+    ///  - Only the <c>loaded == true</c> (load) path is gated; unloads run vanilla.
+    ///  - Objects already loading/loaded (<c>_wantsLoaded</c>) pass straight through so
+    ///    the original's own no-op guard handles them and no budget is wasted.
+    ///  - On release the pump drops anything that has left the debounce deadband
+    ///    (reusing <see cref="FuseSceneryCullingDebouncePatch.ShouldHoldResident"/>), so
+    ///    a backlog can't force-load scenery the camera has already moved away from.
+    ///  - Every failure path is fail-open: if reflection is unavailable or anything
+    ///    throws, the original load runs normally (no stranded scenery).
+    ///
+    /// Always on (no user setting), matching the debounce. The benchmark can force it
+    /// off for an A/B baseline via <see cref="BenchmarkThrottleOverride"/>.
+    /// </summary>
+    [HarmonyPatch(typeof(SceneryAssetInstance), "SetLoaded", new[] { typeof(bool) })]
+    internal static class FuseSceneryLoadThrottlePatch
+    {
+        /// <summary>
+        /// Max FUSE scenery loads allowed to START per frame. The single tunable: too
+        /// low and a big region takes many seconds to populate; too high and the
+        /// Instantiate burst still spikes the frame. Sized so the per-frame
+        /// Instantiate cost stays within a ~30-60&#160;fps frame for typical prefabs.
+        /// </summary>
+        internal const int MaxLoadsPerFrame = 8;
+
+        // Benchmark-only override (NOT a user setting): null = normal always-on
+        // throttling; false = force OFF for an A/B baseline pass; true = force ON.
+        // Set transiently by FuseSceneryBenchmark and cleared after a run.
+        internal static bool? BenchmarkThrottleOverride;
+
+        private static readonly FuseSceneryLoadBudget Budget = new FuseSceneryLoadBudget(MaxLoadsPerFrame);
+
+        // Deferred loads, FIFO. The instance id is captured at enqueue time (while the
+        // object is alive) so set membership never depends on hashing a Unity object —
+        // a destroyed UnityEngine.Object collapses to "== null" and is unsafe as a key.
+        private static readonly Queue<PendingLoad> Pending = new Queue<PendingLoad>();
+        private static readonly HashSet<int> PendingIds = new HashSet<int>();
+
+        // Fast typed accessor for the private load-state flag (also covered by the
+        // reflection-surface canary test). Null only if the game renamed the field, in
+        // which case we fail open and never throttle.
+        private static readonly AccessTools.FieldRef<SceneryAssetInstance, bool> WantsLoadedRef =
+            BuildWantsLoadedRef();
+
+        private static readonly MethodInfo SetLoadedMethod =
+            AccessTools.Method(typeof(SceneryAssetInstance), "SetLoaded", new[] { typeof(bool) });
+
+        // Reused arg buffer for the pump's reflective SetLoaded(true) re-drive
+        // (main-thread only, so a shared buffer is safe).
+        private static readonly object[] LoadTrueArgs = { true };
+
+        // True while the pump is re-driving a deferred load, so our own prefix lets
+        // that call through instead of re-deferring it.
+        private static bool _pumping;
+
+        private static Camera _camera;
+        private static FuseSceneryLoadThrottlePump _pump;
+
+        private static long _deferredLoads;
+        private static long _releasedLoads;
+        private static long _droppedStaleLoads;
+        private static int _peakQueueDepth;
+
+        /// <summary>FUSE loads deferred (queued) since the last reset.</summary>
+        internal static long DeferredLoads => _deferredLoads;
+
+        /// <summary>Deferred loads released by the pump since the last reset.</summary>
+        internal static long ReleasedLoads => _releasedLoads;
+
+        /// <summary>Queued loads dropped because they left the deadband before release.</summary>
+        internal static long DroppedStaleLoads => _droppedStaleLoads;
+
+        /// <summary>High-water mark of the deferred queue since the last reset.</summary>
+        internal static int PeakQueueDepth => _peakQueueDepth;
+
+        /// <summary>Current number of deferred loads awaiting release.</summary>
+        internal static int QueueDepth => Pending.Count;
+
+        /// <summary>True when reflection bound and the throttle can operate.</summary>
+        internal static bool Available => WantsLoadedRef != null && SetLoadedMethod != null;
+
+        internal static void ResetStats()
+        {
+            _deferredLoads = 0;
+            _releasedLoads = 0;
+            _droppedStaleLoads = 0;
+            _peakQueueDepth = 0;
+        }
+
+        /// <summary>
+        /// Pure budget decision, extracted for unit testing: may a load start now
+        /// given how many have already started this frame? Mirrors
+        /// <see cref="FuseSceneryLoadBudget.TryConsume"/>'s ceiling check without the
+        /// side effect.
+        /// </summary>
+        internal static bool ShouldStartLoadNow(int startedThisFrame, int maxLoadsPerFrame)
+        {
+            return startedThisFrame < maxLoadsPerFrame;
+        }
+
+        private static bool Prefix(SceneryAssetInstance __instance, bool loaded)
+        {
+            // Unloads, pump re-drives, the forced-off baseline, and the case where
+            // reflection didn't bind all run the vanilla load path unchanged.
+            if (!loaded || _pumping || __instance == null ||
+                BenchmarkThrottleOverride == false || !Available)
+            {
+                return true;
+            }
+
+            try
+            {
+                if (__instance.GetComponent<FUSE.Runtime.API.SceneryAPI.FuseSceneryMarker>() == null)
+                {
+                    return true; // FUSE-owned scenery only; vanilla loads normally.
+                }
+
+                // Already loading or loaded: the original SetLoaded(true) is a cheap
+                // no-op, so let it through rather than spend a budget slot on it. The
+                // debounce clamps band 3 -> 2 repeatedly for resident objects, which
+                // would otherwise hammer this path.
+                if (WantsLoadedRef(__instance))
+                {
+                    return true;
+                }
+
+                Budget.BeginFrame(Time.frameCount);
+
+                if (PendingIds.Contains(__instance.GetInstanceID()))
+                {
+                    return false; // already queued; the pump will release it.
+                }
+
+                if (Budget.TryConsume())
+                {
+                    return true; // under budget — start the load this frame.
+                }
+
+                Enqueue(__instance);
+                EnsurePump();
+                return false; // over budget — defer to the pump.
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE scenery load-throttle prefix failed", ex);
+                return true; // fail open: never strand a load on our account.
+            }
+        }
+
+        private static void Enqueue(SceneryAssetInstance instance)
+        {
+            var id = instance.GetInstanceID();
+            Pending.Enqueue(new PendingLoad(instance, id));
+            PendingIds.Add(id);
+            _deferredLoads++;
+            if (Pending.Count > _peakQueueDepth)
+            {
+                _peakQueueDepth = Pending.Count;
+            }
+        }
+
+        /// <summary>
+        /// Releases deferred loads up to the remaining per-frame budget. Driven every
+        /// frame by <see cref="FuseSceneryLoadThrottlePump"/> so backlog drains even
+        /// when the culler is quiet. Null skips and deadband drops cost no budget, so a
+        /// stale backlog clears quickly without starving live loads.
+        /// </summary>
+        internal static void Pump()
+        {
+            if (Pending.Count == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                Budget.BeginFrame(Time.frameCount);
+                if (_camera == null)
+                {
+                    _camera = Camera.main;
+                }
+
+                // The queue only shrinks inside this loop, so a count snapshot bounds
+                // the work even though null/stale entries are skipped for free.
+                var safety = Pending.Count;
+                while (safety-- > 0 && Pending.Count > 0 && Budget.Remaining > 0)
+                {
+                    var pending = Pending.Dequeue();
+                    PendingIds.Remove(pending.Id);
+                    var instance = pending.Instance;
+
+                    if (instance == null)
+                    {
+                        continue; // destroyed while queued.
+                    }
+
+                    // Loaded via another path since it was queued: nothing to do.
+                    if (WantsLoadedRef != null && WantsLoadedRef(instance))
+                    {
+                        continue;
+                    }
+
+                    // Left the resident deadband while queued: don't force-load scenery
+                    // the camera has moved away from (consistent with the debounce).
+                    if (_camera != null &&
+                        !FuseSceneryCullingDebouncePatch.ShouldHoldResident(
+                            _camera.transform.position, instance.transform.position))
+                    {
+                        _droppedStaleLoads++;
+                        continue;
+                    }
+
+                    if (!Budget.TryConsume())
+                    {
+                        // Budget exhausted between the Remaining check and here; requeue
+                        // and stop for this frame.
+                        Enqueue(instance);
+                        break;
+                    }
+
+                    Release(instance);
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE scenery load-throttle pump failed", ex);
+            }
+        }
+
+        private static void Release(SceneryAssetInstance instance)
+        {
+            _pumping = true;
+            try
+            {
+                SetLoadedMethod.Invoke(instance, LoadTrueArgs);
+                _releasedLoads++;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE scenery load-throttle release failed", ex);
+            }
+            finally
+            {
+                _pumping = false;
+            }
+        }
+
+        private static void EnsurePump()
+        {
+            if (_pump != null)
+            {
+                return;
+            }
+
+            var host = new GameObject("FUSE.SceneryLoadThrottle");
+            UnityEngine.Object.DontDestroyOnLoad(host);
+            host.hideFlags = HideFlags.HideAndDontSave;
+            _pump = host.AddComponent<FuseSceneryLoadThrottlePump>();
+        }
+
+        /// <summary>Tears down the pump and clears all deferred state (mod unload).</summary>
+        internal static void Shutdown()
+        {
+            try
+            {
+                if (_pump != null)
+                {
+                    UnityEngine.Object.Destroy(_pump.gameObject);
+                    _pump = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE scenery load-throttle shutdown failed", ex);
+            }
+
+            Pending.Clear();
+            PendingIds.Clear();
+            Budget.Reset();
+            _camera = null;
+            _pumping = false;
+            ResetStats();
+        }
+
+        private static AccessTools.FieldRef<SceneryAssetInstance, bool> BuildWantsLoadedRef()
+        {
+            try
+            {
+                return AccessTools.FieldRefAccess<SceneryAssetInstance, bool>("_wantsLoaded");
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception(
+                    "FUSE scenery load-throttle could not bind SceneryAssetInstance._wantsLoaded; " +
+                    "throttling disabled (loads run vanilla)", ex);
+                return null;
+            }
+        }
+
+        private readonly struct PendingLoad
+        {
+            internal PendingLoad(SceneryAssetInstance instance, int id)
+            {
+                Instance = instance;
+                Id = id;
+            }
+
+            internal SceneryAssetInstance Instance { get; }
+
+            internal int Id { get; }
+        }
+    }
+
+    /// <summary>
+    /// Persistent main-thread pump that drains the scenery load-throttle queue a few
+    /// per frame. Created on first deferral and kept alive across scene loads; torn
+    /// down by <see cref="FuseSceneryLoadThrottlePatch.Shutdown"/> on mod unload.
+    /// </summary>
+    internal sealed class FuseSceneryLoadThrottlePump : MonoBehaviour
+    {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Performance", "CA1822:Mark members as static",
+            Justification = "Unity invokes Update() as an instance message via reflection; a static method is never called.")]
+        private void Update()
+        {
+            FuseSceneryLoadThrottlePatch.Pump();
+        }
+    }
+}

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -352,12 +352,6 @@ namespace FUSE.Runtime.API
             return definition;
         }
 
-        // Footprint full size (meters) recorded per deferred object for the opt-in
-        // targeted terrain invalidation (#4). Map tiles are 500m; a 512m box re-bakes
-        // the object's own tile plus any neighbor it straddles, covering typical
-        // building-sized mask cuts. Only consulted when targeted invalidation is on.
-        private const float DeferredMaskFootprintSize = 512f;
-
         public static void RefreshAttachedMapMasks(GameObject root, string reason = null)
         {
             if (root == null)
@@ -368,16 +362,18 @@ namespace FUSE.Runtime.API
             // During a bulk apply that ends in a single terrain rebuild, this
             // per-object refresh is redundant: the trailing rebuild re-evaluates every
             // live mask component at once, and mask components also self-apply on
-            // OnEnable. Skip the GetComponentsInChildren + Rebuild churn here and just
-            // record the footprint so the (opt-in) targeted invalidation can scope the
-            // trailing rebuild to the affected tiles.
+            // OnEnable. Skip the GetComponentsInChildren + Rebuild churn here.
+            //
+            // We deliberately do NOT record an approximate footprint for the opt-in
+            // targeted invalidation: at apply time the scenery model (and its mask
+            // components) hasn't streamed in yet, so there is nothing to measure, and a
+            // fixed-size box would under-cover large rectangle/curve masks and leave
+            // dark, uncut terrain. Flag the footprint incomplete instead so the trailing
+            // reload falls back to a full rebuild (FuseTerrainRefreshScope.BoundsComplete).
             if (FuseTerrainRefreshScope.IsDeferringMaskRefresh)
             {
                 FuseTerrainRefreshScope.NoteDeferredRefresh(0);
-                FuseTerrainRefreshScope.RecordBounds(
-                    new Bounds(
-                        root.transform.position,
-                        new Vector3(DeferredMaskFootprintSize, DeferredMaskFootprintSize, DeferredMaskFootprintSize)));
+                FuseTerrainRefreshScope.MarkBoundsIncomplete();
                 return;
             }
 

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -352,10 +352,32 @@ namespace FUSE.Runtime.API
             return definition;
         }
 
+        // Footprint full size (meters) recorded per deferred object for the opt-in
+        // targeted terrain invalidation (#4). Map tiles are 500m; a 512m box re-bakes
+        // the object's own tile plus any neighbor it straddles, covering typical
+        // building-sized mask cuts. Only consulted when targeted invalidation is on.
+        private const float DeferredMaskFootprintSize = 512f;
+
         public static void RefreshAttachedMapMasks(GameObject root, string reason = null)
         {
             if (root == null)
             {
+                return;
+            }
+
+            // During a bulk apply that ends in a single terrain rebuild, this
+            // per-object refresh is redundant: the trailing rebuild re-evaluates every
+            // live mask component at once, and mask components also self-apply on
+            // OnEnable. Skip the GetComponentsInChildren + Rebuild churn here and just
+            // record the footprint so the (opt-in) targeted invalidation can scope the
+            // trailing rebuild to the affected tiles.
+            if (FuseTerrainRefreshScope.IsDeferringMaskRefresh)
+            {
+                FuseTerrainRefreshScope.NoteDeferredRefresh(0);
+                FuseTerrainRefreshScope.RecordBounds(
+                    new Bounds(
+                        root.transform.position,
+                        new Vector3(DeferredMaskFootprintSize, DeferredMaskFootprintSize, DeferredMaskFootprintSize)));
                 return;
             }
 

--- a/FUSE/Runtime/Cache/FuseCacheRegistry.cs
+++ b/FUSE/Runtime/Cache/FuseCacheRegistry.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Diagnostics;
+using FUSE.Infrastructure;
 
 namespace FUSE.Runtime.Cache
 {
@@ -7,7 +9,20 @@ namespace FUSE.Runtime.Cache
         private static readonly List<object> Caches = new List<object>();
         private static bool _isReady;
 
+        // Diagnostics: how often the full (16-index, scene-scanning) and graph-only
+        // (3-index) rebuilds run. Surfaced to FUSE.log + the Health page so the cost
+        // of repeated rebuilds during a single map load is measurable (issue: tile/
+        // load-time bottleneck investigation).
+        private static int _fullRebuildCount;
+        private static int _graphRebuildCount;
+
         public static bool IsReady => _isReady;
+
+        /// <summary>Full (scene-scanning) cache rebuilds since process start.</summary>
+        public static int FullRebuildCount => _fullRebuildCount;
+
+        /// <summary>Graph-only cache rebuilds since process start.</summary>
+        public static int GraphRebuildCount => _graphRebuildCount;
 
         static FuseCacheRegistry()
         {
@@ -31,9 +46,18 @@ namespace FUSE.Runtime.Cache
 
         public static void RebuildAll()
         {
+            var stopwatch = Stopwatch.StartNew();
+
+            // Graph-derived indexes (read Track.Graph.Shared).
             FuseNodeRuntimeIndex.Instance.Rebuild();
             FuseSegmentRuntimeIndex.Instance.Rebuild();
             FuseSpanRuntimeIndex.Instance.Rebuild();
+
+            // Scene-scanning indexes (each does a FindObjectsOfType / GameObject.Find
+            // pass). These are the expensive ones; the APIs that create/remove these
+            // objects keep the indexes current incrementally (Set/Remove), so a full
+            // rescan is only needed at map load / explicit reload — NOT on every graph
+            // rebuild (see RebuildGraphIndexes).
             FuseAreaRuntimeIndex.Instance.Rebuild();
             FuseIndustryRuntimeIndex.Instance.Rebuild();
             FuseIndustryComponentRuntimeIndex.Instance.Rebuild();
@@ -48,6 +72,39 @@ namespace FUSE.Runtime.Cache
             FuseSplineyRuntimeIndex.Instance.Rebuild();
             FuseMapLabelRuntimeIndex.Instance.Rebuild();
             _isReady = true;
+
+            _fullRebuildCount++;
+            FusePerformanceMetrics.RecordCount("cache full rebuilds", _fullRebuildCount);
+            FuseLog.Info(
+                $"FUSE cache full rebuild #{_fullRebuildCount} (16 indexes) elapsedMs={stopwatch.ElapsedMilliseconds}.");
+        }
+
+        /// <summary>
+        /// Refreshes only the graph-derived indexes (node / segment / span) that read
+        /// <c>Track.Graph.Shared</c>. Use this in response to a graph-rebuild event:
+        /// the track topology changed, but the scene-scanning indexes (industry,
+        /// scenery, station, …) did not, and they are kept current incrementally by
+        /// the APIs that mutate them — so re-running their ~13 FindObjectsOfType scans
+        /// on every graph rebuild is wasted work. Falls back to a full rebuild if the
+        /// caches have never been built (so the scene indexes still get populated).
+        /// </summary>
+        public static void RebuildGraphIndexes()
+        {
+            if (!_isReady)
+            {
+                RebuildAll();
+                return;
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            FuseNodeRuntimeIndex.Instance.Rebuild();
+            FuseSegmentRuntimeIndex.Instance.Rebuild();
+            FuseSpanRuntimeIndex.Instance.Rebuild();
+
+            _graphRebuildCount++;
+            FusePerformanceMetrics.RecordCount("cache graph-only rebuilds", _graphRebuildCount);
+            FuseLog.Info(
+                $"FUSE cache graph-only rebuild #{_graphRebuildCount} (3 graph indexes) elapsedMs={stopwatch.ElapsedMilliseconds}.");
         }
 
         public static void ClearAll()

--- a/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
+++ b/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
@@ -53,8 +53,16 @@ namespace FUSE.Runtime.Lifecycle
             var canMutateWorld = FuseMultiplayerGuard.CanApplyWorldMutations("map load");
             FuseLoadReport.ResetMapLoad();
 
+            // Defer per-object map-mask refresh across the whole apply: the single
+            // trailing terrain rebuild (below) re-evaluates every live mask at once,
+            // so the per-object GetComponentsInChildren + modifier churn during apply
+            // is redundant. Also accumulates the footprint FUSE touched for the opt-in
+            // targeted invalidation. Closed in the finally around the terrain rebuild.
+            IDisposable terrainScope = null;
+
             try
             {
+                terrainScope = FuseTerrainRefreshScope.Begin();
                 FuseLegacyAssemblyHost.LoadAllAvailableAssemblies("map load fallback");
                 var cacheStopwatch = Stopwatch.StartNew();
                 FuseCacheRegistry.RebuildAll();
@@ -129,16 +137,34 @@ namespace FUSE.Runtime.Lifecycle
             // Calling MapManager.RebuildAll() here mirrors what AlinasMapMod's
             // "Rebuild Map" button does and forces the terrain to re-bake with the
             // now-live mask components.
-            if (canMutateWorld)
+            try
             {
-                var mapRebuildStopwatch = Stopwatch.StartNew();
-                FuseRuntimeReloadService.ReloadTerrain("map-load map-mask rebuild");
-                FusePerformanceMetrics.RecordTiming("map mask rebuild", mapRebuildStopwatch.ElapsedMilliseconds);
-                FuseLog.Info($"FUSE load timing phase='map mask rebuild' elapsedMs={mapRebuildStopwatch.ElapsedMilliseconds}.");
+                if (canMutateWorld)
+                {
+                    var mapRebuildStopwatch = Stopwatch.StartNew();
+                    FuseRuntimeReloadService.ReloadTerrain("map-load map-mask rebuild");
+                    FusePerformanceMetrics.RecordTiming("map mask rebuild", mapRebuildStopwatch.ElapsedMilliseconds);
+                    FuseLog.Info($"FUSE load timing phase='map mask rebuild' elapsedMs={mapRebuildStopwatch.ElapsedMilliseconds}.");
+                }
+                else
+                {
+                    FuseLog.Info("FUSE skipped map mask rebuild on non-host multiplayer client.");
+                }
             }
-            else
+            finally
             {
-                FuseLog.Info("FUSE skipped map mask rebuild on non-host multiplayer client.");
+                // Close the deferral scope only AFTER the terrain rebuild has read the
+                // accumulated footprint. Report how much per-object refresh work the
+                // single trailing rebuild absorbed (measurement for the #3 win).
+                var deferredRefreshes = FuseTerrainRefreshScope.DeferredRefreshCalls;
+                terrainScope?.Dispose();
+                if (deferredRefreshes > 0)
+                {
+                    FusePerformanceMetrics.RecordCount("map-load deferred mask refreshes", deferredRefreshes);
+                    FuseLog.Info(
+                        $"FUSE map-load deferred {deferredRefreshes} per-object map-mask refresh call(s); " +
+                        "the single trailing terrain rebuild covered them.");
+                }
             }
 
             // Console handler is created during scene activation, so we re-attempt
@@ -177,7 +203,13 @@ namespace FUSE.Runtime.Lifecycle
         {
             try
             {
-                FuseCacheRegistry.RebuildAll();
+                // A graph rebuild changes track topology only — the scene-scanning
+                // indexes (industry, scenery, station, …) are kept current
+                // incrementally by the APIs that mutate them, so refresh just the
+                // graph-derived indexes (node/segment/span) here instead of re-running
+                // all ~13 FindObjectsOfType scans on every graph rebuild. Falls back to
+                // a full rebuild automatically if the caches were never built.
+                FuseCacheRegistry.RebuildGraphIndexes();
                 FuseWorldSuppressor.ApplyTrackGroupSuppressionsAfterGraphLoad("graph rebuild");
                 TrackAPI.ScrubCtcSignalReferences("graph rebuild");
                 FuseEvents.RaiseGraphRebuilt();

--- a/FUSE/Runtime/Lifecycle/FuseRuntimeReloadService.cs
+++ b/FUSE/Runtime/Lifecycle/FuseRuntimeReloadService.cs
@@ -96,12 +96,23 @@ namespace FUSE.Runtime.Lifecycle
                     FuseTerrainRefreshScope.BoundsComplete &&
                     FuseTerrainRefreshScope.TryGetAccumulatedBounds(out var bounds))
                 {
-                    MapManagerInvalidateBounds.Invoke(instance, new object[] { bounds });
-                    FuseLog.Info(
-                        $"FUSE terrain reload (targeted invalidation) operation='{operation}' " +
-                        $"bounds.center={bounds.center} bounds.size={bounds.size} " +
-                        $"deferredRefreshCalls={FuseTerrainRefreshScope.DeferredRefreshCalls} elapsedMs={stopwatch.ElapsedMilliseconds}.");
-                    return true;
+                    try
+                    {
+                        MapManagerInvalidateBounds.Invoke(instance, new object[] { bounds });
+                        FuseLog.Info(
+                            $"FUSE terrain reload (targeted invalidation) operation='{operation}' " +
+                            $"bounds.center={bounds.center} bounds.size={bounds.size} " +
+                            $"deferredRefreshCalls={FuseTerrainRefreshScope.DeferredRefreshCalls} elapsedMs={stopwatch.ElapsedMilliseconds}.");
+                        return true;
+                    }
+                    catch (Exception ex)
+                    {
+                        // A failed optimization must not become a missed refresh: fall
+                        // through to the full rebuild rather than leaving terrain stale.
+                        FuseLog.Warning(
+                            $"FUSE terrain reload targeted invalidation failed operation='{operation}': " +
+                            $"{ex.GetBaseException().Message}; falling back to full rebuild.");
+                    }
                 }
 
                 MapManagerRebuildAll.Invoke(instance, null);

--- a/FUSE/Runtime/Lifecycle/FuseRuntimeReloadService.cs
+++ b/FUSE/Runtime/Lifecycle/FuseRuntimeReloadService.cs
@@ -84,13 +84,16 @@ namespace FUSE.Runtime.Lifecycle
                     return false;
                 }
 
-                // Targeted invalidation (#4, opt-in): if we captured the footprint of
-                // what FUSE touched during this apply, re-bake just those tiles instead
-                // of tearing down and re-streaming the whole map. Default off, and we
-                // fall back to the full rebuild whenever the toggle is off, the method
-                // didn't resolve, or no footprint was captured (e.g. a manual reload).
+                // Targeted invalidation (#4, opt-in): if we captured an ACCURATE,
+                // complete footprint of what FUSE touched during this apply, re-bake
+                // just those tiles instead of tearing down and re-streaming the whole
+                // map. Default off, and we fall back to the full rebuild whenever the
+                // toggle is off, the method didn't resolve, the footprint is incomplete
+                // (e.g. masks still streaming in — see MapAPI.RefreshAttachedMapMasks),
+                // or nothing was captured (e.g. a manual reload).
                 if (FuseSettings.EnableTargetedTerrainInvalidation &&
                     MapManagerInvalidateBounds != null &&
+                    FuseTerrainRefreshScope.BoundsComplete &&
                     FuseTerrainRefreshScope.TryGetAccumulatedBounds(out var bounds))
                 {
                     MapManagerInvalidateBounds.Invoke(instance, new object[] { bounds });

--- a/FUSE/Runtime/Lifecycle/FuseRuntimeReloadService.cs
+++ b/FUSE/Runtime/Lifecycle/FuseRuntimeReloadService.cs
@@ -5,6 +5,7 @@ using FUSE.Runtime.API;
 using FUSE.Runtime.Cache;
 using FUSE.Infrastructure;
 using FUSE.Loading;
+using UnityEngine;
 
 namespace FUSE.Runtime.Lifecycle
 {
@@ -13,6 +14,14 @@ namespace FUSE.Runtime.Lifecycle
         private static readonly MethodInfo MapManagerRebuildAll =
             Type.GetType("Map.Runtime.MapManager, Map.Runtime")
                 ?.GetMethod("RebuildAll", BindingFlags.Instance | BindingFlags.Public);
+
+        // Private void Invalidate(Bounds) — re-bakes only the tiles overlapping the
+        // given world bounds (vs RebuildAll's full teardown+reload). Used by the
+        // opt-in targeted-invalidation path; null-checked so a rename just falls back
+        // to the full rebuild. Covered by the reflection-surface canary test.
+        private static readonly MethodInfo MapManagerInvalidateBounds =
+            Type.GetType("Map.Runtime.MapManager, Map.Runtime")
+                ?.GetMethod("Invalidate", BindingFlags.Instance | BindingFlags.NonPublic, null, new[] { typeof(Bounds) }, null);
 
         private static readonly PropertyInfo MapManagerInstance =
             Type.GetType("Map.Runtime.MapManager, Map.Runtime")
@@ -75,8 +84,27 @@ namespace FUSE.Runtime.Lifecycle
                     return false;
                 }
 
+                // Targeted invalidation (#4, opt-in): if we captured the footprint of
+                // what FUSE touched during this apply, re-bake just those tiles instead
+                // of tearing down and re-streaming the whole map. Default off, and we
+                // fall back to the full rebuild whenever the toggle is off, the method
+                // didn't resolve, or no footprint was captured (e.g. a manual reload).
+                if (FuseSettings.EnableTargetedTerrainInvalidation &&
+                    MapManagerInvalidateBounds != null &&
+                    FuseTerrainRefreshScope.TryGetAccumulatedBounds(out var bounds))
+                {
+                    MapManagerInvalidateBounds.Invoke(instance, new object[] { bounds });
+                    FuseLog.Info(
+                        $"FUSE terrain reload (targeted invalidation) operation='{operation}' " +
+                        $"bounds.center={bounds.center} bounds.size={bounds.size} " +
+                        $"deferredRefreshCalls={FuseTerrainRefreshScope.DeferredRefreshCalls} elapsedMs={stopwatch.ElapsedMilliseconds}.");
+                    return true;
+                }
+
                 MapManagerRebuildAll.Invoke(instance, null);
-                FuseLog.Info($"FUSE terrain reload completed operation='{operation}' elapsedMs={stopwatch.ElapsedMilliseconds}.");
+                FuseLog.Info(
+                    $"FUSE terrain reload (full rebuild) operation='{operation}' " +
+                    $"deferredRefreshCalls={FuseTerrainRefreshScope.DeferredRefreshCalls} elapsedMs={stopwatch.ElapsedMilliseconds}.");
                 return true;
             }
             catch (Exception ex)


### PR DESCRIPTION
## 🔗 Related Issue

#76 — Asset/Scenery culling issues (popping + slow load). This is the **load-throughput follow-up** explicitly deferred from #92, which noted: *"the fix targets churn, not first-load throughput … a one-time asset-load stall when a large batch loads at once (1 fps / multi-second per-object latency on teleport-in). That's a follow-up, not addressed here."*

## 📝 Description of the Change

Two related performance changes (one commit each). Both are scoped to **FUSE's own code** — the game's core tile/terrain streaming (`MapManager` coroutine, `TerrainBuilder`, `TileData.LoadIfNeeded`) is deliberately **left untouched**, since throttling it would leave holes in the world.

### 1. Frame-budgeted scenery load throttle (`72ef96b`)

The game loads a scenery model in `SceneryAssetInstance.SetLoaded(true)`: an async asset-bundle load, then a main-thread `Object.Instantiate` + component setup. When a whole region crosses into the load band at once (teleport-in — made larger by #92's debounce widening the resident set to its 3 km deadband), all those continuations resume together and the per-frame Instantiate burst tanks the frame rate.

- **`FuseSceneryLoadThrottlePatch`** — a Harmony prefix on `SetLoaded(bool)` caps how many FUSE scenery loads *start* per frame (`MaxLoadsPerFrame`). Over-budget loads defer to a FIFO queue; a persistent pump (`FuseSceneryLoadThrottlePump`) releases a few per frame, so staggered starts stagger the Instantiate work. A pump is required because the culler is event/world-shift driven, not per-frame.
- FUSE-only, load-path only, **fail-open** on any reflection miss/exception; skips already-loading objects; on release it drops anything past the 3 km deadband (reuses `ShouldHoldResident`) so a backlog can't force-load scenery the camera has left. Always on; `BenchmarkThrottleOverride` enables A/B.
- **`FuseSceneryLoadBudget`** — the Unity-free per-frame budget core, extracted for unit testing.
- The scenery benchmark gains a **Throttle A/B** (off vs on) with deferred/released/queue-depth and run-level load-latency (`avg`/`maxLoadMs`) in the JSON summary + per-frame CSV, plus Advanced-page buttons.

### 2. Map-load pipeline cost reduction (`dc0afb3`)

A static-analysis pass on the load/apply pipeline (the part FUSE controls) produced four changes:

1. **Measurement (on).** `FuseCacheRegistry` logs each full vs graph-only rebuild (elapsed ms + counts); `OnMapDidLoad` reports how many per-object mask refreshes the trailing rebuild absorbed; `ReloadTerrain` logs full-rebuild vs targeted. All via the existing `FusePerformanceMetrics`, visible in `FUSE.log`.
2. **Coalesce cache rebuilds (on, behavior-preserving).** The graph-rebuild handler now refreshes only the 3 graph-derived indexes (node/segment/span) via `FuseCacheRegistry.RebuildGraphIndexes()` instead of re-running all ~13 `FindObjectsOfType` scene scans on *every* graph rebuild. Safe because the APIs keep the scene indexes current incrementally (`Set`/`Remove`) and a graph rebuild changes track topology only; it falls back to a full rebuild if the caches aren't built yet.
3. **Defer per-object map-mask refresh during map-load apply (on, behavior-preserving).** `FuseTerrainRefreshScope` wraps `OnMapDidLoad`'s apply + the single trailing terrain rebuild; `MapAPI.RefreshAttachedMapMasks` skips the per-object `GetComponentsInChildren` + modifier churn while the scope is open (the trailing rebuild re-evaluates every live mask at once, and masks also self-apply on `OnEnable`). Runtime single-object API calls (no scope) are unchanged, and the end state is identical to before.
4. **Targeted terrain invalidation (EXPERIMENTAL, OFF by default).** When enabled, `ReloadTerrain` invalidates only the tiles overlapping the footprint FUSE touched (`MapManager.Invalidate(Bounds)`) instead of a full `RebuildAll` teardown + re-stream. Behind `FuseSettings.EnableTargetedTerrainInvalidation` + a Health → Advanced toggle, with a full-rebuild fallback whenever the toggle is off, the method doesn't resolve, or no footprint was captured.

## 🔄 Alternatives Considered

- **Throttle: per-frame start budget vs concurrent-load cap.** Chose per-frame starts — it needs no per-frame `FindObjectsOfType` in-flight scan and no completion-event bookkeeping, and staggered starts naturally stagger completions.
- **Cache coalescing: full suspend/resume batch vs graph-only narrow.** A suspend/resume batch risked stale-cache reads mid-apply; the graph-only narrow is provably safe (scene indexes are maintained incrementally), so that was chosen.
- **Terrain: targeted invalidation as the default vs full rebuild.** Targeted invalidation is timing-sensitive (masks load async; a missed footprint = dark terrain patch), so it ships **off** behind a toggle + fallback rather than changing default behavior.
- **Touching the game's core tile streaming.** Rejected outright — it's the one thing that would actually disrupt the core game.

## ⚠️ Possible Drawbacks

- **Default map-load path changes (#2, #3).** Behavior-preserving by analysis (same trailing terrain rebuild; scene indexes already maintained incrementally), with fallbacks + log lines, but they do alter the core load pipeline and want an in-game smoke test before merge.
- **Targeted terrain invalidation (#4)** is experimental: if a mask footprint is under-estimated you can get dark, uncut terrain patches. It is **off by default** for exactly this reason; enable + validate per-map before relying on it.
- **Throttle memory/async:** scenery now fills in gradually over a couple of smooth seconds on teleport-in instead of one frozen burst; `MaxLoadsPerFrame` (8) and `DeferredMaskFootprintSize` (512 m) are one-line tunables. The queue is FIFO by cull-callback order, not distance, so the very nearest object can pop in slightly after a farther one.
- **Save / multiplayer compatibility:** none affected — these are client-local visual/runtime concerns; no save-format or sync changes. The only persisted addition is the opt-in `EnableTargetedTerrainInvalidation` flag (default off). Non-host multiplayer-client paths are preserved (no apply, no terrain rebuild ⇒ no deferral).
- **Reflection:** the throttle reflects `SceneryAssetInstance.SetLoaded`/`_wantsLoaded`; the targeted path reflects `MapManager.Invalidate(Bounds)`. All are covered by the reflection-surface canary tests so a future game rename fails CI loudly, and every path is fail-open / falls back.

## ✅ Verification Process

- `dotnet build FUSE/FUSE.csproj` → **0 warnings / 0 errors**.
- `dotnet test FUSE.Tests` → **1189 passing** (up from 1170), including:
  - new `FuseSceneryLoadBudget` and `FuseTerrainRefreshScope` unit tests (budget ceiling/reset; scope depth/reset/union),
  - `FusePatchTargetingTests` auto-confirms the new `SetLoaded(bool)` Harmony target resolves against the live game DLL,
  - reflection-surface canaries for `SceneryAssetInstance.SetLoaded` and `MapManager.Invalidate(Bounds)`.
- **Not yet validated in-game** (no running client available here). Recommended pre-merge steps for a reviewer:
  1. Default config (targeted invalidation off): load a heavy/modded map and confirm masks + terrain look identical to before; check `FUSE.log` for the new `cache graph-only rebuild`, deferred-mask, and `terrain reload (full rebuild)` timing lines. Validates #2/#3 didn't regress.
  2. A/B #4: flip *Health → Advanced → Targeted Terrain Rebuild* on, reload, compare the logged `map mask rebuild` timing and watch for dark terrain patches.
  3. Throttle: run *Health → Advanced → Corridor/Sweep Throttle A/B* and compare `minFps` / `maxLoadMs` off vs on.

## 💡 Additional Information

- Both changes are issue #76 follow-ups and compose: the throttle smooths the scenery Instantiate burst that competes with terrain streaming for main-thread time; the map-load changes cut the redundant cache/terrain work around it.
- The benchmark and the targeted-terrain toggle are opt-in/manual and have no effect in normal play.
- Suggested next step once in-game numbers exist: tune `MaxLoadsPerFrame` and decide whether targeted invalidation is safe to promote to default on the maps that matter.
