### PR TITLE
perf(load): halve the loading screen again + cut post-load scenery pop-in

### DIFF
--- a/FUSE/Authoring/Entities/FuseSceneryEntity.cs
+++ b/FUSE/Authoring/Entities/FuseSceneryEntity.cs
@@ -34,9 +34,6 @@ namespace FUSE.Authoring.Entities
         [FuseHidden]
         public SceneryAssetInstance RuntimeScenery { get; private set; }
 
-        [FuseHidden]
-        public Bounds RuntimeBounds { get; private set; }
-
         [FuseEditable("Anchor Spans", Group = "Scenery", Order = 12)]
         public string[] AnchorSpanIds { get; set; } = System.Array.Empty<string>();
 
@@ -107,7 +104,11 @@ namespace FUSE.Authoring.Entities
             RuntimeScenery = SceneryAPI.GetScenery(Id);
             if (RuntimeScenery == null)
             {
-                RuntimeScenery = SceneryAPI.AddScenery(Id, definition, RefreshRuntimeBoundsAfterDeferredActivation);
+                // No deferred-activation callback: the RuntimeBounds it used to
+                // recompute had no readers, and the per-item
+                // GetComponentsInChildren scan sat inside the post-load
+                // activation wave for nothing.
+                RuntimeScenery = SceneryAPI.AddScenery(Id, definition);
             }
             else
             {
@@ -115,7 +116,6 @@ namespace FUSE.Authoring.Entities
                 RuntimeScenery = SceneryAPI.GetScenery(Id);
             }
 
-            UpdateRuntimeBounds();
             BindRuntime(RuntimeScenery != null ? RuntimeScenery.gameObject : null, RuntimeScenery);
         }
 
@@ -139,7 +139,6 @@ namespace FUSE.Authoring.Entities
             Rotation = runtime.transform.localEulerAngles;
             Scale = runtime.transform.localScale;
             RuntimeScenery = runtime;
-            UpdateRuntimeBounds();
             BindRuntime(runtime.gameObject, runtime);
             MarkDirty("captured scenery from runtime");
         }
@@ -149,36 +148,5 @@ namespace FUSE.Authoring.Entities
             return SceneryAPI.GetAvailableSceneryModels();
         }
 
-        /// <summary>
-        /// Re-computes runtime bounds after the deferred scenery activator finally
-        /// activates this scenery; its renderers do not exist until activation. No-op
-        /// for scenery that was activated inline (bounds were already computed).
-        /// </summary>
-        internal void RefreshRuntimeBoundsAfterDeferredActivation()
-        {
-            UpdateRuntimeBounds();
-        }
-
-        private void UpdateRuntimeBounds()
-        {
-            RuntimeBounds = default;
-            var runtime = RuntimeScenery;
-            if (runtime == null)
-            {
-                return;
-            }
-
-            var renderers = runtime.GetComponentsInChildren<Renderer>(true);
-            if (renderers.Length == 0)
-            {
-                return;
-            }
-
-            RuntimeBounds = renderers[0].bounds;
-            for (var index = 1; index < renderers.Length; index++)
-            {
-                RuntimeBounds.Encapsulate(renderers[index].bounds);
-            }
-        }
     }
 }

--- a/FUSE/Interface/FuseHealthUi.AssetsTab.cs
+++ b/FUSE/Interface/FuseHealthUi.AssetsTab.cs
@@ -257,6 +257,7 @@ namespace FUSE.Interface
 
             return InsertBreakHints(value
                 .Replace("__merged-graph-rebuild__", "merged graph rebuild")
+                .Replace("__merged-world-suppressions__", "merged suppressions")
                 .Replace("merged-single-graph-rebuild", "single graph rebuild")
                 .Replace("apply-resident-definitions", "runtime apply"));
         }

--- a/FUSE/Loading/FuseAssetPackRegistry.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.cs
@@ -145,6 +145,7 @@ namespace FUSE.Loading
             }
             FuseLegacyContainerMixintoRegistry.Reset();
             FuseAssetCollisionRegistry.Reset();
+            FUSE.Runtime.API.SceneryAPI.InvalidateKnownSceneryIdentifierIndex();
             FuseLog.Info("FUSE asset pack mount state reset.");
         }
 

