### PR TITLE
feat(ci): verify packaged mod zip is UMM-compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,30 @@ jobs:
 
           Compress-Archive -Path $modFolder -DestinationPath $archivePath -CompressionLevel Optimal
 
+      # Prove the freshly-packaged zip is actually loadable by Unity Mod Manager
+      # before publishing it as an artifact. scripts/Validate-ModPackage.cs resolves
+      # the Info.json EntryMethod against the game's UnityModManager assembly via
+      # MetadataLoadContext (no game launch), checks the manifest fields, and asserts
+      # the archive layout (DLL set + schemas/ + assets/, no stray files or PDBs).
+      # The expected version is the CI build identity (0.0.0-<branch|pr>.<sha>); the
+      # validator tolerates the 0.0.0 version core that PR/push builds intentionally
+      # stamp, while still enforcing it on real release tags (see release.yml).
+      - name: Validate mod package (UMM compatibility)
+        shell: powershell
+        run: |
+          # Resolve the reference dir through the same Paths.user / GameDir the build
+          # used, so the UnityModManager assembly set always matches this runner.
+          $ummDir = (dotnet msbuild FUSE/FUSE.csproj -getProperty:UnityModManagerDir -nologo 2>$null | Select-Object -Last 1)
+          if ($ummDir) { $ummDir = $ummDir.Trim() }
+          Write-Host "UnityModManager reference dir: $ummDir"
+          if ($ummDir -and (Test-Path $ummDir)) {
+            dotnet run scripts/Validate-ModPackage.cs -- "${{ steps.build_id.outputs.archive }}" "${{ steps.build_id.outputs.version }}" "FUSE" "$ummDir"
+          } else {
+            Write-Host "UnityModManagerDir unresolved; falling back to validator env-based resolution."
+            dotnet run scripts/Validate-ModPackage.cs -- "${{ steps.build_id.outputs.archive }}" "${{ steps.build_id.outputs.version }}"
+          }
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Upload build artifact
         id: build_upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,13 @@ jobs:
       # stamp, while still enforcing it on real release tags (see release.yml).
       - name: Validate mod package (UMM compatibility)
         shell: powershell
+        env:
+          # Pass the archive name + build version through the environment rather
+          # than ${{ }} template expansion, so a crafted branch name can't inject
+          # into the script before validation. Mirrors the TAG_NAME hardening in
+          # release.yml.
+          ARCHIVE_PATH: ${{ steps.build_id.outputs.archive }}
+          MOD_VERSION: ${{ steps.build_id.outputs.version }}
         run: |
           # Resolve the reference dir through the same Paths.user / GameDir the build
           # used, so the UnityModManager assembly set always matches this runner.
@@ -277,10 +284,10 @@ jobs:
           if ($ummDir) { $ummDir = $ummDir.Trim() }
           Write-Host "UnityModManager reference dir: $ummDir"
           if ($ummDir -and (Test-Path $ummDir)) {
-            dotnet run scripts/Validate-ModPackage.cs -- "${{ steps.build_id.outputs.archive }}" "${{ steps.build_id.outputs.version }}" "FUSE" "$ummDir"
+            dotnet run scripts/Validate-ModPackage.cs -- "$env:ARCHIVE_PATH" "$env:MOD_VERSION" "FUSE" "$ummDir"
           } else {
             Write-Host "UnityModManagerDir unresolved; falling back to validator env-based resolution."
-            dotnet run scripts/Validate-ModPackage.cs -- "${{ steps.build_id.outputs.archive }}" "${{ steps.build_id.outputs.version }}"
+            dotnet run scripts/Validate-ModPackage.cs -- "$env:ARCHIVE_PATH" "$env:MOD_VERSION"
           }
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,28 @@ jobs:
           "archive_name=$archiveName" >> $env:GITHUB_OUTPUT
           "archive_path=$archivePath" >> $env:GITHUB_OUTPUT
 
