### PR TITLE
feat(OsmTileService): bounded 429/503 retry-with-backoff for OSM tile fetches

### DIFF
--- a/FUSE.ExternalEditor.UiTests/Generation6bTests.cs
+++ b/FUSE.ExternalEditor.UiTests/Generation6bTests.cs
@@ -40,7 +40,7 @@ public class Generation6bTests
     private sealed class FakeOsm : IOsmTileService
     {
         public Task<OsmMosaic> FetchAsync(double minLat, double minLon, double maxLat, double maxLon, int zoom, CancellationToken ct = default)
-            => Task.FromResult(new OsmMosaic(new byte[4 * 4 * 4], 4, 4, 1, maxLat, minLon, minLat, maxLon));
+            => Task.FromResult(new OsmMosaic(new byte[4 * 4 * 4], 4, 4, 1, 0, maxLat, minLon, minLat, maxLon));
     }
 
     private static ViewportViewModel Viewport() => new(new TerrainTileService());

--- a/FUSE.ExternalEditor.UiTests/OsmTileServiceTests.cs
+++ b/FUSE.ExternalEditor.UiTests/OsmTileServiceTests.cs
@@ -53,9 +53,9 @@ public class OsmTileServiceTests
         return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(ms.ToArray()) };
     }
 
-    private static HttpResponseMessage RateLimited(RetryConditionHeaderValue? retryAfter = null)
+    private static HttpResponseMessage RateLimited(RetryConditionHeaderValue? retryAfter = null, HttpStatusCode status = HttpStatusCode.TooManyRequests)
     {
-        var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        var resp = new HttpResponseMessage(status);
         if (retryAfter is not null)
         {
             resp.Headers.RetryAfter = retryAfter;
@@ -123,6 +123,23 @@ public class OsmTileServiceTests
     }
 
     [Fact]
+    public async Task Fetch_Retries_ServiceUnavailable_Like_TooManyRequests()
+    {
+        // 503 takes the same retry branch as 429 (OsmTileService treats them identically).
+        var handler = new ScriptedHandler(call => call < 2 ? RateLimited(status: HttpStatusCode.ServiceUnavailable) : OkTile());
+        var delays = new List<TimeSpan>();
+        var svc = Service(handler, delays);
+
+        var mosaic = await FetchSmallAsync(svc);
+
+        var tiles = (mosaic.Width / 256) * (mosaic.Height / 256);
+        Assert.Equal(tiles, mosaic.TileCount);
+        Assert.Equal(0, mosaic.FailedTileCount);
+        Assert.Equal(tiles + 2, handler.Calls); // two 503s cost one extra request each
+        Assert.Equal(2, delays.Count);
+    }
+
+    [Fact]
     public async Task Fetch_Backoff_Is_Exponential_With_Jitter_When_No_RetryAfter()
     {
         var handler = new ScriptedHandler(call => call < 3 ? RateLimited() : OkTile());
@@ -154,6 +171,28 @@ public class OsmTileServiceTests
 
         Assert.Equal(TimeSpan.FromSeconds(7), delays[0]);
         Assert.Equal(TimeSpan.FromSeconds(30), delays[1]); // 10 min clamped to the 30 s cap
+    }
+
+    [Fact]
+    public async Task Fetch_Honors_RetryAfter_HttpDate_Format_And_Clamps()
+    {
+        // Retry-After as an absolute HTTP-date (the .Date branch) rather than delta-seconds.
+        // Delay is computed as (date - UtcNow), so a sub-second gap elapses before the service
+        // reads it; the generous lower bound tolerates that while still excluding the backoff
+        // fallback (<=1 s) and the delta path, proving the date was actually parsed.
+        var handler = new ScriptedHandler(call => call switch
+        {
+            0 => RateLimited(new RetryConditionHeaderValue(DateTimeOffset.UtcNow.AddSeconds(10))),
+            1 => RateLimited(new RetryConditionHeaderValue(DateTimeOffset.UtcNow.AddMinutes(10))),
+            _ => OkTile(),
+        });
+        var delays = new List<TimeSpan>();
+        var svc = Service(handler, delays);
+
+        await FetchSmallAsync(svc);
+
+        Assert.InRange(delays[0].TotalSeconds, 8.0, 10.0); // ~10 s honored from the HTTP-date
+        Assert.Equal(TimeSpan.FromSeconds(30), delays[1]); // 10 min out clamped to the 30 s cap
     }
 
     [Fact]

--- a/FUSE.ExternalEditor.UiTests/OsmTileServiceTests.cs
+++ b/FUSE.ExternalEditor.UiTests/OsmTileServiceTests.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Fuse.ExternalEditor.Services;
@@ -26,12 +28,53 @@ public class OsmTileServiceTests
                 SawUserAgent = true;
             }
 