--- a/FUSE/Loading/FuseLegacyContainerMixintoRegistry.cs
+++ b/FUSE/Loading/FuseLegacyContainerMixintoRegistry.cs
@@ -90,6 +90,7 @@ namespace FUSE.Loading
 
             if (applied > 0)
             {
+                FUSE.Runtime.API.SceneryAPI.InvalidateKnownSceneryIdentifierIndex();
                 FuseLog.Info(
                     $"FUSE legacy support applied {applied} container mixinto object(s) to asset store '{store.Identifier}'. " +
                     "This is temporary legacy compatibility, not native FUSE package data.");

--- a/FUSE/Loading/FuseModLoader.TrackMerging.cs
+++ b/FUSE/Loading/FuseModLoader.TrackMerging.cs
@@ -333,7 +333,55 @@ namespace FUSE.Loading
                         var definition = candidate.Loaded.Definition;
                         var transaction = candidate.Transaction;
                         transaction.RunPhase("apply-progression", () => ApplyProgressionDefinition(definition, transaction));
-                        transaction.RunPhase("apply-world-suppressions", () => FuseWorldSuppressor.ApplyDefinition(definition, transaction));
+                        // Registration only — claims must land in load order for
+                        // precedence, but the apply pass walks the full claimed
+                        // set, so it runs once after the loop instead of N times.
+                        transaction.RunPhase("register-world-suppressions", () => FuseWorldSuppressor.RegisterDefinition(definition, transaction));
+                    }
+
+                    // One merged suppression apply for all packages. Must run
+                    // before the progression refresh below: area suppression
+                    // flips ProgressionDisabled flags that the refresh reads.
+                    // The batch folds the per-group RequestRebuild calls from
+                    // track-group suppression into a single rebuild.
+                    var suppressionTransaction = new FuseApplyTransaction("__merged-world-suppressions__", reason, false);
+                    TrackAPI.BeginBatch();
+                    try
+                    {
+                        suppressionTransaction.RunPhase("apply-world-suppressions", () => FuseWorldSuppressor.ApplyAllActive("merged suppression apply", suppressionTransaction));
+                    }
+                    finally
+                    {
+                        // Close WITHOUT rebuilding: EndBatch(true) would run the
+                        // deferred rebuild unguarded inside this finally, where a
+                        // throw (TrackObjectManager fragility, GraphRebuilt
+                        // subscribers) skips the per-package outcome/commit loop
+                        // and rolls back every registry transaction while the
+                        // runtime mutations stay applied. The rebuild runs below
+                        // in its own guarded, timed phase instead.
+                        TrackAPI.EndBatch(false);
+                    }
+
+                    // With no outer batch, consume the request the suppression
+                    // pass deferred and rebuild inside RunPhase — a throw becomes
+                    // a fatal on the synthetic report (logged below) and the load
+                    // continues, matching the old per-package behavior where
+                    // RebuildAfterTrackGroupSuppression caught and warned. If an
+                    // outer batch IS open, leave the flag for its EndBatch — the
+                    // pre-existing deferral semantics.
+                    if (!TrackAPI.IsBatching && TrackAPI.ConsumePendingRebuildRequest())
+                    {
+                        suppressionTransaction.RunPhase("merged-suppression-graph-rebuild", () => TrackAPI.RebuildGraph());
+                    }
+
+                    suppressionTransaction.Report.LogSummary();
+                    if (suppressionTransaction.Report.IsFatal || suppressionTransaction.Report.HasErrors)
+                    {
+                        var failure =
+                            "FUSE merged world-suppression apply reported problems: " +
+                            $"fatal={suppressionTransaction.Report.IsFatal} errors={suppressionTransaction.Report.Errors.Count} reason='{reason}'.";
+                        FuseLog.Warning(failure);
+                        FuseLoadReport.RecordNotice(failure);
                     }
 
                     ProgressionAPI.RefreshRuntimeStateAfterApply("staged ApplyProgressionDefinition");
@@ -900,14 +948,28 @@ namespace FUSE.Loading
                     ApplyMergedSpanRemoval(removal);
                 }
 
-                foreach (var removal in plan.RemovedSegments.Values.OrderBy(item => item.Sequence))
+                // Opened after the span removals; the lazily-built index sees the
+                // same scene state the per-removal live scan would — including
+                // spans removed above, which are still pending deferred Destroy
+                // and appear in both (parity with the old per-segment scan, not
+                // exclusion). Segment and node removals below share one scene
+                // scan instead of one per removal.
+                FuseTrackRemovalSnapshotStore.BeginCaptureBatch();
+                try
                 {
-                    ApplyMergedSegmentRemoval(removal);
-                }
+                    foreach (var removal in plan.RemovedSegments.Values.OrderBy(item => item.Sequence))
+                    {
+                        ApplyMergedSegmentRemoval(removal);
+                    }
 
-                foreach (var removal in plan.RemovedNodes.Values.OrderBy(item => item.Sequence))
+                    foreach (var removal in plan.RemovedNodes.Values.OrderBy(item => item.Sequence))
+                    {
+                        ApplyMergedNodeRemoval(removal);
+                    }
+                }
+                finally
                 {
-                    ApplyMergedNodeRemoval(removal);
+                    FuseTrackRemovalSnapshotStore.EndCaptureBatch();
                 }
 
                 foreach (var entry in plan.Turntables.Values.OrderBy(item => item.Sequence))

--- a/FUSE/Loading/FuseTrackRemovalSnapshotStore.cs
+++ b/FUSE/Loading/FuseTrackRemovalSnapshotStore.cs
@@ -28,6 +28,13 @@ namespace FUSE.Loading
         // single scan and every later lookup is a dictionary hit. The index is
         // batch-scoped only: live-reload single-package paths never open a
         // batch and keep the always-fresh scan.
+        //
+        // Thread-safety: these statics carry no synchronization by design. The
+        // whole capture/removal path runs on the Unity main thread (driven
+        // synchronously from the map-load apply pipeline, which calls
+        // FindObjectsOfType — itself main-thread-only), so Begin/EndCaptureBatch
+        // and the lazy build below cannot race. Do not call them off the main
+        // thread.
         private static bool _captureBatchActive;
         private static Dictionary<string, List<TrackSpan>> _captureBatchSpansBySegment;
 
