### PR TITLE
fix(scenery): reliable masked-scenery streaming across teleports and reloads

### DIFF
--- a/FUSE.Tests/API/MapApiDecoupledMaskPlacementTests.cs
+++ b/FUSE.Tests/API/MapApiDecoupledMaskPlacementTests.cs
@@ -1,0 +1,91 @@
+using FUSE.Runtime.API;
+using UnityEngine;
+using Xunit;
+
+namespace FUSE.Tests.API
+{
+    /// <summary>
+    /// Pure-math coverage for <see cref="MapAPI.ComputeMaskGamePosition"/>, the rebase-invariant
+    /// game-space anchor a decoupled map mask registers its terrain modifier at. The inputs are a
+    /// scenery root's local position (its authored game position — a parent translation never
+    /// changes it), the root's world position, and the welded mask's world position. The mask and
+    /// root share a hierarchy, so their world delta is the same in every floating-origin state;
+    /// the sum must therefore return the same game position whether the chain was sampled before
+    /// a MoveWorld rebase, after it, or while the rebase only half-propagated relative to
+    /// MapManager's offset — the race that put the Bryson roundhouse flatten a whole origin block
+    /// (~4000/5000m) off its tile, where no terrain rebuild could ever pick it up.
+    /// </summary>
+    public class MapApiDecoupledMaskPlacementTests
+    {
+        // Bryson roundhouse numbers from the field failure: authored game position of the
+        // scenery root, the mask welded ~22m away inside the model, and the floating-origin
+        // offset after the spawn MoveWorld to tile (8,10).
+        private static readonly Vector3 RootGame = new Vector3(4300f, 529f, 5400f);
+        private static readonly Vector3 MaskOffsetInModel = new Vector3(2.98f, 0.01f, -24.98f);
+        private static readonly Vector3 RebaseOffset = new Vector3(-4000f, 0f, -5000f);
+
+        private static readonly Vector3 ExpectedGame = RootGame + MaskOffsetInModel;
+
+        [Fact]
+        public void PreRebaseChain_YieldsAuthoredGamePosition()
+        {
+            // Before the first MoveWorld the world equals game space: root sits at its authored
+            // position and the mask at the authored offset within the model.
+            var game = MapAPI.ComputeMaskGamePosition(
+                sceneryRootLocalPosition: RootGame,
+                sceneryRootWorldPosition: RootGame,
+                maskWorldPosition: RootGame + MaskOffsetInModel);
+
+            Assert.Equal(ExpectedGame, game);
+        }
+
+        [Fact]
+        public void PostRebaseChain_YieldsSameGamePosition()
+        {
+            // After MoveWorld the whole chain is translated by the offset; localPosition is
+            // untouched. The world delta cancels the offset, so the result is identical.
+            var game = MapAPI.ComputeMaskGamePosition(
+                sceneryRootLocalPosition: RootGame,
+                sceneryRootWorldPosition: RootGame + RebaseOffset,
+                maskWorldPosition: RootGame + RebaseOffset + MaskOffsetInModel);
+
+            Assert.Equal(ExpectedGame, game);
+        }
+
+        [Fact]
+        public void RebasedAndUnRebasedSamples_Agree()
+        {
+            // The race-proof property itself: a decouple burst can sample one mask before the
+            // chain rode a MoveWorld and the next after (or from a chain that never rides, e.g.
+            // a non-moving fallback parent). An absolute transform read differs by a whole
+            // origin block between those samples — the failure that buried the Bryson
+            // roundhouse; the local+delta form must not.
+            var sampledUnRebased = MapAPI.ComputeMaskGamePosition(
+                sceneryRootLocalPosition: RootGame,
+                sceneryRootWorldPosition: RootGame,
+                maskWorldPosition: RootGame + MaskOffsetInModel);
+
+            var sampledRebased = MapAPI.ComputeMaskGamePosition(
+                sceneryRootLocalPosition: RootGame,
+                sceneryRootWorldPosition: RootGame + RebaseOffset,
+                maskWorldPosition: RootGame + RebaseOffset + MaskOffsetInModel);
+
+            Assert.Equal(sampledUnRebased, sampledRebased);
+        }
+
+        [Fact]
+        public void RootMovedByUpdateScenery_TracksTheNewAuthoredPosition()
+        {
+            // UpdateScenery rewrites the root's localPosition; the recomputed anchor must follow
+            // the building, not the original placement.
+            var newRootGame = RootGame + new Vector3(50f, 0f, -75f);
+
+            var game = MapAPI.ComputeMaskGamePosition(
+                sceneryRootLocalPosition: newRootGame,
+                sceneryRootWorldPosition: newRootGame + RebaseOffset,
+                maskWorldPosition: newRootGame + RebaseOffset + MaskOffsetInModel);
+
+            Assert.Equal(newRootGame + MaskOffsetInModel, game);
+        }
+    }
+}

