### PR TITLE
fix(scenery): drop a decoupled terrain mask while its building is hidden

### DIFF
--- a/FUSE.Tests/API/MapApiMaskVisibilityTests.cs
+++ b/FUSE.Tests/API/MapApiMaskVisibilityTests.cs
@@ -93,5 +93,82 @@ namespace FUSE.Tests.API
 
             Assert.Equal(Visibility.Hidden, MapAPI.ClassifyMaskVisibility(renderers));
         }
+
+        // --- Retention: ResolveEffectiveMaskVisibility (the watcher's "hold last state" logic) ---
+        // (Parameterless Facts: the internal enum can't be a parameter on a public xUnit method.)
+
+        [Fact]
+        public void ResolveEffective_DecisiveVisible_WinsOverRetainedHidden()
+        {
+            Assert.Equal(Visibility.Visible, MapAPI.ResolveEffectiveMaskVisibility(Visibility.Visible, Visibility.Hidden));
+        }
+
+        [Fact]
+        public void ResolveEffective_DecisiveHidden_WinsOverRetainedVisible()
+        {
+            Assert.Equal(Visibility.Hidden, MapAPI.ResolveEffectiveMaskVisibility(Visibility.Hidden, Visibility.Visible));
+        }
+
+        [Fact]
+        public void ResolveEffective_Indeterminate_RetainsHidden()
+        {
+            // Key regression: a hidden building that streams out (no renderers) must NOT get its mask back.
+            Assert.Equal(Visibility.Hidden, MapAPI.ResolveEffectiveMaskVisibility(Visibility.Indeterminate, Visibility.Hidden));
+        }
+
+        [Fact]
+        public void ResolveEffective_Indeterminate_RetainsVisible()
+        {
+            Assert.Equal(Visibility.Visible, MapAPI.ResolveEffectiveMaskVisibility(Visibility.Indeterminate, Visibility.Visible));
+        }
+
+        [Fact]
+        public void MaskActiveLifecycle_HiddenSurvivesStreamOut_AndCullerKeepsMask()
+        {
+            // Walk the watcher's decision pipeline (ClassifyMaskVisibility -> ResolveEffective...)
+            // across a building's lifecycle. Visible == mask applied; Hidden == mask dropped. The
+            // seed is Visible (the decouple default: applied until proven hidden).
+            var last = Visibility.Visible;
+
+            // Loads visible -> mask applied.
+            last = Step(last, S(enabled: true, active: true, forceOff: false));
+            Assert.Equal(Visibility.Visible, last);
+
+            // Pack hides it (all renderers disabled) -> mask dropped.
+            last = Step(last, S(enabled: false, active: true, forceOff: false));
+            Assert.Equal(Visibility.Hidden, last);
+
+            // Streams out while hidden (no renderers) -> stays dropped (regression: no re-flatten).
+            last = Step(last);
+            Assert.Equal(Visibility.Hidden, last);
+
+            // Streams back in, still hidden -> still dropped.
+            last = Step(last, S(enabled: false, active: true, forceOff: false));
+            Assert.Equal(Visibility.Hidden, last);
+
+            // Pack shows it again -> mask restored.
+            last = Step(last, S(enabled: true, active: true, forceOff: false));
+            Assert.Equal(Visibility.Visible, last);
+
+            // Game culler parks it (forceRenderingOff) -> mask STAYS applied (not an intentional hide).
+            last = Step(last, S(enabled: true, active: true, forceOff: true));
+            Assert.Equal(Visibility.Visible, last);
+
+            // Streams out while visible -> mask stays applied.
+            last = Step(last);
+            Assert.Equal(Visibility.Visible, last);
+        }
+
+        // One decision step: classify the renderer snapshot, then fold it into the retained state,
+        // exactly as FuseDecoupledMaskVisibilityWatcher.Tick does. No args => no renderers (streamed out).
+        private static Visibility Step(Visibility last, params Sample[] renderers)
+        {
+            return MapAPI.ResolveEffectiveMaskVisibility(MapAPI.ClassifyMaskVisibility(renderers), last);
+        }
+
+        private static Sample S(bool enabled, bool active, bool forceOff)
+        {
+            return new Sample(enabled, active, forceOff);
+        }
     }
 }