@@ -331,6 +338,10 @@ namespace FUSE.Loading
             {
                 var index = _captureBatchSpansBySegment ??
                             (_captureBatchSpansBySegment = BuildSpansBySegmentIndex(packageId));
+                // The null filter mirrors the live scan below (which also skips
+                // null spans) and guards the caller's span.id access: index
+                // entries are non-null at build, but a span an earlier removal in
+                // this same batch destroyed could read back null here.
                 return index.TryGetValue(segmentId, out var spans)
                     ? spans.Where(span => span != null)
                     : Enumerable.Empty<TrackSpan>();

--- a/FUSE/Loading/FuseTrackRemovalSnapshotStore.cs
+++ b/FUSE/Loading/FuseTrackRemovalSnapshotStore.cs
@@ -20,6 +20,29 @@ namespace FUSE.Loading
         private static readonly Dictionary<string, PackageTrackSnapshots> SnapshotsByPackage =
             new Dictionary<string, PackageTrackSnapshots>(StringComparer.OrdinalIgnoreCase);
 
+        // Capture-batch span index. Every segment (and node->segment cascade)
+        // capture needs "which spans reference this segment", which the live
+        // path answers with a full FindObjectsOfType<TrackSpan> scene scan per
+        // segment — ~800 scans on a removal-heavy map load. Inside a capture
+        // batch the first lookup builds one segment-id -> spans index from a
+        // single scan and every later lookup is a dictionary hit. The index is
+        // batch-scoped only: live-reload single-package paths never open a
+        // batch and keep the always-fresh scan.
+        private static bool _captureBatchActive;
+        private static Dictionary<string, List<TrackSpan>> _captureBatchSpansBySegment;
+
+        public static void BeginCaptureBatch()
+        {
+            _captureBatchActive = true;
+            _captureBatchSpansBySegment = null;
+        }
+
+        public static void EndCaptureBatch()
+        {
+            _captureBatchActive = false;
+            _captureBatchSpansBySegment = null;
+        }
+
         public static void CaptureSpanBeforeRemoval(string packageId, string spanId, FuseApplyTransaction transaction)
         {
             if (string.IsNullOrWhiteSpace(packageId) || string.IsNullOrWhiteSpace(spanId))
@@ -304,6 +327,15 @@ namespace FUSE.Loading
                 return Enumerable.Empty<TrackSpan>();
             }
 
+            if (_captureBatchActive)
+            {
+                var index = _captureBatchSpansBySegment ??
+                            (_captureBatchSpansBySegment = BuildSpansBySegmentIndex(packageId));
+                return index.TryGetValue(segmentId, out var spans)
+                    ? spans.Where(span => span != null)
+                    : Enumerable.Empty<TrackSpan>();
+            }
+
             var matches = new List<TrackSpan>();
             foreach (var span in UnityEngine.Object.FindObjectsOfType<TrackSpan>(true))
             {
@@ -336,6 +368,55 @@ namespace FUSE.Loading
             return location.HasValue &&
                    location.Value.segment != null &&
                    string.Equals(location.Value.segment.id, segmentId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static Dictionary<string, List<TrackSpan>> BuildSpansBySegmentIndex(string packageId)
+        {
+            var index = new Dictionary<string, List<TrackSpan>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var span in UnityEngine.Object.FindObjectsOfType<TrackSpan>(true))
+            {
+                if (span == null || string.IsNullOrWhiteSpace(span.id))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    Location? upper = span.upper;
+                    Location? lower = span.lower;
+                    var upperId = upper.HasValue && upper.Value.segment != null ? upper.Value.segment.id : null;
+                    var lowerId = lower.HasValue && lower.Value.segment != null ? lower.Value.segment.id : null;
+                    AddSpanToIndex(index, upperId, span);
+                    if (!string.Equals(lowerId, upperId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        AddSpanToIndex(index, lowerId, span);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not inspect span package='{packageId ?? "<unknown>"}' operation='capture-track-removal-snapshot' " +
+                        $"phase='snapshot' kind='track span' id='{span.id}' segment='<index build>' reason='{ex.Message}'.");
+                }
+            }
+
+            return index;
+        }
+
+        private static void AddSpanToIndex(Dictionary<string, List<TrackSpan>> index, string segmentId, TrackSpan span)
+        {
+            if (string.IsNullOrWhiteSpace(segmentId))
+            {
+                return;
+            }
+
+            if (!index.TryGetValue(segmentId, out var spans))
+            {
+                spans = new List<TrackSpan>();
+                index[segmentId] = spans;
+            }
+
+            spans.Add(span);
         }
 
         private static bool ShouldCaptureBaseTrack(FuseClaimKind kind, string id, string packageId, string label, FuseApplyTransaction transaction)

--- a/FUSE/Loading/FuseWorldSuppressor.cs
+++ b/FUSE/Loading/FuseWorldSuppressor.cs
@@ -49,9 +49,27 @@ namespace FUSE.Loading
         /// </summary>
         public static void ApplyDefinition(FuseModDefinition definition, FuseApplyTransaction transaction = null)
         {
-            if (definition == null || string.IsNullOrWhiteSpace(definition.Id))
+            if (!RegisterDefinition(definition, transaction))
             {
                 return;
+            }
+
+            ApplyAllActive("definition apply", transaction);
+        }
+
+        /// <summary>
+        /// Registers a package's suppression claims without applying them. The
+        /// merged apply path registers every package in load order (so claim
+        /// precedence is preserved) and then runs <see cref="ApplyAllActive"/>
+        /// once — the apply pass walks the full claimed set, so running it per
+        /// package re-applied every earlier package's suppressions again for
+        /// each of the N packages.
+        /// </summary>
+        public static bool RegisterDefinition(FuseModDefinition definition, FuseApplyTransaction transaction = null)
+        {
+            if (definition == null || string.IsNullOrWhiteSpace(definition.Id))
+            {
+                return false;
             }
 
             var scenePaths = NormalizeIds(definition.World?.SuppressBaseScenePaths, definition.World?.SuppressScenePaths);
@@ -70,10 +88,21 @@ namespace FUSE.Loading
             RestoreUnusedScenePaths(old.ScenePaths.Except(scenePaths, StringComparer.OrdinalIgnoreCase));
             RestoreUnusedTrackGroups(old.TrackGroups.Except(groups, StringComparer.OrdinalIgnoreCase));
             RestoreUnusedAreas(old.Areas.Except(areas, StringComparer.OrdinalIgnoreCase));
+            return true;
+        }
 
-            ApplyActiveScenePathSuppressions("definition apply", transaction);
-            ApplyActiveTrackGroupSuppressions("definition apply", true);
-            ApplyActiveAreaSuppressions("definition apply", transaction);
+        /// <summary>
+        /// Applies every currently claimed suppression (scene paths, track
+        /// groups, areas). Track-group changes route through
+        /// TrackAPI.RequestRebuild, so callers applying after a multi-package
+        /// registration pass should wrap this in TrackAPI.BeginBatch/EndBatch
+        /// to fold the per-group rebuilds into one.
+        /// </summary>
+        public static void ApplyAllActive(string reason, FuseApplyTransaction transaction = null)
+        {
+            ApplyActiveScenePathSuppressions(reason, transaction);
+            ApplyActiveTrackGroupSuppressions(reason ?? "apply", true);
+            ApplyActiveAreaSuppressions(reason, transaction);
         }
 
         public static void RegisterEarlyScenePathSuppressionsFromLoadedDefinitions(string reason)
@@ -465,6 +494,14 @@ namespace FUSE.Loading
 
         private static void RebuildAfterTrackGroupSuppression(Graph graph, string reason)
         {
+            // NOTE: _isRebuildingForGroupSuppression only covers the UNBATCHED
+            // path, where RequestRebuild() rebuilds synchronously inside this
+            // frame. When a caller has a TrackAPI batch open the rebuild is
+            // deferred past this method's finally, so the graph-rebuild event
+            // re-enters ApplyTrackGroupSuppressionsAfterGraphLoad without the
+            // guard; that re-walk is harmless because the groups were already
+            // suppressed synchronously above (changed=false, no recursive
+            // rebuild) — the protection there is idempotence, not this flag.
             if (_isRebuildingForGroupSuppression)
             {
                 return;
@@ -504,15 +541,15 @@ namespace FUSE.Loading
                 return;
             }
 
-            var area = TrackAPI.GetArea(areaId);
-            if (area == null)
-            {
-                Warn(transaction, "suppressed area", areaId, $"area was not found for '{reason}'");
-                return;
-            }
-
             try
             {
+                var area = TrackAPI.GetArea(areaId);
+                if (area == null)
+                {
+                    Warn(transaction, "suppressed area", areaId, $"area was not found for '{reason}'");
+                    return;
+                }
+
                 if (!Areas.TryGetValue(areaId, out var state))
                 {
                     state = new AreaSuppressionState(areaId);

--- a/FUSE/Patches/FusePrefabStoreAssetPackPatch.cs
+++ b/FUSE/Patches/FusePrefabStoreAssetPackPatch.cs
@@ -25,6 +25,11 @@ namespace FUSE.Patches
             {
                 FuseLog.Exception($"FUSE direct asset pack store patch failed softly", ex);
             }
+            finally
+            {
+                // Even a partial store add changes the identifier population.
+                FUSE.Runtime.API.SceneryAPI.InvalidateKnownSceneryIdentifierIndex();
+            }
         }
     }
 }

--- a/FUSE/Runtime/API/SceneryAPI.cs
+++ b/FUSE/Runtime/API/SceneryAPI.cs
@@ -402,29 +402,33 @@ namespace FUSE.Runtime.API
                 if (index == null)
                 {
                     var generationBeforeBuild = _knownSceneryIdentifierIndexGeneration;
-                    IEnumerable<string> known;
+                    // The try spans the enumeration too, not just the call:
+                    // GetSceneryDefinitionIdentifiers may hand back a lazy
+                    // enumerable whose real work (store.Container() walks) runs
+                    // here in the foreach, so a throw can surface mid-iteration.
+                    // On failure the partial local index is discarded — never
+                    // published, never returned (we return false below).
                     try
                     {
-                        known = manager.GetSceneryDefinitionIdentifiers();
+                        var known = manager.GetSceneryDefinitionIdentifiers();
+                        if (known == null)
+                        {
+                            return false;
+                        }
+
+                        index = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var id in known)
+                        {
+                            if (!string.IsNullOrEmpty(id) && !index.ContainsKey(id))
+                            {
+                                index.Add(id, id);
+                            }
+                        }
                     }
                     catch (Exception ex)
                     {
                         FuseLog.Exception($"FUSE scenery asset registry enumeration failed while resolving '{candidate}'", ex);
                         return false;
-                    }
-
-                    if (known == null)
-                    {
-                        return false;
-                    }
-
-                    index = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var id in known)
-                    {
-                        if (!string.IsNullOrEmpty(id) && !index.ContainsKey(id))
-                        {
-                            index.Add(id, id);
-                        }
                     }
 
                     // The enumeration itself touches store.Container(), whose postfix

--- a/FUSE/Runtime/API/SceneryAPI.cs
+++ b/FUSE/Runtime/API/SceneryAPI.cs
@@ -362,38 +362,89 @@ namespace FUSE.Runtime.API
                 return true;
             }
 