-            using var img = new Image<Rgba32>(256, 256, new Rgba32(120, 140, 160, 255));
-            using var ms = new MemoryStream();
-            img.SaveAsPng(ms);
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(ms.ToArray()) });
+            return Task.FromResult(OkTile());
         }
     }
+
+    /// <summary>Responds per call index so tests can script 429/503 sequences.</summary>
+    private sealed class ScriptedHandler : HttpMessageHandler
+    {
+        private readonly Func<int, HttpResponseMessage> _respond;
+
+        public ScriptedHandler(Func<int, HttpResponseMessage> respond) => _respond = respond;
+
+        public int Calls { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_respond(Calls++));
+    }
+
+    private static HttpResponseMessage OkTile()
+    {
+        using var img = new Image<Rgba32>(256, 256, new Rgba32(120, 140, 160, 255));
+        using var ms = new MemoryStream();
+        img.SaveAsPng(ms);
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(ms.ToArray()) };
+    }
+
+    private static HttpResponseMessage RateLimited(RetryConditionHeaderValue? retryAfter = null)
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        if (retryAfter is not null)
+        {
+            resp.Headers.RetryAfter = retryAfter;
+        }
+
+        return resp;
+    }
+
+    /// <summary>Service with the backoff wait stubbed out; waits are recorded into <paramref name="delays"/>.</summary>
+    private static OsmTileService Service(HttpMessageHandler handler, List<TimeSpan> delays, int maxAttempts = 4)
+        => new(new HttpClient(handler), maxAttempts, (d, _) =>
+        {
+            delays.Add(d);
+            return Task.CompletedTask;
+        });
+
+    // Small box well inside one z14 tile; mosaic dimensions give the actual tile count.
+    private static Task<OsmMosaic> FetchSmallAsync(OsmTileService svc, CancellationToken ct = default)
+        => svc.FetchAsync(35.390, -83.490, 35.391, -83.489, zoom: 14, ct);
 
     [Fact]
     public async Task Fetch_Stitches_Tiles_And_Sends_UserAgent()
@@ -42,6 +85,7 @@ public class OsmTileServiceTests
         var mosaic = await svc.FetchAsync(35.38, -83.50, 35.40, -83.48, zoom: 14);
 
         Assert.True(mosaic.TileCount >= 1);
+        Assert.Equal(0, mosaic.FailedTileCount);
         Assert.Equal(0, mosaic.Width % 256);
         Assert.Equal(0, mosaic.Height % 256);
         Assert.Equal((mosaic.Width / 256) * (mosaic.Height / 256), mosaic.TileCount);
@@ -61,4 +105,95 @@ public class OsmTileServiceTests
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             svc.FetchAsync(-80, -179, 80, 179, zoom: 10)); // whole-world at z10 ≫ tile cap
     }