--- a/FUSE.Tests/API/MapApiDecoupledMaskPlacementTests.cs
+++ b/FUSE.Tests/API/MapApiDecoupledMaskPlacementTests.cs
@@ -6,19 +6,20 @@ namespace FUSE.Tests.API
 {
     /// <summary>
     /// Pure-math coverage for <see cref="MapAPI.ComputeMaskGamePosition"/>, the rebase-invariant
-    /// game-space anchor a decoupled map mask registers its terrain modifier at. The inputs are a
-    /// scenery root's local position (its authored game position — a parent translation never
-    /// changes it), the root's world position, and the welded mask's world position. The mask and
-    /// root share a hierarchy, so their world delta is the same in every floating-origin state;
-    /// the sum must therefore return the same game position whether the chain was sampled before
-    /// a MoveWorld rebase, after it, or while the rebase only half-propagated relative to
-    /// MapManager's offset — the race that put the Bryson roundhouse flatten a whole origin block
-    /// (~4000/5000m) off its tile, where no terrain rebuild could ever pick it up.
+    /// game-space anchor for a decoupled mask's REBAKE footprint. The inputs are a scenery
+    /// root's local position (its authored game position — a parent translation never changes
+    /// it), the root's world position, and the welded mask's world position. The mask and root
+    /// share a hierarchy, so their world delta is the same in every floating-origin state; the
+    /// sum must therefore return the same game position whether the chain was sampled before a
+    /// MoveWorld rebase or after it. A decouple burst regularly straddles the spawn rebase —
+    /// unioning ABSOLUTE positions across that boundary mixes offset states and inflates the
+    /// rebake footprint by a whole origin block (~4000/5000m at Bryson), mass-invalidating
+    /// terrain that was never touched.
     /// </summary>
     public class MapApiDecoupledMaskPlacementTests
     {
         // Bryson roundhouse numbers from the field failure: authored game position of the
-        // scenery root, the mask welded ~22m away inside the model, and the floating-origin
+        // scenery root, the mask welded ~25m away inside the model, and the floating-origin
         // offset after the spawn MoveWorld to tile (8,10).
         private static readonly Vector3 RootGame = new Vector3(4300f, 529f, 5400f);
         private static readonly Vector3 MaskOffsetInModel = new Vector3(2.98f, 0.01f, -24.98f);
@@ -55,11 +56,10 @@ namespace FUSE.Tests.API
         [Fact]
         public void RebasedAndUnRebasedSamples_Agree()
         {
-            // The race-proof property itself: a decouple burst can sample one mask before the
-            // chain rode a MoveWorld and the next after (or from a chain that never rides, e.g.
-            // a non-moving fallback parent). An absolute transform read differs by a whole
-            // origin block between those samples — the failure that buried the Bryson
-            // roundhouse; the local+delta form must not.
+            // The mixed-space property itself: a decouple burst can sample one mask before the
+            // chain rode a MoveWorld and the next after. Absolute reads differ by a whole
+            // origin block between those samples — unioning them produced kilometres-wide
+            // rebake bounds at Bryson; the local+delta form must not differ.
             var sampledUnRebased = MapAPI.ComputeMaskGamePosition(
                 sceneryRootLocalPosition: RootGame,
                 sceneryRootWorldPosition: RootGame,

--- a/FUSE.Tests/API/MapApiMaskVisibilityTests.cs
+++ b/FUSE.Tests/API/MapApiMaskVisibilityTests.cs
@@ -10,8 +10,10 @@ namespace FUSE.Tests.API
     /// Pure-logic coverage for <see cref="MapAPI.ClassifyMaskVisibility"/>, the decision that
     /// drives the visibility-driven decoupled-mask lifecycle
     /// (<c>FuseDecoupledMaskVisibilityWatcher</c>). It must separate three look-alike states that
-    /// need different mask handling: a building that is drawing (keep mask), one a pack has hidden
-    /// at the renderer level (drop mask), and one merely streamed out or culled (keep mask). The
+    /// need different mask handling: a building that is drawing (keep mask); one a pack has hidden
+    /// via <c>SetActive(false)</c> so every holder is inactive (drop mask); and one the game culler
+    /// merely streamed out or stopped drawing by clearing <c>renderer.enabled</c> while the holders
+    /// stay active (keep mask — the culler owns that flag, so it is a cull, not a hide). The
     /// Unity-side gather and the SetActive toggle need a live game and are exercised in-game.
     /// </summary>
     public class MapApiMaskVisibilityTests
@@ -42,37 +44,56 @@ namespace FUSE.Tests.API
         }
 
         [Fact]
-        public void AllRenderersDisabled_IsHidden()
+        public void AllRenderersDisabledButActive_IsIndeterminate_SoCullKeepsMask()
         {
-            // The canonical intentional hide: renderer.enabled cleared on every renderer.
+            // The game culler clears renderer.enabled on a resident-but-invisible building
+            // (distance band 2) or one that is off-screen, while the holders stay ACTIVE. The
+            // culler OWNS renderer.enabled, so this is a cull, NOT an intentional hide: keep the
+            // decoupled mask (Indeterminate folds to the last decisive state). This is the exact
+            // state that previously dropped the mask the instant a far building streamed in.
             var renderers = new List<Sample>
             {
                 new Sample(enabled: false, activeInHierarchy: true, forceRenderingOff: false),
                 new Sample(enabled: false, activeInHierarchy: true, forceRenderingOff: false),
+            };
+
+            Assert.Equal(Visibility.Indeterminate, MapAPI.ClassifyMaskVisibility(renderers));
+        }
+
+        [Fact]
+        public void EveryHolderInactive_IsHidden_TheIntentionalHide()
+        {
+            // The one hide the culler never performs: a pack/progression SetActive(false) on the
+            // holders (activeInHierarchy = false on every renderer). Nothing draws and it is not a
+            // cull -> drop the mask so a hidden building leaves no flat patch behind.
+            var renderers = new List<Sample>
+            {
+                new Sample(enabled: true, activeInHierarchy: false, forceRenderingOff: false),
+                new Sample(enabled: true, activeInHierarchy: false, forceRenderingOff: false),
             };
 
             Assert.Equal(Visibility.Hidden, MapAPI.ClassifyMaskVisibility(renderers));
         }
 
         [Fact]
-        public void AllRenderersOnInactiveObjects_IsHidden()
+        public void SomeHolderStillActive_EvenIfAllDisabled_KeepsMask()
         {
-            // Hide via a child SetActive(false): renderers stay enabled but are not in an active
-            // hierarchy, so nothing draws — treat as an intentional hide.
+            // As long as ANY holder is still active, the building is present and the culler merely
+            // stopped drawing it -> keep the mask. Only an ALL-inactive set is the intentional hide.
             var renderers = new List<Sample>
             {
-                new Sample(enabled: true, activeInHierarchy: false, forceRenderingOff: false),
-                new Sample(enabled: true, activeInHierarchy: false, forceRenderingOff: false),
+                new Sample(enabled: false, activeInHierarchy: false, forceRenderingOff: false),
+                new Sample(enabled: false, activeInHierarchy: true, forceRenderingOff: false),
             };
 
-            Assert.Equal(Visibility.Hidden, MapAPI.ClassifyMaskVisibility(renderers));
+            Assert.Equal(Visibility.Indeterminate, MapAPI.ClassifyMaskVisibility(renderers));
         }
 
         [Fact]
         public void CullerForceRenderingOff_ButEnabledAndActive_IsVisible_SoMaskIsKept()
         {
-            // The game culler parks a resident model with forceRenderingOff = true while leaving
-            // enabled/active set. That is NOT an intentional hide: the mask must stay so a
+            // The game culler can also park a resident model with forceRenderingOff = true while
+            // leaving enabled/active set. That is NOT an intentional hide: the mask must stay so a
             // culled/streamed building keeps its terrain contribution (the point of decoupling).
             var renderers = new List<Sample>
             {
@@ -85,7 +106,7 @@ namespace FUSE.Tests.API
         [Fact]
         public void DisabledAndInactive_IsHidden()
         {
-            // Both hide signals at once still resolves to hidden.
+            // No active holder at all -> the intentional-hide path (drop).
             var renderers = new List<Sample>
             {
                 new Sample(enabled: false, activeInHierarchy: false, forceRenderingOff: true),
@@ -123,7 +144,7 @@ namespace FUSE.Tests.API
         }
 
         [Fact]
-        public void MaskActiveLifecycle_HiddenSurvivesStreamOut_AndCullerKeepsMask()
+        public void MaskActiveLifecycle_CullKeepsMask_IntentionalHideDropsIt()
         {
             // Walk the watcher's decision pipeline (ClassifyMaskVisibility -> ResolveEffective...)
             // across a building's lifecycle. Visible == mask applied; Hidden == mask dropped. The
@@ -134,16 +155,26 @@ namespace FUSE.Tests.API
             last = Step(last, S(enabled: true, active: true, forceOff: false));
             Assert.Equal(Visibility.Visible, last);
 
-            // Pack hides it (all renderers disabled) -> mask dropped.
+            // Distance-culled at load: culler clears renderer.enabled while holders stay active ->
+            // KEEP. This is the bug the fix targets (a far building streaming in must not drop its
+            // terrain flatten).
             last = Step(last, S(enabled: false, active: true, forceOff: false));
+            Assert.Equal(Visibility.Visible, last);
+
+            // Off-screen near the building (same culler signal) -> still KEEP.
+            last = Step(last, S(enabled: false, active: true, forceOff: false));
+            Assert.Equal(Visibility.Visible, last);
+
+            // Pack hides it via SetActive(false) (every holder inactive) -> mask dropped.
+            last = Step(last, S(enabled: true, active: false, forceOff: false));
             Assert.Equal(Visibility.Hidden, last);
 
             // Streams out while hidden (no renderers) -> stays dropped (regression: no re-flatten).
             last = Step(last);
             Assert.Equal(Visibility.Hidden, last);
 
-            // Streams back in, still hidden -> still dropped.
-            last = Step(last, S(enabled: false, active: true, forceOff: false));
+            // Streams back in, still hidden (inactive) -> still dropped.
+            last = Step(last, S(enabled: true, active: false, forceOff: false));
             Assert.Equal(Visibility.Hidden, last);
 
             // Pack shows it again -> mask restored.

--- a/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
@@ -276,20 +276,6 @@ namespace FUSE.UnityTests
             AssertProperty("Map.Runtime.MapManager", "Instance", BindingFlags.Static | BindingFlags.Public);
         }
 
-        [Test]
-        public void MapManager_gameToWorldOffset_InstanceField()
-        {
-            // MapAPI.PlaceDecoupledMask anchors decoupled mask clones at
-            // gamePosition + this offset so the modifier their OnEnable
-            // registers (which MapManager converts back by subtracting the
-            // SAME field) lands on the right game tile by construction. If
-            // the field is renamed, placement falls back to the
-            // WorldTransformer offset, which can disagree with MapManager's
-            // around a floating-origin rebase and misplace a mask by a whole
-            // origin block.
-            AssertField("Map.Runtime.MapManager", "_gameToWorldOffset", InstanceNonPublic);
-        }
-
         // -----------------------------------------------------------------
         // AssetPackRuntimeStore — heavily-patched store; FUSE's
         // asset-pack mounting reads BasePath, the load task, and the

--- a/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/RailroaderReflectionSurfaceTests.cs
@@ -276,6 +276,20 @@ namespace FUSE.UnityTests
             AssertProperty("Map.Runtime.MapManager", "Instance", BindingFlags.Static | BindingFlags.Public);
         }
 
+        [Test]
+        public void MapManager_gameToWorldOffset_InstanceField()
+        {
+            // MapAPI.PlaceDecoupledMask anchors decoupled mask clones at
+            // gamePosition + this offset so the modifier their OnEnable
+            // registers (which MapManager converts back by subtracting the
+            // SAME field) lands on the right game tile by construction. If
+            // the field is renamed, placement falls back to the
+            // WorldTransformer offset, which can disagree with MapManager's
+            // around a floating-origin rebase and misplace a mask by a whole
+            // origin block.
+            AssertField("Map.Runtime.MapManager", "_gameToWorldOffset", InstanceNonPublic);
+        }
+
         // -----------------------------------------------------------------
         // AssetPackRuntimeStore — heavily-patched store; FUSE's
         // asset-pack mounting reads BasePath, the load task, and the

--- a/FUSE/Patches/FuseCurveMeshCullingGuardPatch.cs
+++ b/FUSE/Patches/FuseCurveMeshCullingGuardPatch.cs
@@ -1,0 +1,73 @@
+using System;
+using BezierCurveMesh;
+using FUSE.Infrastructure;
+using HarmonyLib;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Keeps one broken curve-mesh culling handler from silently killing scenery
+    /// streaming for everything else.
+    ///
+    /// Unity's <c>CullingGroup.SendEvents</c> delivers a whole BATCH of culling state
+    /// changes in one native→managed call. <c>CurveMeshBuilderBase.CullingSphereStateChanged</c>
+    /// regenerates its mesh on those events, and a <c>TrackCurveMeshBuilder</c> whose
+    /// <c>TrackMarker</c> location points at track that no longer exists (e.g. removed by a
+    /// pack's track customizations) throws a <c>NullReferenceException</c> mid-batch — which
+    /// aborts <c>SendEvents</c> and DROPS every remaining event in the batch. The visible
+    /// result is brutal and looks completely unrelated: after a teleport, most scenery
+    /// culling spheres never receive their re-load/re-show events, so buildings simply never
+    /// stream back in (while their decoupled terrain masks stay applied — flattened ground
+    /// with nothing on it).
+    ///
+    /// <see cref="FUSE.Runtime.API.TrackAPI.DisableInvalidTrackMarkers"/> disables the known
+    /// breakage source (builders attached to invalid track markers) at apply time; this
+    /// finalizer is the catch-all so that ANY curve-mesh handler failure — known or novel —
+    /// costs one curve mesh instead of the whole culling batch. The exception is logged
+    /// (throttled) and suppressed; the builder itself is left enabled so a transient failure
+    /// (e.g. mid-rebuild) can recover on its next event.
+    /// </summary>
+    [HarmonyPatch(typeof(CurveMeshBuilderBase), "CullingSphereStateChanged")]
+    internal static class FuseCurveMeshCullingGuardPatch
+    {
+        private static long _suppressed;
+
+        /// <summary>Exceptions suppressed since startup (diagnostics).</summary>
+        internal static long SuppressedExceptions => _suppressed;
+
+        private static Exception Finalizer(Exception __exception, CurveMeshBuilderBase __instance)
+        {
+            if (__exception == null)
+            {
+                return null;
+            }
+
+            _suppressed++;
+            // First few individually (enough to identify the offender), then heartbeat only —
+            // a permanently-broken builder re-throws on every culling event it receives.
+            if (_suppressed <= 5 || _suppressed % 100 == 0)
+            {
+                var name = "<destroyed>";
+                try
+                {
+                    if (__instance != null)
+                    {
+                        var parent = __instance.transform.parent;
+                        name = parent != null ? parent.name + "/" + __instance.name : __instance.name;
+                    }
+                }
+                catch
+                {
+                    // Naming is best-effort; never let diagnostics re-throw inside the batch.
+                }
+
+                FuseLog.Warning(
+                    $"FUSE suppressed curve-mesh culling exception #{_suppressed} on '{name}': " +
+                    $"{__exception.GetBaseException().Message}. Without this guard the exception would " +
+                    "abort the whole CullingGroup event batch and stop other scenery from streaming.");
+            }
+
+            return null;
+        }
+    }
+}

--- a/FUSE/Patches/FuseSceneryCullingDebouncePatch.cs
+++ b/FUSE/Patches/FuseSceneryCullingDebouncePatch.cs
@@ -49,13 +49,6 @@ namespace FUSE.Patches
         private const int RenderBandCeiling = 1;
         private const int ResidentBandCeiling = 2;
 
-        // Mask-bearing scenery is pinned to this nearest band so it stays BOTH loaded and
-        // rendered instead of being parked invisible at band 2 or unloaded at band 3. This
-        // is a safety net layered over the real fix (MapAPI.DecoupleAttachedMapMasks, which
-        // moves the terrain mask off the streamed model); once that is verified in-game the
-        // pin is redundant and masked scenery can stream like any other.
-        private const int RenderResidentBand = 0;
-
         // Deadband outer edge. Band 3 begins ~1500m out (the SceneryDistanceBands
         // ceiling); we keep FUSE scenery resident until it is this far so jitter near
         // 1500m can't flap, then allow the unload. Squared to avoid a sqrt per call.
@@ -125,30 +118,23 @@ namespace FUSE.Patches
                     return;
                 }
 
-                if (marker.IsMaskBearing)
-                {
-                    // Pin a loaded mask-bearing building to the nearest band so it stays BOTH
-                    // loaded and RENDERED. Left alone, the culler pushes it to band 2 (loaded
-                    // but renderers OFF) or band 3 (unloaded) when far, and the on-return
-                    // re-show/reload is unreliable across a teleport world-origin shift —
-                    // which is how you end up standing inside an invisible building. Never
-                    // letting it leave the rendered band sidesteps that. The load throttle is
-                    // bypassed for these too, so the first load is immediate. Unity's
-                    // per-renderer frustum culling still skips it when off-screen, so this is
-                    // "always eligible to draw", not "always drawn". Safety net over the real
-                    // fix (MapAPI.DecoupleAttachedMapMasks); removable once that is verified.
-                    distanceBand = RenderResidentBand;
-                    _suppressedUnloads++;
-                    LogSuppressedIfDue();
-                    return;
-                }
-
-                // Non-mask FUSE scenery: anti-flap only, and only against the UNLOAD band.
-                // Band 2 (loaded-but-hidden) is the game's own behaviour — leave it. At
-                // band 3, hold inside the ~3km deadband so jitter near the ~1500m boundary
-                // can't thrash load/unload, otherwise let the game unload. transform.position
-                // and the camera share the same (floating-origin shifted) space, so the
-                // delta is world-shift safe. Mirrors the unit-tested ShouldHoldResident.
+                // All FUSE scenery — mask-bearing included — gets anti-flap only, and only
+                // against the UNLOAD band. Band 2 (loaded-but-hidden) is the game's own
+                // behaviour — leave it. At band 3, hold inside the ~3km deadband so jitter
+                // near the ~1500m boundary can't thrash load/unload, otherwise let the game
+                // unload. transform.position and the camera share the same (floating-origin
+                // shifted) space, so the delta is world-shift safe. Mirrors the unit-tested
+                // ShouldHoldResident.
+                //
+                // Mask-bearing scenery used to be PINNED to band 0 here (never parked, never
+                // unloaded) as a safety net while the mask decouple was unverified: a welded
+                // mask died with its streamed model, and the on-return reload was unreliable.
+                // Both causes are fixed and verified in-game — the terrain mask lives on a
+                // standalone object that survives streaming (MapAPI.DecoupleAttachedMapMasks),
+                // and reloads are reliable now that a broken curve-mesh culling handler can't
+                // abort the CullingGroup event batch (FuseCurveMeshCullingGuardPatch + the
+                // invalid-marker builder scrub). So masked buildings cull like everything
+                // else; only their terrain contribution is permanent.
                 if (distanceBand <= ResidentBandCeiling)
                 {
                     return;
@@ -181,7 +167,7 @@ namespace FUSE.Patches
             {
                 FuseLog.Info(
                     $"FUSE diag scenery-debounce active: suppressedUnloads={_suppressedUnloads} " +
-                    $"(mask-bearing pinned loaded+rendered; non-mask held within {UnloadDistance:0}m).");
+                    $"(band-3 unloads held while within {UnloadDistance:0}m of the camera).");
             }
         }
     }

--- a/FUSE/Patches/FuseSceneryLoadThrottlePatch.cs
+++ b/FUSE/Patches/FuseSceneryLoadThrottlePatch.cs
@@ -144,12 +144,13 @@ namespace FUSE.Patches
                 }
 
                 // Mask-bearing buildings load immediately — never throttled or deferred.