--- a/FUSE.Tests/API/MapApiMaskVisibilityTests.cs
+++ b/FUSE.Tests/API/MapApiMaskVisibilityTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using FUSE.Runtime.API;
+using Xunit;
+using Sample = FUSE.Runtime.API.MapAPI.SceneryRendererVisibility;
+using Visibility = FUSE.Runtime.API.MapAPI.DecoupledMaskVisibility;
+
+namespace FUSE.Tests.API
+{
+    /// <summary>
+    /// Pure-logic coverage for <see cref="MapAPI.ClassifyMaskVisibility"/>, the decision that
+    /// drives the visibility-driven decoupled-mask lifecycle
+    /// (<c>FuseDecoupledMaskVisibilityWatcher</c>). It must separate three look-alike states that
+    /// need different mask handling: a building that is drawing (keep mask), one a pack has hidden
+    /// at the renderer level (drop mask), and one merely streamed out or culled (keep mask). The
+    /// Unity-side gather and the SetActive toggle need a live game and are exercised in-game.
+    /// </summary>
+    public class MapApiMaskVisibilityTests
+    {
+        [Fact]
+        public void NoRenderers_IsIndeterminate_SoMaskIsKept()
+        {
+            // Streamed out / not yet loaded: cannot tell visible from hidden, so keep the mask.
+            Assert.Equal(Visibility.Indeterminate, MapAPI.ClassifyMaskVisibility(new List<Sample>()));
+        }
+
+        [Fact]
+        public void NullList_IsIndeterminate()
+        {
+            Assert.Equal(Visibility.Indeterminate, MapAPI.ClassifyMaskVisibility(null));
+        }
+
+        [Fact]
+        public void AnyEnabledActiveRenderer_IsVisible()
+        {
+            var renderers = new List<Sample>
+            {
+                new Sample(enabled: false, activeInHierarchy: true, forceRenderingOff: false),
+                new Sample(enabled: true, activeInHierarchy: true, forceRenderingOff: false),
+            };
+
+            Assert.Equal(Visibility.Visible, MapAPI.ClassifyMaskVisibility(renderers));
+        }
+
+        [Fact]
+        public void AllRenderersDisabled_IsHidden()
+        {
+            // The canonical intentional hide: renderer.enabled cleared on every renderer.
+            var renderers = new List<Sample>
+            {
+                new Sample(enabled: false, activeInHierarchy: true, forceRenderingOff: false),
+                new Sample(enabled: false, activeInHierarchy: true, forceRenderingOff: false),
+            };
+
+            Assert.Equal(Visibility.Hidden, MapAPI.ClassifyMaskVisibility(renderers));
+        }
+
+        [Fact]
+        public void AllRenderersOnInactiveObjects_IsHidden()
+        {
+            // Hide via a child SetActive(false): renderers stay enabled but are not in an active
+            // hierarchy, so nothing draws — treat as an intentional hide.
+            var renderers = new List<Sample>
+            {
+                new Sample(enabled: true, activeInHierarchy: false, forceRenderingOff: false),
+                new Sample(enabled: true, activeInHierarchy: false, forceRenderingOff: false),
+            };
+
+            Assert.Equal(Visibility.Hidden, MapAPI.ClassifyMaskVisibility(renderers));
+        }
+
+        [Fact]
+        public void CullerForceRenderingOff_ButEnabledAndActive_IsVisible_SoMaskIsKept()
+        {
+            // The game culler parks a resident model with forceRenderingOff = true while leaving
+            // enabled/active set. That is NOT an intentional hide: the mask must stay so a
+            // culled/streamed building keeps its terrain contribution (the point of decoupling).
+            var renderers = new List<Sample>
+            {
+                new Sample(enabled: true, activeInHierarchy: true, forceRenderingOff: true),
+            };
+
+            Assert.Equal(Visibility.Visible, MapAPI.ClassifyMaskVisibility(renderers));
+        }
+
+        [Fact]
+        public void DisabledAndInactive_IsHidden()
+        {
+            // Both hide signals at once still resolves to hidden.
+            var renderers = new List<Sample>
+            {
+                new Sample(enabled: false, activeInHierarchy: false, forceRenderingOff: true),
+            };
+
+            Assert.Equal(Visibility.Hidden, MapAPI.ClassifyMaskVisibility(renderers));
+        }
+    }
+}

