### PR TITLE
fix(scenery): de-inflate culling debounce + live camera; guard benchmark (#76)

### DIFF
--- a/FUSE.Tests/Interface/FuseSceneryBenchmarkEngagementTests.cs
+++ b/FUSE.Tests/Interface/FuseSceneryBenchmarkEngagementTests.cs
@@ -1,0 +1,34 @@
+using FUSE.Interface;
+using Xunit;
+
+namespace FUSE.Tests.Interface
+{
+    /// <summary>
+    /// Guards the Phase-2 "inconclusive run" classifier. The first "corridor — single"
+    /// benchmark shipped a regression while reporting all-zero counters; these assert
+    /// that an all-zero run is classified NOT engaged (so the JSON/UI marks it
+    /// inconclusive instead of a pass), and that any single non-zero engagement signal
+    /// flips it to engaged.
+    /// </summary>
+    public class FuseSceneryBenchmarkEngagementTests
+    {
+        [Fact]
+        public void AllZero_IsNotEngaged()
+        {
+            // The exact shape of the misleading "corridor — single" run.
+            Assert.False(FuseSceneryBenchmarkEngagement.Engaged(
+                fuseLoads: 0, suppressedUnloads: 0, deferredLoads: 0, peakQueueDepth: 0));
+        }
+
+        [Theory]
+        [InlineData(1, 0, 0, 0)] // FUSE load/unload churn alone
+        [InlineData(0, 1, 0, 0)] // debounce suppression alone
+        [InlineData(0, 0, 1, 0)] // throttle deferral alone
+        [InlineData(0, 0, 0, 1)] // a non-empty throttle queue alone
+        public void AnySingleSignal_IsEngaged(long fuseLoads, long suppressedUnloads, long deferredLoads, int peakQueueDepth)
+        {
+            Assert.True(FuseSceneryBenchmarkEngagement.Engaged(
+                fuseLoads, suppressedUnloads, deferredLoads, peakQueueDepth));
+        }
+    }
+}

--- a/FUSE.UnityTests/Assets/Tests/FuseSceneryCullingDebounceTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/FuseSceneryCullingDebounceTests.cs
@@ -62,5 +62,38 @@ namespace FUSE.UnityTests
             Assert.IsTrue(FuseSceneryCullingDebouncePatch.ShouldHoldResident(camera, near));
             Assert.IsFalse(FuseSceneryCullingDebouncePatch.ShouldHoldResident(camera, far));
         }
+
+        // Issue #76 follow-up (fix #2): the debounce holds ONLY already-loaded scenery.
+        // Force-holding a not-yet-loaded object inside the deadband would clamp band
+        // 3 -> 2 and stream it in, inflating the post-teleport working set to the whole
+        // ~3km sphere (~8x the game's load volume) and feeding it through the throttle.
+        // ShouldHold gates ShouldHoldResident on the model already being requested.
+
+        [Test]
+        public void ShouldHold_NotYetLoaded_DoesNotHold()
+        {
+            var near = new Vector3(0f, 0f, Deadband * 0.5f);
+            Assert.IsFalse(
+                FuseSceneryCullingDebouncePatch.ShouldHold(modelLoadRequested: false, Vector3.zero, near),
+                "Unloaded scenery inside the deadband must not be force-held (it would force a load, inflating the set).");
+        }
+
+        [Test]
+        public void ShouldHold_Loaded_WithinDeadband_Holds()
+        {
+            var near = new Vector3(0f, 0f, Deadband * 0.5f);
+            Assert.IsTrue(
+                FuseSceneryCullingDebouncePatch.ShouldHold(modelLoadRequested: true, Vector3.zero, near),
+                "Already-loaded scenery inside the deadband must be held to absorb boundary jitter (anti-flap).");
+        }
+
+        [Test]
+        public void ShouldHold_Loaded_BeyondDeadband_Releases()
+        {
+            var far = new Vector3(0f, 0f, Deadband * 2f);
+            Assert.IsFalse(
+                FuseSceneryCullingDebouncePatch.ShouldHold(modelLoadRequested: true, Vector3.zero, far),
+                "Loaded scenery beyond the deadband must be released so the game unloads it (culling still works).");
+        }
     }
 }