+      # Gate the release on UMM compatibility before publishing to GitHub and Nexus:
+      # the packaged zip must be loadable by Unity Mod Manager. scripts/Validate-ModPackage.cs
+      # resolves the Info.json EntryMethod to a public static bool Load(ModEntry) against
+      # the game's UnityModManager assembly (via MetadataLoadContext — no game launch) and
+      # asserts the manifest + archive layout. Runs before the installer/exe builds below
+      # so a bad package fails fast.
+      - name: Validate mod package (UMM compatibility)
+        shell: powershell
+        run: |
+          # Resolve the reference dir through the same Paths.user / GameDir the build
+          # used, so the UnityModManager assembly set always matches this runner.
+          $ummDir = (dotnet msbuild FUSE/FUSE.csproj -getProperty:UnityModManagerDir -nologo 2>$null | Select-Object -Last 1)
+          if ($ummDir) { $ummDir = $ummDir.Trim() }
+          Write-Host "UnityModManager reference dir: $ummDir"
+          if ($ummDir -and (Test-Path $ummDir)) {
+            dotnet run scripts/Validate-ModPackage.cs -- "${{ steps.package.outputs.archive_path }}" "${{ steps.version.outputs.version }}" "FUSE" "$ummDir"
+          } else {
+            Write-Host "UnityModManagerDir unresolved; falling back to validator env-based resolution."
+            dotnet run scripts/Validate-ModPackage.cs -- "${{ steps.package.outputs.archive_path }}" "${{ steps.version.outputs.version }}"
+          }
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       # The standalone editor ships in its own release lane (externaleditor-v*
       # tags, .github/workflows/release-externaleditor.yml) so it can be
       # versioned and shipped independently of the mod. Intentionally NOT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,12 @@ jobs:
       # so a bad package fails fast.
       - name: Validate mod package (UMM compatibility)
         shell: powershell
+        env:
+          # Pass the archive path + version through the environment rather than
+          # ${{ }} template expansion, consistent with the TAG_NAME hardening in
+          # the version-parse step above.
+          ARCHIVE_PATH: ${{ steps.package.outputs.archive_path }}
+          MOD_VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Resolve the reference dir through the same Paths.user / GameDir the build
           # used, so the UnityModManager assembly set always matches this runner.
