### PR TITLE
feat(scenery): surface renderer visibility/layer/shader in scenery debug overlay

### DIFF
--- a/FUSE/Interface/FuseSceneryDebugOverlay.cs
+++ b/FUSE/Interface/FuseSceneryDebugOverlay.cs
@@ -714,23 +714,69 @@ namespace FUSE.Interface
             var renderers = root.GetComponentsInChildren<Renderer>(true);
             var lodGroups = root.GetComponentsInChildren<LODGroup>(true);
             var enabledRenderers = 0;
+            var visibleRenderers = 0;
+            var layers = new HashSet<int>();
+            var shaders = new HashSet<string>();
             for (var index = 0; index < renderers.Length; index++)
             {
-                if (renderers[index] != null && renderers[index].enabled)
+                var renderer = renderers[index];
+                if (renderer == null)
+                {
+                    continue;
+                }
+
+                if (renderer.enabled)
                 {
                     enabledRenderers++;
+                }
+
+                // isVisible: rendered by some camera last frame. enabled==true but
+                // isVisible==false (and on-screen) means a layer/frustum cull is
+                // hiding it; enabled==true && isVisible==true but nothing on screen
+                // means a stencil/shader discard (object-mask) is hiding it.
+                if (renderer.isVisible)
+                {
+                    visibleRenderers++;
+                }
+
+                layers.Add(renderer.gameObject.layer);
+
+                var material = renderer.sharedMaterial;
+                if (material != null && material.shader != null)
+                {
+                    shaders.Add(material.shader.name);
                 }
             }
 
             builder.AppendLine();
             builder.Append("<b>Renderers</b>: ").Append(renderers.Length)
-                .Append(" total, ").Append(enabledRenderers).Append(" enabled");
+                .Append(" total, ").Append(enabledRenderers).Append(" enabled, ")
+                .Append(visibleRenderers).Append(" visible");
             if (lodGroups.Length > 0)
             {
                 builder.Append(", ").Append(lodGroups.Length).Append(" LOD group(s)");
             }
 
             builder.AppendLine();
+
+            // Layer + shader breakdown. For the masked-scenery invisibility case:
+            // renderers present + enabled but the building unseen points at
+            // render-state suppression (an object-mask stencil/layer or a
+            // fallback/error shader) rather than a load failure.
+            if (layers.Count > 0)
+            {
+                var layerNames = layers.Select(layer =>
+                {
+                    var name = LayerMask.LayerToName(layer);
+                    return string.IsNullOrEmpty(name) ? layer.ToString() : name + "(" + layer + ")";
+                });
+                builder.Append("layers: ").AppendLine(string.Join(", ", layerNames));
+            }
+
+            if (shaders.Count > 0)
+            {
+                builder.Append("shaders: ").AppendLine(string.Join(", ", shaders));
+            }
 
             var components = root.GetComponents<Component>();
             if (components.Length > 1)


### PR DESCRIPTION
## 🔗 Related Issue

No tracking issue — diagnostic aid for an in-progress investigation. Certain ALW scenery buildings (Bryson roundhouse/shops via `ALW.EFACustomizations`, Stenzel Mfg at Whittier) render their map mask (the terrain cut) but **not** their building mesh, even at point-blank range and in a fresh game. The buildings resolve and their models load without error, so the question is *why the mesh isn't drawn*. This change adds the overlay fields needed to answer that.

## 📝 Description of the Change

`FuseSceneryDebugOverlay`'s advanced tooltip already reports `Renderers: N total, M enabled` for the hovered object. That confirms the mesh exists and whether its renderers are enabled, but not whether they are actually being drawn, what layer they sit on, or which shader they use — exactly the gap when a mesh is present yet invisible.

This extends the advanced renderer block with three fields:
- **`visible`** count — `Renderer.isVisible` (rendered by some camera last frame).
- **`layers:`** — the distinct GameObject layers across the object's renderers.
- **`shaders:`** — the distinct shader names across the renderers' shared materials.

Together these separate render-state *suppression* from a load failure when a mesh is present but unseen:
- `enabled=N, visible=0` on an unexpected layer → a layer/stencil cull is hiding it (e.g. an object-mask).
- `visible=N` but nothing on screen → a shader/stencil discard.
- shader shows a fallback/error shader → a shader-load problem.

## 🔄 Alternatives Considered

A one-off temporary `FuseLog` dump on scenery activation. Rejected: the overlay already aggregates renderer state for a hovered object, is discoverable, and is gated — extending it is lower-noise and reusable for any future "present but not drawn" case.

## ⚠️ Possible Drawbacks

Diagnostic-only. No runtime or save behavior change; fully save-compatible. The added work (a `HashSet` of layers/shaders plus `isVisible` reads) runs only while the debug overlay is open **and** advanced mode is enabled, so there is no cost in normal play.

## ✅ Verification Process

- Builds clean in Release (0 warnings, 0 errors).
- The change is confined to the advanced branch of `AppendAdvancedDetails`, gated by `FuseSettings.ShowSceneryDebugAdvanced`; the non-advanced overlay and every other code path are untouched.
- Not yet exercised in-game — it is pure diagnostic string output. Intended next step: hover the affected buildings with the advanced overlay on and read the new fields to confirm whether the loaded renderers are enabled-but-suppressed (object-mask) vs. disabled.

## 💡 Additional Information

Reuses already-imported `System.Linq` / `System.Collections.Generic` and standard `UnityEngine` APIs (`Renderer.isVisible`, `LayerMask.LayerToName`, `Material.shader`).
