### PR TITLE
perf(track): batch id allocation in TrackGenerators.Commit

### DIFF
--- a/FUSE.Core.Tests/TrackGeneratorsCommitTests.cs
+++ b/FUSE.Core.Tests/TrackGeneratorsCommitTests.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using Fuse.Core.Authoring;
+using Fuse.Core.Geometry;
+using Fuse.Core.Model;
+using Xunit;
+
+namespace Fuse.Core.Tests;
+
+/// <summary>
+/// Id assignment by <see cref="TrackGenerators.Commit"/>. The batched allocator must keep
+/// the original first-free-slot semantics (gaps filled, then sequential) while building the
+/// taken-id set only once per commit instead of once per minted id.
+/// </summary>
+public class TrackGeneratorsCommitTests
+{
+    [Fact]
+    public void Commit_Into_Empty_Definition_Assigns_Sequential_Ids()
+    {
+        var tracks = new FuseTrackDefinition();
+        var generated = TrackGenerators.Straight(0, 0, 0, 0, length: 100, nSegments: 4);
+
+        var (nodeIds, segmentIds) = TrackGenerators.Commit(tracks, generated);
+
+        Assert.Equal(new[] { "n_0001", "n_0002", "n_0003", "n_0004", "n_0005" }, nodeIds);
+        Assert.Equal(new[] { "s_0001", "s_0002", "s_0003", "s_0004" }, segmentIds);
+    }
+
+    [Fact]
+    public void Commit_Fills_Gaps_Then_Continues_Past_Existing_Ids()
+    {
+        var tracks = new FuseTrackDefinition();
+        TrackOps.AddNode(tracks, "n_0001", default, default);
+        TrackOps.AddNode(tracks, "n_0003", default, default);
+        TrackOps.ConnectSegment(tracks, "s_0002", "n_0001", "n_0003");
+
+        var generated = TrackGenerators.Straight(0, 0, 0, 0, length: 60, nSegments: 2);
+
+        var (nodeIds, segmentIds) = TrackGenerators.Commit(tracks, generated);
+
+        Assert.Equal(new[] { "n_0002", "n_0004", "n_0005" }, nodeIds);
+        Assert.Equal(new[] { "s_0001", "s_0003" }, segmentIds);
+    }
+
+    [Fact]
+    public void Commit_Wires_Segments_To_Minted_Node_Ids()
+    {
+        var tracks = new FuseTrackDefinition();
+        TrackOps.AddNode(tracks, "n_0001", default, default);
+
+        var generated = TrackGenerators.Turnout(0, 0, 0, 0);
+
+        var (nodeIds, segmentIds) = TrackGenerators.Commit(tracks, generated);
+
+        Assert.Equal(generated.Nodes.Count, nodeIds.Count);
+        Assert.Equal(generated.Segments.Count, segmentIds.Count);
+        for (var i = 0; i < generated.Segments.Count; i++)
+        {
+            var seg = tracks.Segments[segmentIds[i]];
+            Assert.Equal(nodeIds[generated.Segments[i].StartIndex], seg.StartNodeId);
+            Assert.Equal(nodeIds[generated.Segments[i].EndIndex], seg.EndNodeId);
+        }
+    }
+
+    [Fact]
+    public void Commit_Of_Large_Chain_Assigns_Unique_Sequential_Ids()
+    {
+        var tracks = new FuseTrackDefinition();
+        var generated = TrackGenerators.Straight(0, 0, 0, 0, length: 10000, nSegments: 2000);
+
+        var (nodeIds, segmentIds) = TrackGenerators.Commit(tracks, generated);
+
+        Assert.Equal(2001, new HashSet<string>(nodeIds).Count);
+        Assert.Equal(2000, new HashSet<string>(segmentIds).Count);
+        Assert.Equal("n_0001", nodeIds[0]);
+        Assert.Equal("n_2001", nodeIds[2000]);
+        Assert.Equal("s_2000", segmentIds[1999]);
+    }
+}

--- a/FUSE.Core.Tests/TrackOpsTests.cs
+++ b/FUSE.Core.Tests/TrackOpsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Fuse.Core.Authoring;
 using Fuse.Core.Model;
 using Xunit;
@@ -65,5 +66,76 @@ public class TrackOpsTests
 
         Assert.NotEqual(id1, id2);
         Assert.False(tracks.Nodes.ContainsKey(id2));
