### PR TITLE
fix(converter): convert spanless loadId+rate component patches as partial merges

### DIFF
--- a/FUSE.Converter/Conversion/LegacyIndustryComponentConverter.cs
+++ b/FUSE.Converter/Conversion/LegacyIndustryComponentConverter.cs
@@ -118,10 +118,18 @@ namespace FUSE.Converter.Conversion
             return LegacyLoadOperationKeys.Any(k => item.ContainsKey(k));
         }
 
+        // Only real track-span keys make a component a standalone load
+        // operation. A bare loadId is NOT a binding: a spanless load-op
+        // block (e.g. a Production-Tweaks patch that only adjusts
+        // storageChangeRate/maxStorage/carTransferRate on an existing
+        // base-game loader) is a partial field-merge onto the component
+        // that already owns the spans, not a brand-new loader. Counting
+        // loadId here forces such patches to convert as full loaders,
+        // which then fail the "loader requires at least one track span"
+        // validation rule and fault the whole package.
         private static readonly string[] LoadComponentBindingKeys =
         {
             "trackSpanIds", "trackSpans", "spans",
-            "loadId", "LoadId", "load",
         };
 
         public static bool HasLoadComponentBindingShape(JObject item)

--- a/FUSE.Tests/Converter/LegacyIndustryComponentConverterTests.cs
+++ b/FUSE.Tests/Converter/LegacyIndustryComponentConverterTests.cs
@@ -77,13 +77,20 @@ namespace FUSE.Tests.Converter
         [Fact]
         public void ShouldConvertComponentAsPartial_returns_true_for_legacy_load_op_without_binding()
         {
-            // Has load-op shape (loadId), but no binding (spans/trackSpans);
-            // converter treats this as a partial update to an existing
-            // component rather than a full definition.
+            // A load-op block that names track spans is a full, standalone
+            // loader definition → NOT partial.
             Assert.False(LegacyIndustryComponentConverter.ShouldConvertComponentAsPartial(
                 JObject.Parse("{ \"loadId\": \"oil\", \"trackSpanIds\": [\"s1\"] }")));
+
+            // A load-op block with NO track spans is a partial field-merge
+            // onto an existing component (which already owns the spans) →
+            // partial. A bare loadId must NOT defeat this. Regression for
+            // Nexus 1326 "Production Tweaks", whose l1/lp1/l23 patch
+            // base-game loader rates by id with a loadId but no spans.
             Assert.True(LegacyIndustryComponentConverter.ShouldConvertComponentAsPartial(
                 JObject.Parse("{ \"maxStorage\": 100 }")));
+            Assert.True(LegacyIndustryComponentConverter.ShouldConvertComponentAsPartial(
+                JObject.Parse("{ \"loadId\": \"logs\", \"storageChangeRate\": 72, \"maxStorage\": 72, \"carTransferRate\": 144 }")));
         }
 
         // ------------------------------------------------------------------
@@ -267,6 +274,30 @@ namespace FUSE.Tests.Converter
             var fields = converted["fields"] as JObject;
             Assert.NotNull(fields);
             Assert.Equal(7, fields.Value<int>("weird"));
+        }
+
+        [Fact]
+        public void ConvertComponent_marks_spanless_loadId_rate_patch_as_partial()
+        {
+            // Regression — Nexus 1326 "Woodys ... Production Tweaks": the
+            // mod patches the production rates of an existing base-game
+            // logging-camp loader (l1) by id — a loadId plus rate fields,
+            // but no track spans. This must convert as a partial field-merge
+            // (which the apply path layers onto the existing loader), NOT as
+            // a full loader — a full loader with no spans trips
+            // "loader requires at least one track span".
+            var converted = LegacyIndustryComponentConverter.ConvertComponent(
+                "l1",
+                JObject.Parse("{ \"carTypeFilter\": \"FL\", \"loadId\": \"logs\", \"storageChangeRate\": 72, \"maxStorage\": 72, \"carTransferRate\": 144 }"),
+                context: null);
+
+            Assert.True(converted.Value<bool>("partial"));
+            Assert.Null(converted["type"]);
+            // No spans were invented for the patch.
+            Assert.Null(converted["trackSpanIds"]);
+            // The rate fields the mod actually wants to change survive.
+            Assert.Equal(72, converted.Value<int>("storageChangeRate"));
+            Assert.Equal("logs", converted.Value<string>("loadId"));
         }
 
         // ------------------------------------------------------------------

