### PR TITLE
ci: split mod and external-editor releases into separate tag lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: "10.0.x"
 
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-results
           path: FUSE.Tests/TestResults/test-results.trx
@@ -200,7 +200,7 @@ jobs:
 
       - name: Upload EditMode test results
         if: always() && steps.editmode_gate.outputs.enabled == 'true' && steps.unity_probe.outputs.available == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unity-editmode-results
           path: FUSE.UnityTests/TestResults/editmode-results.xml
@@ -262,7 +262,7 @@ jobs:
 
       - name: Upload build artifact
         id: build_upload
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ steps.build_id.outputs.archive }}
           path: ${{ steps.build_id.outputs.archive }}
@@ -274,7 +274,7 @@ jobs:
       # in place rather than spamming the conversation.
       - name: Post / update PR comment with download link
         if: github.event_name == 'pull_request' && success()
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3
         with:
           header: pr-build-artifact
           message: |
@@ -309,10 +309,10 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: "1"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: "10.0.x"
 
@@ -338,7 +338,7 @@ jobs:
 
       - name: Upload editor publish artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: fuse-external-editor
           path: publish/
@@ -346,7 +346,7 @@ jobs:
 
       - name: Upload net10 test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: net10-test-results
           path: TestResults/*.trx

--- a/.github/workflows/dotnet-lint.yml
+++ b/.github/workflows/dotnet-lint.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/release-editor.yml
+++ b/.github/workflows/release-editor.yml
@@ -1,0 +1,82 @@
+name: Release Editor
+
+# Independent release lane for the standalone FUSE.ExternalEditor (Avalonia,
+# net10, game-free). Triggered by editor-v<semver> tags so the editor ships on
+# its own cadence, decoupled from the mod's v<semver> release (release.yml).
+on:
+  push:
+    tags:
+      - "editor-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    # Game-free (no Unity/UMM DLLs, no GameDir) -> builds on a stock GitHub
+    # runner, the same environment CI's build-net10 job proves it in. No
+    # dependency on the self-hosted Railroader runner release.yml needs.
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: "true"
+      DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Parse semantic version from tag
+        id: version
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          if ($tag -notmatch '^editor-v(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$') {
+            throw "Tag '$tag' must match editor-v<semver>, e.g. editor-v0.2.0 or editor-v1.0.0-rc.1."
+          }
+
+          $version = $Matches.version
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+          # Treat anything in the 0.x series or with a pre-release suffix as a
+          # GitHub pre-release, mirroring release.yml's policy for the mod.
+          if ($version -match '^0\.' -or $version -match '-') {
+            "is_prerelease=true" >> $env:GITHUB_OUTPUT
+          }
+          else {
+            "is_prerelease=false" >> $env:GITHUB_OUTPUT
+          }
+
+      # Self-contained per-OS bundles (no .NET runtime required on the user's
+      # machine). The editor's version comes from the tag via -p:EditorVersion,
+      # not the mod's ModVersion stamp (see FUSE.ExternalEditor.csproj).
+      - name: Publish FUSE.ExternalEditor (per-OS, self-contained)
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          foreach ($rid in @('win-x64', 'linux-x64', 'osx-x64')) {
+            $out = "publish/editor-$rid"
+            dotnet publish FUSE.ExternalEditor/FUSE.ExternalEditor.csproj `
+              -c Release -r $rid --self-contained true `
+              -p:EditorVersion=$version -o $out
+            if ($LASTEXITCODE -ne 0) { throw "publish failed for $rid" }
+            $zip = "FUSE.ExternalEditor-v$version-$rid.zip"
+            if (Test-Path $zip) { Remove-Item $zip -Force }
+            Compress-Archive -Path "$out/*" -DestinationPath $zip -CompressionLevel Optimal
+          }
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: FUSE External Editor v${{ steps.version.outputs.version }}
+          prerelease: ${{ steps.version.outputs.is_prerelease }}
+          generate_release_notes: true
+          files: |
+            FUSE.ExternalEditor-v${{ steps.version.outputs.version }}-win-x64.zip
+            FUSE.ExternalEditor-v${{ steps.version.outputs.version }}-linux-x64.zip
+            FUSE.ExternalEditor-v${{ steps.version.outputs.version }}-osx-x64.zip

--- a/.github/workflows/release-externaleditor.yml
+++ b/.github/workflows/release-externaleditor.yml
@@ -33,14 +33,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # This lane never pushes back to the repo, so don't leave the
           # checkout token persisted in .git/config on the runner.
           persist-credentials: false
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: "10.0.x"
 
@@ -90,7 +90,7 @@ jobs:
           }
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: ${{ github.ref_name }}
           name: FUSE External Editor v${{ steps.version.outputs.version }}

--- a/.github/workflows/release-externaleditor.yml
+++ b/.github/workflows/release-externaleditor.yml
@@ -10,8 +10,16 @@ on:
     tags:
       - "externaleditor-v*"
 
+# A release lane only needs to write repository Contents (create the release and
+# upload the per-OS bundles); no other scopes are required.
 permissions:
   contents: write
+
+# Serialize editor releases so two runs never race on GitHub-release creation or
+# asset uploads. Never cancel an in-flight release.
+concurrency:
+  group: release-externaleditor
+  cancel-in-progress: false
 
 jobs:
   build-and-release:
@@ -26,6 +34,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # This lane never pushes back to the repo, so don't leave the
+          # checkout token persisted in .git/config on the runner.
+          persist-credentials: false
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
@@ -35,8 +47,12 @@ jobs:
       - name: Parse semantic version from tag
         id: version
         shell: pwsh
+        env:
+          # Pass the tag via the environment, not template expansion, so a
+          # crafted tag name can't inject into the script before validation.
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          $tag = "${{ github.ref_name }}"
+          $tag = $env:TAG_NAME
           if ($tag -notmatch '^externaleditor-v(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$') {
             throw "Tag '$tag' must match externaleditor-v<semver>, e.g. externaleditor-v0.2.0 or externaleditor-v1.0.0-rc.1."
           }
@@ -58,8 +74,10 @@ jobs:
       # not the mod's ModVersion stamp (see FUSE.ExternalEditor.csproj).
       - name: Publish FUSE.ExternalEditor (per-OS, self-contained)
         shell: pwsh
+        env:
+          EDITOR_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          $version = "${{ steps.version.outputs.version }}"
+          $version = $env:EDITOR_VERSION
           foreach ($rid in @('win-x64', 'linux-x64', 'osx-x64')) {
             $out = "publish/externaleditor-$rid"
             dotnet publish FUSE.ExternalEditor/FUSE.ExternalEditor.csproj `

--- a/.github/workflows/release-externaleditor.yml
+++ b/.github/workflows/release-externaleditor.yml
@@ -1,12 +1,14 @@
-name: Release Editor
+name: Release External Editor
 
 # Independent release lane for the standalone FUSE.ExternalEditor (Avalonia,
-# net10, game-free). Triggered by editor-v<semver> tags so the editor ships on
-# its own cadence, decoupled from the mod's v<semver> release (release.yml).
+# net10, game-free). Triggered by externaleditor-v<semver> tags so the external
+# editor ships on its own cadence, decoupled from the mod's mod-v<semver>
+# release (release.yml). The prefix is externaleditor- (not editor-) to keep it
+# distinct from the in-game editor, which ships inside the mod.
 on:
   push:
     tags:
-      - "editor-v*"
+      - "externaleditor-v*"
 
 permissions:
   contents: write
@@ -35,8 +37,8 @@ jobs:
         shell: pwsh
         run: |
           $tag = "${{ github.ref_name }}"
-          if ($tag -notmatch '^editor-v(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$') {
-            throw "Tag '$tag' must match editor-v<semver>, e.g. editor-v0.2.0 or editor-v1.0.0-rc.1."
+          if ($tag -notmatch '^externaleditor-v(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$') {
+            throw "Tag '$tag' must match externaleditor-v<semver>, e.g. externaleditor-v0.2.0 or externaleditor-v1.0.0-rc.1."
           }
 
           $version = $Matches.version
@@ -52,17 +54,17 @@ jobs:
           }
 
       # Self-contained per-OS bundles (no .NET runtime required on the user's
-      # machine). The editor's version comes from the tag via -p:EditorVersion,
+      # machine). The version comes from the tag via -p:ExternalEditorVersion,
       # not the mod's ModVersion stamp (see FUSE.ExternalEditor.csproj).
       - name: Publish FUSE.ExternalEditor (per-OS, self-contained)
         shell: pwsh
         run: |
           $version = "${{ steps.version.outputs.version }}"
           foreach ($rid in @('win-x64', 'linux-x64', 'osx-x64')) {
-            $out = "publish/editor-$rid"
+            $out = "publish/externaleditor-$rid"
             dotnet publish FUSE.ExternalEditor/FUSE.ExternalEditor.csproj `
               -c Release -r $rid --self-contained true `
-              -p:EditorVersion=$version -o $out
+              -p:ExternalEditorVersion=$version -o $out
             if ($LASTEXITCODE -ne 0) { throw "publish failed for $rid" }
             $zip = "FUSE.ExternalEditor-v$version-$rid.zip"
             if (Test-Path $zip) { Remove-Item $zip -Force }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: write
 
+# Serialize mod releases: the job reuses fixed working directories (staging,
+# staging-livebridge) on the self-hosted runner, so overlapping runs could race
+# and ship a corrupted archive. Never cancel an in-flight release.
+concurrency:
+  group: release-mod
+  cancel-in-progress: false
+
 jobs:
   build-and-release:
     runs-on: self-hosted

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,20 +104,9 @@ jobs:
           "archive_name=$archiveName" >> $env:GITHUB_OUTPUT
           "archive_path=$archivePath" >> $env:GITHUB_OUTPUT
 
-      # Standalone cross-platform editor: self-contained per-OS bundles (no .NET
-      # runtime required on the user's machine). Built from the game-free net10
-      # projects, so no Unity/UMM DLLs are involved.
-      - name: Publish FUSE.ExternalEditor (per-OS)
-        shell: powershell
-        run: |
-          $version = "${{ steps.version.outputs.version }}"
-          foreach ($rid in @('win-x64', 'linux-x64', 'osx-x64')) {
-            $out = "publish/editor-$rid"
-            dotnet publish FUSE.ExternalEditor/FUSE.ExternalEditor.csproj -c Release -r $rid --self-contained true -o $out
-            $zip = "FUSE.ExternalEditor-v$version-$rid.zip"
-            if (Test-Path $zip) { Remove-Item $zip -Force }
-            Compress-Archive -Path "$out/*" -DestinationPath $zip -CompressionLevel Optimal
-          }
+      # The standalone editor ships in its own release lane (editor-v* tags,
+      # .github/workflows/release-editor.yml) so it can be versioned and shipped
+      # independently of the mod. It is intentionally NOT packaged here.
 
       # FUSE.LiveBridge is an optional in-game mod (net48) that hot-reloads the
       # editor's saves; it ships as its own UMM mod zip.
@@ -164,9 +153,6 @@ jobs:
             dist/FUSE-Converter.exe
             dist/FUSE-Installer.exe
             dist/FUSEConvertFolder.pyz
-            FUSE.ExternalEditor-v${{ steps.version.outputs.version }}-win-x64.zip
-            FUSE.ExternalEditor-v${{ steps.version.outputs.version }}-linux-x64.zip
-            FUSE.ExternalEditor-v${{ steps.version.outputs.version }}-osx-x64.zip
             FUSE.LiveBridge-v${{ steps.version.outputs.version }}.zip
 
       # Uploads the same archive to the mod's Nexus Mods page.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "mod-v*"
 
 permissions:
   contents: write
@@ -34,8 +34,8 @@ jobs:
         shell: powershell
         run: |
           $tag = "${{ github.ref_name }}"
-          if ($tag -notmatch '^v(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$') {
-            throw "Tag '$tag' must match v<semver>, e.g. v0.10.0 or v1.0.0-rc.1."
+          if ($tag -notmatch '^mod-v(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$') {
+            throw "Tag '$tag' must match mod-v<semver>, e.g. mod-v0.13.0 or mod-v1.0.0-rc.1."
           }
 
           $version = $Matches.version
@@ -104,9 +104,10 @@ jobs:
           "archive_name=$archiveName" >> $env:GITHUB_OUTPUT
           "archive_path=$archivePath" >> $env:GITHUB_OUTPUT
 
-      # The standalone editor ships in its own release lane (editor-v* tags,
-      # .github/workflows/release-editor.yml) so it can be versioned and shipped
-      # independently of the mod. It is intentionally NOT packaged here.
+      # The standalone editor ships in its own release lane (externaleditor-v*
+      # tags, .github/workflows/release-externaleditor.yml) so it can be
+      # versioned and shipped independently of the mod. Intentionally NOT
+      # packaged here.
 
       # FUSE.LiveBridge is an optional in-game mod (net48) that hot-reloads the
       # editor's saves; it ships as its own UMM mod zip.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,13 @@ jobs:
       - name: Parse semantic version from tag
         id: version
         shell: powershell
+        env:
+          # Pass the tag via the environment, not template expansion, so a
+          # crafted tag name can't inject into the script before validation.
+          # This step runs on the self-hosted runner, so the hardening matters.
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          $tag = "${{ github.ref_name }}"
+          $tag = $env:TAG_NAME
           if ($tag -notmatch '^mod-v(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$') {
             throw "Tag '$tag' must match mod-v<semver>, e.g. mod-v0.13.0 or mod-v1.0.0-rc.1."
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: "10.0.x"
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -150,7 +150,7 @@ jobs:
         run: python tools/build_folder_converter_pyz.py
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: ${{ github.ref_name }}
           name: FUSE v${{ steps.version.outputs.version }}
@@ -170,7 +170,7 @@ jobs:
       #   - variable NEXUS_FILE_GROUP_ID (from "API Info" on the mod's Files tab)
       - name: Upload to Nexus Mods
         if: ${{ vars.NEXUS_FILE_GROUP_ID != '' }}
-        uses: Nexus-Mods/upload-action@v1.0.0-beta.5
+        uses: Nexus-Mods/upload-action@a746f1867153abc77beed950bf7526ece1a9f8c4 # v1.0.0-beta.5
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
           file_group_id: ${{ vars.NEXUS_FILE_GROUP_ID }}

--- a/.github/workflows/sync-info-json.yml
+++ b/.github/workflows/sync-info-json.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           # Default GITHUB_TOKEN can push back to main; branch protections

--- a/.github/workflows/sync-info-json.yml
+++ b/.github/workflows/sync-info-json.yml
@@ -3,7 +3,7 @@ name: Sync Info.json to latest release
 # Keeps the source FUSE/Info.json "Version" field in step with the latest
 # published GitHub release. Skipped for GitHub pre-releases (incl. the
 # 0.x series treated as pre-release by release.yml) and for any tag that
-# isn't a plain v<MAJOR>.<MINOR>.<PATCH>. The release artifact itself is
+# isn't a plain mod-v<MAJOR>.<MINOR>.<PATCH>. The release artifact itself is
 # already correctly stamped by the build (see InjectModVersionIntoInfoJson
 # in Directory.Build.targets); this workflow only updates the in-repo
 # manifest so the source-of-truth tracks the latest GA release.
@@ -34,8 +34,8 @@ jobs:
         shell: powershell
         run: |
           $tag = "${{ github.event.release.tag_name }}"
-          if ($tag -notmatch '^v(?<version>[0-9]+\.[0-9]+\.[0-9]+)$') {
-            Write-Host "Release tag '$tag' is not a 3-part GA semver; skipping sync."
+          if ($tag -notmatch '^mod-v(?<version>[0-9]+\.[0-9]+\.[0-9]+)$') {
+            Write-Host "Release tag '$tag' is not a 3-part GA mod-v semver; skipping sync."
             "skip=true" >> $env:GITHUB_OUTPUT
             exit 0
           }

--- a/FUSE.ExternalEditor/FUSE.ExternalEditor.csproj
+++ b/FUSE.ExternalEditor/FUSE.ExternalEditor.csproj
@@ -11,10 +11,23 @@
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <!-- Standalone cross-platform desktop app: no game/Unity DLLs, sets its
-         own version (not the net48 mod-version stamp). See Directory.Build.targets. -->
+    <!-- Standalone cross-platform desktop app: no game/Unity DLLs, so it sets
+         its own version instead of the net48 mod-version stamp (see
+         Directory.Build.targets). -->
     <FuseIsGameFree>true</FuseIsGameFree>
-    <Version>0.1.0</Version>
+    <!-- Editor version is tag-driven: release-editor.yml passes
+         -p:EditorVersion=<semver from the editor-v* tag>. Local/CI builds fall
+         back to the dev floor below. Full semver feeds Version/Informational;
+         AssemblyVersion/FileVersion take the numeric core only (those can't
+         hold a prerelease suffix). Mirrors the ModVersion split in
+         Directory.Build.targets. -->
+    <EditorVersion Condition="'$(EditorVersion)' == ''">0.1.0</EditorVersion>
+    <EditorVersionCore>$([System.Text.RegularExpressions.Regex]::Match('$(EditorVersion)', '^[0-9]+\.[0-9]+\.[0-9]+').Value)</EditorVersionCore>
+    <EditorVersionCore Condition="'$(EditorVersionCore)' == ''">0.1.0</EditorVersionCore>
+    <Version>$(EditorVersion)</Version>
+    <AssemblyVersion>$(EditorVersionCore).0</AssemblyVersion>
+    <FileVersion>$(EditorVersionCore).0</FileVersion>
+    <InformationalVersion>$(EditorVersion)</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FUSE.ExternalEditor/FUSE.ExternalEditor.csproj
+++ b/FUSE.ExternalEditor/FUSE.ExternalEditor.csproj
@@ -15,19 +15,19 @@
          its own version instead of the net48 mod-version stamp (see
          Directory.Build.targets). -->
     <FuseIsGameFree>true</FuseIsGameFree>
-    <!-- Editor version is tag-driven: release-editor.yml passes
-         -p:EditorVersion=<semver from the editor-v* tag>. Local/CI builds fall
-         back to the dev floor below. Full semver feeds Version/Informational;
-         AssemblyVersion/FileVersion take the numeric core only (those can't
-         hold a prerelease suffix). Mirrors the ModVersion split in
-         Directory.Build.targets. -->
-    <EditorVersion Condition="'$(EditorVersion)' == ''">0.1.0</EditorVersion>
-    <EditorVersionCore>$([System.Text.RegularExpressions.Regex]::Match('$(EditorVersion)', '^[0-9]+\.[0-9]+\.[0-9]+').Value)</EditorVersionCore>
-    <EditorVersionCore Condition="'$(EditorVersionCore)' == ''">0.1.0</EditorVersionCore>
-    <Version>$(EditorVersion)</Version>
-    <AssemblyVersion>$(EditorVersionCore).0</AssemblyVersion>
-    <FileVersion>$(EditorVersionCore).0</FileVersion>
-    <InformationalVersion>$(EditorVersion)</InformationalVersion>
+    <!-- Version is tag-driven: release-externaleditor.yml passes
+         -p:ExternalEditorVersion=<semver from the externaleditor-v* tag>.
+         Local/CI builds fall back to the dev floor below. Full semver feeds
+         Version/Informational; AssemblyVersion/FileVersion take the numeric
+         core only (those can't hold a prerelease suffix). Mirrors the
+         ModVersion split in Directory.Build.targets. -->
+    <ExternalEditorVersion Condition="'$(ExternalEditorVersion)' == ''">0.1.0</ExternalEditorVersion>
+    <ExternalEditorVersionCore>$([System.Text.RegularExpressions.Regex]::Match('$(ExternalEditorVersion)', '^[0-9]+\.[0-9]+\.[0-9]+').Value)</ExternalEditorVersionCore>
+    <ExternalEditorVersionCore Condition="'$(ExternalEditorVersionCore)' == ''">0.1.0</ExternalEditorVersionCore>
+    <Version>$(ExternalEditorVersion)</Version>
+    <AssemblyVersion>$(ExternalEditorVersionCore).0</AssemblyVersion>
+    <FileVersion>$(ExternalEditorVersionCore).0</FileVersion>
+    <InformationalVersion>$(ExternalEditorVersion)</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,54 @@
+# Releasing
+
+FUSE ships in two independent lanes, each driven by a git tag. Pushing the tag
+is the only trigger — the matching workflow does the build, packaging, and
+GitHub Release.
+
+## Mod release — `v<semver>`
+
+Tag: `v0.13.0`, `v1.0.0-rc.1`, ... (must match `v<major>.<minor>.<patch>` with an
+optional `-prerelease` suffix).
+
+Runs [`.github/workflows/release.yml`](../.github/workflows/release.yml) on the
+**self-hosted** Railroader runner (it needs the game's Unity/UMM reference
+assemblies). Produces and attaches:
+
+- `FUSE-v<ver>.zip` — the UMM mod (FUSE.dll, FUSE.Editor.dll, FUSE.Converter.dll,
+  stamped `Info.json`, schemas, icon)
+- `FUSE.LiveBridge-v<ver>.zip` — optional in-game hot-reload bridge
+- `FUSE-Converter.exe`, `FUSE-Installer.exe`, `FUSEConvertFolder.pyz` — tools
+
+The mod version flows in via `-p:ModVersion=<ver>`, which stamps the assemblies
+and `Info.json` (see `Directory.Build.targets`). On a non-prerelease (GA) tag,
+[`sync-info-json.yml`](../.github/workflows/sync-info-json.yml) commits the
+matching `FUSE/Info.json` version back to `main`.
+
+This lane does **not** ship the standalone editor — that moved to its own lane.
+
+## Editor release — `editor-v<semver>`
+
+Tag: `editor-v0.2.0`, `editor-v1.0.0-rc.1`, ...
+
+Runs [`.github/workflows/release-editor.yml`](../.github/workflows/release-editor.yml)
+on a **GitHub-hosted** `ubuntu-latest` runner — the standalone editor is
+game-free (`FuseIsGameFree=true`), so it needs no Railroader DLLs and builds in
+the same environment CI's `build-net10` job already proves. Produces and
+attaches the self-contained, per-OS bundles:
+
+- `FUSE.ExternalEditor-v<ver>-win-x64.zip`
+- `FUSE.ExternalEditor-v<ver>-linux-x64.zip`
+- `FUSE.ExternalEditor-v<ver>-osx-x64.zip`
+
+The editor version flows in via `-p:EditorVersion=<ver>` (see
+`FUSE.ExternalEditor/FUSE.ExternalEditor.csproj`); local/CI builds without it
+fall back to the dev floor in that csproj. The editor and mod version numbers
+are independent — bump and tag them separately.
+
+## Notes
+
+- Both lanes treat the `0.x` series or any `-prerelease` suffix as a GitHub
+  pre-release (FUSE is pre-1.0).
+- The tag prefixes don't collide: `editor-v*` does not match `release.yml`'s
+  `v*` trigger, and `sync-info-json.yml`'s `^v...` parse skips editor tags.
+- To dry-run a lane, push a throwaway pre-release tag (e.g. `editor-v0.2.0-rc.1`),
+  confirm the release and its assets, then delete the tag and release.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -49,11 +49,11 @@ numbers are independent — bump and tag them separately.
 
 ## Notes
 
-- Both lanes treat the `0.x` series or any `-prerelease` suffix as a GitHub
-  pre-release (FUSE is pre-1.0).
+- Both lanes treat the `0.x` series or any prerelease suffix (e.g. `-rc.1`) as a
+  GitHub prerelease (FUSE is pre-1.0).
 - The tag prefixes don't collide: `mod-v*`, `externaleditor-v*`, and the
   existing `tools-v*` are disjoint globs, and `sync-info-json.yml`'s
   `^mod-v...` parse only ever stamps `Info.json` from a mod release.
-- To dry-run a lane, push a throwaway pre-release tag (e.g.
+- To dry-run a lane, push a throwaway prerelease tag (e.g.
   `externaleditor-v0.2.0-rc.1`), confirm the release and its assets, then
   delete the tag and release.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,10 +4,10 @@ FUSE ships in two independent lanes, each driven by a git tag. Pushing the tag
 is the only trigger — the matching workflow does the build, packaging, and
 GitHub Release.
 
-## Mod release — `v<semver>`
+## Mod release — `mod-v<semver>`
 
-Tag: `v0.13.0`, `v1.0.0-rc.1`, ... (must match `v<major>.<minor>.<patch>` with an
-optional `-prerelease` suffix).
+Tag: `mod-v0.13.0`, `mod-v1.0.0-rc.1`, ... (must match
+`mod-v<major>.<minor>.<patch>` with an optional `-prerelease` suffix).
 
 Runs [`.github/workflows/release.yml`](../.github/workflows/release.yml) on the
 **self-hosted** Railroader runner (it needs the game's Unity/UMM reference
@@ -23,13 +23,16 @@ and `Info.json` (see `Directory.Build.targets`). On a non-prerelease (GA) tag,
 [`sync-info-json.yml`](../.github/workflows/sync-info-json.yml) commits the
 matching `FUSE/Info.json` version back to `main`.
 
-This lane does **not** ship the standalone editor — that moved to its own lane.
+This lane does **not** ship the standalone editor — that has its own lane.
 
-## Editor release — `editor-v<semver>`
+## External editor release — `externaleditor-v<semver>`
 
-Tag: `editor-v0.2.0`, `editor-v1.0.0-rc.1`, ...
+Tag: `externaleditor-v0.2.0`, `externaleditor-v1.0.0-rc.1`, ...
 
-Runs [`.github/workflows/release-editor.yml`](../.github/workflows/release-editor.yml)
+The prefix is `externaleditor-` (not `editor-`) to distinguish the standalone
+desktop editor from the in-game editor, which ships inside the mod.
+
+Runs [`.github/workflows/release-externaleditor.yml`](../.github/workflows/release-externaleditor.yml)
 on a **GitHub-hosted** `ubuntu-latest` runner — the standalone editor is
 game-free (`FuseIsGameFree=true`), so it needs no Railroader DLLs and builds in
 the same environment CI's `build-net10` job already proves. Produces and
@@ -39,16 +42,18 @@ attaches the self-contained, per-OS bundles:
 - `FUSE.ExternalEditor-v<ver>-linux-x64.zip`
 - `FUSE.ExternalEditor-v<ver>-osx-x64.zip`
 
-The editor version flows in via `-p:EditorVersion=<ver>` (see
+The version flows in via `-p:ExternalEditorVersion=<ver>` (see
 `FUSE.ExternalEditor/FUSE.ExternalEditor.csproj`); local/CI builds without it
-fall back to the dev floor in that csproj. The editor and mod version numbers
-are independent — bump and tag them separately.
+fall back to the dev floor in that csproj. The mod and external-editor version
+numbers are independent — bump and tag them separately.
 
 ## Notes
 
 - Both lanes treat the `0.x` series or any `-prerelease` suffix as a GitHub
   pre-release (FUSE is pre-1.0).
-- The tag prefixes don't collide: `editor-v*` does not match `release.yml`'s
-  `v*` trigger, and `sync-info-json.yml`'s `^v...` parse skips editor tags.
-- To dry-run a lane, push a throwaway pre-release tag (e.g. `editor-v0.2.0-rc.1`),
-  confirm the release and its assets, then delete the tag and release.
+- The tag prefixes don't collide: `mod-v*`, `externaleditor-v*`, and the
+  existing `tools-v*` are disjoint globs, and `sync-info-json.yml`'s
+  `^mod-v...` parse only ever stamps `Info.json` from a mod release.
+- To dry-run a lane, push a throwaway pre-release tag (e.g.
+  `externaleditor-v0.2.0-rc.1`), confirm the release and its assets, then
+  delete the tag and release.


### PR DESCRIPTION
## What

Split FUSE's release into two independent, symmetrically-named tag lanes so the standalone editor ships on its own cadence:

| Lane | Tag | Workflow | Runner | Artifacts |
|---|---|---|---|---|
| Mod | `mod-v<semver>` | `release.yml` | self-hosted | mod zip, LiveBridge, converter/installer/pyz tools |
| External editor | `externaleditor-v<semver>` | `release-externaleditor.yml` | ubuntu-latest | self-contained `win`/`linux`/`osx-x64` editor zips |

The standalone editor's prefix is **`externaleditor-`** (not `editor-`) to leave the `editor-*` namespace for the in-game editor that ships inside the mod.

### Background

The build/deploy wiring for both the editor and the mod already landed in `main` (CI's `build-net10` job builds/tests/publishes the editor; `release.yml` published per-OS editor zips on a `v*` tag). It just hadn't shipped: the editor landed after the last release (`v0.12.0`), so no tag has exercised the editor steps. This PR reshapes that wiring into two independent lanes.

### Changes

- **New `.github/workflows/release-externaleditor.yml`** — triggers on `externaleditor-v*`; builds the self-contained per-OS bundles on `ubuntu-latest` (editor is game-free, no self-hosted runner needed) and creates a GitHub Release.
- **Tag-driven editor version** — `FUSE.ExternalEditor.csproj` reads `-p:ExternalEditorVersion` (from the `externaleditor-v*` tag), falling back to a `0.1.0` dev floor for local/CI builds. Mirrors the `ModVersion` split in `Directory.Build.targets`.
- **Mod release renamed `v*` → `mod-v*`** — updated the trigger, version-parse regex, and error message in `release.yml`, plus the GA-sync regex/comment in `sync-info-json.yml`. The first mod release under the new scheme is `mod-v0.13.0`.
- **`release.yml` no longer ships the editor** — dropped the per-OS publish step and the three editor zip assets (mod release still ships mod + LiveBridge + tools).
- **`docs/RELEASING.md`** — documents both lanes.

The prefixes are disjoint globs (`mod-v*`, `externaleditor-v*`, existing `tools-v*`); `externaleditor-v*` doesn't match `release.yml`'s `mod-v*` trigger, and `sync-info-json.yml`'s `^mod-v...` parse only ever stamps `Info.json` from a mod release. Existing `v0.*` tags/releases are unaffected.

## Verification

- `dotnet build FUSE.ExternalEditor -c Release -p:ExternalEditorVersion=0.2.0-rc.1` → `FileVersion 0.2.0.0`, `ProductVersion 0.2.0-rc.1`; no flag → `0.1.0`.
- All three workflow files validated as parseable YAML.
- Editor build succeeds (game-free; no `GameDir` required).

To smoke-test a lane after merge: push a throwaway pre-release tag (e.g. `externaleditor-v0.2.0-rc.1`), confirm the run produces a pre-release with the expected assets, then delete the tag/release.

> Note (out of scope): the build surfaces pre-existing `NU1903`/`NU1902` advisories for `SixLabors.ImageSharp 3.1.5` in the editor. Not touched here — flagged for a separate dependency bump.