### PR TITLE
fix(loading): exclude LiveBridge state files from package discovery

### DIFF
--- a/FUSE.Tests/Loading/FuseDefinitionFileDiscoveryTests.cs
+++ b/FUSE.Tests/Loading/FuseDefinitionFileDiscoveryTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+using Fuse.Core.Bridge;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    /// <summary>
+    /// Locks the rule that the bridge mods' runtime protocol files
+    /// (heartbeats, RPC requests/results) are never treated as fallback
+    /// package definitions. FUSE.LiveBridge writes
+    /// <c>Mods/FUSE.LiveBridge/bridge_state.json</c> while its Info.json
+    /// declares <c>Requirements: ["FUSE"]</c>, so before the exclusion,
+    /// discovery classified the bridge mod folder as a data package and
+    /// every session recorded a permanent "Definition file ... is missing
+    /// an id" fault. FUSE.dll cannot reference FUSE.Core (it ships only
+    /// with the bridge mods), so the exclusion list in
+    /// <see cref="FuseDefinitionFileDiscovery"/> repeats the names as
+    /// literals; the InlineData below references the canonical
+    /// <see cref="BridgeProtocol"/> constants so a rename in FUSE.Core
+    /// fails here instead of silently drifting apart.
+    /// </summary>
+    public class FuseDefinitionFileDiscoveryTests : IDisposable
+    {
+        private readonly string _root;
+        private bool _disposed;
+
+        public FuseDefinitionFileDiscoveryTests()
+        {
+            _root = Path.Combine(
+                Path.GetTempPath(),
+                "FuseDefinitionDiscoveryTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            try
+            {
+                if (Directory.Exists(_root))
+                {
+                    Directory.Delete(_root, recursive: true);
+                }
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                // Best-effort cleanup. Stragglers in TEMP are harmless.
+                System.Console.WriteLine($"Cleanup of '{_root}' failed: {ex.Message}");
+            }
+            GC.SuppressFinalize(this);
+        }
+
+        private string CreateModFolder(string name)
+        {
+            var folder = Path.Combine(_root, name);
+            Directory.CreateDirectory(folder);
+            return folder;
+        }
+
+        [Theory]
+        [InlineData(BridgeProtocol.StateFileName)]
+        [InlineData(BridgeProtocol.CommandFileName)]
+        [InlineData(BridgeProtocol.TestStateFileName)]
+        [InlineData(BridgeProtocol.TestRequestPrefix + "abc123.json")]
+        [InlineData(BridgeProtocol.TestResultPrefix + "abc123.json")]
+        public void Bridge_protocol_files_are_not_fallback_definitions(string fileName)
+        {
+            var folder = CreateModFolder(BridgeProtocol.BridgeModFolderName);
+            File.WriteAllText(Path.Combine(folder, fileName), "{}");
+
+            Assert.Empty(FuseDefinitionFileDiscovery.ResolveFallbackDefinitionPaths(folder));
+            Assert.False(FuseDefinitionFileDiscovery.HasFallbackDefinitionFile(folder));
+        }
+
+        [Fact]
+        public void Real_definition_still_resolves_next_to_bridge_state()
+        {
+            var folder = CreateModFolder("SomePackage");
+            File.WriteAllText(Path.Combine(folder, BridgeProtocol.StateFileName), "{}");
+            var definitionPath = Path.Combine(folder, "trackwork.fuse.json");
+            File.WriteAllText(definitionPath, "{}");
+
+            var resolved = FuseDefinitionFileDiscovery.ResolveFallbackDefinitionPaths(folder);
+
+            Assert.Equal(new[] { definitionPath }, resolved);
+        }
+
+        [Fact]
+        public void LiveBridge_mod_folder_is_not_discovered_as_a_data_package()
+        {
+            // Real-world shape of Mods/FUSE.LiveBridge once the in-game bridge
+            // has published its heartbeat: a UMM Info.json requiring FUSE plus
+            // bridge_state.json. Without the exclusion, the heartbeat counts as
+            // a root definition file and the FUSE requirement promotes the
+            // folder to a data package.
+            var folder = CreateModFolder(BridgeProtocol.BridgeModFolderName);
+            File.WriteAllText(Path.Combine(folder, "Info.json"), @"{
+  ""Id"": ""FUSE.LiveBridge"",
+  ""DisplayName"": ""FUSE Live Bridge"",
+  ""Version"": ""0.1.0"",
+  ""AssemblyName"": ""FUSE.LiveBridge.dll"",
+  ""EntryMethod"": ""FUSE.LiveBridge.Main.Load"",
+  ""Requirements"": [""FUSE""],
+  ""LoadAfter"": [""FUSE""]
+}");
+            File.WriteAllText(
+                Path.Combine(folder, BridgeProtocol.StateFileName),
+                @"{ ""Schema"": 1, ""Pid"": 1234, ""HeartbeatUtc"": ""2026-06-10T00:00:00Z"", ""Ok"": true }");
+
+            Assert.Empty(FuseDataPackageDiscovery.DiscoverPackageFolders(_root));
+        }
+    }
+}