--- a/FUSE/Interface/FuseSceneryBenchmark.cs
+++ b/FUSE/Interface/FuseSceneryBenchmark.cs
@@ -198,6 +198,12 @@ namespace FUSE.Interface
                         $"duration base={baseline.Value<double>("durationMs"):0}ms fix={fixedRun.Value<double>("durationMs"):0}ms.";
                 }
 
+                if (baseline.Value<bool>("inconclusive") || fixedRun.Value<bool>("inconclusive"))
+                {
+                    _status = "INCONCLUSIVE — scenario never engaged FUSE scenery culling; " +
+                              "run it in a denser area / teleport. " + _status;
+                }
+
                 FuseLog.Info("FUSE benchmark A/B: " + _status);
             }
         }
@@ -280,6 +286,25 @@ namespace FUSE.Interface
                     ["maxLoadMs"] = Math.Round(sampler.MaxLoadMs, 0),
                     ["csv"] = sampler.FileName
                 };
+
+                // A run that never engaged the FUSE scenery path can't validate
+                // anything — flag it INCONCLUSIVE so a too-light scenario (all-zero
+                // counters) is not mistaken for a passing regression guard.
+                var engaged = FuseSceneryBenchmarkEngagement.Engaged(
+                    FuseSceneryCullingDiagnosticPatch.FuseLoads,
+                    FuseSceneryCullingDebouncePatch.SuppressedUnloads,
+                    FuseSceneryLoadThrottlePatch.DeferredLoads,
+                    FuseSceneryLoadThrottlePatch.PeakQueueDepth);
+                result["engaged"] = engaged;
+                result["inconclusive"] = !engaged;
+                if (!engaged)
+                {
+                    FuseLog.Warning(
+                        $"FUSE benchmark [{scenario.Name}/{label}] is INCONCLUSIVE: the scenario never engaged FUSE " +
+                        "scenery culling (0 FUSE loads, 0 debounce suppressions, 0 throttle deferrals/queue). Run a " +
+                        "denser area or teleport into heavily-modded scenery so the load path is actually exercised.");
+                }
+
                 AppendResult(result);
                 _status =
                     $"[{scenario.Name}/{label}] done {durationMs:0}ms; loads={FuseSceneryCullingDiagnosticPatch.FuseLoads} " +

--- a/FUSE/Interface/FuseSceneryBenchmarkEngagement.cs
+++ b/FUSE/Interface/FuseSceneryBenchmarkEngagement.cs
@@ -1,0 +1,26 @@
+namespace FUSE.Interface
+{
+    /// <summary>
+    /// Pure classifier for whether a scenery-benchmark run actually exercised the FUSE
+    /// scenery culling path. A run that engaged nothing — no FUSE load/unload churn, no
+    /// debounce suppressions, and no throttle deferrals/queue — is INCONCLUSIVE, not a
+    /// pass: a scenario too light to reproduce the bug must never read as a green
+    /// regression guard (exactly how the first "corridor — single" run came back all
+    /// zeros while the bug shipped). Unity-free so it is unit-testable in FUSE.Tests.
+    /// </summary>
+    internal static class FuseSceneryBenchmarkEngagement
+    {
+        /// <summary>
+        /// True when the run touched the FUSE scenery culling pipeline at all. The
+        /// counters are independent signals (the debounce can suppress without the
+        /// throttle deferring, and vice versa), so engagement is their OR.
+        /// </summary>
+        internal static bool Engaged(long fuseLoads, long suppressedUnloads, long deferredLoads, int peakQueueDepth)
+        {
+            return fuseLoads > 0
+                || suppressedUnloads > 0
+                || deferredLoads > 0
+                || peakQueueDepth > 0;
+        }
+    }
+}

--- a/FUSE/Patches/FuseSceneryCameraRef.cs
+++ b/FUSE/Patches/FuseSceneryCameraRef.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// One shared cache of the scenery culler's distance reference (Camera.main),
+    /// used by both the cull debounce and the load throttle so they always measure
+    /// against the same camera. Refreshed when the cached camera is destroyed OR
+    /// merely disabled — a camera-mode / scene transition leaves the old gameplay
+    /// camera disabled but not destroyed, so a <c>== null</c> check alone would keep a
+    /// stale reference and let the hold / drop-stale decisions misjudge distance after
+    /// the player changes views or teleports.
+    /// </summary>
+    internal static class FuseSceneryCameraRef
+    {
+        private static Camera _camera;
+
+        /// <summary>Camera.main, re-fetched when the cached one is gone or inactive.</summary>
+        internal static Camera Resolve()
+        {
+            if (_camera == null || !_camera.isActiveAndEnabled)
+            {
+                _camera = Camera.main;
+            }
+
+            return _camera;
+        }
+
+        /// <summary>Drops the cached camera (mod unload / throttle teardown).</summary>
+        internal static void Reset()
+        {
+            _camera = null;
+        }
+    }
+}