-                // They are pinned permanently loaded+rendered by
-                // FuseSceneryCullingDebouncePatch, so each loads once and the number near
-                // any single spot is small; throttling them is what made a teleported-to
-                // building take minutes (or get dropped from the queue). Build it now, keep
-                // it. (Safety net alongside MapAPI.DecoupleAttachedMapMasks; removable once
-                // that decouple is verified in-game.)
+                // Their FIRST load is what registers the terrain flatten/cut (the welded
+                // masks are decoupled on model load), so queueing one behind plain scenery
+                // leaves visibly wrong ground for the wait; and the mask-bearing set near
+                // any single spot is small, so the bypass costs little. Reloads after a
+                // teleport keep the bypass too: the standalone mask already holds the
+                // terrain, but the building itself is what the player is usually standing
+                // next to when it re-streams.
                 if (marker.IsMaskBearing)
                 {
                     return true;

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -27,20 +27,6 @@ namespace FUSE.Runtime.API
         private static readonly FieldInfo PolePrefabsField = typeof(TelegraphPoleManager).GetField("polePrefabs", BindingFlags.Instance | BindingFlags.NonPublic);
         private static readonly FieldInfo WirePrefabField = typeof(TelegraphPoleManager).GetField("wirePrefab", BindingFlags.Instance | BindingFlags.NonPublic);
         private static readonly MethodInfo TelegraphRebuildMethod = typeof(TelegraphPoleManager).GetMethod("Rebuild", BindingFlags.Instance | BindingFlags.NonPublic);
-
-        // MapManager's private game<->world offset. The game stores terrain modifiers in GAME
-        // space by subtracting exactly this field from a World-space registration
-        // (MapManager.AddModifier: modifier.OffsetBy(-_gameToWorldOffset)), so placing a mask
-        // clone at gamePosition + THIS offset makes its modifier land at gamePosition by
-        // construction, whatever the floating-origin rebase state. Resolved like the other
-        // MapManager reflection surfaces (see FuseRuntimeReloadService); covered by the
-        // reflection-surface canary test.
-        private static readonly FieldInfo MapManagerGameToWorldOffsetField =
-            Type.GetType("Map.Runtime.MapManager, Map.Runtime")
-                ?.GetField("_gameToWorldOffset", BindingFlags.Instance | BindingFlags.NonPublic);
-        private static readonly PropertyInfo MapManagerInstanceProperty =
-            Type.GetType("Map.Runtime.MapManager, Map.Runtime")
-                ?.GetProperty("Instance", BindingFlags.Static | BindingFlags.Public);
         private static readonly Regex SpeedLimitTextPattern = new Regex(@"^\s*(?<mph>\d{1,3})\s*MPH\.?\s*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex SpeedLimitNumberPattern = new Regex(@"^\s*(?<mph>\d{1,3})\s*$", RegexOptions.Compiled);
 
@@ -476,14 +462,6 @@ namespace FUSE.Runtime.API
                 return 0;
             }
 
-            // The game-space anchor math reads the scenery root's localPosition as its authored
-            // game position and treats parent motion as pure translation; both assumptions hold
-            // for every known container ("World/Large Scenery", SceneryAssetManager, the FUSE
-            // fallback) but are scene data the code can't prove. Warn loudly (once) if a map
-            // ever violates them instead of silently mis-anchoring masks.
-            WarnIfParentBreaksGameSpaceAssumptions(sceneryRoot.transform.parent, "scenery container");
-            WarnIfParentBreaksGameSpaceAssumptions(maskRoot, "mask root");
-
             var masks = sceneryRoot.GetComponentsInChildren<MapMaskBase>(true);
             var decoupled = 0;
             var union = default(Bounds);
@@ -502,11 +480,11 @@ namespace FUSE.Runtime.API
                     continue;
                 }
 
-                // The mask's GAME-space position, from rebase-invariant inputs only. The welded
-                // mask's ABSOLUTE transform.position must never be trusted here: this hook runs
-                // while the floating-origin rebase (MoveWorld) is racing the model stream-in, so
-                // an absolute read can be off by exactly one origin block (~4000/5000m at
-                // Bryson), registering the flatten on a far-away tile that no rebuild can fix.
+                // The mask's GAME-space position, used for the rebake footprint below (and the
+                // diag probe). Computed from rebase-invariant inputs rather than the absolute
+                // transform: this hook runs while the floating-origin rebase (MoveWorld) races
+                // the model stream-in, so a burst's absolute positions can mix offset states
+                // and a union over them spans a whole origin block.
                 var gamePosition = ComputeMaskGamePosition(
                     sceneryRoot.transform.localPosition,
                     sceneryRoot.transform.position,
@@ -514,8 +492,7 @@ namespace FUSE.Runtime.API
 
                 // Ownership is tracked by a marker component (not the name), so a user-authored
                 // mask that happens to share the generated name is never mistaken for our clone.
-                var standalone = FindDecoupledMask(maskRoot, id, index);
-                if (standalone == null)
+                if (FindDecoupledMask(maskRoot, id, index) == null)
                 {
                     try
                     {
@@ -530,10 +507,6 @@ namespace FUSE.Runtime.API
                             $"{ex.Message}; leaving it attached.");
                         continue;
                     }
-                }
-                else
-                {
-                    ReanchorDecoupledMask(standalone, gamePosition);
                 }
 
                 // Stop the welded copy baking on the streamed model. Idempotent across
@@ -617,6 +590,11 @@ namespace FUSE.Runtime.API
             var go = new GameObject(name);
             go.transform.SetParent(maskRoot, false);
             go.SetActive(false);
+            // Copy the welded mask's live transform. The mask and its scenery chain are
+            // always in a mutually consistent floating-origin state with MapManager's
+            // game<->world offset (rebases update both atomically), so OnEnable's World-space
+            // registration lands on the correct game tile from either side of a rebase.
+            go.transform.position = source.transform.position;
             go.transform.rotation = source.transform.rotation;
             // Match the source mask's WORLD scale, not identity. CircleMapMask/RectangleMapMask
             // descriptors are scale-independent (position + radius/size), so this is a no-op for
@@ -625,13 +603,9 @@ namespace FUSE.Runtime.API
             go.transform.localScale = source.transform.lossyScale;
 
             // Ownership marker so reuse/cleanup never depend on the (cosmetic) GameObject name.
-            // It also remembers the game-space anchor so every later (re)activation can re-place
-            // the clone before its OnEnable re-registers the modifier.
             var owner = go.AddComponent<FuseDecoupledMaskMarker>();
             owner.OwnerSceneryId = ownerSceneryId;
             owner.SourceIndex = sourceIndex;
-            owner.GamePosition = gamePosition;
-            owner.HasGamePosition = true;
 
             if (source is CircleMapMask sourceCircle)
             {
@@ -666,14 +640,13 @@ namespace FUSE.Runtime.API
                 throw new InvalidOperationException($"Unsupported map mask type '{source.GetType().Name}'.");
             }
 
-            // Anchor the clone so its OnEnable registration lands at gamePosition exactly, then
-            // enable. Enable the standalone BEFORE the caller disables the welded original so
-            // the flatten/cut is never momentarily dropped. NOT registered with
+            // OnEnable self-applies the modifier to the (persistent) terrain. Enable the
+            // standalone BEFORE the caller disables the welded original so the flatten/cut
+            // is never momentarily dropped. NOT registered with
             // WorldTransformer.AddObjectToMove: the modifier is stored offset-independently in
             // game space the moment it registers, the clone has nothing visual to keep aligned,
-            // and every later (re)activation re-places it from the marker anyway — while a move
-            // registration would double-shift it whenever its parent root also rides a rebase.
-            PlaceDecoupledMask(go.transform, gamePosition);
+            // and its parent root already rides rebases — a move registration would
+            // double-shift it on every world move.
             go.SetActive(true);
 
             // Decisive probe (gated on the existing scenery diagnostics flag): the type + game
@@ -700,80 +673,8 @@ namespace FUSE.Runtime.API
         }
 
         /// <summary>