-            IEnumerable<string> known;
-            try
-            {
-                known = manager.GetSceneryDefinitionIdentifiers();
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception($"FUSE scenery asset registry enumeration failed while resolving '{candidate}'", ex);
-                return false;
-            }
+            return TryResolveFromKnownIdentifierIndex(manager, candidate, out resolvedIdentifier);
+        }
 
-            if (known == null)
-            {
-                return false;
-            }
+        // Case-insensitive identifier -> canonical identifier, built lazily from one
+        // GetSceneryDefinitionIdentifiers() call. That enumeration re-walks every
+        // mounted store's container per call (plus the editor-menu postfix's
+        // direct-store filter), so the miss fallback above used to pay ~200ms for
+        // every unresolved scenery item on the loading-screen critical path — and
+        // re-paid it for each repeat of the same missing identifier. First-wins
+        // insertion in enumeration order reproduces the old linear scan's pick
+        // exactly, and going through the manager (not PrefabStore._stores directly)
+        // keeps the patched direct-only filtering applied. The index must never be
+        // consulted before the exact-case probe and legacy-alias steps above.
+        private static readonly object KnownSceneryIdentifierIndexLock = new object();
+        private static Dictionary<string, string> _knownSceneryIdentifierIndex;
+        private static int _knownSceneryIdentifierIndexGeneration;
 