--- a/FUSE/Patches/FuseSceneryCullingDebouncePatch.cs
+++ b/FUSE/Patches/FuseSceneryCullingDebouncePatch.cs
@@ -59,9 +59,21 @@ namespace FUSE.Patches
         // force ON. Set transiently by FuseSceneryBenchmark and cleared after a run.
         internal static bool? BenchmarkDebounceOverride;
 
-        // Cached camera (the culler's distance reference is the active camera). Cheap
-        // to reuse; re-fetched only when it goes null (scene swap / teardown).
+        // Cached camera (the culler's distance reference is Camera.main). Refreshed
+        // when it is destroyed OR merely disabled (camera-mode / scene transition),
+        // so a stale, no-longer-active camera can't make the hold decision misjudge
+        // distance after the player changes views or teleports.
         private static Camera _camera;
+
+        // Typed accessor for the game's private load-state flag. The debounce holds
+        // only scenery that is ALREADY loaded (true anti-flap). Force-loading a
+        // not-yet-loaded object inside the deadband would expand the resident set to
+        // the whole ~3 km sphere (~8x the game's ~1.5 km load volume) and pour it into
+        // the load throttle on every teleport. Null only if the field was renamed (the
+        // reflection-surface canary test guards the name), in which case we fall back
+        // to the prior "hold anything in range" behavior.
+        private static readonly AccessTools.FieldRef<SceneryAssetInstance, bool> WantsLoadedRef =
+            BuildWantsLoadedRef();
 
         private static long _suppressedUnloads;
 
@@ -81,6 +93,18 @@ namespace FUSE.Patches
             return (cameraPos - objectPos).sqrMagnitude < UnloadDistanceSqr;
         }
 
+        /// <summary>
+        /// Full hold decision (pure, unit-testable): hold a band-3 FUSE object
+        /// resident only when its model load has already been requested
+        /// (<paramref name="modelLoadRequested"/>) AND it is inside the deadband. The
+        /// load-requested gate keeps the debounce to its anti-flap purpose and stops
+        /// it from force-loading the whole deadband sphere on a teleport.
+        /// </summary>
+        internal static bool ShouldHold(bool modelLoadRequested, Vector3 cameraPos, Vector3 objectPos)
+        {
+            return modelLoadRequested && ShouldHoldResident(cameraPos, objectPos);
+        }
+
         private static void Prefix(SceneryAssetInstance __instance, ref int distanceBand)
         {
             // Only the unload band is in scope; in-range bands keep vanilla behavior.
@@ -97,25 +121,32 @@ namespace FUSE.Patches
                     return; // FUSE-owned scenery only; vanilla culls normally.
                 }
 
-                if (_camera == null)
+                // Anti-flap only: hold scenery the game has ALREADY loaded. A
+                // not-yet-loaded object inside the deadband isn't flapping — leaving
+                // it unloaded keeps the post-teleport working set to the game's real
+                // load band instead of force-streaming the whole deadband sphere
+                // through the throttle. (Fail-open: if the field binding is missing we
+                // skip the gate and hold any in-range scenery, the prior behavior.)
+                if (WantsLoadedRef != null && !WantsLoadedRef(__instance))
                 {
-                    _camera = Camera.main;
+                    return;
                 }
 
-                if (_camera == null)
+                var camera = ResolveActiveCamera();
+                if (camera == null)
                 {
                     return; // No reference to measure against: let the game unload.
                 }
 
                 // transform.position and the camera are in the same (floating-origin
                 // shifted) space, so the delta is correct regardless of world shifts.
-                if (!ShouldHoldResident(_camera.transform.position, __instance.transform.position))
+                if (!ShouldHoldResident(camera.transform.position, __instance.transform.position))
                 {
                     return; // Genuinely far: let band 3 through so the game unloads it.
                 }
 