--- a/FUSE/Runtime/API/FuseDecoupledMaskVisibilityWatcher.cs
+++ b/FUSE/Runtime/API/FuseDecoupledMaskVisibilityWatcher.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using FUSE.Infrastructure;
+using UnityEngine;
+
+namespace FUSE.Runtime.API
+{
+    /// <summary>
+    /// Keeps a mask-bearing scenery's decoupled terrain mask in step with whether the building is
+    /// actually drawing. <see cref="MapAPI.DecoupleAttachedMapMasks"/> re-homes the mask onto a
+    /// standalone, always-active object so it survives the model streaming out/in and teleports —
+    /// but "always active" wrongly keeps the ground flattened when a pack HIDES the building at the
+    /// renderer level (renderers disabled while the scenery GameObject stays active), leaving a flat
+    /// patch with no building on it (e.g. Whittier).
+    ///
+    /// Attached to each mask-bearing scenery root, this watcher polls visibility on a low cadence
+    /// and toggles the standalone mask via <see cref="MapAPI.SetDecoupledMasksActive"/>: dropped
+    /// while hidden, restored when shown. Polling — rather than a hide/show event — is required
+    /// because the hide is pack-authored, so FUSE gets no callback when it flips.
+    /// <see cref="MapAPI.ClassifyMaskVisibility"/> keeps the mask while the model is merely streamed
+    /// out (no renderers) or culled (forceRenderingOff), dropping it ONLY for an intentional
+    /// renderer-level hide, so this never undoes the point of decoupling.
+    ///
+    /// Lifecycle: created/refreshed by <see cref="SceneryAPI"/> right after each decouple (on model
+    /// load and on update). It dies with the scenery root — RemoveScenery destroys the root, which
+    /// also drops the standalone via <see cref="MapAPI.RemoveDecoupledMasksFor"/>. Cost is bounded:
+    /// only mask-bearing scenery carries it, that set is small and held resident, and the poll uses
+    /// reused buffers so it allocates nothing after warmup.
+    /// </summary>
+    internal sealed class FuseDecoupledMaskVisibilityWatcher : MonoBehaviour
+    {
+        // The hide is a rare, coarse state change, not a per-frame value: a half-second cadence is
+        // imperceptible for a terrain flatten appearing/disappearing yet negligible to poll.
+        private const float CheckIntervalSeconds = 0.5f;
+
+        // Shared across instances: WaitForSeconds is an immutable duration, so reusing one instance
+        // is safe and avoids a per-iteration allocation on every watcher's loop.
+        private static readonly WaitForSeconds CheckInterval = new WaitForSeconds(CheckIntervalSeconds);
+
+        // Reused per-instance scratch buffers so the 2 Hz poll allocates nothing after warmup.
+        private readonly List<Renderer> _renderers = new List<Renderer>();
+        private readonly List<MapAPI.SceneryRendererVisibility> _samples = new List<MapAPI.SceneryRendererVisibility>();
+
+        private string _sceneryId;
+
+        // Last decisive (non-indeterminate) visibility. While the model is streamed out we cannot
+        // measure, so we hold this instead of flipping: a building hidden THEN streamed out keeps
+        // its mask dropped, and a visible one keeps it applied. Defaults to Visible so the mask
+        // stays applied until the building is proven hidden (matches the decouple default).
+        private MapAPI.DecoupledMaskVisibility _lastDecisive = MapAPI.DecoupledMaskVisibility.Visible;
+
+        private Coroutine _loop;
+
+        /// <summary>
+        /// Ensures <paramref name="sceneryRoot"/> carries a watcher for <paramref name="sceneryId"/>
+        /// and runs one immediate sync. Idempotent: called after every decouple (initial load and
+        /// update), it adds the watcher once and just re-syncs thereafter.
+        /// </summary>
+        internal static FuseDecoupledMaskVisibilityWatcher Ensure(GameObject sceneryRoot, string sceneryId)
+        {
+            if (sceneryRoot == null || string.IsNullOrEmpty(sceneryId))
+            {
+                return null;
+            }
+
+            var watcher = sceneryRoot.GetComponent<FuseDecoupledMaskVisibilityWatcher>();
+            if (watcher == null)
+            {
+                watcher = sceneryRoot.AddComponent<FuseDecoupledMaskVisibilityWatcher>();
+            }
+
+            watcher._sceneryId = sceneryId;
+            // Sync immediately so a building that streamed in already-hidden never shows a flatten
+            // waiting for the first poll, and a re-decouple (update) applies the current state now.
+            watcher.SyncNow();
+            return watcher;
+        }
+
+        /// <summary>Runs one visibility sync immediately, outside the poll cadence.</summary>
+        internal void SyncNow()
+        {
+            try
+            {
+                Tick();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception($"FUSE decoupled-mask visibility sync failed for scenery '{_sceneryId}'", ex);
+            }
+        }
+
+        private void OnEnable()
+        {
+            _loop = StartCoroutine(PollLoop());
+        }
+
+        private void OnDisable()
+        {
+            if (_loop != null)
+            {
+                StopCoroutine(_loop);
+                _loop = null;
+            }
+        }
+
+        private IEnumerator PollLoop()
+        {
+            while (true)
+            {
+                // SyncNow swallows exceptions so a transient failure can't kill the loop.
+                SyncNow();
+                yield return CheckInterval;
+            }
+        }
+
+        private void Tick()
+        {
+            if (string.IsNullOrEmpty(_sceneryId))
+            {
+                return;
+            }
+
+            var visibility = CaptureVisibility();
+            if (visibility == MapAPI.DecoupledMaskVisibility.Indeterminate)
+            {
+                // Streamed out / not loaded: hold the last decisive state (keep the mask).
+                visibility = _lastDecisive;
+            }
+            else
+            {
+                _lastDecisive = visibility;
+            }
+
+            MapAPI.SetDecoupledMasksActive(_sceneryId, visibility == MapAPI.DecoupledMaskVisibility.Visible);
+        }
+
+        private MapAPI.DecoupledMaskVisibility CaptureVisibility()
+        {
+            // Root inactive => not a renderer-level hide (the bug we target); it is likely a
+            // deferred-not-yet-activated window. Treat as indeterminate so we never drop the mask
+            // here. (A whole-root deactivate is ruled out as the hide mechanism: it would revert the
+            // welded mask on its own, so the ground would not have stayed flat in the first place.)
+            if (gameObject == null || !gameObject.activeInHierarchy)
+            {
+                return MapAPI.DecoupledMaskVisibility.Indeterminate;
+            }
+
+            _renderers.Clear();
+            GetComponentsInChildren(true, _renderers);
+
+            _samples.Clear();
+            for (var index = 0; index < _renderers.Count; index++)
+            {
+                var renderer = _renderers[index];
+                if (renderer == null)
+                {
+                    continue;
+                }
+
+                _samples.Add(new MapAPI.SceneryRendererVisibility(
+                    renderer.enabled,
+                    renderer.gameObject.activeInHierarchy,
+                    renderer.forceRenderingOff));
+            }
+
+            return MapAPI.ClassifyMaskVisibility(_samples);
+        }
+    }
+}