-        /// Re-anchors an existing standalone mask on a re-decouple (its building streamed back
-        /// in, or the scenery definition changed). If the game-space anchor moved while the mask
-        /// is actively registered, bounce it (OnDisable removes the old modifier, OnEnable
-        /// re-adds at the new anchor); an unchanged anchor leaves the live modifier untouched so
-        /// routine stream-ins never churn the terrain.
-        /// </summary>
-        private static void ReanchorDecoupledMask(GameObject standalone, Vector3 gamePosition)
-        {
-            var marker = standalone.GetComponent<FuseDecoupledMaskMarker>();
-            var moved = marker == null
-                || !marker.HasGamePosition
-                || (marker.GamePosition - gamePosition).sqrMagnitude > 0.0001f;
-            if (marker != null)
-            {
-                marker.GamePosition = gamePosition;
-                marker.HasGamePosition = true;
-            }
-
-            if (!moved)
-            {
-                return;
-            }
-
-            var wasActive = standalone.activeSelf;
-            if (wasActive)
-            {
-                standalone.SetActive(false);
-            }
-
-            PlaceDecoupledMask(standalone.transform, gamePosition);
-            if (wasActive)
-            {
-                standalone.SetActive(true);
-            }
-        }
-
-        /// <summary>
-        /// Places a standalone mask so the modifier its OnEnable registers lands at
-        /// <paramref name="gamePosition"/> EXACTLY. MapManager converts a World-space
-        /// registration to game space by subtracting its private <c>_gameToWorldOffset</c>
-        /// (AddModifier: <c>OffsetBy(-_gameToWorldOffset)</c>), so the clone is placed at
-        /// gamePosition + that same offset: the round-trip cancels by construction, in the same
-        /// synchronous frame, regardless of the floating-origin rebase state of anything else.
-        /// Must be called (re-)placing the mask BEFORE each SetActive(true).
-        /// </summary>
-        private static void PlaceDecoupledMask(Transform standalone, Vector3 gamePosition)
-        {
-            standalone.position = gamePosition + MapManagerGameToWorldOffset();
-        }
-
-        private static Vector3 MapManagerGameToWorldOffset()
-        {
-            try
-            {
-                var instance = MapManagerInstanceProperty?.GetValue(null);
-                if (instance != null && MapManagerGameToWorldOffsetField != null)
-                {
-                    return (Vector3)MapManagerGameToWorldOffsetField.GetValue(instance);
-                }
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Warning(
-                    $"FUSE could not read MapManager's game-to-world offset: {ex.GetBaseException().Message}; " +
-                    "falling back to the WorldTransformer offset.");
-            }
-
-            // Fallback: the WorldTransformer's current offset (GameToWorld(0) == offset). It
-            // matches MapManager's whenever the two are in sync, which is the steady state.
-            return Helpers.WorldTransformer.GameToWorld(Vector3.zero);
-        }
-
-        /// <summary>
-        /// GAME-space position of a welded mask, computed from rebase-invariant inputs only.
+        /// GAME-space position of a welded mask, computed from rebase-invariant inputs only —
+        /// used to anchor the post-decouple REBAKE footprint (<see cref="MaskGameBounds"/>).
         /// The floating-origin rebase (Helpers.WorldTransformer) is a pure translation applied
         /// to whole root objects, so: (a) the welded mask and its scenery root are in the same
         /// hierarchy and therefore always in the same rebase state — their world-position delta
@@ -781,8 +682,9 @@ namespace FUSE.Runtime.API
         /// container is the authored game position (SceneryAPI parents with
         /// <c>SetParent(parent, false)</c> and writes the definition position to localPosition),
         /// and a parent translation never changes a child's localPosition. Their sum is the
-        /// mask's game position before the first MoveWorld, after it, and in any half-applied
-        /// window in between — which is what makes the modifier registration race-proof.
+        /// same in every rebase state, so a decouple burst that straddles a MoveWorld can be
+        /// unioned without mixing offset states (an absolute-position union across that
+        /// boundary spans a whole origin block and mass-invalidates terrain).
         /// </summary>
         internal static Vector3 ComputeMaskGamePosition(
             Vector3 sceneryRootLocalPosition,
@@ -790,29 +692,6 @@ namespace FUSE.Runtime.API
             Vector3 maskWorldPosition)
         {
             return sceneryRootLocalPosition + (maskWorldPosition - sceneryRootWorldPosition);
-        }
-
-        private static bool _warnedNonIdentityMaskParent;
-
-        private static void WarnIfParentBreaksGameSpaceAssumptions(Transform parent, string role)
-        {
-            if (_warnedNonIdentityMaskParent || parent == null)
-            {
-                return;
-            }
-
-            var rotated = Quaternion.Angle(parent.rotation, Quaternion.identity) > 0.5f;
-            var scaled = (parent.lossyScale - Vector3.one).sqrMagnitude > 0.0001f;
-            if (!rotated && !scaled)
-            {
-                return;
-            }
-
-            _warnedNonIdentityMaskParent = true;
-            FuseLog.Warning(
-                $"FUSE decoupled-mask anchoring assumes the {role} '{GetTransformPath(parent)}' has identity " +
-                $"rotation and unit scale, but it has rotation={parent.rotation.eulerAngles} " +
-                $"lossyScale={parent.lossyScale}. Decoupled terrain masks may be mis-anchored on this map.");
         }
 
         private static void CopyCommonMaskFields(MapMaskBase source, MapMaskBase destination)
@@ -866,45 +745,6 @@ namespace FUSE.Runtime.API
         {
             public string OwnerSceneryId;
             public int SourceIndex;
-
-            /// <summary>
-            /// The mask's anchor in GAME space (offset-independent, the space MapManager stores
-            /// modifiers in). Every (re)activation re-places the standalone from this before its
-            /// OnEnable registers the modifier, so registration is immune to floating-origin
-            /// rebases that happened while the mask was inactive.
-            /// </summary>
-            public Vector3 GamePosition;
-            public bool HasGamePosition;
-
-            /// <summary>
-            /// Self-heal for activation paths that bypass FUSE's explicit re-anchoring (e.g. an
-            /// ANCESTOR of the mask root being toggled re-fires every child OnEnable directly).
-            /// If the transform drifted off the anchor, re-place it and re-register any sibling
-            /// mask that already self-applied from the stale pose. On FUSE's own activation
-            /// paths the transform was just placed, so this is a cheap no-op.
-            /// </summary>
-            private void OnEnable()
-            {
-                if (!HasGamePosition)
-                {
-                    return;
-                }
-
-                var expected = GamePosition + MapManagerGameToWorldOffset();
-                if ((transform.position - expected).sqrMagnitude <= 0.0001f)
-                {
-                    return;
-                }
-
-                transform.position = expected;
-                foreach (var mask in GetComponents<MapMaskBase>())
-                {
-                    if (mask != null && mask.enabled)
-                    {
-                        mask.Rebuild();
-                    }
-                }
-            }
         }
 
         /// <summary>
@@ -1170,13 +1010,6 @@ namespace FUSE.Runtime.API
                 if (go.activeSelf == active)
                 {
                     continue;
-                }
-
-                // Re-anchor before activating: a floating-origin rebase may have happened while
-                // the mask was dropped, and OnEnable registers the modifier from the transform.
-                if (active && marker.HasGamePosition)
-                {
-                    PlaceDecoupledMask(child, marker.GamePosition);
                 }
 
                 go.SetActive(active);

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -27,6 +27,20 @@ namespace FUSE.Runtime.API
         private static readonly FieldInfo PolePrefabsField = typeof(TelegraphPoleManager).GetField("polePrefabs", BindingFlags.Instance | BindingFlags.NonPublic);
         private static readonly FieldInfo WirePrefabField = typeof(TelegraphPoleManager).GetField("wirePrefab", BindingFlags.Instance | BindingFlags.NonPublic);
         private static readonly MethodInfo TelegraphRebuildMethod = typeof(TelegraphPoleManager).GetMethod("Rebuild", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        // MapManager's private game<->world offset. The game stores terrain modifiers in GAME
+        // space by subtracting exactly this field from a World-space registration
+        // (MapManager.AddModifier: modifier.OffsetBy(-_gameToWorldOffset)), so placing a mask
+        // clone at gamePosition + THIS offset makes its modifier land at gamePosition by
+        // construction, whatever the floating-origin rebase state. Resolved like the other
+        // MapManager reflection surfaces (see FuseRuntimeReloadService); covered by the
+        // reflection-surface canary test.
+        private static readonly FieldInfo MapManagerGameToWorldOffsetField =
+            Type.GetType("Map.Runtime.MapManager, Map.Runtime")
+                ?.GetField("_gameToWorldOffset", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly PropertyInfo MapManagerInstanceProperty =
+            Type.GetType("Map.Runtime.MapManager, Map.Runtime")
+                ?.GetProperty("Instance", BindingFlags.Static | BindingFlags.Public);
         private static readonly Regex SpeedLimitTextPattern = new Regex(@"^\s*(?<mph>\d{1,3})\s*MPH\.?\s*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex SpeedLimitNumberPattern = new Regex(@"^\s*(?<mph>\d{1,3})\s*$", RegexOptions.Compiled);
 
@@ -462,8 +476,18 @@ namespace FUSE.Runtime.API
                 return 0;
             }
 
+            // The game-space anchor math reads the scenery root's localPosition as its authored
+            // game position and treats parent motion as pure translation; both assumptions hold
+            // for every known container ("World/Large Scenery", SceneryAssetManager, the FUSE
+            // fallback) but are scene data the code can't prove. Warn loudly (once) if a map
+            // ever violates them instead of silently mis-anchoring masks.
+            WarnIfParentBreaksGameSpaceAssumptions(sceneryRoot.transform.parent, "scenery container");
+            WarnIfParentBreaksGameSpaceAssumptions(maskRoot, "mask root");
+
             var masks = sceneryRoot.GetComponentsInChildren<MapMaskBase>(true);
             var decoupled = 0;
+            var union = default(Bounds);
+            var haveUnion = false;
             for (var index = 0; index < masks.Length; index++)
             {
                 var attached = masks[index];
@@ -478,13 +502,24 @@ namespace FUSE.Runtime.API
                     continue;
                 }
 
+                // The mask's GAME-space position, from rebase-invariant inputs only. The welded
+                // mask's ABSOLUTE transform.position must never be trusted here: this hook runs
+                // while the floating-origin rebase (MoveWorld) is racing the model stream-in, so
+                // an absolute read can be off by exactly one origin block (~4000/5000m at
+                // Bryson), registering the flatten on a far-away tile that no rebuild can fix.
+                var gamePosition = ComputeMaskGamePosition(
+                    sceneryRoot.transform.localPosition,
+                    sceneryRoot.transform.position,
+                    attached.transform.position);
+
                 // Ownership is tracked by a marker component (not the name), so a user-authored
                 // mask that happens to share the generated name is never mistaken for our clone.
-                if (FindDecoupledMask(maskRoot, id, index) == null)
+                var standalone = FindDecoupledMask(maskRoot, id, index);
+                if (standalone == null)
                 {
                     try
                     {
-                        CloneMaskToStandalone(BuildDecoupledMaskId(id, index), attached, maskRoot, id, index);
+                        CloneMaskToStandalone(BuildDecoupledMaskId(id, index), attached, maskRoot, id, index, gamePosition);
                         decoupled++;
                     }
                     catch (Exception ex)
@@ -496,10 +531,30 @@ namespace FUSE.Runtime.API
                         continue;
                     }
                 }
+                else
+                {
+                    ReanchorDecoupledMask(standalone, gamePosition);
+                }
 
                 // Stop the welded copy baking on the streamed model. Idempotent across
                 // reloads: the standalone above already holds the flatten/cut.
                 attached.enabled = false;
+
+                // Union this mask's GAME-space footprint so the post-burst re-bake covers its
+                // tiles. Game space, not world: a decouple burst can straddle a MoveWorld
+                // rebase, so absolute world footprints captured across the burst mix offset
+                // states and inflate the union by ~a full origin block (mass-invalidating
+                // thousands of meters of terrain — the "everything loads slower" symptom).
+                var maskBounds = MaskGameBounds(attached, gamePosition);
+                if (haveUnion)
+                {
+                    union.Encapsulate(maskBounds);
+                }
+                else
+                {
+                    union = maskBounds;
+                    haveUnion = true;
+                }
             }
 
             if (decoupled > 0)