-            foreach (var id in known)
+        // The identifier population changes outside this class: direct-store
+        // mounting (PrefabStore.Create postfix), asset-pack reset, legacy container
+        // mixinto application, and map-load cache rebuilds all drop the index so the
+        // next miss rebuilds it against the current catalog.
+        internal static void InvalidateKnownSceneryIdentifierIndex()
+        {
+            lock (KnownSceneryIdentifierIndexLock)
             {
-                if (string.Equals(id, candidate, StringComparison.Ordinal))
+                _knownSceneryIdentifierIndex = null;
+                _knownSceneryIdentifierIndexGeneration++;
+            }
+        }
+
+        private static bool TryResolveFromKnownIdentifierIndex(SceneryAssetManager manager, string candidate, out string resolvedIdentifier)
+        {
+            resolvedIdentifier = null;
+            Dictionary<string, string> index;
+            lock (KnownSceneryIdentifierIndexLock)
+            {
+                index = _knownSceneryIdentifierIndex;
+                if (index == null)
                 {
-                    resolvedIdentifier = id;
-                    return true;
-                }
+                    var generationBeforeBuild = _knownSceneryIdentifierIndexGeneration;
+                    IEnumerable<string> known;
+                    try
+                    {
+                        known = manager.GetSceneryDefinitionIdentifiers();
+                    }
+                    catch (Exception ex)
+                    {
+                        FuseLog.Exception($"FUSE scenery asset registry enumeration failed while resolving '{candidate}'", ex);
+                        return false;
+                    }
 
-                if (string.Equals(id, candidate, StringComparison.OrdinalIgnoreCase))
-                {
-                    resolvedIdentifier = id;
-                    return true;
+                    if (known == null)
+                    {
+                        return false;
+                    }
+
+                    index = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var id in known)
+                    {
+                        if (!string.IsNullOrEmpty(id) && !index.ContainsKey(id))
+                        {
+                            index.Add(id, id);
+                        }
+                    }
+
+                    // The enumeration itself touches store.Container(), whose postfix
+                    // can apply legacy container mixintos and re-enter
+                    // InvalidateKnownSceneryIdentifierIndex on this thread (the lock is
+                    // reentrant). In that known case the list is actually complete —
+                    // each container is mutated before the manager reads it — but a
+                    // generation bump during the build means some mutation interleaved
+                    // and we can't prove the list reflects it. Use the list for this
+                    // lookup (the pre-cache code saw the same per-call snapshot) but
+                    // don't publish it; the next miss rebuilds, costing at most one
+                    // extra enumeration.
+                    if (_knownSceneryIdentifierIndexGeneration == generationBeforeBuild)
+                    {
+                        _knownSceneryIdentifierIndex = index;
+                    }
                 }
             }
 
-            return false;
+            return index.TryGetValue(candidate, out resolvedIdentifier);
         }
 
         private static bool IsKnownOptionalLegacyAssetReference(string value)

--- a/FUSE/Runtime/API/TrackAPI.cs
+++ b/FUSE/Runtime/API/TrackAPI.cs
@@ -93,6 +93,21 @@ namespace FUSE.Runtime.API
         }
 
         /// <summary>
+        /// Consumes a rebuild request left pending by a batch that ended with
+        /// rebuild=false, so the caller can run <see cref="RebuildGraph"/> under
+        /// its own exception guard and timing phase instead of inside EndBatch's
+        /// unguarded call. Returns whether a request was pending; the flag is
+        /// cleared either way. Only call with no batch open — while batching,
+        /// the pending flag belongs to the outermost EndBatch.
+        /// </summary>
+        public static bool ConsumePendingRebuildRequest()
+        {
+            var pending = _rebuildRequested;
+            _rebuildRequested = false;
+            return pending;
+        }
+
+        /// <summary>
         /// Request a graph rebuild — runs immediately if no batch is active, or
         /// folds into the outermost <see cref="EndBatch(bool)"/> when callers
         /// have opened one. Cleanup paths that need a rebuild "if the caller

--- a/FUSE/Runtime/Cache/FuseCacheRegistry.cs
+++ b/FUSE/Runtime/Cache/FuseCacheRegistry.cs
@@ -71,6 +71,10 @@ namespace FUSE.Runtime.Cache
             FuseSceneryRuntimeIndex.Instance.Rebuild();
             FuseSplineyRuntimeIndex.Instance.Rebuild();
             FuseMapLabelRuntimeIndex.Instance.Rebuild();