-                // Inside the deadband: hold it resident so the ~1500m boundary can't
-                // thrash load/unload.
+                // Inside the deadband and already loaded: hold it resident so the
+                // ~1500m boundary can't thrash load/unload.
                 distanceBand = ResidentBandCeiling;
                 _suppressedUnloads++;
                 if (FuseSettings.EnableSceneryCullingDiagnostics && _suppressedUnloads % 1000 == 0)
@@ -128,6 +159,34 @@ namespace FUSE.Patches
             catch (Exception ex)
             {
                 FuseLog.Exception("FUSE scenery unload debounce prefix failed", ex);
+            }
+        }
+
+        // Camera.main, refreshed when the cached one is destroyed or merely disabled
+        // (a camera-mode or scene transition leaves the old gameplay camera disabled
+        // but not destroyed, so a == null check alone would keep a stale reference).
+        private static Camera ResolveActiveCamera()
+        {
+            if (_camera == null || !_camera.isActiveAndEnabled)
+            {
+                _camera = Camera.main;
+            }
+
+            return _camera;
+        }
+
+        private static AccessTools.FieldRef<SceneryAssetInstance, bool> BuildWantsLoadedRef()
+        {
+            try
+            {
+                return AccessTools.FieldRefAccess<SceneryAssetInstance, bool>("_wantsLoaded");
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception(
+                    "FUSE scenery debounce could not bind SceneryAssetInstance._wantsLoaded; " +
+                    "holding any in-range FUSE scenery (prior behavior)", ex);
+                return null;
             }
         }
     }

--- a/FUSE/Patches/FuseSceneryCullingDebouncePatch.cs
+++ b/FUSE/Patches/FuseSceneryCullingDebouncePatch.cs
@@ -59,22 +59,6 @@ namespace FUSE.Patches
         // force ON. Set transiently by FuseSceneryBenchmark and cleared after a run.
         internal static bool? BenchmarkDebounceOverride;
 
-        // Cached camera (the culler's distance reference is Camera.main). Refreshed
-        // when it is destroyed OR merely disabled (camera-mode / scene transition),
-        // so a stale, no-longer-active camera can't make the hold decision misjudge
-        // distance after the player changes views or teleports.
-        private static Camera _camera;
-
-        // Typed accessor for the game's private load-state flag. The debounce holds
-        // only scenery that is ALREADY loaded (true anti-flap). Force-loading a
-        // not-yet-loaded object inside the deadband would expand the resident set to
-        // the whole ~3 km sphere (~8x the game's ~1.5 km load volume) and pour it into
-        // the load throttle on every teleport. Null only if the field was renamed (the
-        // reflection-surface canary test guards the name), in which case we fall back
-        // to the prior "hold anything in range" behavior.
-        private static readonly AccessTools.FieldRef<SceneryAssetInstance, bool> WantsLoadedRef =
-            BuildWantsLoadedRef();
-
         private static long _suppressedUnloads;
 
         /// <summary>Unloads suppressed (objects held resident) since the last reset.</summary>
@@ -121,28 +105,26 @@ namespace FUSE.Patches
                     return; // FUSE-owned scenery only; vanilla culls normally.
                 }
 
-                // Anti-flap only: hold scenery the game has ALREADY loaded. A
-                // not-yet-loaded object inside the deadband isn't flapping — leaving
-                // it unloaded keeps the post-teleport working set to the game's real
-                // load band instead of force-streaming the whole deadband sphere
-                // through the throttle. (Fail-open: if the field binding is missing we
-                // skip the gate and hold any in-range scenery, the prior behavior.)
-                if (WantsLoadedRef != null && !WantsLoadedRef(__instance))
-                {
-                    return;
-                }
-
-                var camera = ResolveActiveCamera();
+                var camera = FuseSceneryCameraRef.Resolve();
                 if (camera == null)
                 {
                     return; // No reference to measure against: let the game unload.
                 }
 