+    }
+
+    [Fact]
+    public void Batch_Ids_Match_Repeated_Single_Shot_Calls()
+    {
+        var single = new FuseTrackDefinition();
+        var batch = new FuseTrackDefinition();
+        foreach (var id in new[] { "n_0001", "n_0003", "n_0004", "unrelated" })
+        {
+            TrackOps.AddNode(single, id, default, default);
+            TrackOps.AddNode(batch, id, default, default);
+        }
+
+        var takenIds = new HashSet<string>(batch.Nodes.Keys);
+        var nextIndex = 1;
+        var minted = new List<string>();
+        for (var i = 0; i < 5; i++)
+        {
+            var expected = TrackOps.NewNodeId(single);
+            TrackOps.AddNode(single, expected, default, default);
+
+            var actual = TrackOps.NewNodeId(takenIds, ref nextIndex);
+            TrackOps.AddNode(batch, actual, default, default);
+
+            Assert.Equal(expected, actual);
+            minted.Add(actual);
+        }
+
+        // Gap at n_0002 is filled first, then the sequence continues past the taken ids.
+        Assert.Equal(new[] { "n_0002", "n_0005", "n_0006", "n_0007", "n_0008" }, minted);
+    }
+
+    [Fact]
+    public void Batch_Segment_Ids_Use_Segment_Prefix_And_Update_Set()
+    {
+        var takenIds = new HashSet<string> { "s_0001" };
+        var nextIndex = 1;
+
+        var first = TrackOps.NewSegmentId(takenIds, ref nextIndex);
+        var second = TrackOps.NewSegmentId(takenIds, ref nextIndex);
+
+        Assert.Equal("s_0002", first);
+        Assert.Equal("s_0003", second);
+        Assert.Contains("s_0002", takenIds);
+        Assert.Contains("s_0003", takenIds);
+    }
+
+    [Fact]
+    public void Batch_Ids_Widen_Past_9999()
+    {
+        var takenIds = new HashSet<string>();
+        for (var i = 1; i <= 9999; i++)
+        {
+            takenIds.Add($"n_{i:D4}");
+        }
+
+        var nextIndex = 1;
+
+        Assert.Equal("n_10000", TrackOps.NewNodeId(takenIds, ref nextIndex));
+        Assert.Equal("n_10001", TrackOps.NewNodeId(takenIds, ref nextIndex));
+        Assert.Contains("n_10001", takenIds);
+    }
+
+    [Fact]
+    public void Batch_Cursor_Below_One_Is_Clamped()
+    {
+        var takenIds = new HashSet<string>();
+        var nextIndex = -3;
+
+        Assert.Equal("n_0001", TrackOps.NewNodeId(takenIds, ref nextIndex));
+        Assert.Equal(1, nextIndex);
     }
 }

--- a/FUSE.Core.Tests/TrackOpsTests.cs
+++ b/FUSE.Core.Tests/TrackOpsTests.cs
@@ -136,6 +136,8 @@ public class TrackOpsTests
         var nextIndex = -3;
 
         Assert.Equal("n_0001", TrackOps.NewNodeId(takenIds, ref nextIndex));
-        Assert.Equal(1, nextIndex);
+        // The cursor is clamped to 1, then advanced past the minted slot.
+        Assert.Equal(2, nextIndex);
+        Assert.Equal("n_0002", TrackOps.NewNodeId(takenIds, ref nextIndex));
     }
 }

--- a/FUSE.Core/Authoring/TrackOps.cs
+++ b/FUSE.Core/Authoring/TrackOps.cs
@@ -165,6 +165,8 @@ namespace Fuse.Core.Authoring
                 id = $"{prefix}_{nextIndex:D4}";
             }
 
+            // Leave the cursor past the minted slot so the next call doesn't re-test it.
+            nextIndex++;
             return id;
         }
     }

--- a/FUSE.Core/Authoring/TrackOps.cs
+++ b/FUSE.Core/Authoring/TrackOps.cs
@@ -129,16 +129,43 @@ namespace Fuse.Core.Authoring
 
         public static string NewSegmentId(FuseTrackDefinition tracks) => UniqueId(tracks.Segments.Keys, "s");
 
+        /// <summary>
+        /// Batch variant of <see cref="NewNodeId(FuseTrackDefinition)"/> for callers minting many
+        /// ids in one operation: build <paramref name="takenIds"/> from <c>tracks.Nodes.Keys</c>
+        /// once, start <paramref name="nextIndex"/> at 1, and reuse both across calls. Each
+        /// returned id is added to <paramref name="takenIds"/>, so as long as no ids are removed
+        /// mid-batch the sequence matches repeated single-shot calls (first free slot, gaps
+        /// filled) without rescanning every key per id.
+        /// </summary>
+        public static string NewNodeId(ISet<string> takenIds, ref int nextIndex) => UniqueId(takenIds, "n", ref nextIndex);
+
+        /// <summary>Batch variant of <see cref="NewSegmentId(FuseTrackDefinition)"/>; see <see cref="NewNodeId(ISet{string}, ref int)"/>.</summary>
+        public static string NewSegmentId(ISet<string> takenIds, ref int nextIndex) => UniqueId(takenIds, "s", ref nextIndex);
+
         private static string UniqueId(IEnumerable<string> existing, string prefix)
         {
             var set = new HashSet<string>(existing);
             var i = 1;
-            while (set.Contains($"{prefix}_{i:D4}"))
+            return UniqueId(set, prefix, ref i);
+        }
+
+        // Ids are only added while a batch runs, so the first free slot never moves backwards
+        // and the cursor can resume where the previous call stopped instead of rescanning from 1.
+        private static string UniqueId(ISet<string> takenIds, string prefix, ref int nextIndex)
+        {
+            if (nextIndex < 1)
             {
-                i++;
+                nextIndex = 1;
             }
 
-            return $"{prefix}_{i:D4}";
+            var id = $"{prefix}_{nextIndex:D4}";
+            while (!takenIds.Add(id))
+            {
+                nextIndex++;
+                id = $"{prefix}_{nextIndex:D4}";
+            }
+
+            return id;
         }
     }
 }

