### PR TITLE
fix(scenery): keep progression-locked scenery hidden through the deferred-activation wave

### DIFF
--- a/FUSE.Tests/API/FuseProgressionGateEvaluatorTests.cs
+++ b/FUSE.Tests/API/FuseProgressionGateEvaluatorTests.cs
@@ -1,0 +1,130 @@
+using FUSE.Runtime.API;
+using Xunit;
+
+namespace FUSE.Tests.API
+{
+    /// <summary>
+    /// Pins the pure locked-feature gate decision behind the deferred-scenery fix: the
+    /// post-load activation wave must not re-show a prop a locked progression feature
+    /// just hid. <see cref="FuseProgressionGateEvaluator.IsHiddenByLockedGate"/> is the
+    /// decision; the live <c>MapFeature</c>/<c>MapFeatureManager</c> mapping that feeds it
+    /// is covered by the EditMode integration test.
+    ///
+    /// Cases model the real ALW East Whittier shape: the "William Elk Phase 1"
+    /// (<c>ElkStage1</c>) feature gates the factory plus four <c>WoodDock50M</c> decking
+    /// objects via <c>gameObjectsEnableOnUnlock</c>; while it is locked every one must
+    /// report hidden, and once unlocked none may. Plain objects stand in for GameObjects
+    /// so the locked-vs-unlocked filter and reference-identity match are verified without
+    /// a Unity scene.
+    /// </summary>
+    public class FuseProgressionGateEvaluatorTests
+    {
+        private static FuseProgressionGateEvaluator.Gate Locked(params object[] gatedObjects) =>
+            new FuseProgressionGateEvaluator.Gate(unlocked: false, gatedObjects);
+
+        private static FuseProgressionGateEvaluator.Gate Unlocked(params object[] gatedObjects) =>
+            new FuseProgressionGateEvaluator.Gate(unlocked: true, gatedObjects);
+
+        [Fact]
+        public void LockedFeatureGatingObject_IsHidden()
+        {
+            // The bug: a WoodDock gated by still-locked Phase 1 must stay hidden.
+            var dock = new object();
+            Assert.True(FuseProgressionGateEvaluator.IsHiddenByLockedGate(dock, new[] { Locked(dock) }));
+        }
+
+        [Fact]
+        public void UnlockedFeatureGatingObject_IsNotHidden()
+        {
+            // After Phase 1 unlocks, the same dock must be allowed to show again.
+            var dock = new object();
+            Assert.False(FuseProgressionGateEvaluator.IsHiddenByLockedGate(dock, new[] { Unlocked(dock) }));
+        }
+
+        [Fact]
+        public void ObjectGatedByNoFeature_IsNotHidden()
+        {
+            // The ungated East Whittier crib: absent from every gate -> always visible.
+            var crib = new object();
+            var dock = new object();
+            Assert.False(FuseProgressionGateEvaluator.IsHiddenByLockedGate(crib, new[] { Locked(dock) }));
+        }
+
+        [Fact]
+        public void OneLockedFeatureGatingManyObjects_HidesEach()
+        {
+            // ElkStage1 lists the factory + four WoodDock50M decks in a single feature.
+            var factory = new object();
+            var dockA = new object();
+            var dockB = new object();
+            var dockC = new object();
+            var dockD = new object();
+            var gates = new[] { Locked(factory, dockA, dockB, dockC, dockD) };
+
+            Assert.True(FuseProgressionGateEvaluator.IsHiddenByLockedGate(factory, gates));
+            Assert.True(FuseProgressionGateEvaluator.IsHiddenByLockedGate(dockA, gates));
+            Assert.True(FuseProgressionGateEvaluator.IsHiddenByLockedGate(dockB, gates));
+            Assert.True(FuseProgressionGateEvaluator.IsHiddenByLockedGate(dockC, gates));
+            Assert.True(FuseProgressionGateEvaluator.IsHiddenByLockedGate(dockD, gates));
+        }
+
+        [Fact]
+        public void ObjectHeldByAnyLockedFeature_IsHidden_EvenIfAnotherFeatureUnlockedIt()
+        {
+            // If any locked feature still holds the object it stays hidden, even when a
+            // second (unlocked) feature also lists it.
+            var shared = new object();
+            var gates = new[] { Unlocked(shared), Locked(shared) };
+            Assert.True(FuseProgressionGateEvaluator.IsHiddenByLockedGate(shared, gates));
+        }
+
+        [Fact]
+        public void MixedFeatures_OnlyLockedHeldObjectsAreHidden()
+        {
+            var visibleProp = new object();
+            var hiddenProp = new object();
+            var gates = new[] { Unlocked(visibleProp), Locked(hiddenProp) };
+
+            Assert.False(FuseProgressionGateEvaluator.IsHiddenByLockedGate(visibleProp, gates));
+            Assert.True(FuseProgressionGateEvaluator.IsHiddenByLockedGate(hiddenProp, gates));
+        }
+
+        [Fact]
+        public void MatchesByReferenceIdentity_NotByValueEquality()
+        {
+            // Two distinct instances are never interchangeable — mirrors per-GameObject
+            // SetActive gating, where a different object that "looks the same" is not gated.
+            var gatedDock = new object();
+            var lookalike = new object();
+            Assert.False(FuseProgressionGateEvaluator.IsHiddenByLockedGate(lookalike, new[] { Locked(gatedDock) }));
+        }
+
+        [Fact]
+        public void NullTarget_IsNotHidden()
+        {
+            Assert.False(FuseProgressionGateEvaluator.IsHiddenByLockedGate(null, new[] { Locked(new object()) }));
+        }
+
+        [Fact]
+        public void NullGateSet_IsNotHidden()
+        {
+            Assert.False(FuseProgressionGateEvaluator.IsHiddenByLockedGate(new object(), null));
+        }
+
+        [Fact]
+        public void LockedGateWithNullObjectList_IsHandledAndHidesNothing()
+        {
+            // A freshly created MapFeature can carry a null gate array; the core must not
+            // throw and must not hide anything for it.
+            var prop = new object();
+            var gates = new[] { new FuseProgressionGateEvaluator.Gate(unlocked: false, gatedObjects: null) };
+            Assert.False(FuseProgressionGateEvaluator.IsHiddenByLockedGate(prop, gates));
+        }
+
+        [Fact]
+        public void EmptyGateSet_IsNotHidden()
+        {
+            Assert.False(FuseProgressionGateEvaluator.IsHiddenByLockedGate(new object(), System.Array.Empty<FuseProgressionGateEvaluator.Gate>()));
+        }
+    }
+}