-                // transform.position and the camera are in the same (floating-origin
-                // shifted) space, so the delta is correct regardless of world shifts.
-                if (!ShouldHoldResident(camera.transform.position, __instance.transform.position))
+                // Anti-flap only: hold scenery the game has ALREADY loaded. A
+                // not-yet-loaded object inside the deadband isn't flapping — leaving it
+                // unloaded keeps the post-teleport working set to the game's real load
+                // band instead of force-streaming the whole deadband sphere through the
+                // throttle. transform.position and the camera are in the same
+                // (floating-origin shifted) space, so the delta is world-shift safe.
+                // Route through ShouldHold so the production decision is exactly the
+                // unit-tested one; fail-open (binding unavailable) holds any in-range
+                // scenery, the prior behavior.
+                var modelLoadRequested = !FuseSceneryModelState.Available
+                    || FuseSceneryModelState.IsLoadRequested(__instance);
+                if (!ShouldHold(modelLoadRequested, camera.transform.position, __instance.transform.position))
                 {
-                    return; // Genuinely far: let band 3 through so the game unloads it.
+                    return; // Not loaded, or genuinely far: let band 3 through.
                 }
 
                 // Inside the deadband and already loaded: hold it resident so the
@@ -159,34 +141,6 @@ namespace FUSE.Patches
             catch (Exception ex)
             {
                 FuseLog.Exception("FUSE scenery unload debounce prefix failed", ex);
-            }
-        }
-
-        // Camera.main, refreshed when the cached one is destroyed or merely disabled
-        // (a camera-mode or scene transition leaves the old gameplay camera disabled
-        // but not destroyed, so a == null check alone would keep a stale reference).
-        private static Camera ResolveActiveCamera()
-        {
-            if (_camera == null || !_camera.isActiveAndEnabled)
-            {
-                _camera = Camera.main;
-            }
-
-            return _camera;
-        }
-
-        private static AccessTools.FieldRef<SceneryAssetInstance, bool> BuildWantsLoadedRef()
-        {
-            try
-            {
-                return AccessTools.FieldRefAccess<SceneryAssetInstance, bool>("_wantsLoaded");
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception(
-                    "FUSE scenery debounce could not bind SceneryAssetInstance._wantsLoaded; " +
-                    "holding any in-range FUSE scenery (prior behavior)", ex);
-                return null;
             }
         }
     }

--- a/FUSE/Patches/FuseSceneryLoadThrottlePatch.cs
+++ b/FUSE/Patches/FuseSceneryLoadThrottlePatch.cs
@@ -87,6 +87,9 @@ namespace FUSE.Patches
         // that call through instead of re-deferring it.
         private static bool _pumping;
 
+        // Camera.main, refreshed via ResolveActiveCamera when it is destroyed or merely
+        // disabled, so the pump's deadband drop check can't strand a queued load on a
+        // stale camera position after a camera-mode or scene transition.
         private static Camera _camera;
         private static FuseSceneryLoadThrottlePump _pump;
 
@@ -213,10 +216,7 @@ namespace FUSE.Patches
             try
             {
                 Budget.BeginFrame(Time.frameCount);
-                if (_camera == null)
-                {
-                    _camera = Camera.main;
-                }
+                var camera = ResolveActiveCamera();
 
                 // The queue only shrinks inside this loop, so a count snapshot bounds
                 // the work even though null/stale entries are skipped for free.
@@ -240,9 +240,11 @@ namespace FUSE.Patches
 
                     // Left the resident deadband while queued: don't force-load scenery
                     // the camera has moved away from (consistent with the debounce).
-                    if (_camera != null &&
+                    // Uses a freshly-resolved camera so a stale reference can't drop a
+                    // load the player is actually next to.
+                    if (camera != null &&
                         !FuseSceneryCullingDebouncePatch.ShouldHoldResident(
-                            _camera.transform.position, instance.transform.position))
+                            camera.transform.position, instance.transform.position))
                     {
                         _droppedStaleLoads++;
                         continue;
@@ -318,6 +320,19 @@ namespace FUSE.Patches
             _camera = null;
             _pumping = false;
             ResetStats();
+        }
+
+        // Camera.main, refreshed when the cached one is destroyed or merely disabled
+        // (a camera-mode or scene transition leaves the old gameplay camera disabled
+        // but not destroyed, so a == null check alone would keep a stale reference).
+        private static Camera ResolveActiveCamera()
+        {
+            if (_camera == null || !_camera.isActiveAndEnabled)
+            {
+                _camera = Camera.main;
+            }
+
+            return _camera;
         }
 
         private static AccessTools.FieldRef<SceneryAssetInstance, bool> BuildWantsLoadedRef()