--- a/FUSE/Runtime/API/FuseDecoupledMaskVisibilityWatcher.cs
+++ b/FUSE/Runtime/API/FuseDecoupledMaskVisibilityWatcher.cs
@@ -121,18 +121,12 @@ namespace FUSE.Runtime.API
                 return;
             }
 
-            var visibility = CaptureVisibility();
-            if (visibility == MapAPI.DecoupledMaskVisibility.Indeterminate)
-            {
-                // Streamed out / not loaded: hold the last decisive state (keep the mask).
-                visibility = _lastDecisive;
-            }
-            else
-            {
-                _lastDecisive = visibility;
-            }
-
-            MapAPI.SetDecoupledMasksActive(_sceneryId, visibility == MapAPI.DecoupledMaskVisibility.Visible);
+            // Fold the reading into the retained state: Indeterminate (streamed out / not loaded)
+            // holds the last decisive Visible/Hidden, so we never drop a mask just because the model
+            // isn't currently loaded. The result is both the effective decision and the new retained
+            // value (see MapAPI.ResolveEffectiveMaskVisibility).
+            _lastDecisive = MapAPI.ResolveEffectiveMaskVisibility(CaptureVisibility(), _lastDecisive);
+            MapAPI.SetDecoupledMasksActive(_sceneryId, _lastDecisive == MapAPI.DecoupledMaskVisibility.Visible);
         }
 
         private MapAPI.DecoupledMaskVisibility CaptureVisibility()

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -802,6 +802,23 @@ namespace FUSE.Runtime.API
         }
 
         /// <summary>