--- a/FUSE.UnityTests/Assets/Tests/FuseProgressionGateIntegrationTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/FuseProgressionGateIntegrationTests.cs
@@ -1,0 +1,133 @@
+using FUSE.Runtime.API;
+using Game.Progression;
+using NUnit.Framework;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace FUSE.UnityTests
+{
+    /// <summary>
+    /// EditMode integration test for the deferred-scenery progression-lock guard. The
+    /// pure gate decision is pinned by xUnit
+    /// (<c>FUSE.Tests.API.FuseProgressionGateEvaluatorTests</c>) against fake objects;
+    /// this suite verifies the live
+    /// <see cref="ProgressionAPI.IsGameObjectHiddenByLockedFeature(GameObject, System.Collections.Generic.IEnumerable{MapFeature})"/>
+    /// mapping reads <see cref="MapFeature.Unlocked"/> and
+    /// <c>MapFeature.gameObjectsEnableOnUnlock</c> off real components and matches by
+    /// GameObject identity.
+    ///
+    /// This is the exact shape that keeps ALW's East Whittier <c>WoodDock50M</c> decking
+    /// hidden while "William Elk Phase 1" (<c>ElkStage1</c>) is locked, and lets it show
+    /// once the section unlocks. Without this layer a bug in the MapFeature → gate
+    /// mapping (e.g. reading the wrong flag, or comparing by name) would feed the pure
+    /// core a correct-but-wrong input and pass silently.
+    ///
+    /// ProgressionAPI's overload is internal; FUSE.csproj grants InternalsVisibleTo to
+    /// <c>FUSE.UnityTests.Tests</c>.
+    /// </summary>
+    public class FuseProgressionGateIntegrationTests
+    {
+        private GameObject _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            _root = new GameObject("ProgressionGateTestRoot");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_root != null)
+            {
+                Object.DestroyImmediate(_root);
+            }
+        }
+
+        private GameObject NewChild(string name)
+        {
+            var child = new GameObject(name);
+            child.transform.SetParent(_root.transform, worldPositionStays: false);
+            return child;
+        }
+
+        private MapFeature NewFeature(string id, bool unlocked, params GameObject[] gatedObjects)
+        {
+            var feature = NewChild(id).AddComponent<MapFeature>();
+            feature.identifier = id;
+            feature.gameObjectsEnableOnUnlock = gatedObjects;
+            feature.Unlocked = unlocked;
+            return feature;
+        }
+
+        [Test]
+        public void LockedFeature_HidesItsGatedDeck()
+        {
+            var dock = NewChild("WoodDock50M");
+            var feature = NewFeature("ElkStage1", unlocked: false, dock);
+
+            Assert.IsTrue(
+                ProgressionAPI.IsGameObjectHiddenByLockedFeature(dock, new[] { feature }),
+                "A WoodDock gated by the still-locked William Elk Phase 1 feature must report hidden.");
+        }
+
+        [Test]
+        public void UnlockedFeature_DoesNotHideItsGatedDeck()
+        {
+            var dock = NewChild("WoodDock50M");
+            var feature = NewFeature("ElkStage1", unlocked: true, dock);
+
+            Assert.IsFalse(
+                ProgressionAPI.IsGameObjectHiddenByLockedFeature(dock, new[] { feature }),
+                "Once Phase 1 unlocks, the same dock must be allowed to show.");
+        }
+
+        [Test]
+        public void UngatedObject_IsNotHidden()
+        {
+            var crib = NewChild("EastWhittierCrib");
+            var dock = NewChild("WoodDock50M");
+            var feature = NewFeature("ElkStage1", unlocked: false, dock);
+
+            Assert.IsFalse(
+                ProgressionAPI.IsGameObjectHiddenByLockedFeature(crib, new[] { feature }),
+                "An object no feature gates (the ungated crib) must never be reported hidden.");
+        }
+
+        [Test]
+        public void LockedFeature_HidesEveryObjectItGates()
+        {
+            var factory = NewChild("elkphase1");
+            var dockA = NewChild("WoodDock50M_A");
+            var dockB = NewChild("WoodDock50M_B");
+            var feature = NewFeature("ElkStage1", unlocked: false, factory, dockA, dockB);
+            var features = new[] { feature };
+
+            Assert.IsTrue(ProgressionAPI.IsGameObjectHiddenByLockedFeature(factory, features));
+            Assert.IsTrue(ProgressionAPI.IsGameObjectHiddenByLockedFeature(dockA, features));
+            Assert.IsTrue(ProgressionAPI.IsGameObjectHiddenByLockedFeature(dockB, features));
+        }
+
+        [Test]
+        public void DifferentInstanceSharingLeafName_IsNotHidden()
+        {
+            var gatedDock = NewChild("WoodDock50M");
+            var otherDock = NewChild("WoodDock50M"); // same leaf name, different instance
+            var feature = NewFeature("ElkStage1", unlocked: false, gatedDock);
+
+            Assert.IsFalse(
+                ProgressionAPI.IsGameObjectHiddenByLockedFeature(otherDock, new[] { feature }),
+                "Gating is by GameObject identity, not name — a different instance must not be hidden.");
+        }
+
+        [Test]
+        public void NullGameObject_IsNotHidden()
+        {
+            var dock = NewChild("WoodDock50M");
+            var feature = NewFeature("ElkStage1", unlocked: false, dock);
+
+            Assert.IsFalse(ProgressionAPI.IsGameObjectHiddenByLockedFeature(null, new[] { feature }));
+        }
+    }
+}