+            // Full rebuilds mark session boundaries (map load, manual reload) where
+            // SceneryAssetManager.Shared and its catalog may have been replaced
+            // wholesale — drop the identifier index so misses re-probe the new one.
+            API.SceneryAPI.InvalidateKnownSceneryIdentifierIndex();
             _isReady = true;
 
             _fullRebuildCount++;

--- a/FUSE/Runtime/Lifecycle/FuseDeferredSceneryActivator.cs
+++ b/FUSE/Runtime/Lifecycle/FuseDeferredSceneryActivator.cs
@@ -287,13 +287,24 @@ namespace FUSE.Runtime.Lifecycle
                     framesSinceResort++;
                 }
 
-                // Re-validate the streaming camera EVERY frame, not just at wave
-                // start: camera-mode transitions right after the loading screen can
-                // blank or replace Camera.main mid-wave. A frame without a live
-                // streaming camera drains at the near cap — activations that frame
-                // resolve against the null-camera nearest band, so they must stay
-                // throttle-sized.
-                var frameCamera = hadLiveAnchor ? FuseSceneryCameraRef.Resolve() : null;
+                // Re-resolve the streaming camera EVERY frame, not just at wave
+                // start. Two transitions matter: (1) it can blank or be replaced
+                // mid-wave (camera-mode change right after the loading screen) — a
+                // frame without one drains at the near cap, since those
+                // activations resolve against the null-camera nearest band; (2) it
+                // can come up just AFTER the initial 2s wait expired, the
+                // slow-startup path this wave most wants to help — arm the far
+                // drain then by re-anchoring and re-sorting the unprocessed tail.
+                var frameCamera = FuseSceneryCameraRef.Resolve();
+                if (!hadLiveAnchor && frameCamera != null)
+                {
+                    hadLiveAnchor = true;
+                    anchor = frameCamera.transform.position;
+                    ResortUnprocessed(index, anchor);
+                    farStartIndex = FindFarPartitionStart(index);
+                    framesSinceResort = 0;
+                }
+
                 var frameStart = Time.realtimeSinceStartup;
                 var thisFrame = 0;
                 var maxPerFrame = index >= farStartIndex && frameCamera != null

--- a/FUSE/Runtime/Lifecycle/FuseDeferredSceneryActivator.cs
+++ b/FUSE/Runtime/Lifecycle/FuseDeferredSceneryActivator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using FUSE.Infrastructure;
+using FUSE.Patches;
 using FUSE.Runtime.API;
 using Helpers;
 using UnityEngine;
@@ -59,10 +60,31 @@ namespace FUSE.Runtime.Lifecycle
 
         // Activation-wave tuning: per-frame time budget, the hard wave timeout after
         // which any remaining scenery is activated inline, and a per-frame item cap so
-        // a burst of sub-millisecond activations can't spike GC in one frame.
-        private const float FrameBudgetMilliseconds = 6f;
+        // a burst of sub-millisecond activations can't spike GC in one frame. Measured
+        // per-item work is ~0.5ms; the old 6ms/64 settings made the wave budget-bound
+        // (~180 frames, 17-21s wall-clock on a 2,100-item load) rather than work-bound.
+        private const float FrameBudgetMilliseconds = 24f;
         private const float WaveTimeoutSeconds = 30f;
-        private const int MaxItemsPerFrame = 64;
+        private const int MaxItemsPerFrame = 128;
+
+        // Items beyond this distance from the activation anchor cannot trigger model
+        // streaming (the game's streaming band is 1,500m; 2x leaves margin for the
+        // player moving while the wave drains), so SetActive on them is pure
+        // bookkeeping. They drain at a higher item cap to kill the wave's long tail —
+        // on the reference load ~1,550 of 2,111 items sat beyond the band yet were
+        // throttled to the near-item trickle. Only used when a live camera anchored
+        // the distance sort: with no camera the game treats distance as "nearest", so
+        // bulk activation would force-stream everything (see class comment).
+        private const float FarActivationThresholdMeters = 3000f;
+        private const int FarMaxItemsPerFrame = 256;
+
+        // Re-sort trigger: if the camera anchor moves this far from the position the
+        // unprocessed queue was last sorted against (teleport, fast travel), the
+        // nearest-first ordering is stale and near-player items would otherwise
+        // activate up to several seconds late. The frame gap caps how often the
+        // O(n log n) re-sort can run if a camera oscillates across the threshold.
+        private const float AnchorResortDistanceMeters = 500f;
+        private const int MinFramesBetweenResorts = 10;
 
         internal static bool IsDraining => _coroutine != null;
 
@@ -222,21 +244,61 @@ namespace FUSE.Runtime.Lifecycle
                 yield return null;
             }
 
-            SortByDistance(ResolveAnchor());
+            // Do not lengthen this gate: past WaveTimeoutSeconds the remainder
+            // flushes in a single frame, so a longer wait just converts the wave
+            // into one big hitch.
+            //
+            // The far-drain gate is keyed to Camera.main specifically — that is
+            // the camera the game's streaming band resolves against (see
+            // FuseSceneryCameraRef). Camera.current may be live while Camera.main
+            // is still null (common in-editor), and arming the far drain on it
+            // would bulk-activate into the null-camera "nearest band" — the
+            // force-stream-everything case this gate exists to prevent. It
+            // remains acceptable as a position-only fallback for sort ordering.
+            var streamingCamera = Camera.main;
+            var hadLiveAnchor = streamingCamera != null;
+            var sortCamera = streamingCamera != null ? streamingCamera : Camera.current;
+            var anchor = sortCamera != null ? sortCamera.transform.position : Vector3.zero;
+            SortByDistance(anchor);
+
+            // The far partition (no streaming side effects) only exists when the
+            // streaming camera anchored the sort; with no camera every distance is
+            // "nearest" to the game and bulk activation would force-stream the
+            // entire queue.
+            var farStartIndex = hadLiveAnchor ? FindFarPartitionStart(0) : Queue.Count;
 
             var budgetSeconds = Mathf.Max(0.001f, FrameBudgetMilliseconds / 1000f);