@@ -509,22 +564,74 @@ namespace FUSE.Runtime.API
                     $"'{MapMaskRootName}' object(s); the terrain mask now survives the model streaming and teleports.");
             }
 
+            // The single map-load terrain rebuild runs BEFORE these masks stream in with their
+            // building model, and the game's own per-modifier invalidate is debounced and starved
+            // behind the spawn tile-load backlog — so the freshly-registered flatten/cut modifiers
+            // never re-bake an already-built tile (the spawn/roundhouse tile stays unmasked). Ask
+            // the rebaker to re-bake the touched tiles once the decouple burst settles: targeted
+            // (terrain-only, no scenery re-stream) and coalesced (one pass for the whole burst).
+            if (haveUnion)
+            {
+                FUSE.Runtime.Lifecycle.FuseDecoupledMaskTerrainRebaker.Request(union);
+            }
+
             return decoupled;
         }
 
-        private static GameObject CloneMaskToStandalone(string name, MapMaskBase source, Transform maskRoot, string ownerSceneryId, int sourceIndex)
+        // GAME-space footprint of a map mask (centered on its computed game position), used only
+        // to pick which terrain tiles the post-decouple re-bake must invalidate. Deliberately
+        // generous: over-covering re-bakes a few harmless extra tiles, while under-covering would
+        // leave uncut/​unflattened terrain.
+        private static Bounds MaskGameBounds(MapMaskBase mask, Vector3 gameCenter)
+        {
+            var half = 8f;
+            if (mask is CircleMapMask circle)
+            {
+                half = Mathf.Max(circle.radius, 1f) + 4f;
+            }
+            else if (mask is RectangleMapMask rectangle)
+            {
+                half = (Mathf.Max(rectangle.sizeX, rectangle.sizeZ) * 0.5f) + 4f;
+            }
+            else if (mask is CurveMapMask curve)
+            {
+                // Curve masks span between two authored endpoints, which are unbounded — a long
+                // curve easily exceeds any flat half-extent. Cover both endpoints explicitly,
+                // mapped to game space by the same translation-only delta the center uses.
+                var t = mask.transform;
+                var bounds = new Bounds(gameCenter, Vector3.zero);
+                bounds.Encapsulate(gameCenter + (t.TransformPoint(curve.positionA) - t.position));
+                bounds.Encapsulate(gameCenter + (t.TransformPoint(curve.positionB) - t.position));
+                bounds.Expand(new Vector3(
+                    2f * (Mathf.Max(curve.radius + curve.falloff, 16f) + 16f),
+                    64f,
+                    2f * (Mathf.Max(curve.radius + curve.falloff, 16f) + 16f)));
+                return bounds;
+            }
+
+            return new Bounds(gameCenter, new Vector3(half * 2f, 64f, half * 2f));
+        }
+
+        private static GameObject CloneMaskToStandalone(string name, MapMaskBase source, Transform maskRoot, string ownerSceneryId, int sourceIndex, Vector3 gamePosition)
         {
             var go = new GameObject(name);
             go.transform.SetParent(maskRoot, false);
             go.SetActive(false);
-            go.transform.position = source.transform.position;
             go.transform.rotation = source.transform.rotation;
-            go.transform.localScale = Vector3.one;
+            // Match the source mask's WORLD scale, not identity. CircleMapMask/RectangleMapMask
+            // descriptors are scale-independent (position + radius/size), so this is a no-op for
+            // them; but CurveMapMask builds its footprint via transform.TransformPoint, which reads
+            // lossyScale — forcing Vector3.one there shrinks/moves the curve off the building.
+            go.transform.localScale = source.transform.lossyScale;
 
             // Ownership marker so reuse/cleanup never depend on the (cosmetic) GameObject name.
+            // It also remembers the game-space anchor so every later (re)activation can re-place
+            // the clone before its OnEnable re-registers the modifier.
             var owner = go.AddComponent<FuseDecoupledMaskMarker>();
             owner.OwnerSceneryId = ownerSceneryId;
             owner.SourceIndex = sourceIndex;
+            owner.GamePosition = gamePosition;
+            owner.HasGamePosition = true;
 
             if (source is CircleMapMask sourceCircle)
             {
@@ -559,11 +666,153 @@ namespace FUSE.Runtime.API
                 throw new InvalidOperationException($"Unsupported map mask type '{source.GetType().Name}'.");
             }
 
-            // OnEnable self-applies the modifier to the (persistent) terrain. Enable the
-            // standalone BEFORE the caller disables the welded original so the flatten/cut
-            // is never momentarily dropped.
+            // Anchor the clone so its OnEnable registration lands at gamePosition exactly, then
+            // enable. Enable the standalone BEFORE the caller disables the welded original so
+            // the flatten/cut is never momentarily dropped. NOT registered with
+            // WorldTransformer.AddObjectToMove: the modifier is stored offset-independently in
+            // game space the moment it registers, the clone has nothing visual to keep aligned,
+            // and every later (re)activation re-places it from the marker anyway — while a move
+            // registration would double-shift it whenever its parent root also rides a rebase.
+            PlaceDecoupledMask(go.transform, gamePosition);
             go.SetActive(true);
+
+            // Decisive probe (gated on the existing scenery diagnostics flag): the type + game
+            // position + runtime world position + scale of each decoupled mask is exactly what's
+            // needed to tell a curve-scale miss from a placement/offset miss from a
+            // correctly-placed-but-inert mask. The Bryson roundhouse masks sit near game-space
+            // (~4300-4330, 529, 5375-5500); compare gamePos.
+            if (FuseSettings.EnableSceneryCullingDiagnostics)
+            {
+                var srcTransform = source.transform;
+                var extra = source is RectangleMapMask rect
+                    ? $" sizeX={rect.sizeX} sizeZ={rect.sizeZ} deg={rect.degrees}"
+                    : source is CurveMapMask curve
+                        ? $" curveA={curve.positionA} curveB={curve.positionB}"
+                        : string.Empty;
+                FuseLog.Info(
+                    $"FUSE diag map-mask decouple id='{ownerSceneryId}' #{sourceIndex} type='{source.GetType().Name}' " +
+                    $"gamePos={gamePosition} srcWorldPos={srcTransform.position} cloneWorldPos={go.transform.position} " +
+                    $"srcLossyScale={srcTransform.lossyScale} setHeight={source.enableSetHeight} " +
+                    $"cutTrees={source.enableCutTrees} mask='{source.maskName}' radius={source.radius}{extra}.");
+            }
+
             return go;
+        }
+
+        /// <summary>
+        /// Re-anchors an existing standalone mask on a re-decouple (its building streamed back
+        /// in, or the scenery definition changed). If the game-space anchor moved while the mask
+        /// is actively registered, bounce it (OnDisable removes the old modifier, OnEnable
+        /// re-adds at the new anchor); an unchanged anchor leaves the live modifier untouched so
+        /// routine stream-ins never churn the terrain.
+        /// </summary>
+        private static void ReanchorDecoupledMask(GameObject standalone, Vector3 gamePosition)
+        {
+            var marker = standalone.GetComponent<FuseDecoupledMaskMarker>();
+            var moved = marker == null
+                || !marker.HasGamePosition
+                || (marker.GamePosition - gamePosition).sqrMagnitude > 0.0001f;
+            if (marker != null)
+            {
+                marker.GamePosition = gamePosition;
+                marker.HasGamePosition = true;
+            }
+
+            if (!moved)
+            {
+                return;
+            }
+
+            var wasActive = standalone.activeSelf;
+            if (wasActive)
+            {
+                standalone.SetActive(false);
+            }
+
+            PlaceDecoupledMask(standalone.transform, gamePosition);
+            if (wasActive)
+            {
+                standalone.SetActive(true);
+            }
+        }
+
+        /// <summary>
+        /// Places a standalone mask so the modifier its OnEnable registers lands at
+        /// <paramref name="gamePosition"/> EXACTLY. MapManager converts a World-space
+        /// registration to game space by subtracting its private <c>_gameToWorldOffset</c>
+        /// (AddModifier: <c>OffsetBy(-_gameToWorldOffset)</c>), so the clone is placed at
+        /// gamePosition + that same offset: the round-trip cancels by construction, in the same
+        /// synchronous frame, regardless of the floating-origin rebase state of anything else.
+        /// Must be called (re-)placing the mask BEFORE each SetActive(true).
+        /// </summary>
+        private static void PlaceDecoupledMask(Transform standalone, Vector3 gamePosition)
+        {
+            standalone.position = gamePosition + MapManagerGameToWorldOffset();
+        }
+
+        private static Vector3 MapManagerGameToWorldOffset()
+        {
+            try
+            {
+                var instance = MapManagerInstanceProperty?.GetValue(null);
+                if (instance != null && MapManagerGameToWorldOffsetField != null)
+                {
+                    return (Vector3)MapManagerGameToWorldOffsetField.GetValue(instance);
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not read MapManager's game-to-world offset: {ex.GetBaseException().Message}; " +
+                    "falling back to the WorldTransformer offset.");
+            }
+
+            // Fallback: the WorldTransformer's current offset (GameToWorld(0) == offset). It
+            // matches MapManager's whenever the two are in sync, which is the steady state.
+            return Helpers.WorldTransformer.GameToWorld(Vector3.zero);
+        }
+
+        /// <summary>
+        /// GAME-space position of a welded mask, computed from rebase-invariant inputs only.
+        /// The floating-origin rebase (Helpers.WorldTransformer) is a pure translation applied
+        /// to whole root objects, so: (a) the welded mask and its scenery root are in the same
+        /// hierarchy and therefore always in the same rebase state — their world-position delta
+        /// carries no offset in ANY state; and (b) the scenery root's LOCAL position under its
+        /// container is the authored game position (SceneryAPI parents with
+        /// <c>SetParent(parent, false)</c> and writes the definition position to localPosition),
+        /// and a parent translation never changes a child's localPosition. Their sum is the
+        /// mask's game position before the first MoveWorld, after it, and in any half-applied
+        /// window in between — which is what makes the modifier registration race-proof.
+        /// </summary>
+        internal static Vector3 ComputeMaskGamePosition(
+            Vector3 sceneryRootLocalPosition,
+            Vector3 sceneryRootWorldPosition,
+            Vector3 maskWorldPosition)
+        {
+            return sceneryRootLocalPosition + (maskWorldPosition - sceneryRootWorldPosition);
+        }
+
+        private static bool _warnedNonIdentityMaskParent;
+
+        private static void WarnIfParentBreaksGameSpaceAssumptions(Transform parent, string role)
+        {
+            if (_warnedNonIdentityMaskParent || parent == null)
+            {
+                return;
+            }
+
+            var rotated = Quaternion.Angle(parent.rotation, Quaternion.identity) > 0.5f;
+            var scaled = (parent.lossyScale - Vector3.one).sqrMagnitude > 0.0001f;
+            if (!rotated && !scaled)
+            {
+                return;
+            }
+
+            _warnedNonIdentityMaskParent = true;
+            FuseLog.Warning(
+                $"FUSE decoupled-mask anchoring assumes the {role} '{GetTransformPath(parent)}' has identity " +
+                $"rotation and unit scale, but it has rotation={parent.rotation.eulerAngles} " +
+                $"lossyScale={parent.lossyScale}. Decoupled terrain masks may be mis-anchored on this map.");
         }
 
         private static void CopyCommonMaskFields(MapMaskBase source, MapMaskBase destination)