--- a/FUSE/Runtime/API/FuseProgressionGateEvaluator.cs
+++ b/FUSE/Runtime/API/FuseProgressionGateEvaluator.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+
+namespace FUSE.Runtime.API
+{
+    /// <summary>
+    /// Pure decision core behind
+    /// <see cref="ProgressionAPI.IsGameObjectHiddenByLockedFeature(UnityEngine.GameObject)"/>:
+    /// given each progression feature's lock state and the objects it gates, decides
+    /// whether a target object is currently held hidden — i.e. referenced by at least one
+    /// LOCKED feature. Extracted from the live <c>MapFeature</c> / <c>MapFeatureManager</c>
+    /// walk so the locked-vs-unlocked filter, reference-identity match, and null-safety
+    /// can be pinned by fast unit tests without a Unity scene, mirroring how
+    /// <see cref="FuseSceneryDeferralClassifier"/> splits its pure type-name core from the
+    /// game-resolved <c>CanDefer</c> path.
+    /// </summary>
+    internal static class FuseProgressionGateEvaluator
+    {
+        /// <summary>
+        /// One feature's contribution to the decision: its unlock state and the objects
+        /// it enables on unlock (the game's <c>gameObjectsEnableOnUnlock</c>). Objects are
+        /// carried as <see cref="object"/> so the core is independent of UnityEngine types.
+        /// </summary>
+        internal readonly struct Gate
+        {
+            public Gate(bool unlocked, IReadOnlyList<object> gatedObjects)
+            {
+                Unlocked = unlocked;
+                GatedObjects = gatedObjects;
+            }
+
+            public bool Unlocked { get; }
+
+            public IReadOnlyList<object> GatedObjects { get; }
+        }
+
+        /// <summary>
+        /// True when <paramref name="target"/> is referenced (by identity) in any gate
+        /// whose feature is locked (<see cref="Gate.Unlocked"/> is false). Unlocked gates,
+        /// a null target, a null gate set, and a null per-gate object list never hide
+        /// anything, so anything not actively held by a locked feature is reported visible.
+        ///
+        /// The match is reference identity, never value equality: this mirrors the game's
+        /// per-GameObject <c>SetActive</c> gating, where one instance being gated says
+        /// nothing about a different instance that merely looks the same.
+        /// </summary>
+        internal static bool IsHiddenByLockedGate(object target, IEnumerable<Gate> gates)
+        {
+            if (target == null || gates == null)
+            {
+                return false;
+            }
+
+            foreach (var gate in gates)
+            {
+                if (gate.Unlocked)
+                {
+                    continue;
+                }
+
+                var gatedObjects = gate.GatedObjects;
+                if (gatedObjects == null)
+                {
+                    continue;
+                }
+
+                for (var index = 0; index < gatedObjects.Count; index++)
+                {
+                    if (ReferenceEquals(gatedObjects[index], target))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/FUSE/Runtime/API/ProgressionAPI.MapFeatureManager.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.MapFeatureManager.cs
@@ -920,5 +920,77 @@ namespace FUSE.Runtime.API
                 ManagerProgressionsField?.SetValue(manager, UnityEngine.Object.FindObjectsOfType<Progression>());
             }
         }
+
+        /// <summary>
+        /// True when <paramref name="gameObject"/> is currently held hidden by a locked
+        /// progression feature — i.e. some <see cref="MapFeature"/> that is not unlocked
+        /// lists this exact object in <c>gameObjectsEnableOnUnlock</c>. The game disables
+        /// such objects (<c>SetActive(false)</c>) while their feature is locked and only
+        /// re-shows them on the unlock transition, so any one-shot re-activation that
+        /// races that state would leave a locked-area prop permanently visible. The
+        /// deferred-scenery activation wave consults this before its post-load
+        /// <c>SetActive(true)</c> pass so it never re-reveals a prop progression just hid
+        /// (e.g. decking in a not-yet-unlocked area).
+        ///
+        /// Conservative by construction: only a feature whose <c>Unlocked</c> flag is
+        /// false suppresses activation, and an unresolved manager returns false, so
+        /// anything whose gate cannot be determined activates exactly as it did before.
+        /// </summary>
+        internal static bool IsGameObjectHiddenByLockedFeature(GameObject gameObject)
+        {
+            if (gameObject == null)
+            {
+                return false;
+            }
+
+            var manager = MapFeatureManager.Shared;
+            if (manager == null)
+            {
+                return false;
+            }
+
+            IEnumerable<MapFeature> features;
+            try
+            {
+                features = manager.AvailableFeatures;
+            }
+            catch
+            {
+                return false;
+            }
+
+            return IsGameObjectHiddenByLockedFeature(gameObject, features);
+        }
+
+        /// <summary>
+        /// Overload that evaluates against an explicit feature set instead of
+        /// <see cref="MapFeatureManager.Shared"/>, so the live <see cref="MapFeature"/> →
+        /// gate mapping (reading <c>Unlocked</c> + <c>gameObjectsEnableOnUnlock</c> and
+        /// matching by GameObject identity) can be pinned by an EditMode integration test
+        /// with hand-built features. The pure decision itself lives in
+        /// <see cref="FuseProgressionGateEvaluator.IsHiddenByLockedGate"/>.
+        /// </summary>
+        internal static bool IsGameObjectHiddenByLockedFeature(GameObject gameObject, IEnumerable<MapFeature> features)
+        {
+            if (gameObject == null || features == null)
+            {
+                return false;
+            }
+
+            return FuseProgressionGateEvaluator.IsHiddenByLockedGate(gameObject, ToFeatureGates(features));
+        }
+
+        private static IEnumerable<FuseProgressionGateEvaluator.Gate> ToFeatureGates(IEnumerable<MapFeature> features)
+        {
+            foreach (var feature in features)
+            {
+                if (feature == null)
+                {
+                    continue;
+                }
+
+                yield return new FuseProgressionGateEvaluator.Gate(feature.Unlocked, feature.gameObjectsEnableOnUnlock);
+            }
+        }
     }
 }

--- a/FUSE/Runtime/Lifecycle/FuseDeferredSceneryActivator.cs
+++ b/FUSE/Runtime/Lifecycle/FuseDeferredSceneryActivator.cs
@@ -188,16 +188,22 @@ namespace FUSE.Runtime.Lifecycle
 
             var total = Queue.Count;
             var activated = 0;
+            var keptHidden = 0;
             for (var index = 0; index < Queue.Count; index++)
             {
-                if (ActivateOne(Queue[index]))
+                switch (ActivateOne(Queue[index]))
                 {
-                    activated++;
+                    case ActivationResult.Activated:
+                        activated++;
+                        break;
+                    case ActivationResult.KeptHidden:
+                        keptHidden++;
+                        break;
                 }
             }
 
             Queue.Clear();
-            FuseLog.Info($"FUSE deferred scenery flushed synchronously ({activated}/{total}); reason='{reason ?? "unspecified"}'.");
+            FuseLog.Info($"FUSE deferred scenery flushed synchronously ({activated}/{total}, keptHidden={keptHidden}); reason='{reason ?? "unspecified"}'.");
         }
 
         private static IEnumerator DrainRoutine(string reason)