-            var maxPerFrame = Mathf.Max(1, MaxItemsPerFrame);
 
             var index = 0;
             var processed = 0;
             var activated = 0;
             var failed = 0;
             var keptHidden = 0;
+            var frames = 0;
+            var farDrained = 0;
+            var resorts = 0;
+            var framesSinceResort = int.MaxValue;
 
             while (index < Queue.Count)
             {
+                frames++;
+                if (framesSinceResort < int.MaxValue)
+                {
+                    framesSinceResort++;
+                }
+
+                // Re-validate the streaming camera EVERY frame, not just at wave
+                // start: camera-mode transitions right after the loading screen can
+                // blank or replace Camera.main mid-wave. A frame without a live
+                // streaming camera drains at the near cap — activations that frame
+                // resolve against the null-camera nearest band, so they must stay
+                // throttle-sized.
+                var frameCamera = hadLiveAnchor ? FuseSceneryCameraRef.Resolve() : null;
                 var frameStart = Time.realtimeSinceStartup;
                 var thisFrame = 0;
+                var maxPerFrame = index >= farStartIndex && frameCamera != null
+                    ? FarMaxItemsPerFrame
+                    : Mathf.Max(1, MaxItemsPerFrame);
 
                 // Always do at least one item per frame so a single heavy prefab can't
                 // stall progress, then keep going until the time budget or item cap.
@@ -255,6 +317,11 @@ namespace FUSE.Runtime.Lifecycle
                         default:
                             failed++;
                             break;
+                    }
+
+                    if (index >= farStartIndex)
+                    {
+                        farDrained++;
                     }
 
                     index++;
@@ -290,12 +357,45 @@ namespace FUSE.Runtime.Lifecycle
                 }
 
                 yield return null;
+
+                // Teleport/fast-travel handling: if the camera moved far from the
+                // position the remaining items were sorted against, re-sort ONLY the
+                // unprocessed range so near-player scenery activates next instead of
+                // up to several seconds late. Already-processed items are untouched.
+                // Resolved fresh each frame (not the wave-start camera object) so a
+                // destroyed-and-replaced camera keeps the re-sort armed. The frame
+                // gap bounds sort cost if a camera oscillates across the threshold.
+                if (hadLiveAnchor && index < Queue.Count && framesSinceResort >= MinFramesBetweenResorts)
+                {
+                    var current = FuseSceneryCameraRef.Resolve();
+                    if (current != null)
+                    {
+                        var position = current.transform.position;
+                        if ((position - anchor).sqrMagnitude >
+                            AnchorResortDistanceMeters * AnchorResortDistanceMeters)
+                        {
+                            anchor = position;
+                            ResortUnprocessed(index, anchor);
+                            farStartIndex = FindFarPartitionStart(index);
+                            resorts++;
+                            framesSinceResort = 0;
+                        }
+                    }
+                }
             }
 
-            OnDrainComplete(reason, processed, activated, failed, keptHidden);
+            OnDrainComplete(reason, processed, activated, failed, keptHidden, frames, farDrained, resorts);
         }
 
-        private static void OnDrainComplete(string reason, int processed, int activated, int failed, int keptHidden)
+        private static void OnDrainComplete(
+            string reason,
+            int processed,
+            int activated,
+            int failed,
+            int keptHidden,
+            int frames,
+            int farDrained,
+            int resorts)
         {
             _coroutine = null;
             Queue.Clear();
@@ -311,9 +411,50 @@ namespace FUSE.Runtime.Lifecycle
             // 'keptHidden' counts props a locked progression feature is intentionally
             // holding inactive (gameObjectsEnableOnUnlock); leaving them hidden is the
             // point of the lock check and is expected for any not-yet-unlocked area.
+            // 'cullingDiagnostics' is logged because the per-item cost (and therefore
+            // the wave duration) measures higher with the diagnostic logging enabled —
+            // benchmark wave changes against a diagnostics-off log.
             FuseLog.Info(
                 $"FUSE load timing phase='deferred scenery activation wave' elapsedMs={elapsedMs} " +
-                $"reason='{reason ?? "map load"}' activated={activated} failed={failed} keptHidden={keptHidden} processed={processed}.");
+                $"reason='{reason ?? "map load"}' activated={activated} failed={failed} keptHidden={keptHidden} processed={processed} " +
+                $"frames={frames} farDrained={farDrained} resorts={resorts} " +
+                $"cullingDiagnostics={FuseSettings.EnableSceneryCullingDiagnostics}.");
+        }
+
+        /// <summary>
+        /// First index in the (sorted, ascending) queue at or after
+        /// <paramref name="fromIndex"/> where every later item is beyond the
+        /// far-activation threshold. Returns Queue.Count when no far partition exists.
+        /// </summary>
+        private static int FindFarPartitionStart(int fromIndex)
+        {
+            var thresholdSqr = FarActivationThresholdMeters * FarActivationThresholdMeters;
+            var start = Queue.Count;
+            while (start > fromIndex && Queue[start - 1].SortKey > thresholdSqr)
+            {
+                start--;
+            }
+
+            return start;
+        }
+
+        private static void ResortUnprocessed(int fromIndex, Vector3 anchor)
+        {
+            var count = Queue.Count - fromIndex;
+            if (count <= 1)
+            {
+                return;
+            }
+
+            for (var i = fromIndex; i < Queue.Count; i++)
+            {
+                var instance = Queue[i].Instance;
+                Queue[i].SortKey = instance != null
+                    ? (instance.transform.position - anchor).sqrMagnitude
+                    : float.MaxValue;
+            }
+
+            Queue.Sort(fromIndex, count, DeferredScenerySortKeyComparer.Instance);
         }
 
         private static ActivationResult ActivateOne(DeferredScenery item)