@@ -131,10 +137,10 @@ jobs:
           if ($ummDir) { $ummDir = $ummDir.Trim() }
           Write-Host "UnityModManager reference dir: $ummDir"
           if ($ummDir -and (Test-Path $ummDir)) {
-            dotnet run scripts/Validate-ModPackage.cs -- "${{ steps.package.outputs.archive_path }}" "${{ steps.version.outputs.version }}" "FUSE" "$ummDir"
+            dotnet run scripts/Validate-ModPackage.cs -- "$env:ARCHIVE_PATH" "$env:MOD_VERSION" "FUSE" "$ummDir"
           } else {
             Write-Host "UnityModManagerDir unresolved; falling back to validator env-based resolution."
-            dotnet run scripts/Validate-ModPackage.cs -- "${{ steps.package.outputs.archive_path }}" "${{ steps.version.outputs.version }}"
+            dotnet run scripts/Validate-ModPackage.cs -- "$env:ARCHIVE_PATH" "$env:MOD_VERSION"
           }
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/scripts/Validate-ModPackage.cs
+++ b/scripts/Validate-ModPackage.cs
@@ -1,0 +1,419 @@
+#:property TargetFramework=net10.0
+#:property Nullable=enable
+#:property ImplicitUsings=enable
+#:property PublishAot=false
+#:property AppendTargetFrameworkToOutputPath=true
+#:package System.Reflection.MetadataLoadContext@8.0.0
+
+// Validates that a built FUSE release .zip conforms to UnityModManager (UMM)
+// requirements before it gets published. FUSE ships as a *pure* UMM mod (it is
+// the Railloader replacement, so unlike a normal Railroader mod it carries no
+// Railloader Definition.json — only a UMM Info.json), so the checks here are the
+// UMM subset of the cross-repo Validate-ModPackage scripts.
+//
+// Run with: dotnet run scripts/Validate-ModPackage.cs -- <zip> <expected-version> [mod-id] [ref-dir]
+//
+// Checks:
+//   - Archive layout: exactly one top-level folder named <mod-id> containing the
+//     runtime DLL set (FUSE.dll, FUSE.Editor.dll, FUSE.Converter.dll), Info.json,
+//     a non-empty schemas/ tree and assets/fuse_icon.png. No stray files, no *.pdb.
+//   - Info.json: required fields present and non-empty; Version is the version
+//     CORE (MAJOR.MINOR.PATCH, the only shape UMM's System.Version parser accepts)
+//     and matches the expected core; AssemblyName matches the entry DLL;
+//     ManagerVersion is a valid version; HomePage (if a non-empty string) is a
+//     well-formed http(s) URL.
+//   - DLL: EntryMethod from Info.json resolves to a public, static method returning
+//     bool and taking exactly one UnityModManagerNet.UnityModManager.ModEntry
+//     parameter — inspected via System.Reflection.MetadataLoadContext, so no Unity
+//     runtime, no game launch, and no managed-assembly load side effects. This is
+//     the check that actually proves UMM can call into the shipped binary.
+//
+// ref-dir must contain UnityModManager(Net).dll so the ModEntry parameter type
+// resolves. In CI this is the game's managed UnityModManager folder, obtained from
+// `dotnet msbuild FUSE/FUSE.csproj -getProperty:UnityModManagerDir` so it tracks
+// whatever Paths.user / GameDir the build itself resolved. Locally it falls back to
+// the UnityModManagerDir / GameDir environment variables, then to lib/refs.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+const string ExpectedEntryParam = "UnityModManagerNet.UnityModManager+ModEntry";
+
+if (args.Length < 2)
+{
+    Console.Error.WriteLine("Usage: dotnet run scripts/Validate-ModPackage.cs -- <zip> <expected-version> [mod-id] [ref-dir]");
+    return 2;
+}
+
+string zipPath = args[0];
+string expectedVersion = args[1];
+string modId = args.Length > 2 && !string.IsNullOrWhiteSpace(args[2]) ? args[2] : "FUSE";
+string? refDirArg = args.Length > 3 && !string.IsNullOrWhiteSpace(args[3]) ? args[3] : null;
+
+// The entry DLL (carries EntryMethod) plus the companion assemblies FUSE ships
+// alongside it. FUSE.dll loads FUSE.Editor.dll lazily via Assembly.LoadFrom after
+// UMM boots; FUSE.Editor.dll references FUSE.Converter.dll for its Convert button.
+// All three must be present for the mod to be functional, so a release missing any
+// of them is a packaging regression worth failing on.
+string entryDll = $"{modId}.dll";
+string[] companionDlls = { "FUSE.Editor.dll", "FUSE.Converter.dll" };
+
+// UMM does not accept SemVer pre-release tags in Info.json (it parses Version as
+// System.Version, which only allows numeric segments), so the build stamps Info.json
+// with just the version core (e.g. 0.13.0 for a 0.13.0-rc.1 tag). Validate the core.
+var coreMatch = Regex.Match(expectedVersion, @"^(?<core>[0-9]+\.[0-9]+\.[0-9]+)");
+if (!coreMatch.Success)
+{
+    Console.Error.WriteLine($"ERROR: ExpectedVersion '{expectedVersion}' must start with MAJOR.MINOR.PATCH.");
+    return 2;
+}
+string expectedVersionCore = coreMatch.Groups["core"].Value;
+
+// PR/push CI builds intentionally stamp the 0.0.0 core (the artifact identity lives
+// in the pre-release suffix, e.g. 0.0.0-pr42.abc1234), so only treat a literal 0.0.0
+// in Info.json as a stamping failure when the caller expected a real version.
+bool expectPlaceholderVersion = expectedVersionCore == "0.0.0";
+
+string refDir = ResolveRefDir(refDirArg);
+
+if (!File.Exists(zipPath))
+{
+    Console.Error.WriteLine($"ERROR: ZipPath '{zipPath}' does not exist.");
+    return 2;
+}
+
+var failures = new List<string>();
+void Fail(string m) => failures.Add(m);
+void Require(bool cond, string m) { if (!cond) failures.Add(m); }
+
+// Verifies that a manifest field is present and has the expected JSON type. Without
+// this, a payload like `"ManagerVersion": 1` would silently bypass the string checks
+// below because they only run when the value is the right kind.
+void RequireField(JsonElement obj, string source, string field, JsonValueKind expected, bool requireNonEmpty = false)
+{
+    if (!obj.TryGetProperty(field, out var el))
+    {
+        Fail($"{source}: '{field}' is missing.");
+        return;
+    }
+    if (el.ValueKind != expected)
+    {
+        Fail($"{source}: '{field}' must be {expected.ToString().ToLowerInvariant()}; got {el.ValueKind.ToString().ToLowerInvariant()}.");
+        return;
+    }
+    if (requireNonEmpty && expected == JsonValueKind.String && string.IsNullOrWhiteSpace(el.GetString()))
+    {
+        Fail($"{source}: '{field}' must be non-empty.");
+    }
+}
+
+string tempRoot = Path.Combine(Path.GetTempPath(), "modpkg-validate-" + Guid.NewGuid().ToString("N"));
+Directory.CreateDirectory(tempRoot);
+
+try
+{
+    ZipFile.ExtractToDirectory(zipPath, tempRoot);
+
+    // 1. Layout: exactly one top-level folder, named <mod-id>.
+    var rootEntries = new DirectoryInfo(tempRoot).GetFileSystemInfos();
+    if (rootEntries.Length != 1)
+    {
+        Fail($"Zip must contain exactly one top-level entry; found {rootEntries.Length}: {string.Join(", ", rootEntries.Select(e => e.Name))}");
+    }
+
+    var modFolder = rootEntries.OfType<DirectoryInfo>().FirstOrDefault();
+    if (modFolder is null)
+    {
+        Fail("Zip top-level entry is not a directory.");
+        return Report();
+    }
+
+    Require(modFolder.Name == modId, $"Top-level folder must be '{modId}'; got '{modFolder.Name}'.");
+
+    string infoPath = Path.Combine(modFolder.FullName, "Info.json");
+    string entryDllPath = Path.Combine(modFolder.FullName, entryDll);
+
+    bool infoExists = File.Exists(infoPath);
+    bool entryDllExists = File.Exists(entryDllPath);
+
+    Require(infoExists, "Info.json missing from mod folder.");
+    Require(entryDllExists, $"{entryDll} missing from mod folder.");
+    foreach (var dll in companionDlls)
+        Require(File.Exists(Path.Combine(modFolder.FullName, dll)), $"{dll} missing from mod folder.");
+
+    // schemas/ ships the JSON schemas FUSE validates mods against at runtime; an
+    // empty or absent tree means the zip is broken.
+    var schemasDir = new DirectoryInfo(Path.Combine(modFolder.FullName, "schemas"));
+    Require(schemasDir.Exists, "schemas/ folder missing from mod folder.");
+    if (schemasDir.Exists)
+    {
+        Require(schemasDir.GetFiles("*", SearchOption.AllDirectories).Length > 0,
+            "schemas/ folder is present but empty.");
+    }
+
+    Require(File.Exists(Path.Combine(modFolder.FullName, "assets", "fuse_icon.png")),
+        "assets/fuse_icon.png missing from mod folder.");
+
+    // No stray files. The allow-list is the known flat files plus anything under
+    // schemas/ and assets/ (both are controlled, recursively-copied trees). Anything
+    // else — a stray DLL, a doc XML, a .DS_Store — gets flagged. *.pdb is called out
+    // separately because shipping debug symbols in a Release zip is its own smell and
+    // could otherwise hide under an allowed directory.
+    var allowedFlat = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "Info.json",
+        entryDll,
+    };
+    foreach (var dll in companionDlls) allowedFlat.Add(dll);
+
+    bool IsAllowed(string rel) =>
+        allowedFlat.Contains(rel) ||
+        rel.StartsWith("schemas/", StringComparison.OrdinalIgnoreCase) ||
+        rel.StartsWith("assets/", StringComparison.OrdinalIgnoreCase);
+
+    var allFiles = modFolder.GetFiles("*", SearchOption.AllDirectories)
+        .Select(f => Path.GetRelativePath(modFolder.FullName, f.FullName).Replace('\\', '/'))
+        .ToList();
+
+    var extras = allFiles.Where(rel => !IsAllowed(rel)).ToList();
+    if (extras.Count > 0)
+        Fail("Mod folder contains unexpected entries: " + string.Join(", ", extras));
+
+    var pdbs = allFiles.Where(rel => rel.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase)).ToList();
+    if (pdbs.Count > 0)
+        Fail("Mod folder ships debug symbols (Release zip should not): " + string.Join(", ", pdbs));
+
+    // 2. Info.json
+    JsonElement? info = null;
+    if (infoExists)
+    {
+        try { info = JsonDocument.Parse(File.ReadAllText(infoPath)).RootElement; }
+        catch (Exception ex) { Fail($"Info.json failed to parse as JSON: {ex.Message}"); }
+    }
+
+    if (info is JsonElement i)
+    {
+        // Required string fields: present, of JSON-string type, and non-empty.
+        foreach (var field in new[] { "Id", "DisplayName", "Author", "Version", "AssemblyName", "EntryMethod", "ManagerVersion" })
+        {
+            RequireField(i, "Info.json", field, JsonValueKind.String, requireNonEmpty: true);
+        }
+
+        if (TryGetString(i, "Id", out var id))
+            Require(id == modId, $"Info.json: Id should be '{modId}'; got '{id}'.");
+
+        if (TryGetString(i, "AssemblyName", out var asmName))
+            Require(asmName == entryDll, $"Info.json: AssemblyName should be '{entryDll}'; got '{asmName}'.");
+
+        if (TryGetString(i, "Version", out var ver))
+        {
+            Require(Regex.IsMatch(ver, @"^[0-9]+\.[0-9]+\.[0-9]+$"),
+                $"Info.json: Version '{ver}' must be MAJOR.MINOR.PATCH (UMM does not accept pre-release suffixes).");
+            Require(expectPlaceholderVersion || ver != "0.0.0",
+                "Info.json: Version is still placeholder '0.0.0' (InjectModVersionIntoInfoJson target failed?).");
+            Require(ver == expectedVersionCore,
+                $"Info.json: Version '{ver}' does not match expected core '{expectedVersionCore}' (derived from '{expectedVersion}').");
+        }
+
+        if (TryGetString(i, "ManagerVersion", out var mv))
+            Require(Regex.IsMatch(mv, @"^[0-9]+\.[0-9]+(\.[0-9]+)?$"), $"Info.json: ManagerVersion '{mv}' is not a valid version string.");
+
+        // HomePage is optional. FUSE currently ships it as an empty string, which UMM
+        // treats as "unset", so only validate it as a URL when it is a non-empty string.
+        // A present-but-wrong-typed value (number, object) is still a failure.
+        if (i.TryGetProperty("HomePage", out var hpEl))
+        {
+            if (hpEl.ValueKind != JsonValueKind.String)
+            {
+                Fail($"Info.json: 'HomePage' must be a string when present; got {hpEl.ValueKind.ToString().ToLowerInvariant()}.");
+            }
+            else
+            {
+                var hp = hpEl.GetString() ?? "";
+                if (!string.IsNullOrWhiteSpace(hp))
+                {
+                    // Uri.TryCreate is stricter than a "scheme + non-whitespace" regex —
+                    // it rejects malformed authorities like 'http://:' while still
+                    // accepting normal http(s) URLs.
+                    bool wellFormed = Uri.TryCreate(hp, UriKind.Absolute, out var hpUri)
+                                      && (hpUri.Scheme == Uri.UriSchemeHttp || hpUri.Scheme == Uri.UriSchemeHttps);
+                    Require(wellFormed, $"Info.json: HomePage '{hp}' must be a well-formed http(s) URL.");
+                }
+            }
+        }
+    }
+
+    // 3. DLL: EntryMethod resolves to public static bool Load(ModEntry)
+    if (entryDllExists && info is JsonElement i2 && TryGetString(i2, "EntryMethod", out var entry) && !string.IsNullOrWhiteSpace(entry))
+    {
+        int dotIdx = entry.LastIndexOf('.');
+        if (dotIdx <= 0)
+        {
+            Fail($"Info.json: EntryMethod '{entry}' must be a fully-qualified Type.Method name.");
+        }
+        else
+        {
+            string typeName = entry[..dotIdx];
+            string methodName = entry[(dotIdx + 1)..];
+
+            if (!Directory.Exists(refDir))
+            {
+                Fail($"Reference assembly directory '{refDir}' not found; cannot resolve the EntryMethod parameter type. " +
+                     "Pass the game's UnityModManager folder as the 4th argument, or set UnityModManagerDir / GameDir.");
+            }
+            else
+            {
+                ValidateDll(entryDllPath, typeName, methodName, entry, refDir, failures);
+            }
+        }
+    }
+}
+finally
+{
+    try { Directory.Delete(tempRoot, recursive: true); } catch { /* best effort */ }
+}
+
+return Report();
+
+int Report()
+{
+    if (failures.Count == 0)
+    {
+        Console.WriteLine($"Mod package validation OK: {zipPath}");
+        return 0;
+    }
+
+    Console.Error.WriteLine($"Mod package validation FAILED ({failures.Count} issue(s)):");
+    foreach (var f in failures)
+    {
+        Console.Error.WriteLine($"  - {f}");
+    }
+    return 1;
+}
+
+// Resolves the directory that holds UnityModManager(Net).dll. Explicit arg wins;
+// otherwise mirror the build's resolution order (env, then the conventional layout
+// under GameDir), and finally the vendored lib/refs a contributor may have created.
+static string ResolveRefDir(string? arg)
+{
+    if (!string.IsNullOrWhiteSpace(arg)) return arg;
+
+    var umm = Environment.GetEnvironmentVariable("UnityModManagerDir");
+    if (!string.IsNullOrWhiteSpace(umm)) return umm;
+
+    var gameDir = Environment.GetEnvironmentVariable("GameDir");
+    if (!string.IsNullOrWhiteSpace(gameDir))
+        return Path.Combine(gameDir, "Railroader_Data", "Managed", "UnityModManager");
+
+    return Path.Combine(Directory.GetCurrentDirectory(), "lib", "refs");
+}
+
+static bool TryGetString(JsonElement obj, string field, out string value)
+{
+    value = "";
+    if (obj.TryGetProperty(field, out var el) && el.ValueKind == JsonValueKind.String)
+    {
+        value = el.GetString() ?? "";
+        return true;
+    }
+    return false;
+}
+
+static void ValidateDll(string dllPath, string typeName, string methodName, string entryDisplay, string refDir, List<string> failures)
+{
+    var bclDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+    var bclDlls = Directory.GetFiles(bclDir, "*.dll");
+    var refDlls = Directory.GetFiles(refDir, "*.dll");
+
+    // PathAssemblyResolver throws if two inputs share an assembly simple name. The
+    // BCL and the UMM folder don't normally collide, but dedupe defensively (keeping
+    // the BCL copy) so a stray duplicate in the game folder can't crash the validator.
+    var byName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    foreach (var path in bclDlls.Concat(refDlls).Concat(new[] { dllPath }))
+    {
+        var name = Path.GetFileNameWithoutExtension(path);
+        if (!byName.ContainsKey(name)) byName[name] = path;
+    }
+
+    Assembly asm;
+    MetadataLoadContext ctx;
+    try
+    {
+        var resolver = new PathAssemblyResolver(byName.Values);
+        ctx = new MetadataLoadContext(resolver);
+        asm = ctx.LoadFromAssemblyPath(dllPath);
+    }
+    catch (Exception ex)
+    {
+        failures.Add($"DLL: failed to load '{Path.GetFileName(dllPath)}' for inspection: {ex.Message}");
+        return;
+    }
+
+    using (ctx)
+    {
+        Type? type;
+        try { type = asm.GetType(typeName, throwOnError: false, ignoreCase: false); }
+        catch (Exception ex)
+        {
+            failures.Add($"DLL: failed to resolve type '{typeName}' (from EntryMethod '{entryDisplay}'): {ex.Message}");
+            return;
+        }
+
+        if (type is null)
+        {
+            failures.Add($"DLL: type '{typeName}' (from EntryMethod '{entryDisplay}') not found in '{Path.GetFileName(dllPath)}'.");
+            return;
+        }
+
+        // GetMethods(name, flags) throws AmbiguousMatchException on overloads, and the
+        // base-type/parameter-type walk can throw if a referenced assembly is missing
+        // from refDir. Enumerate + inspect inside a try so the validator emits a
+        // structured error (e.g. "UnityModManager.dll not in ref-dir") instead of crashing.
+        try
+        {
+            var candidates = type.GetMethods(
+                    BindingFlags.Public | BindingFlags.NonPublic |
+                    BindingFlags.Static | BindingFlags.Instance)
+                .Where(m => m.Name == methodName)
+                .ToList();
+            if (candidates.Count > 1)
+            {
+                failures.Add($"DLL: EntryMethod '{entryDisplay}' is ambiguous; '{typeName}' declares {candidates.Count} methods named '{methodName}'.");
+                return;
+            }
+
+            var method = candidates.FirstOrDefault();
+            if (method is null)
+            {
+                failures.Add($"DLL: method '{methodName}' not found on type '{typeName}'.");
+                return;
+            }
+
+            if (!method.IsPublic) failures.Add($"DLL: EntryMethod '{entryDisplay}' must be public.");
+            if (!method.IsStatic) failures.Add($"DLL: EntryMethod '{entryDisplay}' must be static.");
+            if (method.ReturnType.FullName != "System.Boolean")
+                failures.Add($"DLL: EntryMethod '{entryDisplay}' must return bool; returns '{method.ReturnType.FullName}'.");
+
+            var ps = method.GetParameters();
+            if (ps.Length != 1)
+            {
+                failures.Add($"DLL: EntryMethod '{entryDisplay}' must take exactly 1 parameter; got {ps.Length}.");
+            }
+            else if (ps[0].ParameterType.FullName != ExpectedEntryParam)
+            {
+                failures.Add($"DLL: EntryMethod '{entryDisplay}' parameter must be '{ExpectedEntryParam}'; got '{ps[0].ParameterType.FullName}'.");
+            }
+        }
+        catch (Exception ex)
+        {
+            failures.Add($"DLL: failed to inspect EntryMethod '{entryDisplay}': {ex.Message} " +
+                         "(is UnityModManager(Net).dll present in the reference directory?)");
+        }
+    }
+}