@@ -219,6 +225,7 @@ namespace FUSE.Runtime.Lifecycle
             var processed = 0;
             var activated = 0;
             var failed = 0;
+            var keptHidden = 0;
 
             while (index < Queue.Count)
             {
@@ -231,13 +238,17 @@ namespace FUSE.Runtime.Lifecycle
                        thisFrame < maxPerFrame &&
                        (thisFrame == 0 || Time.realtimeSinceStartup - frameStart < budgetSeconds))
                 {
-                    if (ActivateOne(Queue[index]))
+                    switch (ActivateOne(Queue[index]))
                     {
-                        activated++;
-                    }
-                    else
-                    {
-                        failed++;
+                        case ActivationResult.Activated:
+                            activated++;
+                            break;
+                        case ActivationResult.KeptHidden:
+                            keptHidden++;
+                            break;
+                        default:
+                            failed++;
+                            break;
                     }
 
                     index++;
@@ -252,13 +263,17 @@ namespace FUSE.Runtime.Lifecycle
                         $"activating the remaining {Queue.Count - index} item(s) inline.");
                     while (index < Queue.Count)
                     {
-                        if (ActivateOne(Queue[index]))
+                        switch (ActivateOne(Queue[index]))
                         {
-                            activated++;
-                        }
-                        else
-                        {
-                            failed++;
+                            case ActivationResult.Activated:
+                                activated++;
+                                break;
+                            case ActivationResult.KeptHidden:
+                                keptHidden++;
+                                break;
+                            default:
+                                failed++;
+                                break;
                         }
 
                         index++;
@@ -271,10 +286,10 @@ namespace FUSE.Runtime.Lifecycle
                 yield return null;
             }
 