--- a/FUSE/Patches/FuseSceneryLoadThrottlePatch.cs
+++ b/FUSE/Patches/FuseSceneryLoadThrottlePatch.cs
@@ -70,12 +70,6 @@ namespace FUSE.Patches
         private static readonly Queue<PendingLoad> Pending = new Queue<PendingLoad>();
         private static readonly HashSet<int> PendingIds = new HashSet<int>();
 
-        // Fast typed accessor for the private load-state flag (also covered by the
-        // reflection-surface canary test). Null only if the game renamed the field, in
-        // which case we fail open and never throttle.
-        private static readonly AccessTools.FieldRef<SceneryAssetInstance, bool> WantsLoadedRef =
-            BuildWantsLoadedRef();
-
         private static readonly MethodInfo SetLoadedMethod =
             AccessTools.Method(typeof(SceneryAssetInstance), "SetLoaded", new[] { typeof(bool) });
 
@@ -87,10 +81,6 @@ namespace FUSE.Patches
         // that call through instead of re-deferring it.
         private static bool _pumping;
 
-        // Camera.main, refreshed via ResolveActiveCamera when it is destroyed or merely
-        // disabled, so the pump's deadband drop check can't strand a queued load on a
-        // stale camera position after a camera-mode or scene transition.
-        private static Camera _camera;
         private static FuseSceneryLoadThrottlePump _pump;
 
         private static long _deferredLoads;
@@ -114,7 +104,7 @@ namespace FUSE.Patches
         internal static int QueueDepth => Pending.Count;
 
         /// <summary>True when reflection bound and the throttle can operate.</summary>
-        internal static bool Available => WantsLoadedRef != null && SetLoadedMethod != null;
+        internal static bool Available => FuseSceneryModelState.Available && SetLoadedMethod != null;
 
         internal static void ResetStats()
         {
@@ -156,7 +146,7 @@ namespace FUSE.Patches
                 // no-op, so let it through rather than spend a budget slot on it. The
                 // debounce clamps band 3 -> 2 repeatedly for resident objects, which
                 // would otherwise hammer this path.
-                if (WantsLoadedRef(__instance))
+                if (FuseSceneryModelState.IsLoadRequested(__instance))
                 {
                     return true;
                 }
@@ -216,7 +206,7 @@ namespace FUSE.Patches
             try
             {
                 Budget.BeginFrame(Time.frameCount);
-                var camera = ResolveActiveCamera();
+                var camera = FuseSceneryCameraRef.Resolve();
 
                 // The queue only shrinks inside this loop, so a count snapshot bounds
                 // the work even though null/stale entries are skipped for free.
@@ -233,7 +223,7 @@ namespace FUSE.Patches
                     }
 
                     // Loaded via another path since it was queued: nothing to do.
-                    if (WantsLoadedRef != null && WantsLoadedRef(instance))
+                    if (FuseSceneryModelState.IsLoadRequested(instance))
                     {
                         continue;
                     }
@@ -317,37 +307,9 @@ namespace FUSE.Patches
             Pending.Clear();
             PendingIds.Clear();
             Budget.Reset();
-            _camera = null;
+            FuseSceneryCameraRef.Reset();
             _pumping = false;
             ResetStats();
-        }
-
-        // Camera.main, refreshed when the cached one is destroyed or merely disabled
-        // (a camera-mode or scene transition leaves the old gameplay camera disabled
-        // but not destroyed, so a == null check alone would keep a stale reference).
-        private static Camera ResolveActiveCamera()
-        {
-            if (_camera == null || !_camera.isActiveAndEnabled)
-            {
-                _camera = Camera.main;
-            }
-
-            return _camera;
-        }
-
-        private static AccessTools.FieldRef<SceneryAssetInstance, bool> BuildWantsLoadedRef()
-        {
-            try
-            {
-                return AccessTools.FieldRefAccess<SceneryAssetInstance, bool>("_wantsLoaded");
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception(
-                    "FUSE scenery load-throttle could not bind SceneryAssetInstance._wantsLoaded; " +
-                    "throttling disabled (loads run vanilla)", ex);
-                return null;
-            }
         }
 
         private readonly struct PendingLoad

