### PR TITLE
chore(actions): persist-credentials hardening + exact SHA-pin comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # No step in this job pushes back to the repo, so don't leave the
+          # checkout token persisted in .git/config on the runner.
+          persist-credentials: false
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: "10.0.x"
 
@@ -71,7 +75,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results
           path: FUSE.Tests/TestResults/test-results.trx
@@ -200,7 +204,7 @@ jobs:
 
       - name: Upload EditMode test results
         if: always() && steps.editmode_gate.outputs.enabled == 'true' && steps.unity_probe.outputs.available == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unity-editmode-results
           path: FUSE.UnityTests/TestResults/editmode-results.xml
@@ -293,7 +297,7 @@ jobs:
 
       - name: Upload build artifact
         id: build_upload
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.build_id.outputs.archive }}
           path: ${{ steps.build_id.outputs.archive }}
@@ -305,7 +309,7 @@ jobs:
       # in place rather than spamming the conversation.
       - name: Post / update PR comment with download link
         if: github.event_name == 'pull_request' && success()
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: pr-build-artifact
           message: |
@@ -340,10 +344,14 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: "1"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # No step in this job pushes back to the repo, so don't leave the
+          # checkout token persisted in .git/config on the runner.
+          persist-credentials: false
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: "10.0.x"
 
@@ -369,7 +377,7 @@ jobs:
 
       - name: Upload editor publish artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuse-external-editor
           path: publish/
@@ -377,7 +385,7 @@ jobs:
 
       - name: Upload net10 test results
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: net10-test-results
           path: TestResults/*.trx

--- a/.github/workflows/dotnet-lint.yml
+++ b/.github/workflows/dotnet-lint.yml
@@ -25,10 +25,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # No step in this job pushes back to the repo, so don't leave the
+          # checkout token persisted in .git/config on the runner.
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
 

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -26,10 +26,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # No step in this job pushes back to the repo, so don't leave the
+          # checkout token persisted in .git/config on the runner.
+          # tools/json_lint.py only needs read-only `git ls-files`.
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
 

--- a/.github/workflows/release-externaleditor.yml
+++ b/.github/workflows/release-externaleditor.yml
@@ -33,14 +33,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # This lane never pushes back to the repo, so don't leave the
           # checkout token persisted in .git/config on the runner.
           persist-credentials: false
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: "10.0.x"
 
@@ -90,7 +90,7 @@ jobs:
           }
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           name: FUSE External Editor v${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # This lane only builds and publishes release assets (via the
+          # GITHUB_TOKEN env the release action receives directly); nothing
+          # pushes back to the repo, so don't leave the checkout token
+          # persisted in .git/config on the self-hosted runner.
+          persist-credentials: false
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: "10.0.x"
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -183,7 +189,7 @@ jobs:
         run: python tools/build_folder_converter_pyz.py
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           name: FUSE v${{ steps.version.outputs.version }}

--- a/.github/workflows/sync-info-json.yml
+++ b/.github/workflows/sync-info-json.yml
@@ -22,12 +22,17 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 # zizmor: ignore[artipacked]
         with:
           ref: main
           # Default GITHUB_TOKEN can push back to main; branch protections
           # that require PRs will block this and need a separate token.
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Deliberately persisted (the checkout default): the final step
+          # commits and pushes FUSE/Info.json back to main with this token.
+          # Every other workflow in the repo sets persist-credentials: false;
+          # this is the one lane that needs write access after checkout.
+          persist-credentials: true
 
       - name: Parse semantic version from release tag
         id: version


### PR DESCRIPTION
Closes #87.

## What

The SHA pinning half of #87 was already on `main` (landed alongside the PR #84 review follow-up), with every `uses:` in `.github/workflows/` pinned to a 40-char commit SHA. This PR finishes the issue:

1. **`persist-credentials: false` on every checkout that does not push** — `ci.yml` (both `build` and `build-net10` jobs), `dotnet-lint.yml`, `json-lint.yml`, `release.yml`. (`release-externaleditor.yml` already had it.)
2. **Explicit, documented exemption for the one checkout that must keep credentials** — `sync-info-json.yml` pushes `FUSE/Info.json` back to `main` in its final step, so its checkout now sets `persist-credentials: true` explicitly with a `# zizmor: ignore[artipacked]` suppression and a comment explaining why.
3. **SHA-pin comments upgraded from floating majors to exact releases** (`# v6` → `# v6.0.3`, etc.), so the comment unambiguously states what is pinned. Every SHA↔version mapping was verified against the upstream repos:

| Action | Pinned SHA | Release |
|---|---|---|
| `actions/checkout` | `df4cb1c` | v6.0.3 |
| `actions/setup-dotnet` | `9a946fd` | v5.3.0 |
| `actions/setup-python` | `a309ff8` | v6.2.0 |
| `actions/upload-artifact` | `043fb46` | v7.0.1 |
| `marocchino/sticky-pull-request-comment` | `0ea0beb` | v3.0.4 |
| `softprops/action-gh-release` | `b430933` | v3.0.0 |
| `Nexus-Mods/upload-action` | `0bf670d` | v1.0.0-beta.7 |

Note: the `sticky-pull-request-comment` pin is *ahead* of the floating `v3` tag (upstream has not advanced the major tag to v3.0.4), which is why its old `# v3` comment looked mismatched — the pin itself was already the newest release.

## Verification

- `zizmor 1.25.2` (default persona): **zero `unpinned-uses` and zero `artipacked` findings** across `.github/workflows/`. The auditor persona confirms the `ignore[artipacked]` directive suppresses the intentional exemption.
- All six workflow files parse as valid YAML.
- Traced every downstream step of each hardened workflow (including `tools/*.py`, `tools/*.ps1`, `scripts/*`): nothing needs authenticated git after checkout. `json_lint.py` uses read-only `git ls-files`; the release/sticky-comment actions receive `GITHUB_TOKEN` via inputs/env, not from `.git/config`.

## Out of scope (pre-existing zizmor findings)

`template-injection` in several `run:` blocks, workflow-level `excessive-permissions`, and `secrets-outside-env` predate this change and are not part of #87. The issue's suggested Dependabot automation is already configured (`.github/dependabot.yml` covers the `github-actions` ecosystem and will keep both the SHA and the version comment current).