-            OnDrainComplete(reason, processed, activated, failed);
+            OnDrainComplete(reason, processed, activated, failed, keptHidden);
         }
 
-        private static void OnDrainComplete(string reason, int processed, int activated, int failed)
+        private static void OnDrainComplete(string reason, int processed, int activated, int failed, int keptHidden)
         {
             _coroutine = null;
             Queue.Clear();
@@ -287,16 +302,19 @@ namespace FUSE.Runtime.Lifecycle
             // Genuine activation errors are logged separately via FuseLog.Exception in
             // ActivateOne. A small non-zero 'failed' is expected. (TODO: split into
             // 'skipped' vs 'errored' if this metric ever causes confusion.)
+            // 'keptHidden' counts props a locked progression feature is intentionally
+            // holding inactive (gameObjectsEnableOnUnlock); leaving them hidden is the
+            // point of the lock check and is expected for any not-yet-unlocked area.
             FuseLog.Info(
                 $"FUSE load timing phase='deferred scenery activation wave' elapsedMs={elapsedMs} " +
-                $"reason='{reason ?? "map load"}' activated={activated} failed={failed} processed={processed}.");
+                $"reason='{reason ?? "map load"}' activated={activated} failed={failed} keptHidden={keptHidden} processed={processed}.");
         }
 
