### PR TITLE
fix(deps): bump SixLabors.ImageSharp 3.1.5 -> 3.1.12 (clears NU1903/NU1902)

### DIFF
--- a/FUSE.ExternalEditor/FUSE.ExternalEditor.csproj
+++ b/FUSE.ExternalEditor/FUSE.ExternalEditor.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <!-- Pure-managed image codec for terrain tile_X_Y.data (RGBA PNG) load/save. -->
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What

Bumps `SixLabors.ImageSharp` from **3.1.5** to **3.1.12** in [`FUSE.ExternalEditor/FUSE.ExternalEditor.csproj`](FUSE.ExternalEditor/FUSE.ExternalEditor.csproj).

This is the only `<PackageReference>` to ImageSharp in the repo (this repo does **not** use Central Package Management). The other consumers — `FUSE.ExternalEditor.UiTests` and the `Services/*` code — pull it transitively via project reference, so a single bump covers everything.

## Why

NuGet audit surfaced two advisories on 3.1.5 when building the editor. GHSA -> CVE mappings below are verified against the GitHub advisory pages:

| Code | Severity | Advisory | CVE | Issue | Fixed in |
|------|----------|----------|-----|-------|----------|
| NU1903 | High | [GHSA-2cmq-823j-5qj8](https://github.com/advisories/GHSA-2cmq-823j-5qj8) | [CVE-2025-27598](https://nvd.nist.gov/vuln/detail/CVE-2025-27598) | Out-of-bounds write in the GIF decoder | 3.1.7 |
| NU1902 | Moderate | [GHSA-rxmq-m78w-7wmc](https://github.com/advisories/GHSA-rxmq-m78w-7wmc) | [CVE-2025-54575](https://nvd.nist.gov/vuln/detail/CVE-2025-54575) | Infinite loop on a malformed GIF comment-extension block (DoS) | 3.1.11 |

**3.1.12** is the latest patched release on the 3.1.x line (released 2025-10-29) and clears both cited advisories (>= 3.1.7 and >= 3.1.11). Deliberately staying on 3.1.x rather than jumping to the 4.0.0 major to avoid breaking-change risk. dependabot is configured for weekly NuGet updates, but this advisory is worth addressing directly rather than waiting.

ImageSharp is the pure-managed codec used for terrain tile (RGBA PNG) load/save in the editor.

## Verification (game-free, no GameDir needed)

- `dotnet build FUSE.ExternalEditor/FUSE.ExternalEditor.csproj -c Release` -> **Build succeeded, 0 warnings, 0 errors** — NU1903/NU1902 no longer appear (confirmed with a forced clean `dotnet restore` too; `project.assets.json` resolves `SixLabors.ImageSharp/3.1.12`).
- `dotnet test FUSE.ExternalEditor.UiTests/FUSE.ExternalEditor.UiTests.csproj -c Release` -> **87/87 passed**, 0 failed, 0 skipped.
- `TerrainTests` (the primary ImageSharp RGBA PNG load/save consumer) -> **9/9 passed**.