--- a/FUSE/Loading/FuseDefinitionFileDiscovery.cs
+++ b/FUSE/Loading/FuseDefinitionFileDiscovery.cs
@@ -6,13 +6,29 @@ namespace FUSE.Loading
 {
     internal static class FuseDefinitionFileDiscovery
     {
+        // The bridge mods (FUSE.LiveBridge, FUSE.TestBridge) write their runtime
+        // protocol files (heartbeats, RPC requests/results) into their own mod
+        // folders, where they would otherwise be picked up as fallback definition
+        // JSON and faulted as packages missing an id. The names mirror
+        // Fuse.Core.Bridge.BridgeProtocol; FUSE.dll cannot reference FUSE.Core
+        // (it ships only with the bridge mods), so FuseDefinitionFileDiscoveryTests
+        // pins this list against those constants instead.
         private static readonly string[] ExcludedFallbackJsonFileNames =
         {
             "Info.json",
             "conversion-report.json",
             "Catalog.json",
             "Definitions.json",
-            "Definition.json"
+            "Definition.json",
+            "bridge_state.json",
+            "bridge_command.json",
+            "test_state.json"
+        };
+
+        private static readonly string[] ExcludedFallbackJsonFileNamePrefixes =
+        {
+            "test_request_",
+            "test_result_"
         };
 
         public static string[] ResolveFallbackDefinitionPaths(string folderPath)
@@ -52,8 +68,14 @@ namespace FUSE.Loading
                 return false;
             }
 
-            return !ExcludedFallbackJsonFileNames.Any(excluded =>
-                string.Equals(fileName, excluded, StringComparison.OrdinalIgnoreCase));
+            if (ExcludedFallbackJsonFileNames.Any(excluded =>
+                string.Equals(fileName, excluded, StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+
+            return !ExcludedFallbackJsonFileNamePrefixes.Any(prefix =>
+                fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
         }
 
         private static int GetJsonFallbackRank(string path)


### PR DESCRIPTION
## Problem

FUSE package discovery treated `Mods/FUSE.LiveBridge/bridge_state.json` — the LiveBridge mod's own **runtime heartbeat** — as a package definition file. Because `Mods/FUSE.LiveBridge/Info.json` declares `Requirements: ["FUSE"]`, discovery promoted the bridge mod folder to a data package the moment the heartbeat existed. The loader then deserialized the heartbeat, found no `id`, and recorded a **permanent package fault** (`Definition file ... is missing an id`, stages validation + deserialization).

Symptoms every session:
- Health UI summary shows `faults 1`
- Two `ERROR` lines per load in `FUSE.log`

## Root cause

`FuseDataPackageDiscovery.TryReadFusePackageManifest` classifies a folder as a data package when its `Info.json` references FUSE **and** the folder has a root definition file. `HasRootDefinitionFile` → `FuseDefinitionFileDiscovery`, which accepted **any** top-level `*.json` not on its small exclusion list. The bridge heartbeat slipped right through.

## Fix

Exclude the entire bridge **runtime-protocol** file family from fallback definition discovery in `FuseDefinitionFileDiscovery`:

- Exact names: `bridge_state.json`, `bridge_command.json`, `test_state.json`
- Prefixes: `test_request_`, `test_result_`

`FUSE.TestBridge` has the identical exposure (its `Info.json` also requires FUSE, and the test driver drops per-request RPC JSON into its folder), so it is covered too — preventing the same fault the first time someone enables it.

### Why literals, not a shared constant

`FUSE.dll` cannot reference `FUSE.Core` — that assembly ships only alongside the bridge mods, so a project reference would add a runtime dependency the main mod's deploy doesn't carry. The names therefore stay literals in `FuseDefinitionFileDiscovery`, and **drift is prevented by the test**: `FuseDefinitionFileDiscoveryTests` (which references both assemblies) builds its file names from the canonical `Fuse.Core.Bridge.BridgeProtocol` constants, so renaming e.g. `StateFileName` breaks the build/test instead of silently diverging.

## Tests

New `FUSE.Tests/Loading/FuseDefinitionFileDiscoveryTests.cs` (7 cases):
- Theory over all five protocol file names → none resolves as a fallback definition
- Positive control: a real `*.fuse.json` still resolves when sitting next to `bridge_state.json`
- End-to-end: recreates the reported shape (a `FUSE.LiveBridge` folder with real Info.json content + a heartbeat) and asserts `DiscoverPackageFolders` returns nothing

Verified the tests bite by temporarily reverting the production change — 6 of 7 fail without it (the 7th is the positive control, green both ways).

- Full suite: **1307 passed, 0 failed**
- slopwatch: **0 issues**