### PR TITLE
fix(map-enhancer): color FUSE-created industries after the load-time graph rebuild

### DIFF
--- a/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
+++ b/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
@@ -177,6 +177,34 @@ namespace FUSE.Runtime.Lifecycle
                 }
             }
 
+            // Replay FUSE's industrial-segment push to Map Enhancer now that the
+            // load-time apply AND the trailing track-graph rebuild (EndBatch(true)
+            // above) have settled. The inline RefreshIndustry in
+            // AddOrUpdateComponents runs DURING apply — before that rebuild — so a
+            // FUSE-created industry's TrackSpans have no resolvable cached segments
+            // yet and nothing lands in Map Enhancer's industrial-segment cache
+            // (observed as componentsRefreshed=0 for FUSE-built industries like the
+            // Whittier sawmill, whose R1 log dropoff then paints as plain track).
+            // Map Enhancer's own IndustryComponent.Start postfix misses them for the
+            // same timing reason, so this post-rebuild pass is the only point where
+            // the segments are resolvable. It no-ops when Map Enhancer isn't
+            // installed and re-affirms already-registered base-game segments harmlessly.
+            try
+            {
+                if (canMutateWorld)
+                {
+                    FUSE.Interface.FuseMapEnhancerCompat.RefreshAllIndustries("map load post-rebuild");
+                }
+                else
+                {
+                    FuseLog.Info("FUSE skipped Map Enhancer post-rebuild backfill on non-host multiplayer client.");
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE Map Enhancer post-rebuild backfill failed", ex);
+            }
+
             // Console handler is created during scene activation, so we re-attempt
             // registration here even if the early Load attempt missed it.
             try


### PR DESCRIPTION
## 🔗 Related Issue

No tracked issue — bug reported in-session by the maintainer: Map Enhancer renders the **Whittier Saw Mill R1** log dropoff (a FUSE-created captive industry) as plain, uncolored track instead of area-colored industrial track.

## 📝 Description of the Change

Map Enhancer colors a track segment by membership in its internal industrial-segment set, which it populates from a postfix on `IndustryComponent.Start` (resolving the component's Area `tagColor` and adding each TrackSpan's cached segment ids). FUSE already mirrors that population in `FuseMapEnhancerCompat.RefreshIndustry` to cover spans it merges in after `Start`.

The bug: that mirror push is invoked from a single inline site — `AddOrUpdateComponents` (`IndustryAPI.Components.cs:406`) — which during map load runs inside `ApplyLoadedPackages` **before** the trailing track-graph rebuild (`InvalidateAllCurves` + `EndBatch(true)`) in `FuseLifecycle.OnMapDidLoad`. For a FUSE-created industry, the components are built during that same apply, so their TrackSpans aren't resolvable yet — the refresh reports `componentsRefreshed=0 segmentsAdded=0` and nothing lands in Map Enhancer's cache. Map Enhancer's own `Start` postfix misses them for the same timing reason. `FuseMapEnhancerCompat.RefreshAllIndustries` already existed as a full backfill but was never called.

The fix wires `RefreshAllIndustries("map load post-rebuild")` into `OnMapDidLoad` (in the `canMutateWorld` path), after the post-apply graph/terrain rebuild has settled. At that point the spans resolve, so every FUSE-touched industry's segments register with the correct area color on the next MapBuilder rebuild. The inline refresh at the `AddOrUpdateComponents` site is kept — it is correct for runtime industry edits made after load (graph already built).

## 🔄 Alternatives Considered

- **Re-sync in `OnGraphDidRebuildCollections`** (fires per graph rebuild): more robust to later in-session rebuilds but heavier; the once-per-load pass is sufficient for this bug.
- **Color progression dropoffs too** (lifting the `ProgressionIndustryComponent` exclusion): explicitly decided against. Map Enhancer never colors that component type (verified against its compatibility surface), and we are keeping parity — so the line-135 exclusion and the matching diagnostic are unchanged.

## ⚠️ Possible Drawbacks

- One extra `RefreshAllIndustries` pass per map load (reflection over industries' spans); negligible against the rest of load, and it no-ops entirely when Map Enhancer isn't installed.
- For base-game industries already registered, it re-adds (deduped) and re-affirms the same area color — harmless.
- No save-format change; this is runtime-only map coloring, fully backwards compatible with existing saves.
- Progression-industry dropoffs remain uncolored (by design, parity with Map Enhancer).

## ✅ Verification Process

- **Build:** clean (0 warnings / 0 errors). **Tests:** 1221 passed / 0 failed (`FUSE.Tests`).
- **Root cause confirmed from `FUSE.log`** (6 sessions identical): `whittier-sawmill` is FUSE-created with 12 spanned components, yet the apply-time refresh logged `componentsRefreshed=0 segmentsAdded=0 totalSegmentsAfter=165`.
- **Local deploy** of the Debug build into the game `Mods\FUSE`. In-game check (maintainer): reload the captive sawmill save → R1 (and the rest of the sawmill) paints with the area color; a base-game industry is unchanged; progression `CF_…track-site` dropoffs stay uncolored. Expected new log line: `FUSE refreshed Map Enhancer industrial segments for industry='whittier-sawmill' operation='map load post-rebuild' componentsRefreshed=12 segmentsAdded>0`.

## 💡 Additional Information

- Reuses the existing-but-previously-unwired `FuseMapEnhancerCompat.RefreshAllIndustries`; no new types.
- Related prior fix: `f9b2ae3` addressed the *wrong-color* (area-reparenting) variant of this same track; this PR addresses the distinct *not-colored* variant for FUSE-created industries.