### PR TITLE
chore(editor): hide WIP FUSE Editor main-menu button behind a flag

### DIFF
--- a/FUSE/Patches/FuseEditorMainMenuPatch.cs
+++ b/FUSE/Patches/FuseEditorMainMenuPatch.cs
@@ -28,12 +28,24 @@ namespace FUSE.Patches
     ///
     /// Skipped when no lifecycle provider is registered so users without
     /// FUSE.Editor.dll deployed don't see a dead button.
+    ///
+    /// Currently gated off via <see cref="EditorButtonEnabled"/> while the
+    /// editor is still under development — the button is not injected even
+    /// when a lifecycle provider is present. Flip the flag to true to
+    /// restore it once the editor is ready to ship.
     /// </summary>
     [HarmonyPatch(typeof(MainMenu), "Awake")]
     internal static class FuseEditorMainMenuPatch
     {
         private const string InjectedButtonName = "FuseEditorMainMenuButton";
         private const string InjectedButtonLabel = "FUSE Editor";
+
+        // Temporary gate: the FUSE Editor surface isn't ready for general
+        // use yet, so its main-menu entry point stays hidden. Kept as a
+        // static readonly (not a const) so the gated-off injection path
+        // below doesn't trip an unreachable-code warning. Flip to true to
+        // surface the button once the editor is shippable.
+        private static readonly bool EditorButtonEnabled = false;
 
         private static readonly FieldInfo MenuManagerGameManagerField =
             AccessTools.Field(typeof(MenuManager), "gameManager");
@@ -56,6 +68,15 @@ namespace FUSE.Patches
             // the flag fresh right before it launches away from here, so
             // this clear never races a real pending session.
             FuseEditorBridge.EditorSessionPending = false;
+
+            // The FUSE Editor isn't ready yet, so its main-menu button
+            // stays hidden for the time being. The stale pending-flag
+            // clear above still runs, so a leftover flag can't spuriously
+            // open the editor on the next sandbox session.
+            if (!EditorButtonEnabled)
+            {
+                return;
+            }
 
             // Optional editor: when FUSE.Editor.dll isn't deployed the
             // bridge has no lifecycle provider, so the button would


### PR DESCRIPTION
## 🔗 Related Issue

N/A — the FUSE Editor is still under active development and not yet ready to expose to players.

## 📝 Description of the Change

The "FUSE Editor" entry on the main menu is injected by a Harmony postfix on `MainMenu.Awake` in `FuseEditorMainMenuPatch`. Because the editor surface isn't ready for general use yet, this hides that button for the time being.

The button injection is now gated behind a new `EditorButtonEnabled` flag (default `false`). The `Awake` postfix returns early — before the button is cloned/instantiated — when the flag is off, so the entry never appears in the menu.

Key details:
- The flag is a `static readonly bool` (not a `const`) on purpose, so the gated-off injection path below it doesn't trip a `CS0162` unreachable-code warning.
- All of the launch/exit machinery (`TryLaunchEditorSession`, `OnEditorExited`, the exit subscription) is left fully intact, so restoring the button is a one-line change: flip `EditorButtonEnabled` to `true` once the editor is shippable.
- The defensive stale-`EditorSessionPending` clear still runs **ahead** of the new gate, so a leftover pending flag can't spuriously open the editor on the next sandbox session.

## 🔄 Alternatives Considered

- **Removing the `[HarmonyPatch]` / deleting the patch** — heavier to revert and loses the wiring we'll want back shortly.
- **A `const bool` flag** — would constant-fold and emit a `CS0162` unreachable-code warning on the now-dead injection path. Using a `static readonly` avoids that while keeping the same intent.
- **A user-facing setting** — undesirable; we don't want players toggling on an unfinished feature. A compile-time gate is the right call for "not ready yet."

## ⚠️ Possible Drawbacks

- The FUSE Editor is simply not reachable from the main menu while the flag is off — intended.
- No save-format or data changes; fully backwards compatible.

## ✅ Verification Process

- `dotnet build FUSE\FUSE.csproj -p:GameDir=<Railroader>` → **Build succeeded, 0 Warning(s), 0 Error(s)** (confirms the `static readonly` gate avoids the unreachable-code warning).
- Confirmed `FuseEditorMainMenuPatch` is the only injector of a main-menu editor entry (the other `*EditorMenuPatch` files target in-game scenery/prefab menus, not the main menu) and that no tests reference this patch.

## 💡 Additional Information

To re-enable the button when the editor is ready, set `EditorButtonEnabled = true` in `FUSE/Patches/FuseEditorMainMenuPatch.cs`.