--- a/scripts/Validate-ModPackage.cs
+++ b/scripts/Validate-ModPackage.cs
@@ -190,10 +190,17 @@ try
         Fail("Mod folder ships debug symbols (Release zip should not): " + string.Join(", ", pdbs));
 
     // 2. Info.json
+    // Parse inside a using and Clone the root: JsonDocument pools its backing
+    // buffers and must be disposed, but a cloned JsonElement is independent of the
+    // document's lifetime, so the checks below can use it after the doc is gone.
     JsonElement? info = null;
     if (infoExists)
     {
-        try { info = JsonDocument.Parse(File.ReadAllText(infoPath)).RootElement; }
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(infoPath));
+            info = doc.RootElement.Clone();
+        }
         catch (Exception ex) { Fail($"Info.json failed to parse as JSON: {ex.Message}"); }
     }
 


### PR DESCRIPTION
## 🔗 Related Issue

No tracking issue — CI/tooling hardening. The motivation: FUSE's `ci.yml`/`release.yml` package a `.zip` and ship it to GitHub/Nexus, but nothing verified the archive was actually loadable by Unity Mod Manager. A broken entry point, a renamed assembly, a placeholder version, or a stray file could ship unnoticed.

## 📝 Description of the Change

Adds `scripts/Validate-ModPackage.cs` — a self-contained .NET 10 file-based program (run with `dotnet run scripts/Validate-ModPackage.cs -- <zip> <version> [mod-id] [ref-dir]`) that unzips a packaged FUSE release and verifies it against UMM requirements:

- **Entry point (the real "UMM-compatible?" check):** loads the shipped `FUSE.dll` via `System.Reflection.MetadataLoadContext` — metadata-only, **no game launch, no managed load side-effects** — and asserts the `Info.json` `EntryMethod` resolves to a `public static bool Load(UnityModManagerNet.UnityModManager.ModEntry)`. The `ModEntry` parameter type is resolved against the game's `UnityModManager.dll`.
- **Manifest:** required `Info.json` fields present/non-empty; `Id`/`AssemblyName` match; `Version` is `MAJOR.MINOR.PATCH` (UMM's `System.Version` parser rejects pre-release tags) and matches the expected core; `ManagerVersion` is a valid version; `HomePage` (if a non-empty string) is a well-formed http(s) URL.
- **Layout:** exactly one top-level `FUSE/` folder containing the DLL set (`FUSE.dll`, `FUSE.Editor.dll`, `FUSE.Converter.dll`), `Info.json`, a non-empty `schemas/` tree and `assets/fuse_icon.png` — with no stray files and no shipped `*.pdb`.

Wired into both workflows so the same gate runs on dev builds and releases:

- **`ci.yml`** (`build` job, self-hosted) — runs after packaging and **before** the artifact upload, so a known-bad zip is never published as an artifact.
- **`release.yml`** — gates every `mod-v*` tag **before** the installer/exe builds and the GitHub/Nexus publish, so a bad package fails fast.

Both resolve the UMM reference directory via `dotnet msbuild FUSE/FUSE.csproj -getProperty:UnityModManagerDir`, i.e. through the exact same `Paths.user`/`GameDir` resolution the build itself uses, so the reference assembly set always matches the runner.

The validator is adapted from the equivalent in TooManyWaybills, retuned for FUSE's package: FUSE ships as a **pure UMM mod** (no Railloader `Definition.json`, so all those checks are dropped), bundles multiple DLLs plus `schemas/`+`assets/`, resolves the UMM assembly from the game install rather than a vendored `lib/refs`, **tolerates the intentional `0.0.0` version core** that PR/push builds stamp (while still enforcing real versions on release tags), and allows the empty `HomePage` FUSE currently ships.

## 🔄 Alternatives Considered

- **Copy TooManyWaybills' validator verbatim** — rejected: it requires a `Definition.json`, exactly three flat files, and a vendored `lib/refs`, none of which match FUSE's package, so it would false-fail on every FUSE build.
- **Vendor `lib/refs/UnityModManager.dll` like TooManyWaybills** — rejected: FUSE deliberately resolves Unity/UMM types from the game install on the self-hosted runner; `-getProperty:UnityModManagerDir` reuses that resolution and avoids committing game binaries.
- **Gate only the release** (as TooManyWaybills does) — rejected in favor of gating CI too, so packaging regressions surface on the PR rather than at release time. Easy to drop the CI step if undesired.

## ⚠️ Possible Drawbacks

- The layout check **requires** `FUSE.Editor.dll` and `FUSE.Converter.dll`; if packaging ever intentionally stops shipping one, the script's `companionDlls` list must be updated alongside.
- Adds a small per-run cost: a `dotnet msbuild -getProperty` evaluation (~sub-second) and a first-run NuGet restore of `System.Reflection.MetadataLoadContext` for the file-based app.
- The validation step only runs where the game/UMM assemblies are present (the self-hosted `build`/release jobs). It is not added to the cross-platform `build-net10` job, which doesn't build the mod. If `UnityModManagerDir` can't be resolved, the step falls back to env-based resolution (`UnityModManagerDir`/`GameDir`) and reports a clear error rather than silently passing.
- No runtime/behavioral change to the mod and no save-format impact — this is build-pipeline only.

## ✅ Verification Process

Tested locally against a real Release build (`-p:ModVersion=0.13.0`), packaging a zip with the exact steps the workflows use, and running the full CI step (including the `-getProperty` resolution):

- ✅ Valid package → `validation OK`, exit 0 — `FUSE.FusePlugin.Load(ModEntry)` resolved against the real `UnityModManager.dll`.
- ✅ Version mismatch (expected `0.14.0`) → FAIL.
- ✅ Non-existent ref-dir → FAIL with actionable guidance.
- ✅ Stray `FUSE.pdb` + missing `FUSE.Converter.dll` → FAIL (both caught).
- ✅ CI scenario: `Info.json` `0.0.0` + expected `0.0.0-pr42.deadbee` → OK (placeholder tolerated).
- ✅ `Info.json` `0.0.0` + expected real `0.13.0` → FAIL (placeholder + mismatch).
- ✅ Full `ci.yml` step body simulated verbatim with `GameDir` provided via env → resolved the UMM dir and passed, step exit 0.
- ✅ Both workflow YAML files parse cleanly.

## 💡 Additional Information

- Source of the pattern: TooManyWaybills' `scripts/Validate-ModPackage.cs` (currently on a feature branch there, invoked from its `release.yml`).
- The validator is a .NET 10 file-based app (`#:package System.Reflection.MetadataLoadContext@8.0.0`); the runners already use the .NET 10 SDK.