-        private static bool ActivateOne(DeferredScenery item)
+        private static ActivationResult ActivateOne(DeferredScenery item)
         {
             if (item == null)
             {
-                return false;
+                return ActivationResult.Failed;
             }
 
             var instance = item.Instance;
@@ -306,13 +324,23 @@ namespace FUSE.Runtime.Lifecycle
             // in OnDrainComplete) — not an error.
             if (instance == null)
             {
-                return false;
+                return ActivationResult.Failed;
             }
 
             var gameObject = instance.gameObject;
             if (gameObject == null)
             {
-                return false;
+                return ActivationResult.Failed;
+            }
+
+            // A locked progression feature may have hidden this prop during apply via
+            // gameObjectsEnableOnUnlock (the game SetActive(false)'d it and only re-shows
+            // it on the unlock transition). Re-activating it here would strand a
+            // not-yet-unlocked prop visible until the next feature change, so leave it
+            // inactive; the game shows it when the owning feature unlocks.
+            if (ProgressionAPI.IsGameObjectHiddenByLockedFeature(gameObject))
+            {
+                return ActivationResult.KeptHidden;
             }
 
             try
@@ -323,13 +351,26 @@ namespace FUSE.Runtime.Lifecycle
                 }
 
                 item.OnActivated?.Invoke();
-                return true;
+                return ActivationResult.Activated;
             }
             catch (Exception ex)
             {
                 FuseLog.Exception($"FUSE deferred scenery activation failed for '{item.Id}'", ex);
-                return false;
+                return ActivationResult.Failed;
             }
+        }
+
+        /// <summary>
+        /// Outcome of a single deferred-activation attempt. <see cref="Failed"/> is the
+        /// benign destroyed/removed case (and genuine errors, which are logged
+        /// separately); <see cref="KeptHidden"/> means a locked progression feature is
+        /// intentionally holding the prop inactive and it must not be shown.
+        /// </summary>
+        private enum ActivationResult
+        {
+            Activated,
+            Failed,
+            KeptHidden
         }
 
         private static void SortByDistance(Vector3 anchor)


### PR DESCRIPTION
## 🔗 Related Issue

No tracked GitHub issue — this is **Issue 1** of the Whittier visibility investigation (FUSE custom scenery not hidden by Railroader progression). It is an independent system from, and not required by, #103 (terrain‑mask decouple).

## 📝 Description of the Change

**Symptom:** ALW's East Whittier "decking" (the `WoodDock50M` props in `ALWWhittierWilliamElkTractor.EFA`) stays visible even though it sits behind a not‑yet‑unlocked progression stage.