--- a/FUSE.Core/Geometry/TrackGenerators.cs
+++ b/FUSE.Core/Geometry/TrackGenerators.cs
@@ -280,9 +280,11 @@ namespace Fuse.Core.Geometry
         public static (List<string> NodeIds, List<string> SegmentIds) Commit(FuseTrackDefinition tracks, GeneratedTrack generated)
         {
             var nodeIds = new List<string>(generated.Nodes.Count);
+            var takenNodeIds = new HashSet<string>(tracks.Nodes.Keys);
+            var nextNodeIndex = 1;
             foreach (var n in generated.Nodes)
             {
-                var id = TrackOps.NewNodeId(tracks);
+                var id = TrackOps.NewNodeId(takenNodeIds, ref nextNodeIndex);
                 TrackOps.AddNode(
                     tracks, id,
                     new FuseVector3((float)n.X, (float)n.Y, (float)n.Z),
@@ -292,9 +294,11 @@ namespace Fuse.Core.Geometry
             }
 
             var segmentIds = new List<string>(generated.Segments.Count);
+            var takenSegmentIds = new HashSet<string>(tracks.Segments.Keys);
+            var nextSegmentIndex = 1;
             foreach (var s in generated.Segments)
             {
-                var id = TrackOps.NewSegmentId(tracks);
+                var id = TrackOps.NewSegmentId(takenSegmentIds, ref nextSegmentIndex);
                 TrackOps.ConnectSegment(
                     tracks, id, nodeIds[s.StartIndex], nodeIds[s.EndIndex],
                     s.TrackClass ?? "main", s.Style ?? "standard", s.SpeedLimit);


### PR DESCRIPTION
## Summary

Fixes #86.

`TrackOps.UniqueId` rebuilt a `HashSet` of every existing key and rescanned from index 1 on every call; `TrackGenerators.Commit` calls it once per node/segment, making large generated chains (fine-grained curves, multi-track `Parallel` commits) O(n²). This adds a cursor-based batch overload — `Commit` now builds each taken-id set once and threads a `ref int` cursor through `TrackOps.NewNodeId/NewSegmentId(ISet<string>, ref int)`, giving O(1) amortized per minted id.

## Id assignment is byte-identical

The issue suggested seeding the cursor from the max existing numeric suffix, but that would skip gaps and change id assignment (e.g. after node deletions). Instead the cursor starts at 1 and persists across calls: a commit only ever *adds* keys, so the first free slot is monotonically increasing and the persistent cursor mints exactly the sequence the old per-call scan did — gaps filled first, then sequential. Pure perf change, zero behavior change. This was verified by mutation: switching the initialization to max-suffix fails `Commit_Fills_Gaps_Then_Continues_Past_Existing_Ids`.

## Changes

- `TrackOps`: private cursor-based `UniqueId(ISet<string>, string, ref int)` core (clamps cursors below 1); the single-shot path delegates to it. Public batch wrappers `NewNodeId`/`NewSegmentId` keep the `n_`/`s_` prefixes encapsulated.
- `TrackGenerators.Commit`: builds the node/segment sets once, threads the cursors.
- Tests: batch-vs-single-shot sequence equivalence (with gaps and a non-pattern key), set mutation by the batch call, `Commit` gap-filling into a non-empty definition, segment wiring via a `Turnout` with offset ids, 2000-segment chain uniqueness, >9999 `D4` widening, and cursor clamping.

## Verification

- `FUSE.Core.Tests` 39/39, `FUSE.ExternalEditor.UiTests` 87/87, `FUSE.Tests` 1300/1300; full solution builds with no new warnings.
- Adversarial multi-agent review (semantics / API-callers / test-adequacy lenses) found no blockers; the two confirmed hardening nits (cursor clamp, rollover test) are included.

## Out of scope

`WorldOps` and `OperationsOps` carry verbatim copies of the old per-call scan, but their only callers are single-shot interactive tools — no quadratic path exists there today. Tracked separately as a consolidation follow-up.