--- a/FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs
@@ -1,4 +1,5 @@
 using FUSE.Authoring.Serialization;
+using FUSE.Authoring.Validation;
 using FUSE.Loading;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -176,6 +177,107 @@ namespace FUSE.Tests.Loading
                 Assert.Equal(0f, industry.Position.Value.x);
                 Assert.Equal(0f, industry.Position.Value.y);
                 Assert.Equal(0f, industry.Position.Value.z);
+            }
+        }
+
+        public class SpanlessLoaderRatePatch
+        {
+            // Regression — Nexus 1326 "Woodys Upper Walker Pulpwood and
+            // Production Tweaks". The mod patches the production rates of
+            // three existing base-game logging-camp loaders (l1/lp1/l23) by
+            // id — each a loadId plus rate fields with no track spans — and
+            // adds one genuinely new loader (lp2) that does declare spans.
+            // Before the fix the converter counted a bare loadId as a load
+            // binding, so the spanless rate patches converted as full
+            // loaders; each then tripped "loader requires at least one track
+            // span" (fuse.operations.component.trackSpanIds) and the whole
+            // .FUSE package faulted at deserialization.
+            private static JObject MakeSource() => new JObject
+            {
+                ["areas"] = new JObject
+                {
+                    ["bryson-above"] = new JObject
+                    {
+                        ["industries"] = new JObject
+                        {
+                            ["logcamp1"] = new JObject
+                            {
+                                ["components"] = new JObject
+                                {
+                                    ["l1"] = new JObject
+                                    {
+                                        ["carTypeFilter"] = "FL",
+                                        ["loadId"] = "logs",
+                                        ["storageChangeRate"] = 72,
+                                        ["maxStorage"] = 72,
+                                        ["carTransferRate"] = 144
+                                    },
+                                    ["lp1"] = new JObject
+                                    {
+                                        ["carTypeFilter"] = "FB",
+                                        ["loadId"] = "pulpwood",
+                                        ["storageChangeRate"] = 4000000.0,
+                                        ["maxStorage"] = 4000000.0,
+                                        ["carTransferRate"] = 3000000.0
+                                    },
+                                    ["l23"] = new JObject
+                                    {
+                                        ["carTypeFilter"] = "FL",
+                                        ["loadId"] = "logs",
+                                        ["storageChangeRate"] = 120,
+                                        ["maxStorage"] = 120,
+                                        ["carTransferRate"] = 240
+                                    },
+                                    ["lp2"] = new JObject
+                                    {
+                                        ["type"] = "Model.Ops.IndustryLoader",
+                                        ["name"] = "Walker Upper Pulpwood",
+                                        ["trackSpans"] = new JArray("WD_Upper_Pulp1", "WD_Upper_Pulp2"),
+                                        ["carTypeFilter"] = "FB",
+                                        ["sharedStorage"] = false,
+                                        ["loadId"] = "pulpwood",
+                                        ["storageChangeRate"] = 6000000.0,
+                                        ["maxStorage"] = 6000000.0,
+                                        ["carTransferRate"] = 3000000.0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            [Fact]
+            public void SpanlessRatePatches_ConvertAsPartial_NewLoaderStaysFull()
+            {
+                var (_, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(MakeSource());
+                var components = (JObject)industries["logcamp1"]["components"];
+
+                foreach (var id in new[] { "l1", "lp1", "l23" })
+                {
+                    var c = (JObject)components[id];
+                    Assert.True(c.Value<bool>("partial"), $"{id} should convert as a partial field-merge patch");
+                    Assert.Null(c["type"]);
+                    // The rate fields the mod actually wants to change survive.
+                    Assert.NotNull(c["storageChangeRate"]);
+                }
+
+                // The genuinely new loader keeps its full shape and its spans.
+                var lp2 = (JObject)components["lp2"];
+                Assert.Null(lp2["partial"]);
+                Assert.False(string.IsNullOrEmpty(lp2.Value<string>("type")));
+                Assert.NotNull(lp2["trackSpanIds"]);
+            }
+
+            [Fact]
+            public void ConvertedDefinition_PassesValidation_NoTrackSpanError()
+            {
+                var (root, _) = FuseLegacyIndustryConverterTests.ConvertIndustries(MakeSource());
+                var definition = FuseSerializer.FromJson(root.ToString());
+
+                var result = new FuseDefinitionValidator().Validate(definition);
+
+                Assert.DoesNotContain(result.Errors, e => e.Code == "fuse.operations.component.trackSpanIds");
             }
         }
 

--- a/FUSE.Tests/Validation/FuseDefinitionValidatorDeeperTests.Industry.cs
+++ b/FUSE.Tests/Validation/FuseDefinitionValidatorDeeperTests.Industry.cs
@@ -79,6 +79,26 @@ namespace FUSE.Tests.Validation
             }
 
             [Fact]
+            public void PartialComponent_WithoutTrackSpans_IsAccepted()
+            {
+                // A partial field-merge patch (e.g. a Production-Tweaks rate
+                // change on an existing base-game loader) carries no spans of
+                // its own — the base component already owns them. The span
+                // requirement must not apply to partial components, which is
+                // what lets the legacy converter emit spanless loadId+rate
+                // patches without faulting the package (Nexus 1326).
+                var result = NewValidator().Validate(WithComponent(new FuseIndustryComponent
+                {
+                    Partial = true,
+                    LoadId = "logs",
+                    StorageChangeRate = 72f,
+                    TrackSpanIds = null
+                }));
+
+                Assert.DoesNotContain(result.Errors, e => e.Code == "fuse.operations.component.trackSpanIds");
+            }
+
+            [Fact]
             public void LoaderType_WithoutLoadId_EmitsWarning()
             {
                 var result = NewValidator().Validate(WithComponent(new FuseIndustryComponent

--- a/FUSE/Loading/FuseLegacyDataConverter.Components.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.Components.cs
@@ -161,12 +161,18 @@ namespace FUSE.Loading
                 return false;
             }
 
+            // Only real track-span keys make a component a standalone load
+            // operation. A bare loadId is NOT a binding: a spanless load-op
+            // block (e.g. a Production-Tweaks patch that only adjusts
+            // storageChangeRate/maxStorage/carTransferRate on an existing
+            // base-game loader) is a partial field-merge onto the component
+            // that already owns the spans, not a brand-new loader. Counting
+            // loadId here forces such patches to convert as full loaders,
+            // which then fail the "loader requires at least one track span"
+            // validation rule and fault the whole package.
             return item["trackSpanIds"] != null ||
                    item["trackSpans"] != null ||
-                   item["spans"] != null ||
-                   item["loadId"] != null ||
-                   item["LoadId"] != null ||
-                   item["load"] != null;
+                   item["spans"] != null;
         }
 
         private static bool HasLoadOperationShape(JObject item)


### PR DESCRIPTION
## 🔗 Related Issue

No tracked GitHub issue — surfaced from a user's in-game FUSE fault report (a Strange Customs map mod failing to load through the legacy converter). The trigger mod is **"Woodys Upper Walker Pulpwood and Production Tweaks"** ([Nexus 1326](https://www.nexusmods.com/railroader/mods/1326)).

Fault signature:
```
[ERROR] FUSE validation error package='WD.WalkerLoggingProductionTweaks.FUSE.industries-graph'
  kind='operations.industries.logcamp1.components.{l1,lp1,l23}.trackSpanIds'
  message="Industry component type 'loader' requires at least one track span."
  code='fuse.operations.component.trackSpanIds'
```
3 errors → `industries-graph` invalid → whole `.FUSE` package faults at deserialization → mod does not load.

## 📝 Description of the Change

Legacy Strange Customs packages routinely **patch the production rates of an existing base-game industry loader by id** — a `loadId` plus `storageChangeRate` / `maxStorage` / `carTransferRate`, with **no track spans of their own** (the base component already owns its spans). In mod 1326, `logcamp1`'s `l1` / `lp1` / `l23` are exactly this; only the genuinely new loader `lp2` declares spans.

The legacy converter's partial-detection counted a bare `loadId` as a *load binding* (`HasLoadComponentBindingShape` / `LoadComponentBindingKeys` included `loadId`/`LoadId`/`load`). So a spanless `loadId`+rate patch was classified as a **full standalone loader** rather than a **partial field-merge**. A full loader with no spans then trips the validator's `fuse.operations.component.trackSpanIds` rule, faulting the package.

Fix: only real track-span keys (`trackSpanIds`/`trackSpans`/`spans`) mark a component as a standalone load operation — a `loadId` does not. Removing `loadId`/`LoadId`/`load` from the binding check in **both** converter copies makes these patches convert as `partial`. Downstream this already does the right thing:
- the validator skips the span requirement for partial components, and
- `IndustryAPI.ApplyPartialComponentDefinition` layers the rate fields (`storageChangeRate`→`productionRate`, `maxStorage`, `carTransferRate`→`carLoadRate`, `loadId`→`load`) onto the existing base-game loader **while keeping its spans** — i.e. the production tweak takes effect, as intended.

`lp2` (explicit `type`) is unaffected and stays a full loader with its spans.

Files:
- `FUSE/Loading/FuseLegacyDataConverter.Components.cs` — in-game runtime path (the one that faulted)
- `FUSE.Converter/Conversion/LegacyIndustryComponentConverter.cs` — editor / standalone path

No `FUSE.Core` change needed: only the converter's classification was wrong; the validator already handled partial components correctly.

## 🔄 Alternatives Considered

- **Relax the validator to allow spanless loaders** — rejected. A genuinely new loader *does* need spans; relaxing the rule would silently pass broken definitions. The problem is misclassification, not the rule itself.
- **Special-case in the operations/industry converter** — unnecessary; the existing `partial` concept already models "field-merge onto an existing component", and the converter's own documented intent (see test at `LegacyIndustryComponentConverterTests.cs`) was already "no spans/trackSpans binding → partial". This just aligns the code with that intent.

## ⚠️ Possible Drawbacks

- A component with `loadId`+rates, **no spans, and no matching existing base component** will now convert as a partial (merge no-op) instead of raising the span error. That is acceptable: such a component can never be a working standalone loader anyway (the validator's own rule), and partial-merge matches legacy Strange Customs `mixinto` semantics.
- Load-time conversion only — **no save-format change; fully backwards compatible with existing saves.**

## ✅ Verification Process

- Added regression tests at three layers:
  - **Converter** (`LegacyIndustryComponentConverterTests`): spanless `loadId`+rate patch → `ShouldConvertComponentAsPartial` true; `ConvertComponent` emits `partial` with rates preserved and no invented spans.
  - **Runtime, end-to-end** (`FuseLegacyIndustryConverterTests.SpanlessLoaderRatePatch`): reproduces the exact mod-1326 `logcamp1` shape, converts via `ConvertSource`, deserializes, runs `FuseDefinitionValidator`, and asserts **no** `fuse.operations.component.trackSpanIds` error (this test fails before the fix).
  - **Validator** (`FuseDefinitionValidatorDeeperTests.Industry`): a `partial` component with no spans is accepted.
- Full suite: `dotnet test FUSE.Tests` → **1221 passed, 0 failed**.

## 💡 Additional Information

The two converter copies are deliberate mirrors (runtime + editor); both were updated identically. The change is two lines of logic plus explanatory comments. The mod was inspected read-only — not installed into a game.