+        /// Folds a freshly captured visibility into a watcher's retained state.
+        /// <see cref="DecoupledMaskVisibility.Indeterminate"/> (no renderers — the model is streamed
+        /// out / not loaded) holds the last decisive Visible/Hidden value: a building hidden THEN
+        /// streamed out keeps its mask dropped, and a visible one keeps it applied. A decisive
+        /// reading replaces it. The returned value is both the effective decision and the new
+        /// retained value (they are always equal), so a caller stores it and applies the mask when
+        /// it is <see cref="DecoupledMaskVisibility.Visible"/>. Pure, so the retention behaviour is
+        /// unit-tested without a live game (see FUSE.Tests MapApiMaskVisibilityTests).
+        /// </summary>
+        internal static DecoupledMaskVisibility ResolveEffectiveMaskVisibility(
+            DecoupledMaskVisibility captured,
+            DecoupledMaskVisibility lastDecisive)
+        {
+            return captured == DecoupledMaskVisibility.Indeterminate ? lastDecisive : captured;
+        }
+
+        /// <summary>
         /// Activates or deactivates the standalone masks <see cref="DecoupleAttachedMapMasks"/>
         /// created for scenery <paramref name="sceneryId"/> (matched by ownership marker, never the
         /// name, so a user-authored mask is never touched). Deactivating reverts the flatten/cut on

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -699,6 +699,161 @@ namespace FUSE.Runtime.API
             return doomed.Count;
         }
 