@@ -617,6 +866,45 @@ namespace FUSE.Runtime.API
         {
             public string OwnerSceneryId;
             public int SourceIndex;
+
+            /// <summary>
+            /// The mask's anchor in GAME space (offset-independent, the space MapManager stores
+            /// modifiers in). Every (re)activation re-places the standalone from this before its
+            /// OnEnable registers the modifier, so registration is immune to floating-origin
+            /// rebases that happened while the mask was inactive.
+            /// </summary>
+            public Vector3 GamePosition;
+            public bool HasGamePosition;
+
+            /// <summary>
+            /// Self-heal for activation paths that bypass FUSE's explicit re-anchoring (e.g. an
+            /// ANCESTOR of the mask root being toggled re-fires every child OnEnable directly).
+            /// If the transform drifted off the anchor, re-place it and re-register any sibling
+            /// mask that already self-applied from the stale pose. On FUSE's own activation
+            /// paths the transform was just placed, so this is a cheap no-op.
+            /// </summary>
+            private void OnEnable()
+            {
+                if (!HasGamePosition)
+                {
+                    return;
+                }
+
+                var expected = GamePosition + MapManagerGameToWorldOffset();
+                if ((transform.position - expected).sqrMagnitude <= 0.0001f)
+                {
+                    return;
+                }
+
+                transform.position = expected;
+                foreach (var mask in GetComponents<MapMaskBase>())
+                {
+                    if (mask != null && mask.enabled)
+                    {
+                        mask.Rebuild();
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -688,6 +976,13 @@ namespace FUSE.Runtime.API
                 }
 
                 go.SetActive(false);
+                // Detach before the (end-of-frame) Destroy. A same-frame re-decouple — the
+                // UpdateScenery/reload-reapply path calls RemoveDecoupledMasksFor and then
+                // DecoupleAttachedMapMasks in one frame — must never find this destroy-pending
+                // clone via FindDecoupledMask: "reusing" it skips the re-clone, the welded mask
+                // is disabled regardless, and when the Destroy lands the scenery has NO mask at
+                // all — a flatten loss no terrain rebuild can recover.
+                go.transform.SetParent(null);
                 UnityEngine.Object.Destroy(go);
             }
 
@@ -777,9 +1072,13 @@ namespace FUSE.Runtime.API
         /// <c>forceRenderingOff</c> is ignored on purpose: the culler parks a resident model with
         /// <c>forceRenderingOff = true</c> while leaving <c>enabled</c>/active set, so a culled
         /// building still reads Visible and KEEPS its mask.</item>
-        /// <item>Renderers present but none enabled &amp; active =&gt; a pack disabled
-        /// (<c>renderer.enabled = false</c>) or deactivated every renderer =&gt;
-        /// <see cref="DecoupledMaskVisibility.Hidden"/> (drop the mask).</item>
+        /// <item>At least one holder active but none drawing — the culler set
+        /// <c>renderer.enabled = false</c> for the resident distance band / off-screen =&gt;
+        /// <see cref="DecoupledMaskVisibility.Indeterminate"/> (KEEP: the culler owns
+        /// <c>renderer.enabled</c>, so disabled-but-active is a cull, not a hide).</item>
+        /// <item>EVERY holder inactive — a pack/progression <c>SetActive(false)</c>, the one
+        /// hide the culler never performs =&gt; <see cref="DecoupledMaskVisibility.Hidden"/>
+        /// (drop the mask so a hidden building leaves no flat patch).</item>
         /// </list>
         /// </summary>
         internal static DecoupledMaskVisibility ClassifyMaskVisibility(IReadOnlyList<SceneryRendererVisibility> renderers)
@@ -789,6 +1088,7 @@ namespace FUSE.Runtime.API
                 return DecoupledMaskVisibility.Indeterminate;
             }
 
+            var anyActiveHolder = false;
             for (var index = 0; index < renderers.Count; index++)
             {
                 var renderer = renderers[index];
@@ -796,9 +1096,24 @@ namespace FUSE.Runtime.API
                 {
                     return DecoupledMaskVisibility.Visible;
                 }
+
+                if (renderer.ActiveInHierarchy)
+                {
+                    anyActiveHolder = true;
+                }
             }
 
-            return DecoupledMaskVisibility.Hidden;
+            // No renderer is currently drawing. The game's culler OWNS renderer.enabled — it
+            // rewrites enabled = (isVisible && distanceBand < 2) on every CullingSphereStateChanged,
+            // so a renderer disabled while its holder is still ACTIVE was turned off by the culler
+            // (resident-but-invisible distance band, or off-screen), NOT by a pack hiding the
+            // building. Keep the decoupled mask there — that is the whole reason it was decoupled.
+            // Only when EVERY holder is inactive (a pack/progression SetActive(false) — the one
+            // intentional-hide mechanism the culler never performs) do we drop it, so a genuinely
+            // hidden building leaves no flat patch behind.
+            return anyActiveHolder
+                ? DecoupledMaskVisibility.Indeterminate
+                : DecoupledMaskVisibility.Hidden;
         }
 
         /// <summary>
@@ -855,6 +1170,13 @@ namespace FUSE.Runtime.API
                 if (go.activeSelf == active)
                 {
                     continue;
+                }
+
+                // Re-anchor before activating: a floating-origin rebase may have happened while
+                // the mask was dropped, and OnEnable registers the modifier from the transform.
+                if (active && marker.HasGamePosition)
+                {
+                    PlaceDecoupledMask(child, marker.GamePosition);
                 }
 
                 go.SetActive(active);

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -543,7 +543,10 @@ namespace FUSE.Runtime.API
             // never re-bake an already-built tile (the spawn/roundhouse tile stays unmasked). Ask
             // the rebaker to re-bake the touched tiles once the decouple burst settles: targeted
             // (terrain-only, no scenery re-stream) and coalesced (one pass for the whole burst).
-            if (haveUnion)
+            // Only when something NEW was decoupled: a routine stream-in that merely reuses
+            // existing standalones changed no modifiers, and masked buildings stream in and out
+            // constantly now that they cull like ordinary scenery.
+            if (decoupled > 0 && haveUnion)
             {
                 FUSE.Runtime.Lifecycle.FuseDecoupledMaskTerrainRebaker.Request(union);
             }

--- a/FUSE/Runtime/API/SceneryAPI.cs
+++ b/FUSE/Runtime/API/SceneryAPI.cs
@@ -76,28 +76,49 @@ namespace FUSE.Runtime.API
             // correctly falls into AddScenery for a brand-new entity.
             var marker = gameObject.AddComponent<FuseSceneryMarker>();
             marker.Id = id;
-            // Tag mask-bearing scenery. Three behaviours key off this: (1) the cull debounce
-            // pins it loaded+rendered (a safety net), (2) the OnDidLoadModels hook below re-homes
-            // its welded map masks into standalone, always-active objects the moment the model
-            // streams in (MapAPI.DecoupleAttachedMapMasks) — the real fix, so the terrain mask
-            // survives the building streaming out/in and teleport world-shifts, and (3) a
-            // visibility watcher (FuseDecoupledMaskVisibilityWatcher) drops that standalone mask
-            // while the building is intentionally hidden (renderers disabled) and restores it when
-            // shown, so a hidden building never leaves a flat patch of ground behind.
+            // Tag mask-bearing scenery. Three behaviours key off this: (1) the load throttle
+            // is bypassed so its first load — which registers the terrain flatten/cut — is
+            // immediate, (2) the OnDidLoadModels hook below re-homes its welded map masks into
+            // standalone, always-active objects the moment the model streams in
+            // (MapAPI.DecoupleAttachedMapMasks) so the terrain mask survives the building
+            // streaming out/in and teleport world-shifts, and (3) a visibility watcher
+            // (FuseDecoupledMaskVisibilityWatcher) drops that standalone mask only while the
+            // building is intentionally hidden (every renderer holder SetActive(false)) and
+            // restores it when shown, so a hidden building never leaves a flat patch of ground
+            // behind. The building MODEL itself culls like any other scenery — only its
+            // terrain contribution is permanent.
+            //
+            // The declared-component check covers masks declared in the definition, but ALW-style
+            // packs WELD masks into the prefab with an empty "components" declaration. So the hook
+            // ALWAYS runs and, on first model load, inspects the real prefab: if a map-mask
+            // component is welded in, the scenery is upgraded to mask-bearing here so it is
+            // decoupled all the same.
             marker.IsMaskBearing = FuseSceneryDeferralClassifier.HasMaskComponent(assetIdentifier);
