### PR TITLE
fix(scenery): decouple terrain masks from the streamed model

### DIFF
--- a/FUSE.Tests/API/FuseSceneryDeferralClassifierTests.cs
+++ b/FUSE.Tests/API/FuseSceneryDeferralClassifierTests.cs
@@ -9,9 +9,10 @@ namespace FUSE.Tests.API
     /// resolves a typed <c>SceneryDefinition</c> from the game's
     /// <c>SceneryAssetManager</c> and is exercised in-game; these tests pin the
     /// decision logic that decides which component type names force eager activation
-    /// (masks, which must precede the terrain bake, and KeyValue/animation
-    /// components, which register persistent state at activation), and the fail-safe
-    /// that treats an unknown/empty type name as eager-only.
+    /// (KeyValue/animation components, which register persistent state at activation;
+    /// masks no longer force eager — they defer and are held resident by the cull
+    /// debounce instead), and the fail-safe that treats an unknown/empty type name as
+    /// eager-only.
     /// </summary>
     public class FuseSceneryDeferralClassifierTests
     {
@@ -35,8 +36,12 @@ namespace FUSE.Tests.API
         }
 
         [Theory]
-        // Masks force eager activation (terrain bake correctness).
-        [InlineData("Model.Definition.Components.MapMasks.RectangleMapMaskComponent", true)]
+        // Mask components are NO LONGER forced eager: they defer like plain scenery (so
+        // they activate against a live camera and stream correctly) and are kept resident
+        // by the cull debounce instead. Only stateful scenery stays eager. (Masks are still
+        // a mask-type-name — see IsMaskTypeName above — which is how they get tagged and
+        // held resident; they just no longer gate deferral.)
+        [InlineData("Model.Definition.Components.MapMasks.RectangleMapMaskComponent", false)]
         // Stateful components force eager activation (save-restore correctness):
         // KeyValue / animation register persistent property objects on activation.
         [InlineData("Some.Pack.KeyValueBoolAnimatorComponent", true)]
@@ -53,7 +58,7 @@ namespace FUSE.Tests.API
         // defer something we could not classify.
         [InlineData("", true)]
         [InlineData(null, true)]
-        public void IsEagerOnlyTypeName_ForcesEagerForMaskAndStateful(string typeName, bool expected)
+        public void IsEagerOnlyTypeName_ForcesEagerForStatefulOnly(string typeName, bool expected)
         {
             Assert.Equal(expected, FuseSceneryDeferralClassifier.IsEagerOnlyTypeName(typeName));
         }