--- a/FUSE/Patches/FuseSceneryModelState.cs
+++ b/FUSE/Patches/FuseSceneryModelState.cs
@@ -1,0 +1,49 @@
+using System;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Helpers;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// One shared binding of <c>SceneryAssetInstance._wantsLoaded</c> — the game's
+    /// private "model load requested" flag — used by both the cull debounce and the
+    /// load throttle so the field name lives in exactly one place (the
+    /// reflection-surface canary test guards it). Fail-safe: when the binding is
+    /// missing, <see cref="IsLoadRequested"/> returns false and callers fall back to
+    /// their prior behavior by gating on <see cref="Available"/>.
+    /// </summary>
+    internal static class FuseSceneryModelState
+    {
+        private static readonly AccessTools.FieldRef<SceneryAssetInstance, bool> WantsLoadedRef = Bind();
+
+        /// <summary>True when <c>_wantsLoaded</c> bound successfully and can be read.</summary>
+        internal static bool Available => WantsLoadedRef != null;
+
+        /// <summary>
+        /// True when the game has requested/started this scenery's model load. Never
+        /// throws: returns false for a null instance or when the binding is
+        /// unavailable — callers that must distinguish "not loaded" from "can't tell"
+        /// check <see cref="Available"/>.
+        /// </summary>
+        internal static bool IsLoadRequested(SceneryAssetInstance instance)
+        {
+            return WantsLoadedRef != null && instance != null && WantsLoadedRef(instance);
+        }
+
+        private static AccessTools.FieldRef<SceneryAssetInstance, bool> Bind()
+        {
+            try
+            {
+                return AccessTools.FieldRefAccess<SceneryAssetInstance, bool>("_wantsLoaded");
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception(
+                    "FUSE scenery could not bind SceneryAssetInstance._wantsLoaded; " +
+                    "debounce/throttle fall back to distance-only behavior", ex);
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Scenery (buildings, mod coal/loader towers) streams in slowly — up to ~45s reported — or fails to appear after a few teleports, ever since the #76 culling/throttle work shipped. Two defects, both in the new patches and both invisible to the existing tests (which only cover extracted pure functions, never the stateful orchestration where the bugs live).

## Root cause

- **Debounce inflated the post-teleport load set ~8×.** `FuseSceneryCullingDebouncePatch` clamped band-3→2 for *every* FUSE object within the 3 km deadband — including not-yet-loaded ones — force-streaming roughly 8× the game's ~1.5 km load volume through the 8-loads/frame throttle on every teleport.
- **Stale camera could permanently drop a load.** Both patches cached `Camera.main` forever; a disabled-but-not-destroyed camera after a camera-mode/scene transition left a stale position, so the throttle pump's drop-stale check could discard a load the player was standing next to with nothing to re-issue it.

(The per-load floor itself — ~305 ms, ~6 concurrent — is the game's async asset-bundle loader, which FUSE can't speed up; the wins here are not inflating the set and not dropping live loads.)

## Changes

- **Fix #2 — debounce holds only already-loaded scenery.** Gate the clamp on the game's `_wantsLoaded`, so the debounce does its anti-flap job without force-loading the whole deadband sphere.
- **Fix #3 — live camera in both patches.** `ResolveActiveCamera()` refreshes when the cached camera is destroyed *or* disabled.
- **Phase 2 — benchmark inconclusive guard.** A run with all-zero engagement counters is stamped `"inconclusive": true` in the JSON and flagged on the A/B status line, so a too-light scenario can't read as a pass (the gap that let the original "corridor — single" run come back green while the bug shipped).
- **Tests.** `ShouldHold` load-gate (FUSE.UnityTests) + benchmark engagement classifier (FUSE.Tests).

## Validation

- `dotnet build FUSE.Editor -c Release` → 0 errors.
- `dotnet test FUSE.Tests` → **1217 passing, 0 failed**.
- `tools/cs_lint.py` + `tools/json_lint.py` → clean.

## Deferred (intentionally)

Nearest-first throttle drain (load the visible building before far scenery) is the main *perceived-speed* lever but is held pending a heavy A/B benchmark run (FUSE culling off vs on, in a dense area) to confirm FUSE — not the game's loader — is what to change. A test build is going to a tester to capture that A/B.

Closes part of #76.
