### PR TITLE
fix(scenery): harden deferred-activation progression-gate check (follow-up to #106)

### DIFF
--- a/FUSE/Runtime/Lifecycle/FuseDeferredSceneryActivator.cs
+++ b/FUSE/Runtime/Lifecycle/FuseDeferredSceneryActivator.cs
@@ -190,6 +190,7 @@ namespace FUSE.Runtime.Lifecycle
 
             var total = Queue.Count;
             var activated = 0;
+            var failed = 0;
             var keptHidden = 0;
             for (var index = 0; index < Queue.Count; index++)
             {
@@ -201,11 +202,14 @@ namespace FUSE.Runtime.Lifecycle
                     case ActivationResult.KeptHidden:
                         keptHidden++;
                         break;
+                    default:
+                        failed++;
+                        break;
                 }
             }
 
             Queue.Clear();
-            FuseLog.Info($"FUSE deferred scenery flushed synchronously ({activated}/{total}, keptHidden={keptHidden}); reason='{reason ?? "unspecified"}'.");
+            FuseLog.Info($"FUSE deferred scenery flushed synchronously ({activated}/{total}, failed={failed}, keptHidden={keptHidden}); reason='{reason ?? "unspecified"}'.");
         }
 
         private static IEnumerator DrainRoutine(string reason)
@@ -340,9 +344,24 @@ namespace FUSE.Runtime.Lifecycle
             // it on the unlock transition). Re-activating it here would strand a
             // not-yet-unlocked prop visible until the next feature change, so leave it
             // inactive; the game shows it when the owning feature unlocks.
-            if (ProgressionAPI.IsGameObjectHiddenByLockedFeature(gameObject))
+            //
+            // Guard the query separately: if progression state is momentarily
+            // inconsistent and the check throws, fall back to activating (the pre-fix
+            // behavior) rather than letting the exception escape ActivateOne and kill the
+            // drain coroutine mid-wave — the class contract is that no deferral problem
+            // leaves scenery stranded or wedges the load.
+            try
             {
-                return ActivationResult.KeptHidden;
+                if (ProgressionAPI.IsGameObjectHiddenByLockedFeature(gameObject))
+                {
+                    return ActivationResult.KeptHidden;
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception(
+                    $"FUSE deferred scenery progression-gate check failed for '{item.Id}'; activating normally.",
+                    ex);
             }
 
             try


### PR DESCRIPTION
## 🔗 Related Issue

Follow‑up to #106 (merged). #106 was merged before I could push the fix for CodeRabbit's incremental review, so its two findings on `FuseDeferredSceneryActivator.cs` are addressed here instead.

## 📝 Description of the Change

Two robustness fixes to the deferred‑scenery progression‑lock guard added in #106:

1. **Exception‑safe gate check (Major).** `ProgressionAPI.IsGameObjectHiddenByLockedFeature` was called in `ActivateOne` *outside* any try/catch. If it threw, the exception would escape `ActivateOne`, kill the `DrainRoutine` coroutine mid‑wave, and strand the remaining queued scenery inactive — violating the class's documented fail‑safe contract ("a deferral problem can never leave scenery invisible or wedge a load"). The check now sits in its own try/catch that logs and **degrades to normal activation** (the pre‑#106 behavior) on any throw, so a momentarily‑inconsistent progression state can't wedge the wave.

2. **Flush counter parity (trivial).** `FlushSynchronously` now tracks a `failed` counter like `DrainRoutine` and includes it in its log line, so a synchronous flush accounts for all three outcomes (`activated`/`failed`/`keptHidden`) instead of dropping failures from the tally.

## 🔄 Alternatives Considered

CodeRabbit's literal suggestion moved the gate check *inside* the existing activation try/catch — but that shared `catch` returns `Failed`, which would leave the prop **inactive** on a gate‑check exception. Instead the gate check gets its own guard and degrades to **activation**, matching the fail‑safe principle that uncertainty should err toward showing scenery, never stranding it or wedging the load.

## ⚠️ Possible Drawbacks

None functional. The gate‑check exception path is extremely unlikely (the helper is already null‑guarded and wraps its feature enumeration) — this is cheap defensive insurance. No serialized‑format change; fully backwards compatible.

## ✅ Verification Process

- **Build:** `FUSE.csproj` (Release, with `GameDir`) — 0 warnings, 0 errors.
- **Tests:** `FUSE.Tests` **1247 passing**, 0 failures (rebased onto current `main`, post‑#106).
- Change is scoped to `FUSE/Runtime/Lifecycle/FuseDeferredSceneryActivator.cs` only.

## 💡 Additional Information

Originated from CodeRabbit's ASSERTIVE incremental review of #106; captured as a small follow‑up so the hardening lands in `main`. The original #106 fix (keep progression‑locked deferred scenery hidden) is unchanged and already merged.