-            if (marker.IsMaskBearing)
             {
                 var sceneryRoot = gameObject;
                 var sceneryId = id;
-                scenery.OnDidLoadModels += _ =>
+                var sceneryMarker = marker;
+                scenery.OnDidLoadModels += model =>
                 {
                     try
                     {
-                        MapAPI.DecoupleAttachedMapMasks(sceneryRoot, sceneryId);
-                        // Keep the just-decoupled mask in step with the building's visibility: if the
-                        // model streamed in already hidden, drop the mask now; otherwise watch for it
-                        // being hidden/shown later.
-                        FuseDecoupledMaskVisibilityWatcher.Ensure(sceneryRoot, sceneryId);
+                        if (!sceneryMarker.IsMaskBearing && ModelHasWeldedMaskComponent(model))
+                        {
+                            sceneryMarker.IsMaskBearing = true;
+                            FuseLog.Info(
+                                $"FUSE upgraded scenery '{sceneryId}' to mask-bearing: a map-mask component is " +
+                                "welded into the loaded prefab but not declared in the definition. Its mask will " +
+                                "be decoupled to a standalone object so the terrain survives streaming and teleports.");
+                        }
+
+                        if (sceneryMarker.IsMaskBearing)
+                        {
+                            MapAPI.DecoupleAttachedMapMasks(sceneryRoot, sceneryId);
+                            // Keep the just-decoupled mask in step with the building's visibility: if the
+                            // model streamed in already hidden, drop the mask now; otherwise watch for it
+                            // being hidden/shown later.
+                            FuseDecoupledMaskVisibilityWatcher.Ensure(sceneryRoot, sceneryId);
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -120,6 +141,32 @@ namespace FUSE.Runtime.API
             FuseSceneryRuntimeIndex.Instance.Set(id, scenery);
             FuseApiPersistence.RecordDefinition(FuseDefinitionKind.Scenery, id, definition);
             return scenery;
+        }
+
+        // Detects a map-mask component WELDED into a loaded scenery prefab — as opposed to one
+        // declared in the definition, which FuseSceneryDeferralClassifier.HasMaskComponent already
+        // covers. ALW-style packs ship the mask inside the prefab with an empty component
+        // declaration, so the only reliable signal is the live model. Reuses the same pure
+        // type-name check the declared path uses; one bounded GetComponentsInChildren pass per load.
+        private static bool ModelHasWeldedMaskComponent(Transform model)
+        {
+            if (model == null)
+            {
+                return false;
+            }
+
+            var behaviours = model.GetComponentsInChildren<MonoBehaviour>(true);
+            for (var index = 0; index < behaviours.Length; index++)
+            {
+                var behaviour = behaviours[index];
+                if (behaviour != null &&
+                    FuseSceneryDeferralClassifier.IsMaskTypeName(behaviour.GetType().FullName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/FUSE/Runtime/API/SceneryAPI.cs
+++ b/FUSE/Runtime/API/SceneryAPI.cs
@@ -137,11 +137,12 @@ namespace FUSE.Runtime.API
         {
             public string Id;
 
-            // True when this scenery declares a map-mask component. The cull debounce
-            // (FuseSceneryCullingDebouncePatch) reads this to hold mask-bearing scenery
-            // resident at any distance — it must never unload, because the game does not
-            // reliably reload masked scenery after a teleport (and a missed reload also
-            // drops its baked terrain mask). Set once at AddScenery time.
+            // True when this scenery declares a map-mask component. Drives the mask
+            // decouple/visibility lifecycle (DecoupleAttachedMapMasks + the visibility
+            // watcher) and the load-throttle bypass so the first load — which registers the
+            // terrain flatten/cut — is immediate. The building model itself culls like any
+            // other scenery; only its terrain contribution is permanent. Set once at
+            // AddScenery time.
             public bool IsMaskBearing;
         }
 

--- a/FUSE/Runtime/API/SceneryAPI.cs
+++ b/FUSE/Runtime/API/SceneryAPI.cs
@@ -87,38 +87,20 @@ namespace FUSE.Runtime.API
             // restores it when shown, so a hidden building never leaves a flat patch of ground
             // behind. The building MODEL itself culls like any other scenery — only its
             // terrain contribution is permanent.
-            //
-            // The declared-component check covers masks declared in the definition, but ALW-style
-            // packs WELD masks into the prefab with an empty "components" declaration. So the hook
-            // ALWAYS runs and, on first model load, inspects the real prefab: if a map-mask
-            // component is welded in, the scenery is upgraded to mask-bearing here so it is
-            // decoupled all the same.
             marker.IsMaskBearing = FuseSceneryDeferralClassifier.HasMaskComponent(assetIdentifier);
+            if (marker.IsMaskBearing)
             {
                 var sceneryRoot = gameObject;
                 var sceneryId = id;
-                var sceneryMarker = marker;
-                scenery.OnDidLoadModels += model =>
+                scenery.OnDidLoadModels += _ =>
                 {
                     try
                     {
-                        if (!sceneryMarker.IsMaskBearing && ModelHasWeldedMaskComponent(model))
-                        {
-                            sceneryMarker.IsMaskBearing = true;
-                            FuseLog.Info(
-                                $"FUSE upgraded scenery '{sceneryId}' to mask-bearing: a map-mask component is " +
-                                "welded into the loaded prefab but not declared in the definition. Its mask will " +
-                                "be decoupled to a standalone object so the terrain survives streaming and teleports.");
-                        }
-
-                        if (sceneryMarker.IsMaskBearing)
-                        {
-                            MapAPI.DecoupleAttachedMapMasks(sceneryRoot, sceneryId);
-                            // Keep the just-decoupled mask in step with the building's visibility: if the
-                            // model streamed in already hidden, drop the mask now; otherwise watch for it
-                            // being hidden/shown later.
-                            FuseDecoupledMaskVisibilityWatcher.Ensure(sceneryRoot, sceneryId);
-                        }
+                        MapAPI.DecoupleAttachedMapMasks(sceneryRoot, sceneryId);
+                        // Keep the just-decoupled mask in step with the building's visibility: if the
+                        // model streamed in already hidden, drop the mask now; otherwise watch for it
+                        // being hidden/shown later.
+                        FuseDecoupledMaskVisibilityWatcher.Ensure(sceneryRoot, sceneryId);
                     }
                     catch (Exception ex)
                     {
@@ -141,32 +123,6 @@ namespace FUSE.Runtime.API
             FuseSceneryRuntimeIndex.Instance.Set(id, scenery);
             FuseApiPersistence.RecordDefinition(FuseDefinitionKind.Scenery, id, definition);
             return scenery;
-        }
-
-        // Detects a map-mask component WELDED into a loaded scenery prefab — as opposed to one
-        // declared in the definition, which FuseSceneryDeferralClassifier.HasMaskComponent already
-        // covers. ALW-style packs ship the mask inside the prefab with an empty component
-        // declaration, so the only reliable signal is the live model. Reuses the same pure
-        // type-name check the declared path uses; one bounded GetComponentsInChildren pass per load.
-        private static bool ModelHasWeldedMaskComponent(Transform model)
-        {
-            if (model == null)
-            {
-                return false;
-            }
-
-            var behaviours = model.GetComponentsInChildren<MonoBehaviour>(true);
-            for (var index = 0; index < behaviours.Length; index++)
-            {
-                var behaviour = behaviours[index];
-                if (behaviour != null &&
-                    FuseSceneryDeferralClassifier.IsMaskTypeName(behaviour.GetType().FullName))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         /// <summary>

--- a/FUSE/Runtime/API/TrackAPI.Graph.cs
+++ b/FUSE/Runtime/API/TrackAPI.Graph.cs
@@ -142,6 +142,21 @@ namespace FUSE.Runtime.API
 
                 marker.enabled = false;
 
+                // Also disable any TrackCurveMeshBuilder on the same GameObject. It reads
+                // this marker via GetComponent — DISABLED markers included — and an invalid
+                // location makes its culling-event handler throw INSIDE Unity's
+                // CullingGroup.SendEvents, aborting the whole event batch: every culling
+                // sphere later in that batch silently loses its event, so unrelated scenery
+                // never streams back in after a teleport. Disabling the builder disposes its
+                // culling token (OnDisable), taking the broken handler out of the dispatch.
+                foreach (var builder in marker.GetComponents<TrackCurveMeshBuilder>())
+                {
+                    if (builder != null && builder.enabled)
+                    {
+                        builder.enabled = false;
+                    }
+                }
+
                 // Don't deactivate the GameObject — that kills every other
                 // component on it. TrackMarker is frequently attached to
                 // scenery (water columns, diesel fueling stands, coaling

--- a/FUSE/Runtime/Lifecycle/FuseDecoupledMaskTerrainRebaker.cs
+++ b/FUSE/Runtime/Lifecycle/FuseDecoupledMaskTerrainRebaker.cs
@@ -29,9 +29,17 @@ namespace FUSE.Runtime.Lifecycle
         // quiesced before we fire, short enough to be unnoticeable. Each request pushes it out.
         private const float SettleSeconds = 1.5f;
 
+        // A rebake can fail transiently (e.g. MapManager briefly unavailable). Retry on the
+        // settle cadence rather than silently dropping the burst's only rebake, but give up
+        // after this many re-attempts so a permanent refusal (multiplayer guard, missing
+        // reflection surface) cannot retry forever — the game's own debounced per-modifier
+        // invalidate remains as the slow-path fallback.
+        private const int MaxRetries = 4;
+
         private static FuseDecoupledMaskTerrainRebaker _instance;
 
         private bool _pending;
+        private int _retries;
         private float _fireAtUnscaledTime;
         private bool _haveBounds;
         // GAME space (offset-independent), never world: requests can arrive on both sides of a
@@ -82,6 +90,7 @@ namespace FUSE.Runtime.Lifecycle
             }
 
             self._pending = true;
+            self._retries = 0;
             self._fireAtUnscaledTime = Time.unscaledTime + SettleSeconds;
             if (self._haveBounds)
             {
@@ -108,6 +117,7 @@ namespace FUSE.Runtime.Lifecycle
             }
 
             self._pending = false;
+            self._retries = 0;
             self._haveBounds = false;
             self._gameBounds = default(Bounds);
             FuseLog.Info($"FUSE decoupled-mask terrain rebake request dropped ({reason}).");
@@ -123,17 +133,37 @@ namespace FUSE.Runtime.Lifecycle
             _pending = false;
             var bounds = _gameBounds;
             var hadBounds = _haveBounds;
-            _haveBounds = false;
-            _gameBounds = default(Bounds);
 
+            var succeeded = false;
             try
             {
-                FuseRuntimeReloadService.RebakeDecoupledMaskTerrain(hadBounds ? (Bounds?)bounds : null);
+                succeeded = FuseRuntimeReloadService.RebakeDecoupledMaskTerrain(hadBounds ? (Bounds?)bounds : null);
             }
             catch (Exception ex)
             {
                 FuseLog.Exception("FUSE decoupled-mask terrain rebake failed", ex);
             }
+
+            if (!succeeded && _retries < MaxRetries)
+            {
+                // Keep the accumulated bounds and try again after another settle period; a
+                // Request arriving meanwhile folds in normally (and resets the retry count).
+                _retries++;
+                _pending = true;
+                _fireAtUnscaledTime = Time.unscaledTime + SettleSeconds;
+                return;
+            }
+
+            if (!succeeded)
+            {
+                FuseLog.Warning(
+                    $"FUSE decoupled-mask terrain rebake gave up after {MaxRetries + 1} attempts; " +
+                    "the game's own debounced modifier invalidate will cover the tiles eventually.");
+            }
+
+            _retries = 0;
+            _haveBounds = false;
+            _gameBounds = default(Bounds);
         }
     }
 }

--- a/FUSE/Runtime/Lifecycle/FuseDecoupledMaskTerrainRebaker.cs
+++ b/FUSE/Runtime/Lifecycle/FuseDecoupledMaskTerrainRebaker.cs
@@ -1,0 +1,139 @@
+using System;
+using FUSE.Infrastructure;
+using UnityEngine;
+
+namespace FUSE.Runtime.Lifecycle
+{
+    /// <summary>
+    /// Coalesces a terrain re-bake after FUSE decouples map masks.
+    ///
+    /// Map masks (terrain flatten / tree-cut / object-cut) are continuous MapManager
+    /// modifiers: a tile bakes exactly the modifiers registered when it builds, and only
+    /// re-bakes when invalidated. FUSE's single map-load terrain rebuild fires at the end of
+    /// the apply, BEFORE building models stream in — so the masks FUSE decouples in
+    /// <c>SceneryAssetInstance.OnDidLoadModels</c> register their modifiers AFTER that rebuild.
+    /// The game's own per-modifier invalidate is a 0.5s debounce that is restarted by every
+    /// AddModifier in the streaming burst and is gathered only once per load pass, so a tile
+    /// that already built (e.g. the spawn/roundhouse tile) does not re-evaluate the new masks
+    /// until the whole spawn tile-load backlog drains (~30s observed) — i.e. the flatten/cut
+    /// never visibly applies.
+    ///
+    /// This host waits for the decouple burst (and any world-origin rebase re-bake) to settle,
+    /// then issues ONE targeted invalidate over the union of the touched tiles. Targeted
+    /// (terrain-only) so it never re-streams scenery models — which would re-enter the decouple
+    /// path and loop. Union-coalesced so the burst collapses to a single re-bake.
+    /// </summary>
+    internal sealed class FuseDecoupledMaskTerrainRebaker : MonoBehaviour
+    {
+        // Long enough that the streaming burst (async asset loads, a few per second) has
+        // quiesced before we fire, short enough to be unnoticeable. Each request pushes it out.
+        private const float SettleSeconds = 1.5f;
+
+        private static FuseDecoupledMaskTerrainRebaker _instance;
+
+        private bool _pending;
+        private float _fireAtUnscaledTime;
+        private bool _haveBounds;
+        // GAME space (offset-independent), never world: requests can arrive on both sides of a
+        // floating-origin rebase, and a world-space union across that boundary mixes offset
+        // states — inflating the union by a whole origin block and re-baking kilometres of
+        // terrain that were never touched.
+        private Bounds _gameBounds;
+
+        private static FuseDecoupledMaskTerrainRebaker Instance
+        {
+            get
+            {
+                if (_instance != null)
+                {
+                    return _instance;
+                }
+
+                try
+                {
+                    var host = new GameObject("FUSE Decoupled Mask Terrain Rebaker")
+                    {
+                        hideFlags = HideFlags.HideAndDontSave,
+                    };
+                    UnityEngine.Object.DontDestroyOnLoad(host);
+                    _instance = host.AddComponent<FuseDecoupledMaskTerrainRebaker>();
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception("FUSE could not create the decoupled-mask terrain rebaker host", ex);
+                }
+
+                return _instance;
+            }
+        }
+
+        /// <summary>
+        /// Requests a coalesced terrain re-bake over <paramref name="gameBounds"/> (GAME-space,
+        /// the offset-independent space MapManager stores modifiers and tiles in) once the
+        /// decouple burst settles. Safe to call many times per burst; the bounds union and the
+        /// settle timer absorb it into a single re-bake. Must be called on the main thread.
+        /// </summary>
+        internal static void Request(Bounds gameBounds)
+        {
+            var self = Instance;
+            if (self == null)
+            {
+                return;
+            }
+
+            self._pending = true;
+            self._fireAtUnscaledTime = Time.unscaledTime + SettleSeconds;
+            if (self._haveBounds)
+            {
+                self._gameBounds.Encapsulate(gameBounds);
+            }
+            else
+            {
+                self._gameBounds = gameBounds;
+                self._haveBounds = true;
+            }
+        }
+
+        /// <summary>
+        /// Drops any settling request. Called on map unload: the host is DontDestroyOnLoad, so
+        /// without this a request raised at the end of one map would fire into the teardown (or
+        /// the next map's half-initialized MapManager) with bounds from the wrong map.
+        /// </summary>
+        internal static void Clear(string reason)
+        {
+            var self = _instance;
+            if (self == null || !self._pending)
+            {
+                return;
+            }
+
+            self._pending = false;
+            self._haveBounds = false;
+            self._gameBounds = default(Bounds);
+            FuseLog.Info($"FUSE decoupled-mask terrain rebake request dropped ({reason}).");
+        }
+
+        private void Update()
+        {
+            if (!_pending || Time.unscaledTime < _fireAtUnscaledTime)
+            {
+                return;
+            }
+
+            _pending = false;
+            var bounds = _gameBounds;
+            var hadBounds = _haveBounds;
+            _haveBounds = false;
+            _gameBounds = default(Bounds);
+
+            try
+            {
+                FuseRuntimeReloadService.RebakeDecoupledMaskTerrain(hadBounds ? (Bounds?)bounds : null);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE decoupled-mask terrain rebake failed", ex);
+            }
+        }
+    }
+}

--- a/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
+++ b/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
@@ -265,6 +265,10 @@ namespace FUSE.Runtime.Lifecycle
                 // Cancel any in-flight deferred scenery wave before the scenery
                 // GameObjects it references are destroyed below.
                 FuseDeferredSceneryActivator.CancelAndClear("map unload");
+                // Drop any settling decoupled-mask re-bake: its bounds belong to the map being
+                // torn down, and firing during/after unload would invalidate (or full-rebuild)
+                // a half-initialized MapManager on the next load.
+                FuseDecoupledMaskTerrainRebaker.Clear("map unload");
                 FuseWorldSuppressor.RestoreAll("map unload");
                 FuseEarlyLoader.RestoreOnMapUnload();
                 FuseModLoader.UnloadAll(resetDiscovery: true, restoreTrackSnapshots: false);

--- a/FUSE/Runtime/Lifecycle/FuseRuntimeReloadService.cs
+++ b/FUSE/Runtime/Lifecycle/FuseRuntimeReloadService.cs
@@ -127,5 +127,68 @@ namespace FUSE.Runtime.Lifecycle
                 return false;
             }
         }
+
+        /// <summary>
+        /// Re-bakes terrain after FUSE decoupled map masks that registered AFTER the map-load
+        /// terrain rebuild (masks stream in with their building model and self-apply their
+        /// MapManager modifiers; the game's per-modifier invalidate is debounced and starved
+        /// behind the spawn tile-load backlog, so an already-built tile never re-evaluates them).
+        /// Prefers a targeted invalidate of just the touched tiles (terrain-only, so it never
+        /// re-streams scenery and cannot re-enter the decouple path); falls back to a full
+        /// rebuild only if the targeted reflection surface is unavailable. Called, coalesced,
+        /// by <see cref="FuseDecoupledMaskTerrainRebaker"/> once the decouple burst settles.
+        /// </summary>
+        public static bool RebakeDecoupledMaskTerrain(Bounds? gameBounds)
+        {
+            const string operation = "decoupled-mask post-stream terrain rebake";
+            if (!FuseMultiplayerGuard.CanApplyWorldMutations(operation))
+            {
+                return false;
+            }
+
+            try
+            {
+                var instance = MapManagerInstance?.GetValue(null);
+                if (instance == null)
+                {
+                    return false;
+                }
+
+                // The footprint arrives already in GAME space — the offset-independent space
+                // MapManager.Invalidate(Bounds) tiles in and modifiers are stored in (AddModifier
+                // does OffsetBy(-gameToWorldOffset)). No conversion here: converting at fire time
+                // through a live offset would shift bounds that were captured before a
+                // floating-origin rebase by a whole origin block.
+                if (MapManagerInvalidateBounds != null && gameBounds.HasValue)
+                {
+                    try
+                    {
+                        MapManagerInvalidateBounds.Invoke(instance, new object[] { gameBounds.Value });
+                        FuseLog.Info(
+                            $"FUSE {operation} (targeted invalidate) gameBounds.center={gameBounds.Value.center} size={gameBounds.Value.size}.");
+                        return true;
+                    }
+                    catch (Exception ex)
+                    {
+                        FuseLog.Warning(
+                            $"FUSE {operation} targeted invalidate failed: {ex.GetBaseException().Message}; falling back to full rebuild.");
+                    }
+                }
+
+                if (MapManagerRebuildAll != null)
+                {
+                    MapManagerRebuildAll.Invoke(instance, null);
+                    FuseLog.Info($"FUSE {operation} (full rebuild).");
+                    return true;
+                }
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning($"FUSE {operation} failed: {ex.GetBaseException().Message}");
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem

At Bryson with the ALW/EF&A packs, masked buildings showed a cluster of symptoms: buildings and the turntable never re-streamed after teleporting away and back, the manual terrain reload permanently erased the decoupled terrain masks, teleports left kilometres of terrain re-baking for no reason, and mask-bearing buildings were never culled at all.

## Root causes & fixes

1. **Culling event batches were being poisoned.** A `TrackCurveMeshBuilder` sitting on a track marker invalidated by pack track edits throws from its culling-event handler inside Unity's `CullingGroup.SendEvents`, which aborts the whole batch — every later culling sphere silently loses its re-load/re-show event, so most scenery never streams back in after a teleport. `DisableInvalidTrackMarkers` now also disables the crash-prone sibling builders (disposing their culling tokens), and a new Harmony finalizer (`FuseCurveMeshCullingGuardPatch`) contains any remaining curve-mesh handler exception so one broken mesh costs itself, not the map.

2. **The reload path destroyed its own masks.** `RemoveDecoupledMasksFor` schedules a deferred `Destroy`; the same-frame re-decouple then found the destroy-pending clone via `FindDecoupledMask`, "reused" it, and disabled the welded mask — leaving the scenery with no mask at all once the destroy landed. No terrain rebuild can recover from that, which is why reloads appeared to make things worse. Clones now detach from the mask root before `Destroy`.

3. **Rebake footprints mixed floating-origin states.** A decouple burst regularly straddles the spawn world-rebase; unioning absolute world positions across that boundary inflated the rebake bounds by a whole origin block (observed 4 km x 5 km), mass-invalidating terrain — the "everything loads slower" symptom. Footprints are now computed rebase-invariantly per mask (`ComputeMaskGamePosition`, unit-tested), carried in game space end-to-end with no fire-time conversion, cover curve-mask endpoints, and pending rebakes are dropped on map unload.

4. **The mask-bearing band-0 cull pin is removed.** It was an explicit safety net from before decoupling was verified; it kept every mask-bearing building (now including whole roundhouse complexes) permanently loaded and rendered. With masks decoupled to standalone objects and re-streaming reliable (fix 1), masked buildings cull like any other scenery — only their terrain contribution is permanent. The first-load throttle bypass stays, since the first load is what registers the terrain mask.

5. **A culled building no longer drops its mask.** The game's culler owns `renderer.enabled` and parks resident-but-far models with it; `ClassifyMaskVisibility` now treats disabled-but-active holders as a cull (keep the mask) and only an all-inactive holder set as an intentional hide (drop it). This is load-bearing once the pin is gone.

The second commit removes ~270 lines of clone re-anchoring machinery that had been built against a suspected mask-misplacement bug; runtime evidence showed registrations were always correct (the scenery chain and the map system's offset update atomically on a rebase), so the machinery guarded against a bug that does not exist.

## Verification

- Build clean; 1253 unit tests pass (new coverage: rebase-invariant footprint math, cull-vs-hide visibility classification).
- In-game at Bryson: masks register at correct game positions on both sides of the spawn rebase, rebake bounds collapsed from ~4 km to ~200 m, zero culling exceptions in the player log, and buildings re-stream after teleport-away-and-back.
- In-game checklist for this PR: masked buildings cull out beyond ~3 km and re-stream on return; flattened/cleared ground persists while the building is streamed out; FUSE health-page terrain/track reloads no longer lose masks.