+
+    [Fact]
+    public async Task Fetch_Retries_RateLimited_Tile_Then_Succeeds()
+    {
+        var handler = new ScriptedHandler(call => call < 2 ? RateLimited() : OkTile());
+        var delays = new List<TimeSpan>();
+        var svc = Service(handler, delays);
+
+        var mosaic = await FetchSmallAsync(svc);
+
+        var tiles = (mosaic.Width / 256) * (mosaic.Height / 256);
+        Assert.Equal(tiles, mosaic.TileCount);
+        Assert.Equal(0, mosaic.FailedTileCount);
+        Assert.Equal(tiles + 2, handler.Calls); // two 429s cost one extra request each
+        Assert.Equal(2, delays.Count);
+    }
+
+    [Fact]
+    public async Task Fetch_Backoff_Is_Exponential_With_Jitter_When_No_RetryAfter()
+    {
+        var handler = new ScriptedHandler(call => call < 3 ? RateLimited() : OkTile());
+        var delays = new List<TimeSpan>();
+        var svc = Service(handler, delays);
+
+        await FetchSmallAsync(svc);
+
+        Assert.Equal(3, delays.Count);
+        // base 500ms doubling per attempt, jittered into [50%, 100%] of nominal
+        Assert.InRange(delays[0].TotalMilliseconds, 250, 500);
+        Assert.InRange(delays[1].TotalMilliseconds, 500, 1000);
+        Assert.InRange(delays[2].TotalMilliseconds, 1000, 2000);
+    }
+
+    [Fact]
+    public async Task Fetch_Honors_RetryAfter_Header_And_Clamps_Excessive_Values()
+    {
+        var handler = new ScriptedHandler(call => call switch
+        {
+            0 => RateLimited(new RetryConditionHeaderValue(TimeSpan.FromSeconds(7))),
+            1 => RateLimited(new RetryConditionHeaderValue(TimeSpan.FromMinutes(10))),
+            _ => OkTile(),
+        });
+        var delays = new List<TimeSpan>();
+        var svc = Service(handler, delays);
+
+        await FetchSmallAsync(svc);
+
+        Assert.Equal(TimeSpan.FromSeconds(7), delays[0]);
+        Assert.Equal(TimeSpan.FromSeconds(30), delays[1]); // 10 min clamped to the 30 s cap
+    }
+
+    [Fact]
+    public async Task Fetch_Leaves_Exhausted_Tile_Transparent_And_Stops_Retrying_Later_Tiles()
+    {
+        var handler = new ScriptedHandler(_ => RateLimited(new RetryConditionHeaderValue(TimeSpan.Zero)));
+        var delays = new List<TimeSpan>();
+        var svc = Service(handler, delays, maxAttempts: 3);
+
+        var mosaic = await FetchSmallAsync(svc);
+
+        var tiles = (mosaic.Width / 256) * (mosaic.Height / 256);
+        Assert.Equal(0, mosaic.TileCount);
+        Assert.Equal(tiles, mosaic.FailedTileCount);
+        Assert.All(mosaic.Rgba, b => Assert.Equal(0, b)); // failed tiles stay transparent
+        Assert.Equal(3 + (tiles - 1), handler.Calls); // full retries once, then one attempt per tile
+        Assert.Equal(2, delays.Count);
+    }
+
+    [Fact]
+    public async Task Fetch_Throws_On_NonRetryable_Status()
+    {
+        var handler = new ScriptedHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+        var svc = Service(handler, new List<TimeSpan>());
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => FetchSmallAsync(svc));
+        Assert.Equal(1, handler.Calls); // no retry for non-429/503
+    }
+
+    [Fact]
+    public async Task Fetch_Propagates_Cancellation_During_Backoff()
+    {
+        var handler = new ScriptedHandler(_ => RateLimited());
+        var svc = new OsmTileService(new HttpClient(handler), maxAttempts: 4, (_, ct) => throw new OperationCanceledException(ct));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => FetchSmallAsync(svc));
+        Assert.Equal(1, handler.Calls); // cancelled in the first backoff wait
+    }
+
+    [Fact]
+    public void Constructor_Rejects_NonPositive_MaxAttempts()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new OsmTileService(new HttpClient(new FakeHandler()), maxAttempts: 0));
 }