--- a/FUSE.Tests/API/MapApiDecoupledMaskTests.cs
+++ b/FUSE.Tests/API/MapApiDecoupledMaskTests.cs
@@ -4,12 +4,11 @@ using Xunit;
 namespace FUSE.Tests.API
 {
     /// <summary>
-    /// Pure-logic coverage for the decoupled-mask naming/ownership helpers in
-    /// <see cref="MapAPI"/>. These are the contract that ties a scenery to the standalone
-    /// terrain masks <c>DecoupleAttachedMapMasks</c> creates for it: the cleanup path
-    /// (<c>RemoveDecoupledMasksFor</c> via <c>SceneryAPI.TryRemoveScenery</c>/<c>UpdateScenery</c>)
-    /// must find exactly that scenery's masks and nothing else. The clone itself uses Unity
-    /// mask components and is exercised in-game, not here.
+    /// Pure-logic coverage for the decoupled-mask NAME format in <see cref="MapAPI"/>.
+    /// <c>DecoupleAttachedMapMasks</c> names each standalone clone via
+    /// <c>BuildDecoupledMaskId</c> for readability only; ownership (reuse on reload, cleanup
+    /// on removal/update) is tracked by the <c>FuseDecoupledMaskMarker</c> component, which
+    /// needs Unity GameObjects and is exercised in-game rather than here.
     /// </summary>
     public class MapApiDecoupledMaskTests
     {
@@ -20,40 +19,6 @@ namespace FUSE.Tests.API
         public void BuildDecoupledMaskId_FormatsIndexTwoDigits(string sceneryId, int index, string expected)
         {
             Assert.Equal(expected, MapAPI.BuildDecoupledMaskId(sceneryId, index));
-        }
-
-        [Fact]
-        public void IsDecoupledMaskOf_MatchesIdsItBuilt()
-        {
-            for (var index = 0; index < 15; index++)
-            {
-                var built = MapAPI.BuildDecoupledMaskId("BryShop4", index);
-                Assert.True(MapAPI.IsDecoupledMaskOf(built, "BryShop4"));
-            }
-        }
-
-        [Theory]
-        // A scenery whose id is a PREFIX of the mask owner must NOT match — the "__mask"
-        // separator guarantees it (Shop4 vs Shop4X, Shop4 vs Shop40).
-        [InlineData("BryShop4X__mask00", "BryShop4")]
-        [InlineData("BryShop40__mask00", "BryShop4")]
-        [InlineData("OtherShop__mask00", "BryShop4")]
-        // The plain scenery id (no decoupled-mask infix) and unrelated names never match.
-        [InlineData("BryShop4", "BryShop4")]
-        [InlineData("some-user-authored-mask", "BryShop4")]
-        [InlineData("", "BryShop4")]
-        [InlineData(null, "BryShop4")]
-        public void IsDecoupledMaskOf_RejectsNonOwnedNames(string maskName, string sceneryId)
-        {
-            Assert.False(MapAPI.IsDecoupledMaskOf(maskName, sceneryId));
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void IsDecoupledMaskOf_NullOrEmptySceneryId_IsFalse(string sceneryId)
-        {
-            Assert.False(MapAPI.IsDecoupledMaskOf("anything__mask00", sceneryId));
         }
     }
 }

--- a/FUSE.Tests/API/MapApiDecoupledMaskTests.cs
+++ b/FUSE.Tests/API/MapApiDecoupledMaskTests.cs
@@ -1,0 +1,59 @@
+using FUSE.Runtime.API;
+using Xunit;
+
+namespace FUSE.Tests.API
+{
+    /// <summary>
+    /// Pure-logic coverage for the decoupled-mask naming/ownership helpers in
+    /// <see cref="MapAPI"/>. These are the contract that ties a scenery to the standalone
+    /// terrain masks <c>DecoupleAttachedMapMasks</c> creates for it: the cleanup path
+    /// (<c>RemoveDecoupledMasksFor</c> via <c>SceneryAPI.TryRemoveScenery</c>/<c>UpdateScenery</c>)
+    /// must find exactly that scenery's masks and nothing else. The clone itself uses Unity
+    /// mask components and is exercised in-game, not here.
+    /// </summary>
+    public class MapApiDecoupledMaskTests
+    {
+        [Theory]
+        [InlineData("BryShop4", 0, "BryShop4__mask00")]
+        [InlineData("BryShop4", 7, "BryShop4__mask07")]
+        [InlineData("BryShop4", 12, "BryShop4__mask12")]
+        public void BuildDecoupledMaskId_FormatsIndexTwoDigits(string sceneryId, int index, string expected)
+        {
+            Assert.Equal(expected, MapAPI.BuildDecoupledMaskId(sceneryId, index));
+        }
+
+        [Fact]
+        public void IsDecoupledMaskOf_MatchesIdsItBuilt()
+        {
+            for (var index = 0; index < 15; index++)
+            {
+                var built = MapAPI.BuildDecoupledMaskId("BryShop4", index);
+                Assert.True(MapAPI.IsDecoupledMaskOf(built, "BryShop4"));
+            }
+        }
+
+        [Theory]
+        // A scenery whose id is a PREFIX of the mask owner must NOT match — the "__mask"
+        // separator guarantees it (Shop4 vs Shop4X, Shop4 vs Shop40).
+        [InlineData("BryShop4X__mask00", "BryShop4")]
+        [InlineData("BryShop40__mask00", "BryShop4")]
+        [InlineData("OtherShop__mask00", "BryShop4")]
+        // The plain scenery id (no decoupled-mask infix) and unrelated names never match.
+        [InlineData("BryShop4", "BryShop4")]
+        [InlineData("some-user-authored-mask", "BryShop4")]
+        [InlineData("", "BryShop4")]
+        [InlineData(null, "BryShop4")]
+        public void IsDecoupledMaskOf_RejectsNonOwnedNames(string maskName, string sceneryId)
+        {
+            Assert.False(MapAPI.IsDecoupledMaskOf(maskName, sceneryId));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void IsDecoupledMaskOf_NullOrEmptySceneryId_IsFalse(string sceneryId)
+        {
+            Assert.False(MapAPI.IsDecoupledMaskOf("anything__mask00", sceneryId));
+        }
+    }
+}

--- a/FUSE/Patches/FuseSceneryAnimationFixPatches.cs
+++ b/FUSE/Patches/FuseSceneryAnimationFixPatches.cs
@@ -203,6 +203,13 @@ namespace FUSE.Patches
 
         private static KeyValueObject EnsureKeyValueObject(SceneryAssetInstance instance)
         {
+            // Invariant: the KeyValueObject (and its StateManager registration) is hosted on
+            // the scenery's PERSISTENT root GameObject, never inside the streamed model. That
+            // is what lets save-state survive the model streaming out and back: the value
+            // persists on the root while the model is gone, and Model-lifetime observers
+            // re-subscribe to it on reload (see WillUnloadModel + SetupComponents). Terrain
+            // masks follow this same persistent-world-contribution principle, via
+            // MapAPI.DecoupleAttachedMapMasks.
             var keyValueObject = instance.GetComponent<KeyValueObject>();
             if (keyValueObject == null)
             {

--- a/FUSE/Patches/FuseSceneryCullingDebouncePatch.cs
+++ b/FUSE/Patches/FuseSceneryCullingDebouncePatch.cs
@@ -43,10 +43,18 @@ namespace FUSE.Patches
     [HarmonyPatch(typeof(SceneryAssetInstance), "CullingSphereStateChanged")]
     internal static class FuseSceneryCullingDebouncePatch
     {
-        // Vanilla: SetLoaded(distanceBand <= 2). Bands 0-2 keep the model resident
-        // (band 0-1 render, band 2 resident-but-invisible); band 3 unloads. Holding
-        // an object at band 2 is a no-op visually but skips the destroy + reload.
+        // Vanilla: SetLoaded(distanceBand <= 2). Band 0-1 = loaded AND rendered,
+        // band 2 = loaded but renderers OFF (resident-but-invisible), band 3 = unloaded.
+        // So a RENDER band is <= 1; the model merely stays loaded up to <= 2.
+        private const int RenderBandCeiling = 1;
         private const int ResidentBandCeiling = 2;
+
+        // Mask-bearing scenery is pinned to this nearest band so it stays BOTH loaded and
+        // rendered instead of being parked invisible at band 2 or unloaded at band 3. This
+        // is a safety net layered over the real fix (MapAPI.DecoupleAttachedMapMasks, which
+        // moves the terrain mask off the streamed model); once that is verified in-game the
+        // pin is redundant and masked scenery can stream like any other.
+        private const int RenderResidentBand = 0;
 
         // Deadband outer edge. Band 3 begins ~1500m out (the SceneryDistanceBands
         // ceiling); we keep FUSE scenery resident until it is this far so jitter near
@@ -91,18 +99,59 @@ namespace FUSE.Patches
 
         private static void Prefix(SceneryAssetInstance __instance, ref int distanceBand)
         {
-            // Only the unload band is in scope; in-range bands keep vanilla behavior.
-            // BenchmarkDebounceOverride == false forces a baseline (no-debounce) pass.
-            if (distanceBand <= ResidentBandCeiling || __instance == null || BenchmarkDebounceOverride == false)
+            // Bands 0-1 are already loaded AND rendered, so there is nothing to keep
+            // resident there. We act only at band 2 (loaded but renderers off) and band 3
+            // (unload). BenchmarkDebounceOverride == false forces a no-debounce baseline.
+            if (distanceBand <= RenderBandCeiling || __instance == null || BenchmarkDebounceOverride == false)
             {
                 return;
             }
 
             try
             {
-                if (__instance.GetComponent<FUSE.Runtime.API.SceneryAPI.FuseSceneryMarker>() == null)
+                var marker = __instance.GetComponent<FUSE.Runtime.API.SceneryAPI.FuseSceneryMarker>();
+                if (marker == null)
                 {
                     return; // FUSE-owned scenery only; vanilla culls normally.
+                }
+
+                // Only ever hold scenery the game has ALREADY loaded; a not-yet-loaded
+                // object has nothing to keep resident. Fail-open: when _wantsLoaded can't
+                // be read we treat it as loaded (the prior behavior).
+                var modelLoadRequested = !FuseSceneryModelState.Available
+                    || FuseSceneryModelState.IsLoadRequested(__instance);
+                if (!modelLoadRequested)
+                {
+                    return;
+                }
+
+                if (marker.IsMaskBearing)
+                {
+                    // Pin a loaded mask-bearing building to the nearest band so it stays BOTH
+                    // loaded and RENDERED. Left alone, the culler pushes it to band 2 (loaded
+                    // but renderers OFF) or band 3 (unloaded) when far, and the on-return
+                    // re-show/reload is unreliable across a teleport world-origin shift —
+                    // which is how you end up standing inside an invisible building. Never
+                    // letting it leave the rendered band sidesteps that. The load throttle is
+                    // bypassed for these too, so the first load is immediate. Unity's
+                    // per-renderer frustum culling still skips it when off-screen, so this is
+                    // "always eligible to draw", not "always drawn". Safety net over the real
+                    // fix (MapAPI.DecoupleAttachedMapMasks); removable once that is verified.
+                    distanceBand = RenderResidentBand;
+                    _suppressedUnloads++;
+                    LogSuppressedIfDue();
+                    return;
+                }
+
+                // Non-mask FUSE scenery: anti-flap only, and only against the UNLOAD band.
+                // Band 2 (loaded-but-hidden) is the game's own behaviour — leave it. At
+                // band 3, hold inside the ~3km deadband so jitter near the ~1500m boundary
+                // can't thrash load/unload, otherwise let the game unload. transform.position
+                // and the camera share the same (floating-origin shifted) space, so the
+                // delta is world-shift safe. Mirrors the unit-tested ShouldHoldResident.
+                if (distanceBand <= ResidentBandCeiling)
+                {
+                    return;
                 }
 
                 var camera = FuseSceneryCameraRef.Resolve();
@@ -111,36 +160,28 @@ namespace FUSE.Patches
                     return; // No reference to measure against: let the game unload.
                 }
 
-                // Anti-flap only: hold scenery the game has ALREADY loaded. A
-                // not-yet-loaded object inside the deadband isn't flapping — leaving it
-                // unloaded keeps the post-teleport working set to the game's real load
-                // band instead of force-streaming the whole deadband sphere through the
-                // throttle. transform.position and the camera are in the same
-                // (floating-origin shifted) space, so the delta is world-shift safe.
-                // Route through ShouldHold so the production decision is exactly the
-                // unit-tested one; fail-open (binding unavailable) holds any in-range
-                // scenery, the prior behavior.
-                var modelLoadRequested = !FuseSceneryModelState.Available
-                    || FuseSceneryModelState.IsLoadRequested(__instance);
-                if (!ShouldHold(modelLoadRequested, camera.transform.position, __instance.transform.position))
+                if (!ShouldHoldResident(camera.transform.position, __instance.transform.position))
                 {
-                    return; // Not loaded, or genuinely far: let band 3 through.
+                    return; // Genuinely far: let band 3 through.
                 }
 
-                // Inside the deadband and already loaded: hold it resident so the
-                // ~1500m boundary can't thrash load/unload.
-                distanceBand = ResidentBandCeiling;
+                distanceBand = ResidentBandCeiling; // clamp 3 -> 2 (resident anti-flap).
                 _suppressedUnloads++;
-                if (FuseSettings.EnableSceneryCullingDiagnostics && _suppressedUnloads % 1000 == 0)
-                {
-                    FuseLog.Info(
-                        $"FUSE diag scenery-debounce active: suppressedUnloads={_suppressedUnloads} " +
-                        $"(holding FUSE scenery resident within {UnloadDistance:0}m).");
-                }
+                LogSuppressedIfDue();
             }
             catch (Exception ex)
             {
                 FuseLog.Exception("FUSE scenery unload debounce prefix failed", ex);
+            }
+        }
+
+        private static void LogSuppressedIfDue()
+        {
+            if (FuseSettings.EnableSceneryCullingDiagnostics && _suppressedUnloads % 1000 == 0)
+            {
+                FuseLog.Info(
+                    $"FUSE diag scenery-debounce active: suppressedUnloads={_suppressedUnloads} " +
+                    $"(mask-bearing pinned loaded+rendered; non-mask held within {UnloadDistance:0}m).");
             }
         }
     }

--- a/FUSE/Patches/FuseSceneryLoadThrottlePatch.cs
+++ b/FUSE/Patches/FuseSceneryLoadThrottlePatch.cs
@@ -137,9 +137,22 @@ namespace FUSE.Patches
 
             try
             {
-                if (__instance.GetComponent<FUSE.Runtime.API.SceneryAPI.FuseSceneryMarker>() == null)
+                var marker = __instance.GetComponent<FUSE.Runtime.API.SceneryAPI.FuseSceneryMarker>();
+                if (marker == null)
                 {
                     return true; // FUSE-owned scenery only; vanilla loads normally.
+                }
+
+                // Mask-bearing buildings load immediately — never throttled or deferred.
+                // They are pinned permanently loaded+rendered by
+                // FuseSceneryCullingDebouncePatch, so each loads once and the number near
+                // any single spot is small; throttling them is what made a teleported-to
+                // building take minutes (or get dropped from the queue). Build it now, keep
+                // it. (Safety net alongside MapAPI.DecoupleAttachedMapMasks; removable once
+                // that decouple is verified in-game.)
+                if (marker.IsMaskBearing)
+                {
+                    return true;
                 }
 
                 // Already loading or loaded: the original SetLoaded(true) is a cheap

--- a/FUSE/Runtime/API/FuseSceneryDeferralClassifier.cs
+++ b/FUSE/Runtime/API/FuseSceneryDeferralClassifier.cs
@@ -12,14 +12,21 @@ namespace FUSE.Runtime.API
     /// Decides whether a scenery asset is eligible to have its activation deferred
     /// off the map-load critical path (see <c>FuseDeferredSceneryActivator</c>).
     ///
-    /// Two classes of scenery must stay eager (activated synchronously during apply):
-    ///  - <b>Mask-bearing</b> scenery, because the single terrain SDF bake runs once
-    ///    right after apply (FuseLifecycle map-mask rebuild). A mask activated after
-    ///    that bake would leave dark uncut terrain.
-    ///  - <b>Stateful</b> scenery whose components register KeyValue/StateManager
-    ///    property objects at activation (animated/toggleable props). Keeping these
-    ///    eager guarantees a save restore never races a not-yet-activated property
-    ///    object. This is the chosen conservative scope ("static-mesh only").
+    /// Only <b>stateful</b> scenery must stay eager (activated synchronously during
+    /// apply): components that register KeyValue/StateManager property objects at
+    /// activation (animated/toggleable props). Keeping these eager guarantees a save
+    /// restore never races a not-yet-activated property object.
+    ///
+    /// <b>Mask-bearing</b> scenery USED to be forced eager too (so the one-shot map-load
+    /// terrain bake saw its masks), but eager activation runs before the gameplay camera
+    /// exists and registered the cull sphere camera-less, leaving masked objects stuck
+    /// (never streaming in — confirmed on a lower-end PC where masked buildings never
+    /// appeared). Masks now defer like plain scenery, so they activate against a live
+    /// camera and bake their terrain as each piece streams in. Once loaded they are held
+    /// resident (never unloaded) by FuseSceneryCullingDebouncePatch as a safety net, while
+    /// MapAPI.DecoupleAttachedMapMasks moves the terrain mask onto a persistent object — so
+    /// the building and its baked terrain mask survive the player moving or teleporting away
+    /// and back.
     ///
     /// Everything else — plain meshes, materials, colorizers, ambient VFX/audio —
     /// is safe to defer; the worst case is brief cosmetic pop-in, exactly how the
@@ -97,6 +104,85 @@ namespace FUSE.Runtime.API
             }
         }
 
+        /// <summary>
+        /// True when the scenery identified by <paramref name="assetIdentifier"/> declares a
+        /// map-mask component. Used to tag mask-bearing scenery at creation so the cull
+        /// debounce can hold it resident — masked scenery must never unload, because the game
+        /// fails to reload it after a teleport (and a missed reload also drops its baked
+        /// terrain mask). Fail-safe: false when the definition cannot be resolved/inspected.
+        /// </summary>
+        internal static bool HasMaskComponent(string assetIdentifier)
+        {
+            if (string.IsNullOrWhiteSpace(assetIdentifier))
+            {
+                return false;
+            }
+
+            var manager = SceneryAssetManager.Shared;
+            if (manager == null)
+            {
+                return false;
+            }
+
+            SceneryDefinition definition;
+            try
+            {
+                if (!manager.TryGetSceneryDefinition(assetIdentifier, out definition) || definition == null)
+                {
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception($"FUSE deferred-scenery classifier could not resolve definition '{assetIdentifier}' for mask check", ex);
+                return false;
+            }
+
+            try
+            {
+                return DeclaresMaskComponent(definition, ComponentLifetime.Static)
+                    || DeclaresMaskComponent(definition, ComponentLifetime.Model);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception($"FUSE deferred-scenery classifier could not inspect '{assetIdentifier}' for mask components", ex);
+                return false;
+            }
+        }
+
+        private static bool DeclaresMaskComponent(SceneryDefinition definition, ComponentLifetime lifetime)
+        {
+            IEnumerable<DefinitionComponent> components;
+            try
+            {
+                components = definition.EnabledComponentsForLifetime(lifetime);
+            }
+            catch
+            {
+                return false;
+            }
+
+            if (components == null)
+            {
+                return false;
+            }
+
+            foreach (var component in components)
+            {
+                if (component == null)
+                {
+                    continue;
+                }
+
+                if (IsMaskTypeName(component.GetType().FullName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private static bool DeclaresEagerOnlyComponent(SceneryDefinition definition, ComponentLifetime lifetime)
         {
             IEnumerable<DefinitionComponent> components;
@@ -144,8 +230,17 @@ namespace FUSE.Runtime.API
                 return true;
             }
 
-            return ContainsAny(componentTypeFullName, MaskTypeNameFragments)
-                || ContainsAny(componentTypeFullName, StatefulTypeNameFragments);
+            // Mask-bearing scenery used to be forced eager so the one-shot map-load
+            // terrain bake saw its masks. But eager activation happens during apply,
+            // before the gameplay camera exists, which registers the cull sphere
+            // camera-less and leaves the object STUCK — it never streams in (confirmed:
+            // masked roundhouse pieces sat at band 3 while the unmasked office next to
+            // them loaded). Masks now defer like plain scenery, so they activate against
+            // a live camera and stream in correctly; each masked piece bakes its terrain
+            // as it loads, and FuseSceneryCullingDebouncePatch then holds it resident so
+            // it never unloads (and therefore never has to reload). Only stateful scenery
+            // stays eager.
+            return ContainsAny(componentTypeFullName, StatefulTypeNameFragments);
         }
 
         /// <summary>Pure, unit-testable: true when the type name is a map-mask component.</summary>

--- a/FUSE/Runtime/API/FuseSceneryDeferralClassifier.cs
+++ b/FUSE/Runtime/API/FuseSceneryDeferralClassifier.cs
@@ -61,12 +61,14 @@ namespace FUSE.Runtime.API
         };
 
         /// <summary>
-        /// True when the scenery identified by <paramref name="assetIdentifier"/> is a
-        /// plain static/visual asset whose activation can be deferred. Fail-safe:
-        /// returns false whenever the definition cannot be resolved or inspected.
+        /// Shared fail-safe resolution of a <see cref="SceneryDefinition"/> from
+        /// <see cref="SceneryAssetManager"/>. A null/empty id, a missing manager, a missing
+        /// definition, or any thrown lookup all return false (callers treat that as "cannot
+        /// classify"). <paramref name="operation"/> tags the failure log.
         /// </summary>
-        internal static bool CanDefer(string assetIdentifier)
+        private static bool TryResolveDefinition(string assetIdentifier, string operation, out SceneryDefinition definition)
         {
+            definition = null;
             if (string.IsNullOrWhiteSpace(assetIdentifier))
             {
                 return false;
@@ -78,7 +80,6 @@ namespace FUSE.Runtime.API
                 return false;
             }
 
-            SceneryDefinition definition;
             try
             {
                 if (!manager.TryGetSceneryDefinition(assetIdentifier, out definition) || definition == null)
@@ -88,7 +89,22 @@ namespace FUSE.Runtime.API
             }
             catch (Exception ex)
             {
-                FuseLog.Exception($"FUSE deferred-scenery classifier could not resolve definition '{assetIdentifier}'", ex);
+                FuseLog.Exception($"FUSE deferred-scenery classifier could not resolve definition '{assetIdentifier}' for {operation}", ex);
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// True when the scenery identified by <paramref name="assetIdentifier"/> is a
+        /// plain static/visual asset whose activation can be deferred. Fail-safe:
+        /// returns false whenever the definition cannot be resolved or inspected.
+        /// </summary>
+        internal static bool CanDefer(string assetIdentifier)
+        {
+            if (!TryResolveDefinition(assetIdentifier, "deferral check", out var definition))
+            {
                 return false;
             }
 
@@ -113,28 +129,8 @@ namespace FUSE.Runtime.API
         /// </summary>
         internal static bool HasMaskComponent(string assetIdentifier)
         {
-            if (string.IsNullOrWhiteSpace(assetIdentifier))
+            if (!TryResolveDefinition(assetIdentifier, "mask check", out var definition))
             {
-                return false;
-            }
-
-            var manager = SceneryAssetManager.Shared;
-            if (manager == null)
-            {
-                return false;
-            }
-
-            SceneryDefinition definition;
-            try
-            {
-                if (!manager.TryGetSceneryDefinition(assetIdentifier, out definition) || definition == null)
-                {
-                    return false;
-                }
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception($"FUSE deferred-scenery classifier could not resolve definition '{assetIdentifier}' for mask check", ex);
                 return false;
             }
 

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -223,6 +223,14 @@ namespace FUSE.Runtime.API
             return definition;
         }
 
+        /// <summary>
+        /// Creates a standalone, always-active map mask under the permanent
+        /// <c>World/FUSE Map Masks</c> root. This is the preferred way to author a terrain
+        /// mask: hosted here it is decoupled from any scenery's streaming, so it bakes once
+        /// and stays applied through the player moving or teleporting. Masks authored instead
+        /// as components on a scenery are re-homed here automatically on load by
+        /// <see cref="DecoupleAttachedMapMasks"/> — the compatibility path for existing packs.
+        /// </summary>
         public static GameObject AddMapMask(string id, FuseMapMask definition)
         {
             RequireId(id, nameof(id));
@@ -404,6 +412,248 @@ namespace FUSE.Runtime.API
                     $"FUSE refreshed {refreshed} attached map mask component(s) on '{root.name}' " +
                     $"after '{reason ?? "unspecified"}'.");
             }
+        }
+
+        /// <summary>
+        /// Re-homes a scenery's terrain map masks from components welded inside its streamed
+        /// model into standalone, always-active objects under the permanent
+        /// <c>FUSE Map Masks</c> root.
+        ///
+        /// Design principle — a FUSE scenery is a STREAMED VISUAL MODEL plus a PERSISTENT
+        /// WORLD-CONTRIBUTION. The <c>SceneryAssetInstance</c> streams its visual model in/out
+        /// by camera distance, but a terrain mask is a world contribution that must outlive
+        /// that streaming. Welded into the model it rides the cull lifecycle: it re-bakes
+        /// terrain on every load (slow) and loses its flatten/cut when the model streams out
+        /// or a teleport re-bakes terrain mid-stream, leaving the building buried in
+        /// un-flattened ground. Hosted standalone it is baked once and always applied while
+        /// the visual streams freely. Save-state already follows this shape (its
+        /// KeyValueObject lives on the persistent scenery root, not the model — see
+        /// FuseSceneryAnimationFixPatches). Effects that only matter up close — colliders,
+        /// audio, lights, particles — are intentionally left in the streamed model: they are
+        /// loaded whenever the player is near enough to perceive them, so a brief stream-in
+        /// gap is acceptable rather than worth a permanent companion.
+        ///
+        /// Mechanism: called from <c>SceneryAPI.AddScenery</c> via
+        /// <c>SceneryAssetInstance.OnDidLoadModels</c>, so it runs the moment the model (and
+        /// its mask components) finish streaming in, and again on any reload. Idempotent — the
+        /// standalone is created once (keyed by scenery id + mask index via
+        /// <see cref="BuildDecoupledMaskId"/>) and the welded copy is disabled on every load
+        /// so it never bakes on the model. Fail-safe — if a mask can't be cloned the welded
+        /// original is left enabled rather than dropped. Cleaned up by
+        /// <see cref="RemoveDecoupledMasksFor"/> on scenery removal/update. To decouple a
+        /// future world-contribution type, mirror this shape: clone to the persistent root on
+        /// load, disable the welded source, clean up by id on removal.
+        /// </summary>
+        internal static int DecoupleAttachedMapMasks(GameObject sceneryRoot, string id)
+        {
+            if (sceneryRoot == null || string.IsNullOrEmpty(id))
+            {
+                return 0;
+            }
+
+            // A freshly (re)loaded model can come back with its renderers disabled (e.g.
+            // an object-mask forceRenderingOff hide that never cleared); force them on so
+            // the building actually draws. Same fix the turntable visuals apply on load.
+            EnableRenderers(sceneryRoot);
+
+            var maskRoot = GetOrCreateWorldRoot(MapMaskRootName, ref _fallbackMapMaskRoot);
+            if (maskRoot == null)
+            {
+                return 0;
+            }
+
+            var masks = sceneryRoot.GetComponentsInChildren<MapMaskBase>(true);
+            var decoupled = 0;
+            for (var index = 0; index < masks.Length; index++)
+            {
+                var attached = masks[index];
+                if (attached == null)
+                {
+                    continue;
+                }
+
+                // One of our own standalone masks (re-entrant call): leave it alone.
+                if (attached.transform.IsChildOf(maskRoot))
+                {
+                    continue;
+                }
+
+                var standaloneId = BuildDecoupledMaskId(id, index);
+                if (GetMapMask(standaloneId) == null)
+                {
+                    try
+                    {
+                        CloneMaskToStandalone(standaloneId, attached, maskRoot);
+                        decoupled++;
+                    }
+                    catch (Exception ex)
+                    {
+                        // Fail-safe: keep the welded mask working rather than lose the flatten.
+                        FuseLog.Warning(
+                            $"FUSE could not decouple map mask '{standaloneId}' from scenery '{id}': " +
+                            $"{ex.Message}; leaving it attached.");
+                        continue;
+                    }
+                }
+
+                // Stop the welded copy baking on the streamed model. Idempotent across
+                // reloads: the standalone above already holds the flatten/cut.
+                attached.enabled = false;
+            }
+
+            if (decoupled > 0)
+            {
+                FuseLog.Info(
+                    $"FUSE decoupled {decoupled} map mask(s) from scenery '{id}' into standalone " +
+                    $"'{MapMaskRootName}' object(s); the terrain mask now survives the model streaming and teleports.");
+            }
+
+            return decoupled;
+        }
+
+        private static GameObject CloneMaskToStandalone(string id, MapMaskBase source, Transform maskRoot)
+        {
+            var go = new GameObject(id);
+            go.transform.SetParent(maskRoot, false);
+            go.SetActive(false);
+            go.transform.position = source.transform.position;
+            go.transform.rotation = source.transform.rotation;
+            go.transform.localScale = Vector3.one;
+
+            if (source is CircleMapMask sourceCircle)
+            {
+                var clone = go.AddComponent<CircleMapMask>();
+                CopyCommonMaskFields(sourceCircle, clone);
+                clone.radius = sourceCircle.radius;
+            }
+            else if (source is RectangleMapMask sourceRectangle)
+            {
+                var clone = go.AddComponent<RectangleMapMask>();
+                CopyCommonMaskFields(sourceRectangle, clone);
+                clone.sizeX = sourceRectangle.sizeX;
+                clone.sizeZ = sourceRectangle.sizeZ;
+                clone.degrees = sourceRectangle.degrees;
+            }
+            else if (source is CurveMapMask sourceCurve)
+            {
+                var clone = go.AddComponent<CurveMapMask>();
+                CopyCommonMaskFields(sourceCurve, clone);
+                clone.positionA = sourceCurve.positionA;
+                clone.positionB = sourceCurve.positionB;
+                clone.rotationA = sourceCurve.rotationA;
+                clone.rotationB = sourceCurve.rotationB;
+                clone.sizeA = sourceCurve.sizeA;
+                clone.sizeB = sourceCurve.sizeB;
+                clone.radiusNoise = sourceCurve.radiusNoise;
+                clone.noiseScale = sourceCurve.noiseScale;
+            }
+            else
+            {
+                UnityEngine.Object.Destroy(go);
+                throw new InvalidOperationException($"Unsupported map mask type '{source.GetType().Name}'.");
+            }
+
+            // OnEnable self-applies the modifier to the (persistent) terrain. Enable the
+            // standalone BEFORE the caller disables the welded original so the flatten/cut
+            // is never momentarily dropped.
+            go.SetActive(true);
+            return go;
+        }
+
+        private static void CopyCommonMaskFields(MapMaskBase source, MapMaskBase destination)
+        {
+            destination.radius = source.radius;
+            destination.falloff = source.falloff;
+            destination.enableSetHeight = source.enableSetHeight;
+            destination.enableCutTrees = source.enableCutTrees;
+            destination.enableMaskModifier = source.enableMaskModifier;
+            destination.maskName = source.maskName;
+            destination.order = source.order;
+        }
+
+        private static void EnableRenderers(GameObject root)
+        {
+            if (root == null)
+            {
+                return;
+            }
+
+            foreach (var renderer in root.GetComponentsInChildren<Renderer>(true))
+            {
+                renderer.enabled = true;
+                renderer.forceRenderingOff = false;
+            }
+        }
+
+        // Standalone masks that DecoupleAttachedMapMasks creates from a scenery's welded
+        // masks are named "<sceneryId>__mask<NN>" under the FUSE Map Masks root, so they can
+        // be located for cleanup when that scenery is removed or updated. The "__mask"
+        // separator keeps the prefix unambiguous: scenery "Shop4" never matches "Shop4X".
+        internal const string DecoupledMaskInfix = "__mask";
+
+        /// <summary>Pure: the standalone id for a scenery's decoupled mask at <paramref name="index"/>.</summary>
+        internal static string BuildDecoupledMaskId(string sceneryId, int index)
+        {
+            return sceneryId + DecoupledMaskInfix + index.ToString("D2");
+        }
+
+        /// <summary>Pure: true when <paramref name="maskName"/> is a decoupled mask owned by <paramref name="sceneryId"/>.</summary>
+        internal static bool IsDecoupledMaskOf(string maskName, string sceneryId)
+        {
+            return !string.IsNullOrEmpty(maskName)
+                && !string.IsNullOrEmpty(sceneryId)
+                && maskName.StartsWith(sceneryId + DecoupledMaskInfix, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Destroys the standalone masks that <see cref="DecoupleAttachedMapMasks"/> created
+        /// for scenery <paramref name="sceneryId"/>. Call when the scenery is removed (so a
+        /// deleted building doesn't leave its terrain permanently flattened) or when its
+        /// definition/position changes (so the next load re-decouples at the new transform
+        /// instead of leaving a stale mask behind). Like <see cref="TryRemoveMapMask"/>, the
+        /// terrain reverts on the next rebuild rather than being force-rebuilt here.
+        /// </summary>
+        internal static int RemoveDecoupledMasksFor(string sceneryId)
+        {
+            if (string.IsNullOrEmpty(sceneryId))
+            {
+                return 0;
+            }
+
+            var root = GetOrCreateWorldRoot(MapMaskRootName, ref _fallbackMapMaskRoot);
+            if (root == null)
+            {
+                return 0;
+            }
+
+            // Collect before destroying: Destroy reindexes the parent's children.
+            var doomed = new List<GameObject>();
+            for (var i = 0; i < root.childCount; i++)
+            {
+                var child = root.GetChild(i);
+                if (child != null && IsDecoupledMaskOf(child.name, sceneryId))
+                {
+                    doomed.Add(child.gameObject);
+                }
+            }
+
+            foreach (var go in doomed)
+            {
+                if (go == null)
+                {
+                    continue;
+                }
+
+                go.SetActive(false);
+                UnityEngine.Object.Destroy(go);
+            }
+
+            if (doomed.Count > 0)
+            {
+                FuseLog.Info($"FUSE removed {doomed.Count} decoupled map mask(s) for scenery '{sceneryId}'.");
+            }
+
+            return doomed.Count;
         }
 
         public static GameObject AddTelegraphPoles(string id, FuseTelegraphPoles definition)

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -478,19 +478,20 @@ namespace FUSE.Runtime.API
                     continue;
                 }
 
-                var standaloneId = BuildDecoupledMaskId(id, index);
-                if (GetMapMask(standaloneId) == null)
+                // Ownership is tracked by a marker component (not the name), so a user-authored
+                // mask that happens to share the generated name is never mistaken for our clone.
+                if (FindDecoupledMask(maskRoot, id, index) == null)
                 {
                     try
                     {
-                        CloneMaskToStandalone(standaloneId, attached, maskRoot);
+                        CloneMaskToStandalone(BuildDecoupledMaskId(id, index), attached, maskRoot, id, index);
                         decoupled++;
                     }
                     catch (Exception ex)
                     {
                         // Fail-safe: keep the welded mask working rather than lose the flatten.
                         FuseLog.Warning(
-                            $"FUSE could not decouple map mask '{standaloneId}' from scenery '{id}': " +
+                            $"FUSE could not decouple map mask #{index} from scenery '{id}': " +
                             $"{ex.Message}; leaving it attached.");
                         continue;
                     }
@@ -511,14 +512,19 @@ namespace FUSE.Runtime.API
             return decoupled;
         }
 
-        private static GameObject CloneMaskToStandalone(string id, MapMaskBase source, Transform maskRoot)
+        private static GameObject CloneMaskToStandalone(string name, MapMaskBase source, Transform maskRoot, string ownerSceneryId, int sourceIndex)
         {
-            var go = new GameObject(id);
+            var go = new GameObject(name);
             go.transform.SetParent(maskRoot, false);
             go.SetActive(false);
             go.transform.position = source.transform.position;
             go.transform.rotation = source.transform.rotation;
             go.transform.localScale = Vector3.one;
+
+            // Ownership marker so reuse/cleanup never depend on the (cosmetic) GameObject name.
+            var owner = go.AddComponent<FuseDecoupledMaskMarker>();
+            owner.OwnerSceneryId = ownerSceneryId;
+            owner.SourceIndex = sourceIndex;
 
             if (source is CircleMapMask sourceCircle)
             {
@@ -588,10 +594,10 @@ namespace FUSE.Runtime.API
             }
         }
 
-        // Standalone masks that DecoupleAttachedMapMasks creates from a scenery's welded
-        // masks are named "<sceneryId>__mask<NN>" under the FUSE Map Masks root, so they can
-        // be located for cleanup when that scenery is removed or updated. The "__mask"
-        // separator keeps the prefix unambiguous: scenery "Shop4" never matches "Shop4X".
+        // Decoupled masks are NAMED "<sceneryId>__mask<NN>" for readability only. Ownership
+        // (reuse on reload + cleanup on removal/update) is tracked by the
+        // FuseDecoupledMaskMarker component, never the name, so a user-authored mask that
+        // happens to share the generated name is never reused or destroyed by mistake.
         internal const string DecoupledMaskInfix = "__mask";
 
         /// <summary>Pure: the standalone id for a scenery's decoupled mask at <paramref name="index"/>.</summary>
@@ -600,12 +606,44 @@ namespace FUSE.Runtime.API
             return sceneryId + DecoupledMaskInfix + index.ToString("D2");
         }
 
-        /// <summary>Pure: true when <paramref name="maskName"/> is a decoupled mask owned by <paramref name="sceneryId"/>.</summary>
-        internal static bool IsDecoupledMaskOf(string maskName, string sceneryId)
+        /// <summary>
+        /// Inert ownership marker on a standalone mask that
+        /// <see cref="DecoupleAttachedMapMasks"/> cloned from a scenery's welded mask.
+        /// Ownership decisions (reuse on reload, cleanup on removal/update) read this marker,
+        /// not the GameObject name, so a user-authored mask that shares the generated name is
+        /// never reused or destroyed by mistake.
+        /// </summary>
+        internal sealed class FuseDecoupledMaskMarker : MonoBehaviour
         {
-            return !string.IsNullOrEmpty(maskName)
-                && !string.IsNullOrEmpty(sceneryId)
-                && maskName.StartsWith(sceneryId + DecoupledMaskInfix, StringComparison.Ordinal);
+            public string OwnerSceneryId;
+            public int SourceIndex;
+        }
+
+        /// <summary>
+        /// The standalone mask this scenery already decoupled for the welded mask at
+        /// <paramref name="sourceIndex"/> (matched by ownership marker), or null if it has
+        /// not been cloned yet.
+        /// </summary>
+        private static GameObject FindDecoupledMask(Transform maskRoot, string sceneryId, int sourceIndex)
+        {
+            if (maskRoot == null)
+            {
+                return null;
+            }
+
+            for (var i = 0; i < maskRoot.childCount; i++)
+            {
+                var child = maskRoot.GetChild(i);
+                var marker = child != null ? child.GetComponent<FuseDecoupledMaskMarker>() : null;
+                if (marker != null
+                    && marker.SourceIndex == sourceIndex
+                    && string.Equals(marker.OwnerSceneryId, sceneryId, StringComparison.Ordinal))
+                {
+                    return child.gameObject;
+                }
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -629,12 +667,14 @@ namespace FUSE.Runtime.API
                 return 0;
             }
 
-            // Collect before destroying: Destroy reindexes the parent's children.
+            // Collect before destroying: Destroy reindexes the parent's children. Match by
+            // ownership marker (not name) so a user-authored mask is never destroyed.
             var doomed = new List<GameObject>();
             for (var i = 0; i < root.childCount; i++)
             {
                 var child = root.GetChild(i);
-                if (child != null && IsDecoupledMaskOf(child.name, sceneryId))
+                var marker = child != null ? child.GetComponent<FuseDecoupledMaskMarker>() : null;
+                if (marker != null && string.Equals(marker.OwnerSceneryId, sceneryId, StringComparison.Ordinal))
                 {
                     doomed.Add(child.gameObject);
                 }

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -451,10 +451,10 @@ namespace FUSE.Runtime.API
                 return 0;
             }
 
-            // A freshly (re)loaded model can come back with its renderers disabled (e.g.
-            // an object-mask forceRenderingOff hide that never cleared); force them on so
-            // the building actually draws. Same fix the turntable visuals apply on load.
-            EnableRenderers(sceneryRoot);
+            // A freshly (re)loaded model can come back with an object-mask forceRenderingOff
+            // hide stuck on, leaving the building invisible; clear that so it draws. Scoped to
+            // forceRenderingOff only, so pack-authored disabled renderers stay disabled.
+            ClearForcedRendererHides(sceneryRoot);
 
             var maskRoot = GetOrCreateWorldRoot(MapMaskRootName, ref _fallbackMapMaskRoot);
             if (maskRoot == null)
@@ -571,16 +571,19 @@ namespace FUSE.Runtime.API
             destination.order = source.order;
         }
 
-        private static void EnableRenderers(GameObject root)
+        private static void ClearForcedRendererHides(GameObject root)
         {
             if (root == null)
             {
                 return;
             }
 
+            // Only clear forceRenderingOff -- a runtime culling flag that can stick "on" and
+            // leave a loaded building invisible. Deliberately do NOT touch renderer.enabled:
+            // a pack author may have intentionally disabled specific sub-mesh renderers, and
+            // forcing them on would override that intent.
             foreach (var renderer in root.GetComponentsInChildren<Renderer>(true))
             {
-                renderer.enabled = true;
                 renderer.forceRenderingOff = false;
             }
         }

--- a/FUSE/Runtime/API/SceneryAPI.cs
+++ b/FUSE/Runtime/API/SceneryAPI.cs
@@ -76,6 +76,28 @@ namespace FUSE.Runtime.API
             // correctly falls into AddScenery for a brand-new entity.
             var marker = gameObject.AddComponent<FuseSceneryMarker>();
             marker.Id = id;
+            // Tag mask-bearing scenery. Two behaviours key off this: (1) the cull debounce
+            // pins it loaded+rendered (a safety net), and (2) the OnDidLoadModels hook below
+            // re-homes its welded map masks into standalone, always-active objects the moment
+            // the model streams in (MapAPI.DecoupleAttachedMapMasks) — the real fix, so the
+            // terrain mask survives the building streaming out/in and teleport world-shifts.
+            marker.IsMaskBearing = FuseSceneryDeferralClassifier.HasMaskComponent(assetIdentifier);
+            if (marker.IsMaskBearing)
+            {
+                var sceneryRoot = gameObject;
+                var sceneryId = id;
+                scenery.OnDidLoadModels += _ =>
+                {
+                    try
+                    {
+                        MapAPI.DecoupleAttachedMapMasks(sceneryRoot, sceneryId);
+                    }
+                    catch (Exception ex)
+                    {
+                        FuseLog.Exception($"FUSE map-mask decouple-on-load failed for scenery '{sceneryId}'", ex);
+                    }
+                };
+            }
             ApplyDefinition(scenery, definition, assetIdentifier);
 
             // Activate inline unless the deferred activator takes ownership of this
@@ -104,6 +126,13 @@ namespace FUSE.Runtime.API
         internal sealed class FuseSceneryMarker : MonoBehaviour
         {
             public string Id;
+
+            // True when this scenery declares a map-mask component. The cull debounce
+            // (FuseSceneryCullingDebouncePatch) reads this to hold mask-bearing scenery
+            // resident at any distance — it must never unload, because the game does not
+            // reliably reload masked scenery after a teleport (and a missed reload also
+            // drops its baked terrain mask). Set once at AddScenery time.
+            public bool IsMaskBearing;
         }
 
         public static void UpdateScenery(string id, FuseScenery definition)
@@ -133,6 +162,17 @@ namespace FUSE.Runtime.API
 
             MapAPI.RefreshAttachedMapMasks(scenery.gameObject, $"scenery '{id}' update");
 
+            // Mask-bearing scenery: its terrain mask was decoupled to a standalone object at
+            // the previous transform. Drop those and re-decouple from the (now-moved) welded
+            // masks so the flatten follows the scenery. If the model isn't currently streamed
+            // in, the re-decouple is a no-op and OnDidLoadModels redoes it on the next load.
+            var marker = scenery.GetComponent<FuseSceneryMarker>();
+            if (marker != null && marker.IsMaskBearing)
+            {
+                MapAPI.RemoveDecoupledMasksFor(id);
+                MapAPI.DecoupleAttachedMapMasks(scenery.gameObject, id);
+            }
+
             FuseSceneryRuntimeIndex.Instance.Set(id, scenery);
             FuseApiPersistence.RecordDefinition(FuseDefinitionKind.Scenery, id, definition);
         }
@@ -159,6 +199,9 @@ namespace FUSE.Runtime.API
             UnityEngine.Object.Destroy(root);
             FuseSceneryRuntimeIndex.Instance.Remove(id);
             FuseRuntimeDefinitionCache.Remove(FuseDefinitionKind.Scenery, id);
+            // Remove any terrain masks this scenery decoupled to standalone objects, so a
+            // deleted building doesn't leave its ground permanently flattened.
+            MapAPI.RemoveDecoupledMasksFor(id);
             FuseLog.Info($"FUSE removed scenery '{id}' from '{path}'.");
             return true;
         }

--- a/FUSE/Runtime/Lifecycle/FuseDeferredSceneryActivator.cs
+++ b/FUSE/Runtime/Lifecycle/FuseDeferredSceneryActivator.cs
@@ -23,12 +23,14 @@ namespace FUSE.Runtime.Lifecycle
     /// genuinely-near scenery and stream the rest as the player moves, exactly how
     /// vanilla scenery behaves.
     ///
-    /// Only plain static/visual scenery is deferred (see
-    /// <see cref="FuseSceneryDeferralClassifier"/>); mask-bearing and stateful
-    /// scenery stay eager. Every failure path falls back to inline (synchronous)
-    /// activation, so a deferral problem can never leave scenery invisible or wedge
-    /// a load. Only the initial map-load wave defers; reapply/live-reload stay
-    /// synchronous.
+    /// Plain static/visual scenery and mask-bearing scenery are deferred (see
+    /// <see cref="FuseSceneryDeferralClassifier"/>); only stateful scenery (KeyValue/
+    /// animation) stays eager. Mask-bearing scenery defers so it activates against a
+    /// live camera — camera-less activation left masks stuck — and is then held
+    /// resident by FuseSceneryCullingDebouncePatch so it never unloads. Every failure
+    /// path falls back to inline (synchronous) activation, so a deferral problem can
+    /// never leave scenery invisible or wedge a load. Only the initial map-load wave
+    /// defers; reapply/live-reload stay synchronous.
     ///
     /// FLAGGED — measured impact is modest (heavy 38-package install, 2026-06):
     /// loading screen ~110s -> ~96s (~13%); only ~14s of scenery activation moved


### PR DESCRIPTION
## Problem

Masked buildings (e.g. ALW's Bryson roundhouse/shops) load slowly and **bury in un-flattened terrain after a teleport**. Root cause: a building's map mask is authored as a **Model-lifetime component**, so it's welded inside the `SceneryAssetInstance` model that the game streams by camera distance. When the model streams out -- or a teleport re-bakes terrain while the model is mid-stream -- the mask is gone, the terrain isn't flattened, and the building sits buried. An *unmasked* building loads instantly because nothing world-affecting rides its cull.

This generalizes: any world-affecting contribution welded at Model lifetime rides the streaming lifecycle.

## Fix

Harden the loading path around the principle that **a FUSE scenery is a streamed visual model plus a persistent world-contribution**. The contribution (terrain masks; save-state) must outlive the model's streaming; the visual streams freely.

- **`MapAPI.DecoupleAttachedMapMasks`** — on `SceneryAssetInstance.OnDidLoadModels`, clones each welded `CircleMapMask`/`RectangleMapMask`/`CurveMapMask` to a standalone, always-active object under `World/FUSE Map Masks` and disables the welded copy. Idempotent across reloads, fail-safe (a clone failure leaves the welded mask working).
- **Full lifecycle** — cleaned up on `TryRemoveScenery` (no orphan flatten), re-synced on `UpdateScenery` (mask follows a moved scenery). Ownership via pure helpers `BuildDecoupledMaskId` / `IsDecoupledMaskOf` with prefix-collision safety.
- **Audit + docs** — save-state already follows this pattern (`KeyValueObject` on the persistent root, observers re-sync on reload); documented as the reference. Colliders / audio / light / particle are intentionally left stream-coupled (they only matter up close, where the model is loaded). Authoring guidance added to `AddMapMask`.

## Tests / static analysis

- New: **13** unit tests for the decoupled-mask id helpers (naming + prefix-collision safety).
- `FUSE.Tests` **1234**, `FUSE.Core.Tests` **31**, `FUSE.ExternalEditor.UiTests` **87** — all pass.
- Build clean at the repo analyzer level; `latest-all` analyzers and `dotnet format --verify-no-changes` clean on changed files.

## Not done here (deliberate)

- **In-game verification pending** — deploy was off during development. Repro to confirm: teleport Dillsboro->Bryson and back; `FUSE.log` should show `FUSE decoupled N map mask(s) from scenery 'BryShop...'` and the shop staying solid on flattened ground.
- The earlier **band-0 cull pin + load-throttle bypass** for mask-bearing scenery remain as a safety net (labeled in-code as removable). Collapsing them is a **gated follow-up** once the decouple is verified in-game -- they become dead weight (extra resident memory) once the mask persists independently.