@@ -407,14 +548,6 @@ namespace FUSE.Runtime.Lifecycle
             Queue.Sort((left, right) => left.SortKey.CompareTo(right.SortKey));
         }
 
-        private static Vector3 ResolveAnchor()
-        {
-            // Camera.main is usually live by the time the wait above completes; fall
-            // back to the active camera, then the world origin.
-            var camera = Camera.main ?? Camera.current;
-            return camera != null ? camera.transform.position : Vector3.zero;
-        }
-
         private static void EnsureRunner()
         {
             if (_runner != null)
@@ -433,6 +566,16 @@ namespace FUSE.Runtime.Lifecycle
             public string Id;
             public Action OnActivated;
             public float SortKey;
+        }
+
+        private sealed class DeferredScenerySortKeyComparer : IComparer<DeferredScenery>
+        {
+            public static readonly DeferredScenerySortKeyComparer Instance = new DeferredScenerySortKeyComparer();
+
+            public int Compare(DeferredScenery left, DeferredScenery right)
+            {
+                return left.SortKey.CompareTo(right.SortKey);
+            }
         }
 
         private sealed class FuseDeferredSceneryRunner : MonoBehaviour


### PR DESCRIPTION
## Summary

Three map-load performance fixes, continuing from the load-time analysis. Measured baseline (45 packages / 81 definitions): **36.1s loading screen** + **17–21s post-load scenery pop-in**.

### 1. Scenery asset-miss identifier cache *(validated in-game: 36.1s → 17.2s)*
Every unresolved scenery asset re-enumerated the game''s full identifier set (~210ms/call — the editor-menu postfix re-walks all ~331 direct stores per call), re-paid per referencing instance: ~15–16s across 76 misses. The case-insensitive fallback now builds a first-wins dictionary from **one** enumeration and resolves misses via `TryGetValue`. Resolution order (exact → alias → fallback) unchanged; invalidated on store mount / pack reset / mixinto apply / cache rebuild; a generation counter refuses to publish when an invalidation interleaves with the build. **Already verified on the reference modlist: apply 34.9s → 16.1s; `appalachiascenery` 12,192ms → 1,697ms; `apprwyroadsigns` 2,854ms → 41ms.**

### 2. Merged world-suppression apply + span-capture index *(projected: −4s more)*
- Each of 81 packages re-applied the **entire** claimed suppression set (3.3s). Packages now register claims in load order; one merged apply runs after the loop (synthetic `__merged-world-suppressions__` phase, batched so K group rebuilds fold into one). The deferred rebuild runs **guarded and timed** via `EndBatch(false)` + `ConsumePendingRebuildRequest` — review caught that `EndBatch(true)` in the `finally` would have run it unguarded, where a throw rolls back every package''s registry claims while runtime mutations persist.
- Track-removal snapshot capture ran a full `FindObjectsOfType<TrackSpan>` scan per removed segment (~813 scans, ~1.4s). The merged removal loops now share one lazily-built segment→spans index; live-reload paths keep the fresh scan.

### 3. Deferred-wave unthrottle *(projected: 17–21s pop-in → ~5–8s)*
The wave was budget-bound (~0.5ms real work/item vs 6ms/64 frame budget). Now 24ms/128, with items beyond 3,000m (2× the streaming band) draining at 256/frame — armed **only on `Camera.main`** (the streaming-band camera), re-validated **every frame**, falling back to the near cap on camera-less frames. A >500m anchor jump re-sorts the unprocessed tail (≤1 re-sort/10 frames). Dead `RuntimeBounds` computation removed outright (zero readers; deferred recompute always ran before models streamed; multi-renderer encapsulation was a silent struct-copy no-op).

## Verification
- 1300/1300 tests pass; slopwatch clean.
- Adversarial 4-reviewer pass over the diff: 0 blockers; all 5 should-fix findings addressed in the final commits (unguarded rebuild containment, `Camera.current` arming hole, per-frame camera re-validation, merged-pass fault surfacing via `LogSummary`+load-report notice, `GetArea` moved inside its guard).
- Fix 1 validated in-game (log-confirmed). Fixes 2–3 need one in-game load to confirm: watch `apply resident definitions` (~16.1s → ~12–13s expected) and the wave line''s new `frames=/farDrained=/resorts=` fields with `EnableSceneryCullingDiagnostics=False`.

## Log instrumentation changes
Per-package phase `apply-world-suppressions` → `register-world-suppressions`; new synthetic phases `__merged-world-suppressions__/apply-world-suppressions` and `merged-suppression-graph-rebuild`; wave-completion line gains `frames= farDrained= resorts= cullingDiagnostics=`.