--- a/FUSE.ExternalEditor/Services/IOsmTileService.cs
+++ b/FUSE.ExternalEditor/Services/IOsmTileService.cs
@@ -6,12 +6,13 @@ namespace Fuse.ExternalEditor.Services;
 /// <summary>A stitched OSM raster mosaic plus the geo bounds it covers (for alignment).</summary>
 public sealed class OsmMosaic
 {
-    public OsmMosaic(byte[] rgba, int width, int height, int tileCount, double northLat, double westLon, double southLat, double eastLon)
+    public OsmMosaic(byte[] rgba, int width, int height, int tileCount, int failedTileCount, double northLat, double westLon, double southLat, double eastLon)
     {
         Rgba = rgba;
         Width = width;
         Height = height;
         TileCount = tileCount;
+        FailedTileCount = failedTileCount;
         NorthLat = northLat;
         WestLon = westLon;
         SouthLat = southLat;
@@ -22,6 +23,9 @@ public sealed class OsmMosaic
     public int Width { get; }
     public int Height { get; }
     public int TileCount { get; }
+
+    /// <summary>Tiles left transparent after rate-limit retries were exhausted (429/503).</summary>
+    public int FailedTileCount { get; }
     public double NorthLat { get; }
     public double WestLon { get; }
     public double SouthLat { get; }

--- a/FUSE.ExternalEditor/Services/OsmTileService.cs
+++ b/FUSE.ExternalEditor/Services/OsmTileService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,13 +16,36 @@ namespace Fuse.ExternalEditor.Services;
 /// can align it to the world tiles. Sends a User-Agent per OSM tile-usage policy. HTTP is
 /// injectable for testing.
 /// </summary>
+/// <remarks>
+/// The OSM tile servers actively rate-limit, so 429/503 responses get a bounded retry:
+/// the <c>Retry-After</c> header is honoured when present, otherwise exponential backoff
+/// with jitter. A tile that exhausts its retries is left transparent (the overlay is a
+/// best-effort guide layer) and counted in <see cref="OsmMosaic.FailedTileCount"/>; once
+/// one tile gives up, later tiles get a single attempt each so a persistently throttling
+/// server is not hammered with more backoff rounds.
+/// </remarks>
 public sealed class OsmTileService : IOsmTileService
 {
     private const int TileSize = 256;
     private const int MaxTiles = 256; // guard against runaway requests
-    private readonly HttpClient _http;
+    private const int DefaultMaxAttempts = 4;
+    private static readonly TimeSpan BaseRetryDelay = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(30);
 
-    public OsmTileService(HttpClient http) => _http = http;
+    private readonly HttpClient _http;
+    private readonly int _maxAttempts;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delay;
+
+    /// <param name="http">Transport; injectable for testing.</param>
+    /// <param name="maxAttempts">Total tries per tile (first attempt + retries) on 429/503.</param>
+    /// <param name="delay">Backoff wait; defaults to <see cref="Task.Delay(TimeSpan, CancellationToken)"/>, injectable for testing.</param>
+    public OsmTileService(HttpClient http, int maxAttempts = DefaultMaxAttempts, Func<TimeSpan, CancellationToken, Task>? delay = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxAttempts, 1);
+        _http = http;
+        _maxAttempts = maxAttempts;
+        _delay = delay ?? Task.Delay;
+    }
 
     public async Task<OsmMosaic> FetchAsync(double minLat, double minLon, double maxLat, double maxLon, int zoom, CancellationToken ct = default)
     {
@@ -45,14 +69,21 @@ public sealed class OsmTileService : IOsmTileService
         }
 
         int w = cols * TileSize, h = rows * TileSize;
-        var rgba = new byte[w * h * 4];
+        var rgba = new byte[w * h * 4]; // zero-initialised = transparent, so failed tiles need no blit
         var count = 0;
+        var failed = 0;
         for (var ty = y0; ty <= y1; ty++)
         {
             for (var tx = x0; tx <= x1; tx++)
             {
                 var url = $"https://tile.openstreetmap.org/{zoom}/{tx}/{ty}.png";
-                var tile = await FetchTileAsync(url, ct).ConfigureAwait(false);
+                var tile = await FetchTileAsync(url, failed > 0 ? 1 : _maxAttempts, ct).ConfigureAwait(false);
+                if (tile is null)
+                {
+                    failed++;
+                    continue;
+                }
+
                 Blit(tile, rgba, w, (tx - x0) * TileSize, (ty - y0) * TileSize);
                 count++;
             }
@@ -60,17 +91,52 @@ public sealed class OsmTileService : IOsmTileService
 
         var nw = OsmTileMath.Tile2Deg(x0, y0, zoom);
         var se = OsmTileMath.Tile2Deg(x1 + 1, y1 + 1, zoom);
-        return new OsmMosaic(rgba, w, h, count, nw.Lat, nw.Lon, se.Lat, se.Lon);
+        return new OsmMosaic(rgba, w, h, count, failed, nw.Lat, nw.Lon, se.Lat, se.Lon);
     }
 
-    private async Task<byte[]> FetchTileAsync(string url, CancellationToken ct)
+    /// <summary>One tile with bounded 429/503 retry; null when retries are exhausted.</summary>
+    private async Task<byte[]?> FetchTileAsync(string url, int maxAttempts, CancellationToken ct)
     {
-        using var req = new HttpRequestMessage(HttpMethod.Get, url);
-        req.Headers.TryAddWithoutValidation("User-Agent", "FUSE.ExternalEditor/1.0 (+https://github.com/F-U-S-E-E/FuseDevelopmentGroup)");
-        using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
-        resp.EnsureSuccessStatusCode();
-        var bytes = await resp.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
+        for (var attempt = 1; ; attempt++)
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            req.Headers.TryAddWithoutValidation("User-Agent", "FUSE.ExternalEditor/1.0 (+https://github.com/F-U-S-E-E/FuseDevelopmentGroup)");
+            using var resp = await _http.SendAsync(req, ct).ConfigureAwait(false);
+            if (resp.StatusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable)
+            {
+                if (attempt >= maxAttempts)
+                {
+                    return null;
+                }
 
+                await _delay(RetryDelay(resp, attempt), ct).ConfigureAwait(false);
+                continue;
+            }
+
+            resp.EnsureSuccessStatusCode();
+            var bytes = await resp.Content.ReadAsByteArrayAsync(ct).ConfigureAwait(false);
+            return DecodeTile(bytes);
+        }
+    }
+
+    /// <summary>Server-directed wait (clamped <c>Retry-After</c>) or exponential backoff with jitter.</summary>
+    private static TimeSpan RetryDelay(HttpResponseMessage resp, int attempt)
+    {
+        var retryAfter = resp.Headers.RetryAfter;
+        var wait = retryAfter?.Delta ?? (retryAfter?.Date is { } date ? date - DateTimeOffset.UtcNow : null);
+        if (wait is { } server)
+        {
+            return server < TimeSpan.Zero ? TimeSpan.Zero
+                : server > MaxRetryDelay ? MaxRetryDelay
+                : server;
+        }
+
+        var backoff = BaseRetryDelay * (1 << Math.Min(attempt - 1, 6)) * (0.5 + (Random.Shared.NextDouble() * 0.5));
+        return backoff > MaxRetryDelay ? MaxRetryDelay : backoff;
+    }
+
+    private static byte[] DecodeTile(byte[] bytes)
+    {
         using var ms = new MemoryStream(bytes);
         using var image = Image.Load<Rgba32>(ms);
         var tile = new byte[TileSize * TileSize * 4];

--- a/FUSE.ExternalEditor/ViewModels/OsmOverlayViewModel.cs
+++ b/FUSE.ExternalEditor/ViewModels/OsmOverlayViewModel.cs
@@ -69,7 +69,9 @@ public partial class OsmOverlayViewModel : ViewModelBase
                 Math.Min(nw.WorldX, se.WorldX), Math.Max(nw.WorldX, se.WorldX),
                 Math.Min(nw.WorldZ, se.WorldZ), Math.Max(nw.WorldZ, se.WorldZ));
             Enabled = true;
-            Status = $"OSM: {mosaic.TileCount} tile(s) @ z{Zoom}.";
+            Status = mosaic.FailedTileCount > 0
+                ? $"OSM: {mosaic.TileCount} tile(s) @ z{Zoom}; {mosaic.FailedTileCount} skipped (rate limited)."
+                : $"OSM: {mosaic.TileCount} tile(s) @ z{Zoom}.";
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Closes #85.

## What

`OsmTileService` fetched tiles sequentially and called `EnsureSuccessStatusCode()` on each response, so a single `429 Too Many Requests` or `503 Service Unavailable` mid-mosaic aborted the entire fetch with no retry. OSM actively rate-limits, and the overlay is a best-effort guide layer, so this makes it resilient.

## Behaviour

- **429 / 503** → honour the `Retry-After` header when present (delta-seconds or HTTP-date), clamped to a 30 s cap; otherwise **exponential backoff with jitter** (500 ms base, doubling per attempt, ×[0.5–1.0], 30 s cap).
- **Configurable attempt count** (`maxAttempts = 4` default) via constructor; injectable `delay` func keeps tests fast. Guards `maxAttempts >= 1`.
- **Exhaustion → continue, don't crash**: a tile that runs out of retries is left transparent and counted in the new `OsmMosaic.FailedTileCount`. A fetch-wide fuse drops later tiles to a single attempt each once one tile gives up, so a persistently throttling server isn't hammered with more backoff rounds.
- **`CancellationToken` threaded through every await.**
- Other (non-429/503) failures still throw immediately — no behaviour change for real errors.
- `OsmOverlayViewModel` reports skipped tiles in the status bar: `OSM: N tile(s) @ zZ; M skipped (rate limited).`

## Tests

7 new cases in `OsmTileServiceTests` (injected handler + delay, no real sleeps): retry-then-succeed, exponential-jitter ranges, `Retry-After` honour + clamp, exhaustion-leaves-transparent + fuse, non-retryable status throws, cancellation-during-backoff, and the constructor guard. Full UI suite: **94 passed, 0 failed**. Slopwatch: clean.

> Raised during review of #84 (https://github.com/F-U-S-E-E/FuseDevelopmentGroup/pull/84#discussion_r3337253605).