+        // --- Visibility-driven decoupled-mask lifecycle ---
+        //
+        // DecoupleAttachedMapMasks re-homes a building's terrain mask onto a standalone,
+        // always-active object so the flatten/cut survives the model streaming out/in and
+        // teleports. But "always active" is wrong when the building is INTENTIONALLY hidden — a
+        // pack disables its renderers (renderer.enabled = false / a child SetActive(false)) while
+        // the scenery GameObject stays active. The standalone mask then keeps flattening the
+        // ground under a building that is not drawn, leaving a bare flat patch (e.g. Whittier).
+        //
+        // FuseDecoupledMaskVisibilityWatcher polls each mask-bearing scenery and calls
+        // SetDecoupledMasksActive to drop the standalone mask while the building is hidden and
+        // restore it when shown. The decision (ClassifyMaskVisibility) is careful to KEEP the
+        // mask when the building is merely streamed out or culled — dropping it only for a real
+        // renderer-level hide — so this never undoes the point of the decouple.
+
+        /// <summary>
+        /// Whether a mask-bearing scenery's building is currently drawing, and therefore whether
+        /// its decoupled terrain mask should apply.
+        /// </summary>
+        internal enum DecoupledMaskVisibility
+        {
+            /// <summary>At least one renderer would draw (enabled and active). Keep the mask applied.</summary>
+            Visible,
+
+            /// <summary>The model is loaded but a pack has disabled/deactivated every renderer (an
+            /// intentional hide). Drop the mask so the ground is not flattened under nothing.</summary>
+            Hidden,
+
+            /// <summary>No renderers to inspect — the model is streamed out (or not yet loaded), so
+            /// visible and hidden are indistinguishable. Keep the last known state (and, by default,
+            /// keep the mask): a streamed-out building must retain its terrain contribution.</summary>
+            Indeterminate
+        }
+
+        /// <summary>
+        /// A Unity-free snapshot of the three renderer flags the visibility decision can read, so
+        /// <see cref="ClassifyMaskVisibility"/> is unit-testable without a live game.
+        /// </summary>
+        internal readonly struct SceneryRendererVisibility
+        {
+            public SceneryRendererVisibility(bool enabled, bool activeInHierarchy, bool forceRenderingOff)
+            {
+                Enabled = enabled;
+                ActiveInHierarchy = activeInHierarchy;
+                ForceRenderingOff = forceRenderingOff;
+            }
+
+            /// <summary>Renderer.enabled — a pack clears this to hide a sub-mesh.</summary>
+            public bool Enabled { get; }
+
+            /// <summary>Renderer.gameObject.activeInHierarchy — false when a pack deactivates the holder.</summary>
+            public bool ActiveInHierarchy { get; }
+
+            /// <summary>
+            /// Renderer.forceRenderingOff — the GAME CULLER's hide flag (resident band 2),
+            /// deliberately NOT consulted by the decision: a culled-but-resident building must keep
+            /// its mask. Carried on the snapshot only so the "culled, not hidden" case is explicit
+            /// in tests.
+            /// </summary>
+            public bool ForceRenderingOff { get; }
+        }
+
+        /// <summary>
+        /// Pure visibility decision for a mask-bearing scenery, mirroring the renderer-presence
+        /// audit (<c>FusePrefabSanitizer.ValidateRendererPresence</c> /
+        /// <c>FuseHealthUi.AuditsTab</c>): a renderer "would draw" when it is
+        /// <c>enabled &amp;&amp; activeInHierarchy</c>.
+        ///
+        /// Crucially this separates an INTENTIONAL hide from the game culler streaming the model
+        /// out — the two states look alike but need opposite mask handling:
+        /// <list type="bullet">
+        /// <item>No renderers =&gt; the model is streamed out / not loaded =&gt;
+        /// <see cref="DecoupledMaskVisibility.Indeterminate"/> (keep the mask; a streamed-out
+        /// building must retain its terrain contribution — the reason the mask was decoupled).</item>
+        /// <item>Any renderer enabled &amp; active =&gt; <see cref="DecoupledMaskVisibility.Visible"/>.
+        /// <c>forceRenderingOff</c> is ignored on purpose: the culler parks a resident model with
+        /// <c>forceRenderingOff = true</c> while leaving <c>enabled</c>/active set, so a culled
+        /// building still reads Visible and KEEPS its mask.</item>
+        /// <item>Renderers present but none enabled &amp; active =&gt; a pack disabled
+        /// (<c>renderer.enabled = false</c>) or deactivated every renderer =&gt;
+        /// <see cref="DecoupledMaskVisibility.Hidden"/> (drop the mask).</item>
+        /// </list>
+        /// </summary>
+        internal static DecoupledMaskVisibility ClassifyMaskVisibility(IReadOnlyList<SceneryRendererVisibility> renderers)
+        {
+            if (renderers == null || renderers.Count == 0)
+            {
+                return DecoupledMaskVisibility.Indeterminate;
+            }
+
+            for (var index = 0; index < renderers.Count; index++)
+            {
+                var renderer = renderers[index];
+                if (renderer.Enabled && renderer.ActiveInHierarchy)
+                {
+                    return DecoupledMaskVisibility.Visible;
+                }
+            }
+
+            return DecoupledMaskVisibility.Hidden;
+        }
+
+        /// <summary>
+        /// Activates or deactivates the standalone masks <see cref="DecoupleAttachedMapMasks"/>
+        /// created for scenery <paramref name="sceneryId"/> (matched by ownership marker, never the
+        /// name, so a user-authored mask is never touched). Deactivating reverts the flatten/cut on
+        /// the next terrain rebuild — like <see cref="RemoveDecoupledMasksFor"/> but reversible:
+        /// re-activating re-applies it without re-cloning. Driven by
+        /// <see cref="FuseDecoupledMaskVisibilityWatcher"/> as the building hides/shows. Returns the
+        /// number of standalone masks whose active state actually changed (0 = already in the
+        /// requested state, the steady-state path — no log, no terrain churn).
+        /// </summary>
+        internal static int SetDecoupledMasksActive(string sceneryId, bool active)
+        {
+            if (string.IsNullOrEmpty(sceneryId))
+            {
+                return 0;
+            }
+
+            var root = GetOrCreateWorldRoot(MapMaskRootName, ref _fallbackMapMaskRoot);
+            if (root == null)
+            {
+                return 0;
+            }
+
+            var changed = 0;
+            for (var i = 0; i < root.childCount; i++)
+            {
+                var child = root.GetChild(i);
+                var marker = child != null ? child.GetComponent<FuseDecoupledMaskMarker>() : null;
+                if (marker == null || !string.Equals(marker.OwnerSceneryId, sceneryId, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var go = child.gameObject;
+                if (go.activeSelf == active)
+                {
+                    continue;
+                }
+
+                go.SetActive(active);
+                changed++;
+            }
+
+            if (changed > 0)
+            {
+                FuseLog.Info(
+                    $"FUSE {(active ? "restored" : "dropped")} {changed} decoupled map mask(s) for scenery " +
+                    $"'{sceneryId}' (building {(active ? "shown" : "hidden")}).");
+            }
+
+            return changed;
+        }
+
         public static GameObject AddTelegraphPoles(string id, FuseTelegraphPoles definition)
         {
             RequireId(id, nameof(id));

--- a/FUSE/Runtime/API/SceneryAPI.cs
+++ b/FUSE/Runtime/API/SceneryAPI.cs
@@ -76,11 +76,14 @@ namespace FUSE.Runtime.API
             // correctly falls into AddScenery for a brand-new entity.
             var marker = gameObject.AddComponent<FuseSceneryMarker>();
             marker.Id = id;
-            // Tag mask-bearing scenery. Two behaviours key off this: (1) the cull debounce
-            // pins it loaded+rendered (a safety net), and (2) the OnDidLoadModels hook below
-            // re-homes its welded map masks into standalone, always-active objects the moment
-            // the model streams in (MapAPI.DecoupleAttachedMapMasks) — the real fix, so the
-            // terrain mask survives the building streaming out/in and teleport world-shifts.
+            // Tag mask-bearing scenery. Three behaviours key off this: (1) the cull debounce
+            // pins it loaded+rendered (a safety net), (2) the OnDidLoadModels hook below re-homes
+            // its welded map masks into standalone, always-active objects the moment the model
+            // streams in (MapAPI.DecoupleAttachedMapMasks) — the real fix, so the terrain mask
+            // survives the building streaming out/in and teleport world-shifts, and (3) a
+            // visibility watcher (FuseDecoupledMaskVisibilityWatcher) drops that standalone mask
+            // while the building is intentionally hidden (renderers disabled) and restores it when
+            // shown, so a hidden building never leaves a flat patch of ground behind.
             marker.IsMaskBearing = FuseSceneryDeferralClassifier.HasMaskComponent(assetIdentifier);
             if (marker.IsMaskBearing)
             {
@@ -91,6 +94,10 @@ namespace FUSE.Runtime.API
                     try
                     {
                         MapAPI.DecoupleAttachedMapMasks(sceneryRoot, sceneryId);
+                        // Keep the just-decoupled mask in step with the building's visibility: if the
+                        // model streamed in already hidden, drop the mask now; otherwise watch for it
+                        // being hidden/shown later.
+                        FuseDecoupledMaskVisibilityWatcher.Ensure(sceneryRoot, sceneryId);
                     }
                     catch (Exception ex)
                     {
@@ -171,6 +178,9 @@ namespace FUSE.Runtime.API
             {
                 MapAPI.RemoveDecoupledMasksFor(id);
                 MapAPI.DecoupleAttachedMapMasks(scenery.gameObject, id);
+                // Re-attach/refresh the visibility watcher and apply the current hidden/shown state
+                // to the freshly re-decoupled mask.
+                FuseDecoupledMaskVisibilityWatcher.Ensure(scenery.gameObject, id);
             }
 
             FuseSceneryRuntimeIndex.Instance.Set(id, scenery);


### PR DESCRIPTION
## ⚠️ Stacked on #103 — draft

Based off `alex/harden-scenery-mask-decouple`. **Merge #103 first** — GitHub will auto-retarget this PR's base to `main` once #103 lands. Kept as a draft until then and until the in-game verification below passes (I can't run Railroader).

## Problem — Whittier "flat patch, no building"

A FUSE custom building hidden at the **renderer level** (renderers disabled while the scenery GameObject stays active) left its terrain map mask applied, leaving a flattened/cut patch of ground with no building on it.

#103 does **not** fix this and isn't meant to: its decoupled standalone mask under `World/FUSE Map Masks` is always-active and removed only on `TryRemoveScenery`/`UpdateScenery`, so it persists through an intentional hide.

## Fix — tie the standalone mask to the building's visibility

- **`MapAPI.ClassifyMaskVisibility`** (pure, unit-tested) — `Visible` / `Hidden` / `Indeterminate` from renderer flags.
- **`MapAPI.ResolveEffectiveMaskVisibility`** (pure, unit-tested) — folds a reading into retained state: `Indeterminate` (streamed out) holds the last decisive value.
- **`MapAPI.SetDecoupledMasksActive`** — toggles the standalone mask's active state (revert on disable, re-apply on enable) without re-cloning.
- **`FuseDecoupledMaskVisibilityWatcher`** — polls each mask-bearing scenery at 2 Hz (pack hides fire no event) and applies the decision; attached + immediately synced after every decouple (load + update). Dies with the scenery root.

### Discriminator — "streamed out" (keep) vs "intentionally hidden" (drop)

| Renderer state | Meaning | Mask |
|---|---|---|
| any `enabled && activeInHierarchy` | drawing | **keep** |
| `forceRenderingOff` only (enabled+active) | game culler parked it | **keep** |
| no renderers | streamed out / not loaded | **keep** (holds last decisive state) |
| renderers present, none enabled+active | pack hid it (`enabled=false` / child `SetActive(false)`) | **drop** |

`forceRenderingOff` is deliberately ignored — that's the culler's flag, and a culled-but-resident building must keep its mask (the whole point of #103). Whole-root `SetActive(false)` is ruled out as the hide mechanism (it would revert the welded mask on its own). Reuses the renderer-presence test from `FusePrefabSanitizer.ValidateRendererPresence` / `FuseHealthUi.AuditsTab`.

## Tests

- `FUSE.Tests` green (**1236 passed**), incl. 12 `MapApiMaskVisibilityTests`:
  - `ClassifyMaskVisibility` (pure decision): empty/null, any-enabled, all-disabled, all-inactive, culler-forceRenderingOff-kept, disabled+inactive.
  - `ResolveEffectiveMaskVisibility` (retention): decisive-wins; `Indeterminate` holds last state.
  - Full-lifecycle scenario: load visible → pack-hide → stream out *(stays dropped)* → stream in still hidden → show *(restored)* → culler `forceRenderingOff` *(stays applied)* → stream out.
- Remaining Unity glue — `CaptureVisibility` (reading real `Renderer` flags) and `SetDecoupledMasksActive` (SetActive + terrain revert) — needs a live game (checklist below).

## In-game verification (pending — checklist)

Confirm the mechanism:
- [ ] FUSE Health → Audits near Whittier flags *"has renderers but none are currently enabled."*
- [ ] Scenery debug overlay: renderers `enabled=false` (or inactive children) while the GameObject is active. *(If it's a different mechanism, the discriminator may need a tweak.)*

Verify the fix:
- [ ] Hidden building → flat patch gone — log `FUSE dropped N decoupled map mask(s) ... (building hidden)`.
- [ ] Toggle visible → patch + building return — log `FUSE restored N ... (building shown)`.
- [ ] **Regression:** a normal masked building keeps its mask through streaming/teleport (Dillsboro→Bryson) — must not drop when merely streamed out.
- [ ] No terrain-flatten flicker when a hidden building streams in.