**How Railroader hides scenery (observed runtime contract):** a `MapFeature` hides the objects in its `gameObjectsEnableOnUnlock` with `SetActive(unlocked)`, and re‑applies that **only on feature enable/disable transitions** — it is not continuously enforced. (Feature‑gated *areas* only toggle `ProgressionDisabled` on industries/passenger stops; they have no scenery hook.)

**Root cause:** the gating is authored correctly — ALW lists `scenery://ZP1Scenery_*` in `ElkStage1.gameObjectsEnableOnUnlock`, so during apply the locked feature `SetActive(false)`s the docks. But the always‑on deferred‑scenery activation wave then runs its post‑load drain and `SetActive(true)`s **everything it queued**, including those just‑hidden props. Because the game only re‑applies on the next unlock transition, the decking stays visible permanently. Eager (mask‑bearing) gated scenery was unaffected — it is `SetActive(false)` after its inline activation and nothing re‑shows it; only **deferred static** scenery regressed once deferral became always‑on.

**Fix:** `FuseDeferredSceneryActivator.ActivateOne` now returns a tri‑state and returns `KeptHidden` (skipping `SetActive(true)`) when the object is currently held hidden by a locked feature, surfaced via the new `ProgressionAPI.IsGameObjectHiddenByLockedFeature` (object referenced by any feature whose `Unlocked` is false in its `gameObjectsEnableOnUnlock`). The drain/flush loops and the wave log gain a `keptHidden` counter. The decision is extracted into the pure, unit‑testable `FuseProgressionGateEvaluator`. When the player later unlocks the stage, the game's own transition `SetActive(true)`s the props through `gameObjectsEnableOnUnlock` as before.

## 🔄 Alternatives Considered

- **Extend `FuseWorldSuppressor` area suppression to scenery** — rejected: area‑lock (`areasEnableOnUnlock`) only sets `ProgressionDisabled` on industries/passenger stops and has no scenery hook, and the game's *natural* progression locking never routes through the suppressor. Wrong layer; couldn't use the game's real scenery‑hide path.
- **Add a `Feature` gate field to `FuseScenery` authoring** — rejected as unnecessary: ALW already gates the decking through the documented `gameObjectsEnableOnUnlock` + `scenery://` mechanism. The defect was the deferral wave un‑hiding it, not a missing authoring surface. (Could still be a future ergonomics enhancement for plugin‑built scenery, but it is not needed to fix this.)

## ⚠️ Possible Drawbacks

- Behavior change is narrowly scoped to **deferred static scenery gated by a currently‑locked feature**: it now stays hidden after the load wave (previously shown). The check is conservative — it only suppresses activation when a feature is confidently locked; an unresolved `MapFeatureManager`/indeterminate state activates exactly as before, so nothing that should be visible is hidden.
- **No serialized‑format change and no new authoring fields**, so the change is fully backwards‑compatible with existing saves and packs.
- Per‑item cost is a short scan over `AvailableFeatures` during the post‑load wave — negligible.

## ✅ Verification Process

- **Build:** `FUSE.csproj` (Release, with `GameDir`) — 0 warnings, 0 errors.
- **Tests:** `FUSE.Tests` **1232 passing** (+11 new pure‑evaluator cases; full suite green, no new analyzer warnings). New **EditMode integration test** (`FUSE.UnityTests`) builds real `MapFeature` components + GameObjects and asserts the live `MapFeature → gate` mapping (runs in the Unity editor test pass).
- **Confirmed against ALW data:** `ALWTractorFactoryScenery.json` places the `WoodDock50M` docks (`ZP1Scenery_*`) and `ALWTractorProgressions.json` gates them in `ElkStage1.gameObjectsEnableOnUnlock`. A gated static dock can only end up visible by being deferred then drained — exactly the path this fix closes.
- **Pending live sign‑off:** load with William Elk Phase 1 incomplete → the four `WoodDock50M` docks hidden (`keptHidden≥4` on the `deferred scenery activation wave` log line); complete Phase 1 → they appear.

## 💡 Additional Information

- The `deferred scenery activation wave` log line now reports `keptHidden=N` (props a locked feature is intentionally holding inactive).
- In‑game, the scenery debug overlay's **"Progressions impacting"** panel shows which feature gates a clicked object and its `unlocked` state — handy for confirming the gate is wired.
