### PR TITLE
FUSE.Converter CLI + validation fix-hint catalog (#82)

### DIFF
--- a/FUSE.Converter/FUSE.Converter.csproj
+++ b/FUSE.Converter/FUSE.Converter.csproj
@@ -27,6 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- FUSE.Core supplies the unified FuseDiagnostic shape so conversion
+         reports render through the same path as validation issues. -->
+    <ProjectReference Include="..\FUSE.Core\FUSE.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- FUSE.Tests and the editor's Convert button reach into the
          internal types to drive conversion without exposing a wide API. -->
     <InternalsVisibleTo Include="FUSE.Tests" />

--- a/FUSE.Converter/FuseConversionDiagnostics.cs
+++ b/FUSE.Converter/FuseConversionDiagnostics.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using Fuse.Core.Validation;
+using FUSE.Converter.Models;
+
+namespace FUSE.Converter
+{
+    /// <summary>
+    /// Adapts a conversion report into the unified
+    /// <see cref="FuseDiagnostic"/> shape so the CLI and the editors render
+    /// conversion and validation findings through one path. Lives here (not
+    /// in FUSE.Core) because Core must not reference the converter layer.
+    /// </summary>
+    public static class FuseConversionDiagnostics
+    {
+        public static List<FuseDiagnostic> FromConversion(FuseConversionResult result)
+        {
+            var diagnostics = new List<FuseDiagnostic>();
+            if (result?.Report == null)
+            {
+                return diagnostics;
+            }
+
+            foreach (var entry in result.Report)
+            {
+                if (entry == null)
+                {
+                    continue;
+                }
+
+                diagnostics.Add(new FuseDiagnostic(
+                    ToSeverity(entry.Level),
+                    entry.Concept,
+                    field: null,
+                    entry.Message,
+                    entry.SourceFile));
+            }
+
+            return diagnostics;
+        }
+
+        private static FuseDiagnosticSeverity ToSeverity(FuseConversionReportLevel level)
+        {
+            switch (level)
+            {
+                case FuseConversionReportLevel.Error:
+                    return FuseDiagnosticSeverity.Error;
+                case FuseConversionReportLevel.Warning:
+                    return FuseDiagnosticSeverity.Warning;
+                default:
+                    return FuseDiagnosticSeverity.Info;
+            }
+        }
+    }
+}

--- a/FUSE.Converter/FuseLegacyConverter.cs
+++ b/FUSE.Converter/FuseLegacyConverter.cs
@@ -24,7 +24,7 @@ namespace FUSE.Converter
     /// (<c>&lt;input&gt;.FUSE</c>) so the user sees the new mod next
     /// to the original in <c>Mods/</c>.
     /// </remarks>
-    internal static class FuseLegacyConverter
+    public static class FuseLegacyConverter
     {
         public static FuseConversionResult ConvertMod(string modFolder, string outputFolder)
         {

--- a/FUSE.Converter/Models/FuseConversionReportEntry.cs
+++ b/FUSE.Converter/Models/FuseConversionReportEntry.cs
@@ -6,7 +6,7 @@ namespace FUSE.Converter.Models
     /// button surfaces warnings in the status panel so the modder can
     /// see what's missing without the conversion outright failing.
     /// </summary>
-    internal enum FuseConversionReportLevel
+    public enum FuseConversionReportLevel
     {
         Info,
         Warning,
@@ -18,7 +18,7 @@ namespace FUSE.Converter.Models
     /// <c>ReportEntry</c> dataclass: level + message + optional
     /// originating file + originating concept.
     /// </summary>
-    internal sealed class FuseConversionReportEntry
+    public sealed class FuseConversionReportEntry
     {
         public FuseConversionReportLevel Level { get; set; }
         public string Message { get; set; }

--- a/FUSE.Converter/Models/FuseConversionResult.cs
+++ b/FUSE.Converter/Models/FuseConversionResult.cs
@@ -9,7 +9,7 @@ namespace FUSE.Converter.Models
     /// partial conversion shows the modder the work that DID complete
     /// alongside the error that stopped it).
     /// </summary>
-    internal sealed class FuseConversionResult
+    public sealed class FuseConversionResult
     {
         public bool Success { get; set; }
 

--- a/FUSE.ConverterCli/CliOptions.cs
+++ b/FUSE.ConverterCli/CliOptions.cs
@@ -51,9 +51,15 @@ internal sealed class CliOptions
                     break;
 
                 case "--kind":
-                    if (++index >= args.Length || !Kinds.Contains(args[index]))
+                    if (++index >= args.Length)
                     {
-                        error = "--kind requires one of: auto, route, audio, asset.";
+                        error = "--kind requires a value (auto, route, audio, or asset).";
+                        return null;
+                    }
+
+                    if (!Kinds.Contains(args[index]))
+                    {
+                        error = $"--kind: invalid value '{args[index]}'. Allowed: auto, route, audio, asset.";
                         return null;
                     }
 
@@ -61,9 +67,15 @@ internal sealed class CliOptions
                     break;
 
                 case "--format":
-                    if (++index >= args.Length || !Formats.Contains(args[index]))
+                    if (++index >= args.Length)
                     {
-                        error = "--format requires one of: console, json, markdown, all.";
+                        error = "--format requires a value (console, json, markdown, or all).";
+                        return null;
+                    }
+
+                    if (!Formats.Contains(args[index]))
+                    {
+                        error = $"--format: invalid value '{args[index]}'. Allowed: console, json, markdown, all.";
                         return null;
                     }
 

--- a/FUSE.ConverterCli/CliOptions.cs
+++ b/FUSE.ConverterCli/CliOptions.cs
@@ -1,0 +1,151 @@
+namespace Fuse.ConverterCli;
+
+/// <summary>
+/// Parsed `fuse-convert` arguments. Mirrors the legacy Python converter's
+/// surface (inputs, --out, --kind, --clean, --batch) plus the validation
+/// flags from the convert→validate→report pipeline.
+/// </summary>
+internal sealed class CliOptions
+{
+    public List<string> Inputs { get; } = new();
+    public string? OutputRoot { get; set; }
+    public string Kind { get; set; } = "auto";
+    public bool Clean { get; set; }
+    public bool Batch { get; set; }
+    public bool Validate { get; set; } = true;
+    public bool Strict { get; set; }
+    public string Format { get; set; } = "console";
+    public bool Quiet { get; set; }
+    public bool ShowHelp { get; set; }
+
+    private static readonly string[] Kinds = { "auto", "route", "audio", "asset" };
+    private static readonly string[] Formats = { "console", "json", "markdown", "all" };
+
+    public bool WriteJsonReport => Format is "json" or "all";
+    public bool WriteMarkdownReport => Format is "markdown" or "all";
+
+    /// <summary>Returns the parsed options, or null with an error message on a usage problem.</summary>
+    public static CliOptions? Parse(string[] args, out string? error)
+    {
+        error = null;
+        var options = new CliOptions();
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var arg = args[index];
+            switch (arg)
+            {
+                case "-h":
+                case "--help":
+                    options.ShowHelp = true;
+                    return options;
+
+                case "--out":
+                    if (++index >= args.Length)
+                    {
+                        error = "--out requires a directory path.";
+                        return null;
+                    }
+
+                    options.OutputRoot = args[index];
+                    break;
+
+                case "--kind":
+                    if (++index >= args.Length || !Kinds.Contains(args[index]))
+                    {
+                        error = "--kind requires one of: auto, route, audio, asset.";
+                        return null;
+                    }
+
+                    options.Kind = args[index];
+                    break;
+
+                case "--format":
+                    if (++index >= args.Length || !Formats.Contains(args[index]))
+                    {
+                        error = "--format requires one of: console, json, markdown, all.";
+                        return null;
+                    }
+
+                    options.Format = args[index];
+                    break;
+
+                case "--clean":
+                    options.Clean = true;
+                    break;
+
+                case "--batch":
+                    options.Batch = true;
+                    break;
+
+                case "--validate":
+                    options.Validate = true;
+                    break;
+
+                case "--no-validate":
+                    options.Validate = false;
+                    break;
+
+                case "--strict":
+                    options.Strict = true;
+                    break;
+
+                case "--quiet":
+                    options.Quiet = true;
+                    break;
+
+                default:
+                    if (arg.StartsWith('-'))
+                    {
+                        error = $"Unknown option: {arg}";
+                        return null;
+                    }
+
+                    options.Inputs.Add(arg);
+                    break;
+            }
+        }
+
+        if (options.Inputs.Count == 0)
+        {
+            error = "At least one input folder is required.";
+            return null;
+        }
+
+        return options;
+    }
+
+    public const string Usage = @"fuse-convert — convert legacy Railroader mods to FUSE packages and validate the result.
+
+USAGE:
+  fuse-convert <inputs...> [--out <dir>] [--kind <kind>] [--clean] [--batch]
+               [--no-validate] [--strict] [--format <fmt>] [--quiet]
+
+ARGUMENTS:
+  <inputs...>     One or more legacy mod folders. With --batch, container
+                  folders whose child folders are converted individually.
+                  Zip archives and bare JSON files are not supported here;
+                  extract the zip (or place the JSON in a mod folder) first.
+
+OPTIONS:
+  --out <dir>     Output root. Each mod converts into '<dir>\<ModFolder>.FUSE'.
+                  Default: '.\FUSEConverted'.
+  --kind <kind>   Force a package kind: auto | route | audio | asset. Default: auto.
+  --clean         Replace an existing '.FUSE' output folder for each converted mod.
+  --batch         Treat each input as a container of mods and convert every
+                  recognized child folder.
+  --validate      Validate converted fragments and print fix-hints (default: on).
+  --no-validate   Skip validation.
+  --strict        Exit with code 2 when validation produces warnings, not just errors.
+  --format <fmt>  console (default) | json | markdown | all. json writes
+                  conversion-report.json and markdown writes conversion-report.md
+                  into each mod's output folder; all writes both.
+  --quiet         Suppress per-diagnostic console output; print only summaries.
+  -h, --help      Show this help.
+
+EXIT CODES:
+  0   success (validation warnings allowed unless --strict)
+  1   conversion failed
+  2   validation errors (or --strict and validation warnings)
+  64  usage error";
+}

--- a/FUSE.ConverterCli/FUSE.ConverterCli.csproj
+++ b/FUSE.ConverterCli/FUSE.ConverterCli.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <!-- Binary name is the user-facing contract: `fuse-convert`. -->
+    <AssemblyName>fuse-convert</AssemblyName>
+    <RootNamespace>Fuse.ConverterCli</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <!-- Convert → validate → report pipeline over FUSE.Core + FUSE.Converter;
+         no game/Unity DLLs, builds with no GameDir. -->
+    <FuseIsGameFree>true</FuseIsGameFree>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FUSE.Core\FUSE.Core.csproj" />
+    <ProjectReference Include="..\FUSE.Converter\FUSE.Converter.csproj" />
+  </ItemGroup>
+</Project>

--- a/FUSE.ConverterCli/Program.cs
+++ b/FUSE.ConverterCli/Program.cs
@@ -53,7 +53,16 @@ internal static class Program
             var outputFolder = Path.Combine(outputRoot, Path.GetFileName(modFolder.TrimEnd('\\', '/')) + ".FUSE");
             if (options.Clean && Directory.Exists(outputFolder))
             {
-                Directory.Delete(outputFolder, recursive: true);
+                try
+                {
+                    Directory.Delete(outputFolder, recursive: true);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"fuse-convert: failed to clean existing output folder '{outputFolder}': {ex.Message}");
+                    anyConversionFailed = true;
+                    continue;
+                }
             }
 
             var result = FuseLegacyConverter.ConvertPackage(modFolder, outputFolder, options.Kind);
@@ -204,8 +213,14 @@ internal static class Program
         List<FuseDiagnostic> conversionDiagnostics,
         List<FuseDiagnostic> validationDiagnostics)
     {
-        if ((!options.WriteJsonReport && !options.WriteMarkdownReport) || !Directory.Exists(result.OutputFolderPath))
+        if (!options.WriteJsonReport && !options.WriteMarkdownReport)
         {
+            return;
+        }
+
+        if (!Directory.Exists(result.OutputFolderPath))
+        {
+            Console.Error.WriteLine($"fuse-convert: cannot write reports; output folder does not exist: {result.OutputFolderPath}");
             return;
         }
 
@@ -222,9 +237,16 @@ internal static class Program
                 ["conversion"] = FuseValidationRenderer.ToJsonArray(conversionDiagnostics),
                 ["validation"] = FuseValidationRenderer.ToJsonArray(validationDiagnostics),
             };
-            File.WriteAllText(
-                Path.Combine(result.OutputFolderPath, "conversion-report.json"),
-                report.ToString(Formatting.Indented));
+            try
+            {
+                File.WriteAllText(
+                    Path.Combine(result.OutputFolderPath, "conversion-report.json"),
+                    report.ToString(Formatting.Indented));
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"fuse-convert: failed to write conversion-report.json: {ex.Message}");
+            }
         }
 
         if (options.WriteMarkdownReport)
@@ -238,7 +260,14 @@ internal static class Program
                 (conversionDiagnostics.Count > 0 ? FuseValidationRenderer.ToMarkdown(conversionDiagnostics) : "No conversion findings.\n") +
                 "\n## Validation\n\n" +
                 (validationDiagnostics.Count > 0 ? FuseValidationRenderer.ToMarkdown(validationDiagnostics) : "No validation findings.\n");
-            File.WriteAllText(Path.Combine(result.OutputFolderPath, "conversion-report.md"), markdown);
+            try
+            {
+                File.WriteAllText(Path.Combine(result.OutputFolderPath, "conversion-report.md"), markdown);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"fuse-convert: failed to write conversion-report.md: {ex.Message}");
+            }
         }
     }
 }

--- a/FUSE.ConverterCli/Program.cs
+++ b/FUSE.ConverterCli/Program.cs
@@ -1,0 +1,244 @@
+using Fuse.Core.Serialization;
+using Fuse.Core.Validation;
+using FUSE.Converter;
+using FUSE.Converter.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Fuse.ConverterCli;
+
+/// <summary>
+/// `fuse-convert`: convert legacy Railroader mods to FUSE packages, then
+/// validate every written fragment and render each finding with its
+/// fix-hint from the FUSE.Core catalog. Exit codes let CI gate conversion
+/// failures (1) separately from validation findings (2).
+/// </summary>
+internal static class Program
+{
+    private const int ExitOk = 0;
+    private const int ExitConversionFailed = 1;
+    private const int ExitValidationFailed = 2;
+    private const int ExitUsage = 64;
+
+    private static int Main(string[] args)
+    {
+        var options = CliOptions.Parse(args, out var usageError);
+        if (options == null)
+        {
+            Console.Error.WriteLine($"fuse-convert: {usageError}");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine(CliOptions.Usage);
+            return ExitUsage;
+        }
+
+        if (options.ShowHelp)
+        {
+            Console.WriteLine(CliOptions.Usage);
+            return ExitOk;
+        }
+
+        var modFolders = ResolveModFolders(options, out var inputErrors);
+        foreach (var inputError in inputErrors)
+        {
+            Console.Error.WriteLine($"fuse-convert: {inputError}");
+        }
+
+        var anyConversionFailed = inputErrors.Count > 0;
+        var anyValidationErrors = false;
+        var anyValidationWarnings = false;
+
+        var outputRoot = Path.GetFullPath(options.OutputRoot ?? Path.Combine(".", "FUSEConverted"));
+        foreach (var modFolder in modFolders)
+        {
+            var outputFolder = Path.Combine(outputRoot, Path.GetFileName(modFolder.TrimEnd('\\', '/')) + ".FUSE");
+            if (options.Clean && Directory.Exists(outputFolder))
+            {
+                Directory.Delete(outputFolder, recursive: true);
+            }
+
+            var result = FuseLegacyConverter.ConvertPackage(modFolder, outputFolder, options.Kind);
+            var conversionDiagnostics = FuseConversionDiagnostics.FromConversion(result);
+            var validationDiagnostics = options.Validate
+                ? ValidateFragments(result)
+                : new List<FuseDiagnostic>();
+
+            anyConversionFailed |= !result.Success;
+            anyValidationErrors |= FuseValidationRenderer.CountErrors(validationDiagnostics) > 0;
+            anyValidationWarnings |= FuseValidationRenderer.CountWarnings(validationDiagnostics) > 0;
+
+            PrintMod(options, modFolder, result, conversionDiagnostics, validationDiagnostics);
+            WriteReports(options, result, conversionDiagnostics, validationDiagnostics);
+        }
+
+        if (anyConversionFailed)
+        {
+            return ExitConversionFailed;
+        }
+
+        if (anyValidationErrors || (options.Strict && anyValidationWarnings))
+        {
+            return ExitValidationFailed;
+        }
+
+        return ExitOk;
+    }
+
+    /// <summary>
+    /// Expands the raw inputs into the list of mod folders to convert.
+    /// In batch mode each input is a container whose recognized child
+    /// folders are converted individually.
+    /// </summary>
+    private static List<string> ResolveModFolders(CliOptions options, out List<string> errors)
+    {
+        errors = new List<string>();
+        var folders = new List<string>();
+        foreach (var input in options.Inputs)
+        {
+            if (File.Exists(input))
+            {
+                errors.Add($"'{input}' is a file. Zip archives and bare JSON files are not supported; extract the zip (or place the JSON in a mod folder) and pass the folder.");
+                continue;
+            }
+
+            if (!Directory.Exists(input))
+            {
+                errors.Add($"Input folder does not exist: {input}");
+                continue;
+            }
+
+            if (!options.Batch)
+            {
+                folders.Add(input);
+                continue;
+            }
+
+            var recognized = Directory.GetDirectories(input)
+                .Where(child => FuseLegacyConverter.DetectKind(child, options.Kind) != "unknown")
+                .OrderBy(child => child, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            if (recognized.Count == 0)
+            {
+                errors.Add($"--batch found no recognizable mod folders under: {input}");
+                continue;
+            }
+
+            folders.AddRange(recognized);
+        }
+
+        return folders;
+    }
+
+    /// <summary>
+    /// Loads each written fragment back through the shared serializer
+    /// (running migrations exactly as the game would) and validates it,
+    /// resolving every issue's fix-hint via the renderer.
+    /// </summary>
+    private static List<FuseDiagnostic> ValidateFragments(FuseConversionResult result)
+    {
+        var diagnostics = new List<FuseDiagnostic>();
+        var validator = new FuseDefinitionValidator();
+        foreach (var fragment in result.WrittenFragments.Where(name => name.EndsWith(".fuse.json", StringComparison.OrdinalIgnoreCase)))
+        {
+            var path = Path.Combine(result.OutputFolderPath, fragment);
+            try
+            {
+                var definition = FuseCoreSerializer.Load(path);
+                diagnostics.AddRange(FuseValidationRenderer.FromValidation(fragment, validator.Validate(definition)));
+            }
+            catch (Exception ex)
+            {
+                diagnostics.Add(new FuseDiagnostic(
+                    FuseDiagnosticSeverity.Error,
+                    code: null,
+                    field: null,
+                    $"Fragment failed to load for validation: {ex.Message}",
+                    fragment));
+            }
+        }
+
+        return diagnostics;
+    }
+
+    private static void PrintMod(
+        CliOptions options,
+        string modFolder,
+        FuseConversionResult result,
+        IReadOnlyList<FuseDiagnostic> conversionDiagnostics,
+        IReadOnlyList<FuseDiagnostic> validationDiagnostics)
+    {
+        var name = string.IsNullOrEmpty(result.ModName) ? Path.GetFileName(modFolder) : result.ModName;
+        Console.WriteLine($"== {name} ({modFolder})");
+        Console.WriteLine($"   conversion: {(result.Success ? "ok" : "FAILED")}, {result.WrittenFragments.Count} fragment(s) -> {result.OutputFolderPath}");
+        if (options.Validate)
+        {
+            Console.WriteLine($"   validation: {FuseValidationRenderer.CountErrors(validationDiagnostics)} error(s), {FuseValidationRenderer.CountWarnings(validationDiagnostics)} warning(s)");
+        }
+
+        Console.WriteLine();
+
+        if (options.Quiet)
+        {
+            return;
+        }
+
+        var conversionText = FuseValidationRenderer.ToConsole(conversionDiagnostics);
+        if (conversionText.Length > 0)
+        {
+            Console.WriteLine(conversionText);
+        }
+
+        var validationText = FuseValidationRenderer.ToConsole(validationDiagnostics);
+        if (validationText.Length > 0)
+        {
+            Console.WriteLine(validationText);
+        }
+    }
+
+    /// <summary>
+    /// Writes conversion-report.json / conversion-report.md (the legacy
+    /// Python converter's report file names) into the mod's output folder.
+    /// </summary>
+    private static void WriteReports(
+        CliOptions options,
+        FuseConversionResult result,
+        List<FuseDiagnostic> conversionDiagnostics,
+        List<FuseDiagnostic> validationDiagnostics)
+    {
+        if ((!options.WriteJsonReport && !options.WriteMarkdownReport) || !Directory.Exists(result.OutputFolderPath))
+        {
+            return;
+        }
+
+        if (options.WriteJsonReport)
+        {
+            var report = new JObject
+            {
+                ["tool"] = "fuse-convert",
+                ["modId"] = result.ModId,
+                ["modName"] = result.ModName,
+                ["success"] = result.Success,
+                ["outputFolder"] = result.OutputFolderPath,
+                ["fragments"] = JArray.FromObject(result.WrittenFragments),
+                ["conversion"] = FuseValidationRenderer.ToJsonArray(conversionDiagnostics),
+                ["validation"] = FuseValidationRenderer.ToJsonArray(validationDiagnostics),
+            };
+            File.WriteAllText(
+                Path.Combine(result.OutputFolderPath, "conversion-report.json"),
+                report.ToString(Formatting.Indented));
+        }
+
+        if (options.WriteMarkdownReport)
+        {
+            var markdown =
+                $"# Conversion report: {result.ModName}\n\n" +
+                $"- Source mod id: `{result.ModId}`\n" +
+                $"- Conversion: {(result.Success ? "ok" : "**failed**")}\n" +
+                $"- Fragments written: {result.WrittenFragments.Count}\n\n" +
+                "## Conversion\n\n" +
+                (conversionDiagnostics.Count > 0 ? FuseValidationRenderer.ToMarkdown(conversionDiagnostics) : "No conversion findings.\n") +
+                "\n## Validation\n\n" +
+                (validationDiagnostics.Count > 0 ? FuseValidationRenderer.ToMarkdown(validationDiagnostics) : "No validation findings.\n");
+            File.WriteAllText(Path.Combine(result.OutputFolderPath, "conversion-report.md"), markdown);
+        }
+    }
+}

--- a/FUSE.Core.Tests/CarTypeFilterValidationTests.cs
+++ b/FUSE.Core.Tests/CarTypeFilterValidationTests.cs
@@ -1,0 +1,172 @@
+using System.Linq;
+using Fuse.Core.Model;
+using Fuse.Core.Validation;
+using Xunit;
+
+namespace Fuse.Core.Tests
+{
+    /// <summary>
+    /// Exercises the carTypeFilter rule at all four model sites. The filter
+    /// is matched verbatim per comma-separated token at runtime, so
+    /// surrounding whitespace is an error (the token can never match) and an
+    /// empty token from a doubled/edge comma is a warning (the game ignores
+    /// it).
+    /// </summary>
+    public class CarTypeFilterValidationTests
+    {
+        private const string MalformedCode = "fuse.operations.component.carTypeFilter.malformed";
+        private const string EmptyTokenCode = "fuse.operations.component.carTypeFilter.emptyToken";
+
+        private static FuseModDefinition Minimal() => new FuseModDefinition { Id = "pkg", Name = "Package" };
+
+        private static ValidationResult Validate(FuseModDefinition definition) =>
+            new FuseDefinitionValidator().Validate(definition);
+
+        private static FuseModDefinition WithComponentFilter(string? filter)
+        {
+            var definition = Minimal();
+            definition.Operations.Industries["mill"] = new FuseIndustry
+            {
+                Name = "Mill",
+                Components =
+                {
+                    ["dock"] = new FuseIndustryComponent { Partial = true, CarTypeFilter = filter },
+                },
+            };
+            return definition;
+        }
+
+        [Fact]
+        public void Component_Filter_With_Surrounding_Whitespace_Is_An_Error()
+        {
+            var result = Validate(WithComponentFilter("FB, XM"));
+
+            var issue = Assert.Single(result.Errors, e => e.Code == MalformedCode);
+            Assert.Equal("operations.industries.mill.components.dock.carTypeFilter", issue.Field);
+            Assert.Equal("FB, XM", issue.Value);
+        }
+
+        [Fact]
+        public void Component_Filter_With_Doubled_Comma_Is_A_Warning()
+        {
+            var result = Validate(WithComponentFilter("FB,,XM"));
+
+            var issue = Assert.Single(result.Warnings, w => w.Code == EmptyTokenCode);
+            Assert.Equal("operations.industries.mill.components.dock.carTypeFilter", issue.Field);
+            Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
+        }
+
+        [Theory]
+        [InlineData("FB,XM")]
+        [InlineData("*")]
+        [InlineData("FB*")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void Component_Filter_Valid_Values_Stay_Silent(string? filter)
+        {
+            var result = Validate(WithComponentFilter(filter));
+
+            Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
+            Assert.DoesNotContain(result.Warnings, w => w.Code == EmptyTokenCode);
+        }
+
+        [Fact]
+        public void Trailing_Comma_Is_A_Warning_Not_An_Error()
+        {
+            var result = Validate(WithComponentFilter("FB,XM,"));
+
+            Assert.Contains(result.Warnings, w => w.Code == EmptyTokenCode);
+            Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
+        }
+
+        [Fact]
+        public void Whitespace_Padded_Wildcard_Is_An_Error()
+        {
+            // " * " is not the bare "any" wildcard: the runtime keeps the
+            // padding and the token can never match.
+            var result = Validate(WithComponentFilter(" * "));
+
+            Assert.Contains(result.Errors, e => e.Code == MalformedCode);
+        }
+
+        [Fact]
+        public void TeamProfile_Filter_Is_Validated()
+        {
+            var definition = Minimal();
+            definition.Operations.Industries["mill"] = new FuseIndustry
+            {
+                Name = "Mill",
+                Components =
+                {
+                    ["team"] = new FuseIndustryComponent
+                    {
+                        Partial = true,
+                        TeamProfiles =
+                        {
+                            ["lumber"] = new FuseTeamTrackEntry { LoadId = "lumber", CarTypeFilter = "FB, GB" },
+                        },
+                    },
+                },
+            };
+
+            var result = Validate(definition);
+
+            var issue = Assert.Single(result.Errors, e => e.Code == MalformedCode);
+            Assert.Equal("operations.industries.mill.components.team.teamProfiles.lumber.carTypeFilter", issue.Field);
+        }
+
+        [Fact]
+        public void Load_Filter_Is_Validated()
+        {
+            var definition = Minimal();
+            definition.Operations.Loads["coal"] = new FuseLoad { Name = "Coal", CarTypeFilter = "HM ,HT" };
+
+            var result = Validate(definition);
+
+            var issue = Assert.Single(result.Errors, e => e.Code == MalformedCode);
+            Assert.Equal("operations.loads.coal.carTypeFilter", issue.Field);
+        }
+
+        [Fact]
+        public void Delivery_Filter_Is_Validated()
+        {
+            var definition = Minimal();
+            definition.Progression.Progressions["main"] = new FuseProgression
+            {
+                Sections =
+                {
+                    ["s1"] = new FuseSection
+                    {
+                        DisplayName = "Section 1",
+                        DeliveryPhases = new[]
+                        {
+                            new FuseDeliveryPhase
+                            {
+                                IndustryComponentId = "mill.dock",
+                                Deliveries = new[]
+                                {
+                                    new FuseDelivery { Count = 1, CarTypeFilter = "FB, XM" },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            var result = Validate(definition);
+
+            var issue = Assert.Single(result.Errors, e => e.Code == MalformedCode);
+            Assert.Equal(
+                "progression.progressions.main.sections.s1.deliveryPhases[0].deliveries[0].carTypeFilter",
+                issue.Field);
+        }
+
+        [Fact]
+        public void Multiple_Bad_Tokens_Flag_Each_Token()
+        {
+            var result = Validate(WithComponentFilter(" FB , XM "));
+
+            Assert.Equal(2, result.Errors.Count(e => e.Code == MalformedCode));
+        }
+    }
+}

--- a/FUSE.Core.Tests/FUSE.Core.Tests.csproj
+++ b/FUSE.Core.Tests/FUSE.Core.Tests.csproj
@@ -33,6 +33,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The fix-hint coverage test scans BOTH validator sources (the FUSE.Core
+         mirror and the shipping in-game copy) so every emitted code is checked
+         against the catalog no matter which validator gains a rule first. -->
+    <EmbeddedResource Include="..\FUSE.Core\Validation\FuseDefinitionValidator.cs" LogicalName="ValidatorSource.Core.cs" />
+    <EmbeddedResource Include="..\FUSE\Authoring\Validation\FuseDefinitionValidator.cs" LogicalName="ValidatorSource.Game.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\schemas\fuse-mod.example.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/FUSE.Core.Tests/ValidationHelpCoverageTests.cs
+++ b/FUSE.Core.Tests/ValidationHelpCoverageTests.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Fuse.Core.Validation.Help;
+using Xunit;
+
+namespace Fuse.Core.Tests
+{
+    /// <summary>
+    /// Keeps the fix-hint catalog (<c>fuse-validation-help.json</c>) in
+    /// lockstep with the codes the validators emit. Source-scan based: every
+    /// <c>"fuse.*"</c> string literal in either validator source file counts
+    /// as an emitted code, so the test needs no churn when rules move between
+    /// single-line and multi-line calls or pass codes through helpers.
+    /// </summary>
+    public class ValidationHelpCoverageTests
+    {
+        private static readonly Regex CodePattern = new Regex("\"(fuse\\.\\w[\\w.]*)\"", RegexOptions.Compiled);
+
+        private static readonly string[] ValidatorSourceResources =
+        {
+            "ValidatorSource.Core.cs",
+            "ValidatorSource.Game.cs",
+        };
+
+        private static HashSet<string> EmittedCodes()
+        {
+            var codes = new HashSet<string>();
+            foreach (var resource in ValidatorSourceResources)
+            {
+                using (var stream = typeof(ValidationHelpCoverageTests).Assembly.GetManifestResourceStream(resource))
+                {
+                    Assert.True(stream != null, $"Embedded validator source '{resource}' is missing.");
+                    using (var reader = new StreamReader(stream!))
+                    {
+                        foreach (Match match in CodePattern.Matches(reader.ReadToEnd()))
+                        {
+                            codes.Add(match.Groups[1].Value);
+                        }
+                    }
+                }
+            }
+
+            return codes;
+        }
+
+        [Fact]
+        public void Every_Emitted_Code_Has_A_Catalog_Entry()
+        {
+            var missing = EmittedCodes()
+                .Where(code => !FuseValidationHelp.TryGet(code, out _))
+                .OrderBy(code => code)
+                .ToList();
+
+            Assert.True(
+                missing.Count == 0,
+                "Validation codes without a fix-hint catalog entry (add them to FUSE.Core/Validation/Help/fuse-validation-help.json): " +
+                string.Join(", ", missing));
+        }
+
+        [Fact]
+        public void Every_Catalog_Entry_Is_An_Emitted_Code()
+        {
+            var emitted = EmittedCodes();
+            var orphans = FuseValidationHelp.AllCodes
+                .Where(code => !emitted.Contains(code))
+                .OrderBy(code => code)
+                .ToList();
+
+            Assert.True(
+                orphans.Count == 0,
+                "Catalog entries whose code no validator emits (stale key or typo in fuse-validation-help.json): " +
+                string.Join(", ", orphans));
+        }
+
+        [Fact]
+        public void Catalog_Entries_Have_Title_Why_And_Fix()
+        {
+            var incomplete = FuseValidationHelp.AllCodes
+                .Where(code =>
+                {
+                    FuseValidationHelpEntry? entry;
+                    FuseValidationHelp.TryGet(code, out entry);
+                    return entry == null ||
+                           string.IsNullOrWhiteSpace(entry.Title) ||
+                           string.IsNullOrWhiteSpace(entry.Why) ||
+                           string.IsNullOrWhiteSpace(entry.Fix);
+                })
+                .OrderBy(code => code)
+                .ToList();
+
+            Assert.True(
+                incomplete.Count == 0,
+                "Catalog entries with an empty title/why/fix: " + string.Join(", ", incomplete));
+        }
+
+        [Fact]
+        public void Unknown_Code_Degrades_To_No_Help()
+        {
+            Assert.False(FuseValidationHelp.TryGet("fuse.not.a.real.code", out _));
+            Assert.Null(FuseValidationHelp.For("fuse.not.a.real.code"));
+            Assert.Null(FuseValidationHelp.For(null));
+        }
+    }
+}

--- a/FUSE.Core/FUSE.Core.csproj
+++ b/FUSE.Core/FUSE.Core.csproj
@@ -24,6 +24,11 @@
     <InternalsVisibleTo Include="FUSE.Core.Tests" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Fix-hint catalog: one embedded copy shared by the CLI, the editors,
+         and the coverage test in FUSE.Core.Tests. -->
+    <EmbeddedResource Include="Validation\Help\fuse-validation-help.json" LogicalName="Fuse.Core.Validation.Help.fuse-validation-help.json" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="..\schemas\**\*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>schemas\%(RecursiveDir)%(Filename)%(Extension)</Link>

--- a/FUSE.Core/Validation/FuseDefinitionValidator.cs
+++ b/FUSE.Core/Validation/FuseDefinitionValidator.cs
@@ -441,6 +441,7 @@ namespace Fuse.Core.Validation
                         result.AddError($"{path}.unitWeightInPounds", "Load unitWeightInPounds must be greater than or equal to 0.", "fuse.operations.loads.unitWeightInPounds", load.Value.UnitWeightInPounds.Value);
                     }
 
+                    ValidateCarTypeFilter(result, $"{path}.carTypeFilter", load.Value.CarTypeFilter);
                 }
             }
 
@@ -942,6 +943,8 @@ namespace Fuse.Core.Validation
                             result.AddError($"{deliveryPath}.direction", "Delivery direction must be loadToIndustry or loadFromIndustry.", "fuse.progression.delivery.direction", delivery.Direction);
                         }
                     }
+
+                    ValidateCarTypeFilter(result, $"{deliveryPath}.carTypeFilter", delivery.CarTypeFilter);
                 }
             }
         }
@@ -971,6 +974,32 @@ namespace Fuse.Core.Validation
                 }
 
                 index++;
+            }
+        }
+
+        private static void ValidateCarTypeFilter(ValidationResult result, string path, string filter)
+        {
+            // Empty and "*" both mean "any car type" at runtime, so only a
+            // filter with real tokens needs checking. The game splits the
+            // expression on ',' without trimming, so a token with surrounding
+            // whitespace can never match a car type.
+            if (string.IsNullOrWhiteSpace(filter) || filter == "*")
+            {
+                return;
+            }
+
+            var tokens = filter.Split(',');
+            for (var index = 0; index < tokens.Length; index++)
+            {
+                var token = tokens[index];
+                if (string.IsNullOrWhiteSpace(token))
+                {
+                    result.AddWarning(path, "Car type filter contains an empty entry (doubled, leading, or trailing comma); the game ignores it.", "fuse.operations.component.carTypeFilter.emptyToken", filter);
+                }
+                else if (token.Trim().Length != token.Length)
+                {
+                    result.AddError(path, $"Car type filter entry '{token}' has surrounding whitespace and can never match a car type; write the filter without spaces (e.g. \"FB,XM\").", "fuse.operations.component.carTypeFilter.malformed", filter);
+                }
             }
         }
 
@@ -1065,6 +1094,15 @@ namespace Fuse.Core.Validation
             if (component.CarTransferRate.HasValue && component.CarTransferRate.Value < 0f)
             {
                 result.AddError($"{path}.carTransferRate", "Car transfer rate must be greater than or equal to 0.", "fuse.operations.component.carTransferRate", component.CarTransferRate.Value);
+            }
+
+            ValidateCarTypeFilter(result, $"{path}.carTypeFilter", component.CarTypeFilter);
+            if (component.TeamProfiles != null)
+            {
+                foreach (var profile in component.TeamProfiles)
+                {
+                    ValidateCarTypeFilter(result, $"{path}.teamProfiles.{profile.Key}.carTypeFilter", profile.Value?.CarTypeFilter);
+                }
             }
 
             if (!partial &&

--- a/FUSE.Core/Validation/FuseDiagnostic.cs
+++ b/FUSE.Core/Validation/FuseDiagnostic.cs
@@ -1,0 +1,52 @@
+using Fuse.Core.Validation.Help;
+
+namespace Fuse.Core.Validation
+{
+    public enum FuseDiagnosticSeverity
+    {
+        Info,
+        Warning,
+        Error,
+    }
+
+    /// <summary>
+    /// One rendered-ready diagnostic row: a validation issue (or conversion
+    /// report line) plus the resolved fix-hint catalog entry. The CLI and
+    /// the editors bind the same list — there is intentionally no second
+    /// presentation model anywhere else.
+    /// </summary>
+    public sealed class FuseDiagnostic
+    {
+        public FuseDiagnostic(
+            FuseDiagnosticSeverity severity,
+            string code,
+            string field,
+            string message,
+            string source,
+            object value = null,
+            FuseValidationHelpEntry help = null)
+        {
+            Severity = severity;
+            Code = code ?? string.Empty;
+            Field = field ?? string.Empty;
+            Message = message ?? string.Empty;
+            Source = source ?? string.Empty;
+            Value = value;
+            Help = help;
+        }
+
+        public FuseDiagnosticSeverity Severity { get; }
+        public string Code { get; }
+        public string Field { get; }
+        public string Message { get; }
+
+        /// <summary>Where the diagnostic came from, e.g. a fragment file name.</summary>
+        public string Source { get; }
+
+        /// <summary>The offending value, when the issue captured one.</summary>
+        public object Value { get; }
+
+        /// <summary>Resolved fix-hint, or null when the code has no catalog entry.</summary>
+        public FuseValidationHelpEntry Help { get; }
+    }
+}

--- a/FUSE.Core/Validation/FuseValidationRenderer.cs
+++ b/FUSE.Core/Validation/FuseValidationRenderer.cs
@@ -1,0 +1,212 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Fuse.Core.Validation.Help;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Fuse.Core.Validation
+{
+    /// <summary>
+    /// Converts validation results into unified <see cref="FuseDiagnostic"/>
+    /// rows (resolving each issue's fix-hint from the embedded catalog) and
+    /// renders diagnostic lists for the console, Markdown reports, and JSON
+    /// reports. Conversion reports flow through the same shape via the
+    /// adapter in FUSE.Converter, so every front end shares one renderer.
+    /// </summary>
+    public static class FuseValidationRenderer
+    {
+        public static List<FuseDiagnostic> FromValidation(string source, ValidationResult result)
+        {
+            var diagnostics = new List<FuseDiagnostic>();
+            if (result == null)
+            {
+                return diagnostics;
+            }
+
+            foreach (var issue in result.Errors)
+            {
+                diagnostics.Add(ToDiagnostic(FuseDiagnosticSeverity.Error, source, issue));
+            }
+
+            foreach (var issue in result.Warnings)
+            {
+                diagnostics.Add(ToDiagnostic(FuseDiagnosticSeverity.Warning, source, issue));
+            }
+
+            return diagnostics;
+        }
+
+        private static FuseDiagnostic ToDiagnostic(FuseDiagnosticSeverity severity, string source, ValidationIssue issue)
+        {
+            return new FuseDiagnostic(
+                severity,
+                issue.Code,
+                issue.Field,
+                issue.Message,
+                source,
+                issue.Value,
+                FuseValidationHelp.For(issue.Code));
+        }
+
+        public static string ToConsole(IReadOnlyList<FuseDiagnostic> diagnostics)
+        {
+            var builder = new StringBuilder();
+            foreach (var diagnostic in diagnostics ?? (IReadOnlyList<FuseDiagnostic>)new FuseDiagnostic[0])
+            {
+                builder.Append(diagnostic.Severity.ToString().ToLowerInvariant());
+                if (!string.IsNullOrEmpty(diagnostic.Code))
+                {
+                    builder.Append(' ').Append(diagnostic.Code);
+                }
+
+                builder.AppendLine();
+
+                var location = JoinLocation(diagnostic);
+                if (location.Length > 0)
+                {
+                    builder.Append("  at:      ").AppendLine(location);
+                }
+
+                builder.Append("  problem: ").AppendLine(diagnostic.Message);
+                if (diagnostic.Value != null)
+                {
+                    builder.Append("  value:   ").AppendLine(diagnostic.Value.ToString());
+                }
+
+                if (diagnostic.Help != null)
+                {
+                    if (!string.IsNullOrEmpty(diagnostic.Help.Why))
+                    {
+                        builder.Append("  why:     ").AppendLine(diagnostic.Help.Why);
+                    }
+
+                    if (!string.IsNullOrEmpty(diagnostic.Help.Fix))
+                    {
+                        builder.Append("  fix:     ").AppendLine(diagnostic.Help.Fix);
+                    }
+
+                    if (!string.IsNullOrEmpty(diagnostic.Help.Example))
+                    {
+                        builder.Append("  example: ").AppendLine(diagnostic.Help.Example);
+                    }
+                }
+
+                builder.AppendLine();
+            }
+
+            return builder.ToString();
+        }
+
+        public static string ToMarkdown(IReadOnlyList<FuseDiagnostic> diagnostics)
+        {
+            var builder = new StringBuilder();
+            foreach (var diagnostic in diagnostics ?? (IReadOnlyList<FuseDiagnostic>)new FuseDiagnostic[0])
+            {
+                var title = diagnostic.Help != null && !string.IsNullOrEmpty(diagnostic.Help.Title)
+                    ? diagnostic.Help.Title
+                    : diagnostic.Message;
+                builder.Append("- **").Append(diagnostic.Severity.ToString().ToLowerInvariant()).Append("** ");
+                if (!string.IsNullOrEmpty(diagnostic.Code))
+                {
+                    builder.Append('`').Append(diagnostic.Code).Append("` ");
+                }
+
+                builder.AppendLine(title);
+
+                var location = JoinLocation(diagnostic);
+                if (location.Length > 0)
+                {
+                    builder.Append("  - At: `").Append(location).AppendLine("`");
+                }
+
+                builder.Append("  - Problem: ").AppendLine(diagnostic.Message);
+                if (diagnostic.Help != null)
+                {
+                    if (!string.IsNullOrEmpty(diagnostic.Help.Why))
+                    {
+                        builder.Append("  - Why: ").AppendLine(diagnostic.Help.Why);
+                    }
+
+                    if (!string.IsNullOrEmpty(diagnostic.Help.Fix))
+                    {
+                        builder.Append("  - Fix: ").AppendLine(diagnostic.Help.Fix);
+                    }
+
+                    if (!string.IsNullOrEmpty(diagnostic.Help.Example))
+                    {
+                        builder.Append("  - Example: `").Append(diagnostic.Help.Example).AppendLine("`");
+                    }
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        public static string ToJson(IReadOnlyList<FuseDiagnostic> diagnostics)
+        {
+            return ToJsonArray(diagnostics).ToString(Formatting.Indented);
+        }
+
+        public static JArray ToJsonArray(IReadOnlyList<FuseDiagnostic> diagnostics)
+        {
+            var rows = new JArray();
+            foreach (var diagnostic in diagnostics ?? (IReadOnlyList<FuseDiagnostic>)new FuseDiagnostic[0])
+            {
+                var row = new JObject
+                {
+                    ["severity"] = diagnostic.Severity.ToString().ToLowerInvariant(),
+                    ["code"] = diagnostic.Code,
+                    ["field"] = diagnostic.Field,
+                    ["message"] = diagnostic.Message,
+                    ["source"] = diagnostic.Source,
+                };
+
+                if (diagnostic.Value != null)
+                {
+                    row["value"] = JToken.FromObject(diagnostic.Value);
+                }
+
+                if (diagnostic.Help != null)
+                {
+                    row["help"] = new JObject
+                    {
+                        ["title"] = diagnostic.Help.Title,
+                        ["why"] = diagnostic.Help.Why,
+                        ["fix"] = diagnostic.Help.Fix,
+                        ["example"] = diagnostic.Help.Example,
+                    };
+                }
+
+                rows.Add(row);
+            }
+
+            return rows;
+        }
+
+        public static int CountErrors(IEnumerable<FuseDiagnostic> diagnostics)
+        {
+            return diagnostics?.Count(diagnostic => diagnostic.Severity == FuseDiagnosticSeverity.Error) ?? 0;
+        }
+
+        public static int CountWarnings(IEnumerable<FuseDiagnostic> diagnostics)
+        {
+            return diagnostics?.Count(diagnostic => diagnostic.Severity == FuseDiagnosticSeverity.Warning) ?? 0;
+        }
+
+        private static string JoinLocation(FuseDiagnostic diagnostic)
+        {
+            if (string.IsNullOrEmpty(diagnostic.Source))
+            {
+                return diagnostic.Field ?? string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(diagnostic.Field))
+            {
+                return diagnostic.Source;
+            }
+
+            return diagnostic.Source + " :: " + diagnostic.Field;
+        }
+    }
+}

--- a/FUSE.Core/Validation/Help/FuseValidationHelp.cs
+++ b/FUSE.Core/Validation/Help/FuseValidationHelp.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Fuse.Core.Validation.Help
+{
+    /// <summary>
+    /// One fix-hint catalog entry: the "what's wrong &amp; how to fix it"
+    /// guidance rendered next to a flagged validation issue.
+    /// </summary>
+    public sealed class FuseValidationHelpEntry
+    {
+        public string Title { get; set; }
+        public string Why { get; set; }
+        public string Fix { get; set; }
+        public string Example { get; set; }
+    }
+
+    /// <summary>
+    /// Lookup over the fix-hint catalog embedded in FUSE.Core
+    /// (<c>Validation/Help/fuse-validation-help.json</c>), keyed by
+    /// validation code. The catalog is data, not code, so docs authors can
+    /// extend it without touching the validators; the coverage test in
+    /// FUSE.Core.Tests keeps it in lockstep with the codes the validators
+    /// actually emit. Unknown codes return null so formatters degrade to
+    /// message-only output.
+    /// </summary>
+    public static class FuseValidationHelp
+    {
+        private const string ResourceName = "Fuse.Core.Validation.Help.fuse-validation-help.json";
+
+        private static readonly object Gate = new object();
+        private static Dictionary<string, FuseValidationHelpEntry> _entries;
+
+        public static FuseValidationHelpEntry For(string code)
+        {
+            FuseValidationHelpEntry entry;
+            return TryGet(code, out entry) ? entry : null;
+        }
+
+        public static bool TryGet(string code, out FuseValidationHelpEntry entry)
+        {
+            entry = null;
+            if (string.IsNullOrEmpty(code))
+            {
+                return false;
+            }
+
+            EnsureLoaded();
+            return _entries.TryGetValue(code, out entry) && entry != null;
+        }
+
+        public static IReadOnlyCollection<string> AllCodes
+        {
+            get
+            {
+                EnsureLoaded();
+                return _entries.Keys;
+            }
+        }
+
+        private static void EnsureLoaded()
+        {
+            if (_entries != null)
+            {
+                return;
+            }
+
+            lock (Gate)
+            {
+                if (_entries != null)
+                {
+                    return;
+                }
+
+                using (var stream = typeof(FuseValidationHelp).Assembly.GetManifestResourceStream(ResourceName))
+                {
+                    if (stream == null)
+                    {
+                        _entries = new Dictionary<string, FuseValidationHelpEntry>();
+                        return;
+                    }
+
+                    using (var reader = new StreamReader(stream))
+                    {
+                        _entries = JsonConvert.DeserializeObject<Dictionary<string, FuseValidationHelpEntry>>(reader.ReadToEnd())
+                                   ?? new Dictionary<string, FuseValidationHelpEntry>();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/FUSE.Core/Validation/Help/fuse-validation-help.json
+++ b/FUSE.Core/Validation/Help/fuse-validation-help.json
@@ -1,0 +1,650 @@
+{
+  "fuse.audio.bell.required": {
+    "title": "Bell audio entry is empty",
+    "why": "An entry under audio.bells maps to null instead of a bell definition object, so FUSE has nothing to build the bell sound from. This is an error: the definition fails validation until the entry is a real object.",
+    "fix": "Replace the null value with a bell object that provides at least name and file.",
+    "example": "{\"audio\":{\"bells\":{\"steelBell\":{\"name\":\"Steel Bell\",\"file\":\"sounds/steel-bell.ogg\"}}}}"
+  },
+  "fuse.audio.horn.keyframes.empty": {
+    "title": "Horn layer has no keyframes",
+    "why": "A horn layer's keyframes array is missing or empty. This is only a warning — the mod still loads, but FUSE falls back to a constant volume curve for that layer instead of a shaped one.",
+    "fix": "Add at least one keyframe with t and value to shape the layer's volume, or leave it empty if constant volume is what you want.",
+    "example": "{\"audio\":{\"horns\":{\"k5la\":{\"name\":\"K5LA\",\"layers\":[{\"file\":\"sounds/horn-low.ogg\",\"keyframes\":[{\"t\":0,\"value\":0},{\"t\":1,\"value\":1}]}]}}}}"
+  },
+  "fuse.audio.horn.layer.required": {
+    "title": "Horn layer entry is null",
+    "why": "An element inside the horn's layers array is null (for example a stray comma or an unfinished placeholder), so there is no layer definition at that index. This is an error and blocks validation.",
+    "fix": "Delete the null array element, or replace it with a layer object that has a file.",
+    "example": "{\"audio\":{\"horns\":{\"k5la\":{\"name\":\"K5LA\",\"layers\":[{\"file\":\"sounds/horn-low.ogg\"},{\"file\":\"sounds/horn-high.ogg\"}]}}}}"
+  },
+  "fuse.audio.horn.layers": {
+    "title": "Horn has no layers",
+    "why": "The horn's layers array is missing or empty, and a horn needs at least one layer to produce any sound. This is an error: validation stops for this horn until a layer exists.",
+    "fix": "Add a layers array with at least one layer object pointing at an audio file.",
+    "example": "{\"audio\":{\"horns\":{\"k5la\":{\"name\":\"K5LA\",\"layers\":[{\"file\":\"sounds/horn.ogg\"}]}}}}"
+  },
+  "fuse.audio.horn.required": {
+    "title": "Horn audio entry is empty",
+    "why": "An entry under audio.horns maps to null instead of a horn definition object, so FUSE has no name or layers to build the horn from. This is an error until the entry is a real object.",
+    "fix": "Replace the null value with a horn object that has a name and at least one layer.",
+    "example": "{\"audio\":{\"horns\":{\"k5la\":{\"name\":\"K5LA\",\"layers\":[{\"file\":\"sounds/horn.ogg\"}]}}}}"
+  },
+  "fuse.audio.whistle.required": {
+    "title": "Whistle audio entry is empty",
+    "why": "An entry under audio.whistles maps to null instead of a whistle definition object, so FUSE has no name or clip to build the whistle from. This is an error until the entry is a real object.",
+    "fix": "Replace the null value with a whistle object that provides at least name and clip.",
+    "example": "{\"audio\":{\"whistles\":{\"steamWhistle\":{\"name\":\"Steam Whistle\",\"clip\":\"sounds/whistle.ogg\"}}}}"
+  },
+  "fuse.definition.required": {
+    "title": "Mod definition is missing",
+    "why": "The *.fuse.json document deserialized to nothing — the file is empty or contains no definition object — so there is no definition to validate and nothing in the file can take effect. Validation stops immediately at the document root ($).",
+    "fix": "Make the top level of the file a JSON object, with at least id and name set.",
+    "example": "{\"id\":\"my-mod\",\"name\":\"My Mod\"}"
+  },
+  "fuse.mapMask.circle.radius": {
+    "title": "Circle mask needs a positive radius",
+    "why": "A map mask with type circle has no radius, or its radius is zero or negative, so the circle would cover no area. This is an error and must be fixed before the mask is usable.",
+    "fix": "Set radius on the circle mask to a value greater than 0.",
+    "example": "{\"world\":{\"mapMasks\":{\"yardClearing\":{\"type\":\"circle\",\"center\":{\"x\":1000,\"y\":0,\"z\":2000},\"radius\":75}}}}"
+  },
+  "fuse.mapMask.curve.points": {
+    "title": "Curve mask needs at least two points",
+    "why": "A map mask with type curve has a missing points array or fewer than two points, so no curve can be formed. This is an error and must be fixed before the mask is usable.",
+    "fix": "Give the curve mask a points array containing at least two positions.",
+    "example": "{\"world\":{\"mapMasks\":{\"trackCut\":{\"type\":\"curve\",\"width\":10,\"points\":[{\"x\":100,\"y\":0,\"z\":200},{\"x\":150,\"y\":0,\"z\":260}]}}}}"
+  },
+  "fuse.mapMask.rectangle.size": {
+    "title": "Rectangle mask needs a positive size",
+    "why": "A map mask with type rectangle has no size, or its size has an x or z component of zero or less, so the rectangle's footprint would be empty. This is an error and must be fixed before the mask is usable.",
+    "fix": "Set size on the rectangle mask with x and z both greater than 0.",
+    "example": "{\"world\":{\"mapMasks\":{\"depotPad\":{\"type\":\"rectangle\",\"center\":{\"x\":500,\"y\":0,\"z\":800},\"size\":{\"x\":40,\"y\":1,\"z\":25}}}}}"
+  },
+  "fuse.mapMask.type": {
+    "title": "Unknown map mask type",
+    "why": "The mask's type is missing or is not one of circle, rectangle, or curve (matched case-insensitively), so FUSE does not know what shape to build. This is an error and the mask cannot be validated further.",
+    "fix": "Set type to \"circle\", \"rectangle\", or \"curve\", then supply that shape's fields (radius, size, or points).",
+    "example": "{\"world\":{\"mapMasks\":{\"yardClearing\":{\"type\":\"circle\",\"center\":{\"x\":1000,\"y\":0,\"z\":2000},\"radius\":75}}}}"
+  },
+  "fuse.mapTiles.required": {
+    "title": "Map tile source is empty",
+    "why": "An entry under world.mapTiles maps to null instead of a tile source object, so FUSE has no directory or sourceFolder to load map tiles from. This is an error until the entry is a real object.",
+    "fix": "Replace the null value with an object that sets directory and sourceFolder.",
+    "example": "{\"world\":{\"mapTiles\":{\"newValley\":{\"directory\":\"mapTiles\",\"sourceFolder\":\"newValley\"}}}}"
+  },
+  "fuse.mixinto.requirement.id.blank": {
+    "title": "Mixinto requirement id is blank",
+    "why": "An entry in mixinto.requires has a blank or whitespace-only id, so FUSE ignores that requirement entirely. The fragment will not be gated on the mod you meant to require and may apply even when that mod is absent.",
+    "fix": "Set the requirement's id to the identifier of the mod this fragment depends on, or delete the entry if no dependency is intended.",
+    "example": "{\"mixinto\": {\"requires\": [{\"id\": \"ExampleMod\"}]}}"
+  },
+  "fuse.mixinto.requirement.null": {
+    "title": "Null mixinto requirement entry",
+    "why": "The mixinto.requires array contains a null entry, which FUSE skips at load. A null requirement cannot gate the fragment, so any conditional-loading intent behind it is silently lost.",
+    "fix": "Remove the null entry from the requires array, or replace it with a requirement object that has an id.",
+    "example": "{\"mixinto\": {\"requires\": [{\"id\": \"ExampleMod\"}]}}"
+  },
+  "fuse.mixinto.sourceFile.blank": {
+    "title": "Mixinto sourceFile is blank",
+    "why": "The mixinto section is present but sourceFile is blank. sourceFile records which legacy file produced this converted fragment; leaving it empty makes the conversion provenance less clear when debugging the mod later.",
+    "fix": "Set sourceFile to the path of the legacy file this fragment was converted from.",
+    "example": "{\"mixinto\": {\"target\": \"game-graph\", \"sourceFile\": \"legacy/game-graph.json\"}}"
+  },
+  "fuse.mixinto.target.blank": {
+    "title": "Mixinto target is blank",
+    "why": "The mixinto section is present but target is blank. FUSE still loads the fragment as a normal conditional data file, but the legacy mixinto target name (e.g. game-graph, progressions) that documents where this fragment came from is missing.",
+    "fix": "Set target to the legacy mixinto target name this fragment was converted from, or drop the mixinto section if the file is not a converted fragment.",
+    "example": "{\"mixinto\": {\"target\": \"game-graph\", \"sourceFile\": \"legacy/game-graph.json\"}}"
+  },
+  "fuse.operations.component.carTransferRate": {
+    "title": "Negative car transfer rate",
+    "why": "An industry component's carTransferRate is negative, which the validator rejects as an error: the rate must be greater than or equal to 0. This blocks the mod and must be fixed.",
+    "fix": "Set carTransferRate to 0 or a positive number, or remove the field (only a present, negative value is rejected).",
+    "example": "{\"components\": {\"unload\": {\"carTransferRate\": 1.0}}}"
+  },
+  "fuse.operations.component.carTypeFilter.emptyToken": {
+    "title": "Empty entry in car type filter",
+    "why": "The carTypeFilter expression contains a doubled, leading, or trailing comma, producing an empty entry between separators. The game splits the filter on commas and simply ignores the empty entry, so it does nothing.",
+    "fix": "Remove the extra comma so every comma sits between two real car-type tokens (e.g. \"FB,XM\", not \"FB,,XM\" or \"FB,XM,\").",
+    "example": "{\"components\": {\"loader\": {\"carTypeFilter\": \"FB,XM\"}}}"
+  },
+  "fuse.operations.component.carTypeFilter.malformed": {
+    "title": "Whitespace inside car type filter entry",
+    "why": "A carTypeFilter entry has surrounding whitespace (e.g. \"FB, XM\"). The game splits the expression on commas without trimming and matches each token verbatim, so a padded token can never match any car type; the validator rejects this as an error that must be fixed.",
+    "fix": "Write the filter as a single comma-delimited string with no spaces around the commas; tokens match verbatim, with optional * suffix wildcards or a bare * for any car.",
+    "example": "{\"components\": {\"loader\": {\"carTypeFilter\": \"FB,XM\"}}}"
+  },
+  "fuse.operations.component.loadId": {
+    "title": "Component is missing a loadId",
+    "why": "This component type (loader, unloader, repairTrack, interchangedLoader, or interchangedUnloader) usually needs a loadId to function, but none is set. Without it the component has no load to move and will likely do nothing in-game.",
+    "fix": "Set loadId to the id of the load this component handles (a built-in load or one defined under operations.loads).",
+    "example": "{\"components\": {\"logs-in\": {\"type\": \"unloader\", \"name\": \"Log Dump\", \"loadId\": \"logs\", \"trackSpanIds\": [\"sawmill-1\"]}}}"
+  },
+  "fuse.operations.component.maxStorage": {
+    "title": "Negative max storage",
+    "why": "An industry component's maxStorage is negative, which the validator rejects as an error: max storage must be greater than or equal to 0. This blocks the mod and must be fixed.",
+    "fix": "Set maxStorage to 0 or a positive number, or remove the field (only a present, negative value is rejected).",
+    "example": "{\"components\": {\"unload\": {\"maxStorage\": 5000}}}"
+  },
+  "fuse.operations.component.required": {
+    "title": "Industry component definition is null",
+    "why": "A key under an industry's components maps to null instead of a component object, which is an error — every component entry must be a definition. Note that null here is not a deletion: FUSE deletes runtime sub-components via a remove sentinel, not a null value.",
+    "fix": "Replace the null with a component object (at minimum type and name for a full definition), or use {\"remove\": true} if you intend to delete the matching runtime sub-component.",
+    "example": "{\"components\": {\"unload\": {\"type\": \"unloader\", \"name\": \"Log Unload\"}}}"
+  },
+  "fuse.operations.component.storageChangeRate": {
+    "title": "Negative storage change rate",
+    "why": "An industry component's storageChangeRate is negative, which the validator rejects as an error: the rate must be greater than or equal to 0. This blocks the mod and must be fixed.",
+    "fix": "Set storageChangeRate to 0 or a positive number, or remove the field (only a present, negative value is rejected).",
+    "example": "{\"components\": {\"load\": {\"storageChangeRate\": 0.25}}}"
+  },
+  "fuse.operations.component.trackSpanIds": {
+    "title": "Component has no track spans",
+    "why": "This component type (loader, unloader, repairTrack, teamTrack, interchange, interchangedLoader, interchangedUnloader, or progression) requires at least one track span, but trackSpanIds is missing or empty in a full (non-partial) definition. The error blocks the mod; only passengerStop components may legitimately omit spans (virtual timetable stops with no physical platform).",
+    "fix": "Add a trackSpanIds array containing at least one track span id where cars are spotted for this component.",
+    "example": "{\"components\": {\"team\": {\"type\": \"teamTrack\", \"name\": \"Team Track\", \"trackSpanIds\": [\"whittier-team-1\"]}}}"
+  },
+  "fuse.operations.component.type": {
+    "title": "Unknown industry component type",
+    "why": "The component's type is not one of FUSE's built-in component types and does not look like a fully-qualified custom type (it contains no dot), so FUSE cannot construct the component and the definition fails validation. Validation of the rest of this component is also skipped until the type is fixed.",
+    "fix": "Set type to one of the built-in values: formulaic, interchange, interchangedLoader, interchangedUnloader, loader, passengerStop, progression, repairTrack, teamTrack, teleportLoading, or unloader. For a custom component, use its fully-qualified type name (namespace included).",
+    "example": "{ \"operations\": { \"industries\": { \"sawmill\": { \"components\": { \"logDock\": { \"type\": \"loader\" } } } } } }"
+  },
+  "fuse.operations.component.type.custom": {
+    "title": "Component type resolved from loaded assemblies",
+    "why": "The component's type is not a built-in FUSE type, but because it is dotted (fully qualified) the runtime will attempt to resolve it from loaded assemblies. This is a warning: the mod still loads, but the component only works if an assembly actually provides that exact type.",
+    "fix": "Verify the fully-qualified type name is spelled exactly right and that the mod providing it is installed. If you meant a built-in component, use its canonical name (loader, unloader, teamTrack, ...) instead.",
+    "example": "{ \"operations\": { \"industries\": { \"depot\": { \"components\": { \"pay\": { \"type\": \"ConfusingSupplements.IndustryComponents.Pay4Resource\" } } } } } }"
+  },
+  "fuse.operations.formulaic.terms": {
+    "title": "Formulaic component missing terms",
+    "why": "A formulaic component declares neither inputTermsPerDay nor outputTermsPerDay entries, so it has no loads to consume or produce. The validator reports this as an error and the definition fails validation.",
+    "fix": "Add at least one entry to inputTermsPerDay and/or outputTermsPerDay, mapping a load id to its per-day rate.",
+    "example": "{ \"type\": \"formulaic\", \"inputTermsPerDay\": { \"logs\": 6 }, \"outputTermsPerDay\": { \"lumber\": 4 } }"
+  },
+  "fuse.operations.loads.density": {
+    "title": "Negative load density",
+    "why": "The load's density is set to a value below 0, which the validator rejects — density must be greater than or equal to 0. The definition fails validation until corrected.",
+    "fix": "Set density to 0 or a positive number, or omit the field to use the default.",
+    "example": "{ \"operations\": { \"loads\": { \"coal\": { \"name\": \"Coal\", \"units\": \"pounds\", \"density\": 47.5 } } } }"
+  },
+  "fuse.operations.loads.units": {
+    "title": "Invalid load units",
+    "why": "The load's units value is not one of the three recognized unit kinds. The validator only accepts Pounds, Gallons, or Quantity (case-insensitive), and anything else is an error that fails validation.",
+    "fix": "Set units to \"pounds\", \"gallons\", or \"quantity\".",
+    "example": "{ \"operations\": { \"loads\": { \"diesel\": { \"name\": \"Diesel Fuel\", \"units\": \"gallons\" } } } }"
+  },
+  "fuse.operations.loads.unitWeightInPounds": {
+    "title": "Negative load unit weight",
+    "why": "The load's unitWeightInPounds is set to a value below 0, which the validator rejects — it must be greater than or equal to 0. The definition fails validation until corrected.",
+    "fix": "Set unitWeightInPounds to 0 or a positive number of pounds per unit, or omit the field.",
+    "example": "{ \"operations\": { \"loads\": { \"crates\": { \"name\": \"Crates\", \"units\": \"quantity\", \"unitWeightInPounds\": 1200 } } } }"
+  },
+  "fuse.operations.teamTrack.profile": {
+    "title": "Team track missing team profiles",
+    "why": "A teamTrack component has an empty or missing teamProfiles map, but team track components require at least one team profile entry to define what gets loaded or unloaded there. The validator reports this as an error and the definition fails validation.",
+    "fix": "Add at least one entry to teamProfiles, keyed by a profile id, describing the load and car filter for that team service.",
+    "example": "{ \"type\": \"teamTrack\", \"trackSpanIds\": [\"myMod.span.team1\"], \"teamProfiles\": { \"merchandise\": { \"loadId\": \"crates\", \"isExport\": false, \"loadingTimeDays\": 0.5, \"carTypeFilter\": \"XM*\" } } }"
+  },
+  "fuse.operations.teleportLoading.carLengthFeet": {
+    "title": "Negative teleport loading car length",
+    "why": "A teleportLoading component sets carLengthFeet below 0, which the validator rejects — it must be greater than or equal to 0. The definition fails validation until corrected.",
+    "fix": "Set carLengthFeet to 0 or a positive length in feet, or omit the field to use the default.",
+    "example": "{ \"type\": \"teleportLoading\", \"inputSpanIds\": [\"myMod.span.loadout\"], \"carLengthFeet\": 40 }"
+  },
+  "fuse.operations.teleportLoading.carLoadPeriod": {
+    "title": "Negative teleport loading car load period",
+    "why": "A teleportLoading component sets carLoadPeriod below 0, which the validator rejects — it must be greater than or equal to 0. The definition fails validation until corrected.",
+    "fix": "Set carLoadPeriod to 0 or a positive value, or omit the field to use the default.",
+    "example": "{ \"type\": \"teleportLoading\", \"inputSpanIds\": [\"myMod.span.loadout\"], \"carLoadPeriod\": 0.5 }"
+  },
+  "fuse.operations.teleportLoading.spans": {
+    "title": "Teleport loading missing span ids",
+    "why": "A teleportLoading component declares neither inputSpanIds nor outputSpanIds, so it has no track spans to teleport cars onto or off of. The validator requires at least one of the two arrays to be non-empty and fails validation otherwise.",
+    "fix": "Add at least one span id to inputSpanIds and/or outputSpanIds.",
+    "example": "{ \"type\": \"teleportLoading\", \"inputSpanIds\": [\"myMod.span.inbound\"], \"outputSpanIds\": [\"myMod.span.outbound\"] }"
+  },
+  "fuse.progression.delivery.count": {
+    "title": "Delivery count not positive",
+    "why": "A progression delivery has a count below 1 (omitting count leaves it at 0), but a delivery must require at least one car. The validator reports \"Delivery count must be greater than 0\" as an error and the definition fails validation.",
+    "fix": "Set count to 1 or more on the delivery entry.",
+    "example": "{ \"deliveryPhases\": [ { \"cost\": 100, \"deliveries\": [ { \"load\": \"gravel\", \"count\": 4, \"direction\": \"loadToIndustry\", \"carTypeFilter\": \"GB*\" } ] } ] }"
+  },
+  "fuse.progression.delivery.direction": {
+    "title": "Invalid delivery direction",
+    "why": "The delivery's direction is not a recognized value. The validator accepts loadToIndustry (also toIndustry, to, import) and loadFromIndustry (also fromIndustry, from, export), case-insensitive; anything else is an error that fails validation.",
+    "fix": "Set direction to \"loadToIndustry\" for cars delivered to the industry, or \"loadFromIndustry\" for cars shipped out of it.",
+    "example": "{ \"deliveryPhases\": [ { \"cost\": 100, \"deliveries\": [ { \"load\": \"logs\", \"count\": 2, \"direction\": \"loadFromIndustry\" } ] } ] }"
+  },
+  "fuse.progression.delivery.required": {
+    "title": "Null entry in deliveries list",
+    "why": "An entry in a delivery phase's deliveries array is a literal null. This is an error: FUSE has no delivery to create from it, so the phase cannot load as written.",
+    "fix": "Replace the null entry with a full delivery object, or delete it from the array.",
+    "example": "\"deliveries\": [{\"carTypeFilter\": \"GB*\", \"count\": 4, \"direction\": \"loadToIndustry\"}]"
+  },
+  "fuse.progression.deliveryPhase.cost.legacyNegative": {
+    "title": "Negative delivery phase cost",
+    "why": "A delivery phase's cost is below zero. This is only a warning: FUSE keeps the negative value because some legacy route mods deliberately use negative costs as progression credits — but if that's not your intent, the phase acts as a credit instead of a charge.",
+    "fix": "Set cost to 0 or a positive amount unless you are intentionally using the legacy negative-cost-as-credit behavior.",
+    "example": "\"deliveryPhases\": [{\"cost\": 2500, \"industryComponentId\": \"sylva-paper-siding\", \"deliveries\": [{\"count\": 3, \"direction\": \"loadFromIndustry\"}]}]"
+  },
+  "fuse.progression.deliveryPhase.industryComponentId": {
+    "title": "Delivery phase missing industry component id",
+    "why": "The phase contains deliveries but has no industryComponentId, and none of its deliveries carries a destinationIndustryId for runtime inference. This is an error: FUSE cannot determine which industry component the deliveries belong to.",
+    "fix": "Add industryComponentId to the phase, or give at least one delivery a destinationIndustryId so the component can be inferred at runtime.",
+    "example": "\"deliveryPhases\": [{\"cost\": 500, \"industryComponentId\": \"sylva-paper-siding\", \"deliveries\": [{\"carTypeFilter\": \"GB*\", \"count\": 4, \"direction\": \"loadToIndustry\"}]}]"
+  },
+  "fuse.progression.deliveryPhase.required": {
+    "title": "Null entry in deliveryPhases list",
+    "why": "An entry in a section's deliveryPhases array is a literal null. This is an error: FUSE cannot build a phase from nothing, so the section's delivery progression cannot load as written.",
+    "fix": "Replace the null entry with a phase object (cost plus deliveries), or remove it from the array.",
+    "example": "\"deliveryPhases\": [{\"cost\": 1000, \"industryComponentId\": \"alarka-depot\", \"deliveries\": [{\"count\": 2, \"direction\": \"loadToIndustry\"}]}]"
+  },
+  "fuse.progression.interchangeTransfer.sameTarget": {
+    "title": "Interchange transfer targets itself",
+    "why": "A transfer's source and target ids are the same (compared case-insensitively after trimming). This is only a warning — FUSE will still create the transfer — but it has no practical effect in-game.",
+    "fix": "Point the transfer at a different target interchange, or delete the entry if it was a copy-paste slip.",
+    "example": "\"interchangeTransfers\": {\"sylva-interchange\": \"dillsboro-interchange\"}"
+  },
+  "fuse.progression.interchangeTransfer.source.empty": {
+    "title": "Blank interchange transfer source id",
+    "why": "A key in the interchangeTransfers map is empty or whitespace. The key is the source interchange id, so a blank one identifies no source interchange — this is an error.",
+    "fix": "Use the real source interchange id as the map key.",
+    "example": "\"interchangeTransfers\": {\"sylva-interchange\": \"dillsboro-interchange\"}"
+  },
+  "fuse.progression.mapFeature.area.empty": {
+    "title": "Blank area id in map feature",
+    "why": "An entry added via areasEnableOnUnlock is empty or whitespace. This is a warning: areas are resolved by their identifier, so a blank entry can never match an area — it usually means an id was lost or a stray comma left an empty string.",
+    "fix": "Fill in the intended area identifier or delete the blank entry from the list.",
+    "example": "\"progression\": {\"mapFeatures\": {\"alarka\": {\"areasEnableOnUnlock\": [\"alarka\"]}}}"
+  },
+  "fuse.progression.mapFeature.gameObject.empty": {
+    "title": "Blank game object path in map feature",
+    "why": "An entry added via gameObjectsEnableOnUnlock is empty or whitespace. This is a warning: each entry must be a hierarchical scene path (e.g. \"World/Foo/Bar\") resolved at apply time, so a blank entry can never resolve to a GameObject to enable on unlock.",
+    "fix": "Fill in the full scene path of the object to enable, or delete the blank entry.",
+    "example": "\"progression\": {\"mapFeatures\": {\"alarka\": {\"gameObjectsEnableOnUnlock\": [\"World/Alarka/Depot\"]}}}"
+  },
+  "fuse.progression.mapFeature.industry.empty": {
+    "title": "Blank industry id in map feature",
+    "why": "An entry added via unlockIncludeIndustries or unlockExcludeIndustries is empty or whitespace. This is a warning: a blank id matches no industry, so it contributes nothing to the feature's unlock graph and almost certainly hides a missing id.",
+    "fix": "Fill in the intended industry id or remove the blank entry from the list.",
+    "example": "\"progression\": {\"mapFeatures\": {\"alarka\": {\"unlockIncludeIndustries\": [\"alarka-depot\"]}}}"
+  },
+  "fuse.progression.mapFeature.industryComponent.empty": {
+    "title": "Blank industry component id in map feature",
+    "why": "An entry added via unlockIncludeIndustryComponents is empty or whitespace. This is a warning: a blank id matches no industry component, so it adds nothing to the feature's unlock graph and usually indicates a lost id or stray comma.",
+    "fix": "Fill in the intended industry component id or delete the blank entry.",
+    "example": "\"progression\": {\"mapFeatures\": {\"alarka\": {\"unlockIncludeIndustryComponents\": [\"alarka-depot.platform\"]}}}"
+  },
+  "fuse.progression.mapFeature.required": {
+    "title": "Map feature definition is null",
+    "why": "A key under progression.mapFeatures maps to null instead of a map feature object. This is an error: FUSE has no definition to apply, and the rest of the feature (displayName, unlock lists) is never validated or created.",
+    "fix": "Give the key a feature object — at minimum a displayName — or remove the key entirely.",
+    "example": "\"progression\": {\"mapFeatures\": {\"alarka\": {\"displayName\": \"Alarka Branch\"}}}"
+  },
+  "fuse.progression.mapFeature.trackGroup.empty": {
+    "title": "Blank track group id in map feature",
+    "why": "An entry added via trackGroupsEnableOnUnlock or trackGroupsAvailableOnUnlock is empty or whitespace. This is a warning: a blank id names no track group, so unlocking the feature cannot enable or make available any track for that entry.",
+    "fix": "Fill in the intended track group id or remove the blank entry from the list.",
+    "example": "\"progression\": {\"mapFeatures\": {\"alarka\": {\"trackGroupsEnableOnUnlock\": [\"alarka-branch\"]}}}"
+  },
+  "fuse.progression.required": {
+    "title": "Missing progression definition",
+    "why": "An entry under progression.progressions maps to null instead of a progression object, so there is nothing to validate or load. This is an error: the package fails validation until the entry is a real progression.",
+    "fix": "Give the key a real progression object with its sections (each section needs a displayName), or delete the key entirely. Do not leave the value as null.",
+    "example": "{\"progression\": {\"progressions\": {\"myProgression\": {\"sections\": {\"phase-1\": {\"displayName\": \"Phase 1\"}}}}}}"
+  },
+  "fuse.progression.section.area.empty": {
+    "title": "Blank area name in unlock list",
+    "why": "A progression section's areasEnableOnUnlock list (under progression.progressions.*.sections) contains an entry that is empty or only whitespace. A blank entry names no area, so it can never enable anything when the section unlocks; this is a warning and the mod still loads with the entry doing nothing.",
+    "fix": "Remove the blank entry, or replace it with the identifier of the area you meant to enable on unlock.",
+    "example": "{\"areasEnableOnUnlock\": [\"sylva\", \"dillsboro\"]}"
+  },
+  "fuse.progression.section.duplicate": {
+    "title": "Duplicate root section ID",
+    "why": "Two or more sections in the root progression.sections array share the same id (compared case-insensitively). Root progression section IDs must be unique within a package; this is an error and the package fails validation.",
+    "fix": "Rename one of the sections so every root section has a unique id. Remember that IDs differing only in letter case still count as duplicates.",
+    "example": "{\"progression\": {\"sections\": [{\"id\": \"east-yard\"}, {\"id\": \"west-yard\"}]}}"
+  },
+  "fuse.progression.section.gameObject.empty": {
+    "title": "Blank game object path in unlock list",
+    "why": "A progression section's gameObjectsEnableOnUnlock list contains an empty or whitespace-only entry. It points at no scene object, so nothing can be enabled by it when the section unlocks; this is a warning and the mod still loads with the entry doing nothing.",
+    "fix": "Delete the blank entry, or fill in the hierarchical scene path of the object you intended to enable on unlock.",
+    "example": "{\"gameObjectsEnableOnUnlock\": [\"Large Scenery/Sylva Depot\"]}"
+  },
+  "fuse.progression.section.industry.empty": {
+    "title": "Blank industry ID in unlock list",
+    "why": "A progression section's unlockIncludeIndustries or unlockExcludeIndustries list contains an empty or whitespace-only entry. A blank ID matches no industry, so it cannot include or exclude anything when the section unlocks; this is a warning and the mod still loads with the entry ignored.",
+    "fix": "Remove the blank entry, or replace it with the industry identifier you meant to include or exclude.",
+    "example": "{\"unlockIncludeIndustries\": [\"sylva-paperboard\"], \"unlockExcludeIndustries\": [\"dillsboro-interchange\"]}"
+  },
+  "fuse.progression.section.industryComponent.empty": {
+    "title": "Blank industry component ID in unlocks",
+    "why": "A progression section's unlockIncludeIndustryComponents list contains an empty or whitespace-only entry. It identifies no component, so it cannot add anything to the unlock graph; this is a warning and the mod still loads with the entry doing nothing.",
+    "fix": "Delete the blank entry, or put in the real industry component identifier to include on unlock.",
+    "example": "{\"unlockIncludeIndustryComponents\": [\"sylva-paperboard.unload\"]}"
+  },
+  "fuse.progression.section.required": {
+    "title": "Missing progression section",
+    "why": "A section slot is null — either an entry in the root progression.sections array or a value in a progression's sections map. There is no section content to validate or load, so this is an error and the package fails validation.",
+    "fix": "Replace the null with a real section object — root sections need at least an id, and sections inside a named progression need at least a displayName — or remove the entry entirely.",
+    "example": "{\"progression\": {\"sections\": [{\"id\": \"phase-1\"}], \"progressions\": {\"myProgression\": {\"sections\": {\"phase-1\": {\"displayName\": \"Phase 1\"}}}}}}"
+  },
+  "fuse.progression.section.trackGroup.empty": {
+    "title": "Blank track group in unlock list",
+    "why": "A progression section's trackGroupsEnableOnUnlock or trackGroupsAvailableOnUnlock list contains an empty or whitespace-only entry. A blank entry names no track group, so it can never enable or make anything available; this is a warning and the mod still loads with the entry doing nothing.",
+    "fix": "Remove the blank entry, or replace it with the actual track group ID you intended.",
+    "example": "{\"trackGroupsEnableOnUnlock\": [\"tg-sylva-yard\"], \"trackGroupsAvailableOnUnlock\": [\"tg-dillsboro-spur\"]}"
+  },
+  "fuse.required": {
+    "title": "Required value is missing",
+    "why": "A field that FUSE requires (such as an id, name, prefab, displayName, targetPath, or file) is missing, empty, or only whitespace at the flagged path. This is an error: the definition cannot be loaded without it and the package fails validation.",
+    "fix": "Set the flagged field to a real, non-blank value. The field path on the message tells you exactly which entry and property to fill in.",
+    "example": "{\"displayName\": \"Sylva Depot\"}"
+  },
+  "fuse.sceneClone.required": {
+    "title": "Missing scene clone definition",
+    "why": "An entry under world.sceneClones maps to null instead of a scene clone object, so FUSE has nothing to clone. This is an error and the package fails validation; a valid clone also needs a non-blank targetPath (flagged separately as fuse.required).",
+    "fix": "Give the key a real scene clone object including its targetPath, or delete the key if the clone is no longer wanted.",
+    "example": "{\"world\": {\"sceneClones\": {\"depot-copy\": {\"targetPath\": \"Large Scenery/Sylva Depot\"}}}}"
+  },
+  "fuse.schema.version": {
+    "title": "Unsupported schema version",
+    "why": "The document's schemaVersion is not the version this runtime supports (1.0) and does not parse as a newer version — typically an older schema version. This is an error: the message states the schema version must be 1.0, and the package fails validation until it is.",
+    "fix": "Set schemaVersion to \"1.0\" at the top of the document and make sure the document follows the current schema.",
+    "example": "{\"schemaVersion\": \"1.0\"}"
+  },
+  "fuse.schema.version.future": {
+    "title": "Schema version newer than runtime",
+    "why": "The document declares a schemaVersion newer than this runtime supports (1.0), so FUSE only applies a best-effort load — anything the newer schema adds may be misread or ignored. This is a warning, not a hard failure.",
+    "fix": "Set schemaVersion to \"1.0\" if the document does not actually use newer schema features; otherwise update FUSE to a runtime that supports the declared version.",
+    "example": "{\"schemaVersion\": \"1.0\"}"
+  },
+  "fuse.settings.enum.values.empty": {
+    "title": "Enum setting has no values",
+    "why": "An enum-type setting (type enum, choice, or select) has a missing or empty values array, so FUSE has no options to offer and falls back to rendering the setting as a plain text field.",
+    "fix": "Add a values array listing the selectable options for the setting. If free-form input is actually intended, change the type to text instead.",
+    "example": "{\"settings\": {\"theme\": {\"type\": \"enum\", \"values\": [\"light\", \"dark\"], \"default\": \"light\"}}}"
+  },
+  "fuse.settings.id.blank": {
+    "title": "Blank setting ID",
+    "why": "A key in the settings object is empty or only whitespace, so the setting cannot be identified. This is an error and the definition fails validation until fixed.",
+    "fix": "Give every entry under settings a non-empty key; the key is the setting's ID. Remove or rename any \"\" or whitespace-only keys.",
+    "example": "{\"settings\": {\"maxTrainLength\": {\"type\": \"number\", \"default\": 30}}}"
+  },
+  "fuse.settings.null": {
+    "title": "Setting definition is null",
+    "why": "The setting's value is JSON null instead of an object. The Settings UI ignores null definitions, so the setting will silently not appear in-game.",
+    "fix": "Replace the null with a setting object declaring a type (and usually a default), or delete the entry entirely.",
+    "example": "{\"settings\": {\"enableLogging\": {\"type\": \"bool\", \"default\": false}}}"
+  },
+  "fuse.settings.number.range": {
+    "title": "Number setting min exceeds max",
+    "why": "A number-type setting declares both min and max, but min is greater than max, leaving the setting with no valid range. This is an error and must be fixed.",
+    "fix": "Correct min and max so that min is less than or equal to max (you may have swapped the two values).",
+    "example": "{\"settings\": {\"volume\": {\"type\": \"number\", \"min\": 0, \"max\": 100, \"default\": 50}}}"
+  },
+  "fuse.settings.number.step": {
+    "title": "Number setting step not positive",
+    "why": "A number-type setting declares a step of zero or less. Step should be greater than zero; a non-positive value is not a usable increment.",
+    "fix": "Set step to a positive value such as 1 or 0.5, or remove the step field to use the default behavior.",
+    "example": "{\"settings\": {\"volume\": {\"type\": \"number\", \"min\": 0, \"max\": 100, \"step\": 5}}}"
+  },
+  "fuse.settings.server.reloadRequired": {
+    "title": "Server setting needs reload documentation",
+    "why": "The setting is server-scoped (scope server, shared, or multiplayer) and marked reloadRequired, so values shared via multiplayer profile sharing only take effect after a reload. The validator emits this warning as a reminder to document that behavior for users.",
+    "fix": "Document the reload requirement in the setting's description so multiplayer users know a reload is needed. Alternatively drop reloadRequired or move the setting off server scope if either is unnecessary.",
+    "example": "{\"settings\": {\"trackGauge\": {\"type\": \"number\", \"scope\": \"server\", \"reloadRequired\": true, \"description\": \"Synced to all players; requires a reload to apply.\"}}}"
+  },
+  "fuse.spliney.points": {
+    "title": "Spliney needs at least two points",
+    "why": "The spliney's points array is missing or has fewer than two entries. Spliney objects require at least two points to define a path; this is an error and must be fixed.",
+    "fix": "Add a points array with two or more point entries (each with a position) tracing the spliney's path.",
+    "example": "{\"world\": {\"splineys\": {\"yardFence\": {\"type\": \"fence\", \"points\": [{\"position\": {\"x\": 0, \"y\": 560, \"z\": 0}}, {\"position\": {\"x\": 25, \"y\": 560, \"z\": 10}}]}}}}"
+  },
+  "fuse.telegraph.points": {
+    "title": "Telegraph pole set needs two points",
+    "why": "The telegraph pole set's points array is missing or has fewer than two entries, so there is no run to place poles and string wire along; this is an error and must be fixed.",
+    "fix": "Add a points array with at least two positions defining the line the poles follow.",
+    "example": "{\"world\": {\"telegraphPoles\": {\"mainLine\": {\"points\": [{\"x\": 0, \"y\": 560, \"z\": 0}, {\"x\": 40, \"y\": 561, \"z\": 25}]}}}}"
+  },
+  "fuse.telegraphPoleMovement.duplicatePoleIndex": {
+    "title": "Duplicate pole index in movement",
+    "why": "The same pole index appears more than once in a single movement's poleIndices array. The validator warns about the repeat, which is often a typo for a different pole index.",
+    "fix": "List each pole index only once per movement; remove the repeated entries or correct them to the intended indices.",
+    "example": "{\"world\": {\"telegraphPoleMovements\": [{\"poleIndices\": [2, 3, 4], \"offset\": {\"x\": 0, \"y\": 0, \"z\": 5}}]}}"
+  },
+  "fuse.telegraphPoleMovement.poleIndex": {
+    "title": "Negative telegraph pole index",
+    "why": "An entry in poleIndices is less than 0. Pole indices must be greater than or equal to 0; this is an error and must be fixed.",
+    "fix": "Replace any negative entries with the correct zero-based index of the pole you want to move.",
+    "example": "{\"world\": {\"telegraphPoleMovements\": [{\"poleIndices\": [0, 1], \"offset\": {\"x\": 0, \"y\": 0, \"z\": 5}}]}}"
+  },
+  "fuse.telegraphPoleMovement.poleIndices": {
+    "title": "Movement has no pole indices",
+    "why": "The movement's poleIndices array is missing or empty, so it does not target any poles and has nothing to move; this is an error and must be fixed.",
+    "fix": "Add a poleIndices array with at least one zero-based pole index that the movement should apply to.",
+    "example": "{\"world\": {\"telegraphPoleMovements\": [{\"poleIndices\": [3], \"offset\": {\"x\": 2, \"y\": 0, \"z\": 0}}]}}"
+  },
+  "fuse.telegraphPoleMovement.required": {
+    "title": "Null telegraph pole movement entry",
+    "why": "An entry in the world.telegraphPoleMovements array is JSON null instead of a movement object. Every entry must be a movement; this is an error and must be fixed.",
+    "fix": "Remove the null entry, or replace it with a movement object containing poleIndices and an offset.",
+    "example": "{\"world\": {\"telegraphPoleMovements\": [{\"poleIndices\": [0], \"offset\": {\"x\": 0, \"y\": 0, \"z\": 3}}]}}"
+  },
+  "fuse.telegraphPoleMovement.zeroOffset": {
+    "title": "Telegraph pole movement offset is zero",
+    "why": "The movement's offset is the zero vector (omitting offset leaves it at all zeros), so the listed pole indices would not be moved at all. Flagged as a warning because the entry has no effect and usually means a forgotten value.",
+    "fix": "Set offset to the displacement you want applied to the listed poles, or delete the movement entry if it is no longer needed.",
+    "example": "{\"world\":{\"telegraphPoleMovements\":[{\"poleIndices\":[412,413],\"offset\":{\"x\":1.5,\"y\":0,\"z\":-2.0}}]}}"
+  },
+  "fuse.track.area.radius": {
+    "title": "Area radius is negative",
+    "why": "The area's radius is set to a value less than 0, which the validator rejects as an error; a radius must be greater than or equal to 0.",
+    "fix": "Set radius to 0 or greater, or omit it entirely — the check only runs when radius is present.",
+    "example": "{\"tracks\":{\"areas\":{\"elaYard\":{\"name\":\"Ela Yard\",\"radius\":150}}}}"
+  },
+  "fuse.track.area.tagColor": {
+    "title": "Area tagColor has wrong component count",
+    "why": "tagColor must contain exactly 3 (RGB) or 4 (RGBA) numeric components; any other array length is rejected as an error.",
+    "fix": "Provide exactly 3 or 4 components in the tagColor array.",
+    "example": "{\"tracks\":{\"areas\":{\"elaYard\":{\"name\":\"Ela Yard\",\"tagColor\":[0.9,0.2,0.2,1.0]}}}}"
+  },
+  "fuse.track.location.distance": {
+    "title": "Track location distance is negative",
+    "why": "The location's distance is less than 0; distance measures meters along the segment and must be 0 or greater, so a negative value is an error.",
+    "fix": "Set distance to a non-negative number of meters along the segment, or use normalized (a 0..1 fraction) instead — never both.",
+    "example": "{\"tracks\":{\"spans\":{\"spanEla1\":{\"upper\":{\"segmentId\":\"segEla1\",\"distance\":12.5},\"lower\":{\"segmentId\":\"segEla1\",\"distance\":80,\"end\":\"B\"}}}}}"
+  },
+  "fuse.track.location.end": {
+    "title": "Track location end value not recognized",
+    "why": "end is set to something other than A/B or Start/End (matched case-insensitively), so the validator cannot tell which end of the segment to measure from and reports an error.",
+    "fix": "Set end to \"A\", \"B\", \"Start\", or \"End\" — or omit it, which defaults to the A end.",
+    "example": "{\"tracks\":{\"spans\":{\"spanEla1\":{\"upper\":{\"segmentId\":\"segEla1\",\"normalized\":0.25,\"end\":\"B\"},\"lower\":{\"segmentId\":\"segEla1\",\"normalized\":0.75}}}}}"
+  },
+  "fuse.track.location.measure": {
+    "title": "Track location missing normalized or distance",
+    "why": "The location sets neither normalized nor distance, so there is no way to know where on the segment it sits; the validator reports an error.",
+    "fix": "Add exactly one measure: normalized (a 0..1 fraction of the segment) or distance (meters along the segment).",
+    "example": "{\"tracks\":{\"spans\":{\"spanEla1\":{\"upper\":{\"segmentId\":\"segEla1\",\"normalized\":0.5},\"lower\":{\"segmentId\":\"segEla1\",\"normalized\":0.9,\"end\":\"B\"}}}}}"
+  },
+  "fuse.track.location.measure.exclusive": {
+    "title": "Track location sets both normalized and distance",
+    "why": "The location sets both normalized and distance, but a track location must position itself with one measure or the other; setting both is rejected as an error.",
+    "fix": "Keep exactly one of normalized or distance and delete the other.",
+    "example": "{\"tracks\":{\"spans\":{\"spanEla1\":{\"upper\":{\"segmentId\":\"segEla1\",\"distance\":30},\"lower\":{\"segmentId\":\"segEla1\",\"distance\":75,\"end\":\"B\"}}}}}"
+  },
+  "fuse.track.location.normalized": {
+    "title": "Normalized location outside 0 to 1",
+    "why": "normalized positions the location as a fraction of the segment's length and must be between 0 and 1 inclusive; the value here falls outside that range, which is an error.",
+    "fix": "Bring the value into the 0..1 range, or switch to distance (meters) if you meant an absolute measure.",
+    "example": "{\"tracks\":{\"spans\":{\"spanEla1\":{\"upper\":{\"segmentId\":\"segEla1\",\"normalized\":0.1},\"lower\":{\"segmentId\":\"segEla1\",\"normalized\":0.85,\"end\":\"B\"}}}}}"
+  },
+  "fuse.track.location.required": {
+    "title": "Required track location is missing",
+    "why": "A span's upper or lower track location is null or absent, so the span cannot be anchored to a segment and the validator reports an error.",
+    "fix": "Add the missing location object with a segmentId and exactly one measure (normalized or distance).",
+    "example": "{\"tracks\":{\"spans\":{\"spanEla1\":{\"upper\":{\"segmentId\":\"segEla1\",\"normalized\":0.1},\"lower\":{\"segmentId\":\"segEla1\",\"normalized\":0.9,\"end\":\"B\"}}}}}"
+  },
+  "fuse.track.node.external": {
+    "title": "Segment references node outside this document",
+    "why": "The segment's startNodeId or endNodeId is not defined under tracks.nodes in this document and is not generated by its operations, so it must already exist in the base game graph at runtime. This is a warning: intentional when attaching to base-game track, but a typo means the segment cannot resolve in-game.",
+    "fix": "Verify the id matches a real base-game node, or define the node under tracks.nodes if it is meant to be new.",
+    "example": "{\"tracks\":{\"nodes\":{\"nodeSpur1\":{\"position\":{\"x\":120,\"y\":4,\"z\":-310}},\"nodeSpur2\":{\"position\":{\"x\":160,\"y\":4,\"z\":-340}}},\"segments\":{\"segSpur1\":{\"startNodeId\":\"nodeSpur1\",\"endNodeId\":\"nodeSpur2\"}}}}"
+  },
+  "fuse.track.removal.blank": {
+    "title": "Blank ID in track removals list",
+    "why": "An entry in a tracks.removals list (nodes, segments, or spans) is empty or whitespace-only. A blank id cannot target anything to remove, so it is rejected as an error.",
+    "fix": "Delete the empty or whitespace-only entry, or replace it with the real id of the node, segment, or span you want removed.",
+    "example": "{\"tracks\":{\"removals\":{\"segments\":[\"segOldWye1\",\"segOldWye2\"]}}}"
+  },
+  "fuse.track.removal.conflict": {
+    "title": "Same track object defined and removed",
+    "why": "An id in tracks.removals also appears (matched case-insensitively) as a definition key in the matching section of the same document — removals.nodes against tracks.nodes, removals.segments against tracks.segments, removals.spans against tracks.spans. Defining and removing the same object is contradictory, so it is rejected as an error.",
+    "fix": "Drop the id from the removals list if you mean to define it, or delete the definition if you mean to remove the base-game object.",
+    "example": "{\"tracks\":{\"nodes\":{\"nodeNew1\":{\"position\":{\"x\":0,\"y\":0,\"z\":0}}},\"removals\":{\"nodes\":[\"nodeOldBase1\"]}}}"
+  },
+  "fuse.track.removal.duplicate": {
+    "title": "Duplicate removal ID",
+    "why": "The same ID is listed more than once in a tracks.removals list (nodes, segments, or spans); IDs compare case-insensitively. The repeated entry is redundant and the validator flags it as a warning.",
+    "fix": "Delete the repeated entry so each removal ID appears exactly once in the list.",
+    "example": "{\"tracks\": {\"removals\": {\"segments\": [\"sOldYard1\", \"sOldYard2\"]}}}"
+  },
+  "fuse.track.segment.external": {
+    "title": "Span references segment outside this document",
+    "why": "A span endpoint's segmentId is not defined in this document's tracks.segments (and is not an ID FUSE generates for a turntable in the same document), so it must exist in the base game's track graph at runtime. If no base-game segment has that exact ID, the span cannot resolve when the mod loads.",
+    "fix": "Verify the segmentId exactly matches a base-game segment ID, or define that segment in tracks.segments. If you are intentionally anchoring to base-game track, you can leave this warning as-is.",
+    "example": "{\"tracks\": {\"segments\": {\"sDepot1\": {\"startNodeId\": \"nDepot1\", \"endNodeId\": \"nDepot2\"}}, \"spans\": {\"spanDepot\": {\"upper\": {\"segmentId\": \"sDepot1\", \"normalized\": 1.0, \"end\": \"B\"}, \"lower\": {\"segmentId\": \"sDepot1\", \"normalized\": 0.0, \"end\": \"A\"}}}}}"
+  },
+  "fuse.track.segment.partialEndpoint": {
+    "title": "Partial segment patch missing one endpoint",
+    "why": "A segment with \"partial\": true supplies only one of startNodeId / endNodeId. The runtime will hydrate the missing endpoint from the runtime graph — fine if intentional, but you are not controlling that end of the segment.",
+    "fix": "If you meant to patch only one end, leave it as-is. Otherwise add the missing startNodeId or endNodeId so both endpoints are explicit.",
+    "example": "{\"tracks\": {\"segments\": {\"sMain12\": {\"partial\": true, \"startNodeId\": \"nNewJunction\", \"endNodeId\": \"nMain13\"}}}}"
+  },
+  "fuse.track.segment.partialEndpoint.empty": {
+    "title": "Partial segment patch has no endpoints",
+    "why": "A segment marked \"partial\": true provides neither startNodeId nor endNodeId, leaving the patch nothing to anchor to. This is an error and the document fails validation until fixed.",
+    "fix": "Add startNodeId, endNodeId, or both to the partial segment patch.",
+    "example": "{\"tracks\": {\"segments\": {\"sMain12\": {\"partial\": true, \"endNodeId\": \"nMain13\"}}}}"
+  },
+  "fuse.track.segment.required": {
+    "title": "Track segment entry is empty",
+    "why": "An entry under tracks.segments has no value (e.g. \"sYard1\": null), so there is no segment definition to validate or apply. This is an error and breaks the mod.",
+    "fix": "Replace the null with a segment object that includes startNodeId and endNodeId, or delete the key. To remove an existing segment, list its ID under tracks.removals.segments instead.",
+    "example": "{\"tracks\": {\"segments\": {\"sYard1\": {\"startNodeId\": \"nYard1\", \"endNodeId\": \"nYard2\"}}}}"
+  },
+  "fuse.track.span.lower.distance": {
+    "title": "Lower span endpoint outside segment length",
+    "why": "Both span endpoints sit on a segment defined in this document, and the lower endpoint's computed position (distance, or normalized times the segment length, plus offset) falls outside the segment's estimated straight-line length. The estimate ignores curvature, so this is a warning — runtime graph validation uses the actual curved length — but a position genuinely off the segment will not land where you intend.",
+    "fix": "Adjust the lower location's distance, normalized, or offset so the resulting position lies between 0 and the segment's length.",
+    "example": "{\"tracks\": {\"nodes\": {\"nSide1\": {\"position\": {\"x\": 0, \"y\": 0, \"z\": 0}}, \"nSide2\": {\"position\": {\"x\": 0, \"y\": 0, \"z\": 100}}}, \"segments\": {\"sSiding1\": {\"startNodeId\": \"nSide1\", \"endNodeId\": \"nSide2\"}}, \"spans\": {\"spanSiding\": {\"lower\": {\"segmentId\": \"sSiding1\", \"distance\": 5.0, \"end\": \"A\"}, \"upper\": {\"segmentId\": \"sSiding1\", \"distance\": 85.0, \"end\": \"B\"}}}}}"
+  },
+  "fuse.track.span.required": {
+    "title": "Track span entry is empty",
+    "why": "An entry under tracks.spans has no value (e.g. \"spanDepot\": null), so there is no span definition to validate or apply. This is an error and breaks the mod.",
+    "fix": "Replace the null with a span object containing upper and lower track locations (each with a segmentId and either normalized or distance), or delete the key. To remove an existing span, list its ID under tracks.removals.spans instead.",
+    "example": "{\"tracks\": {\"spans\": {\"spanDepot\": {\"upper\": {\"segmentId\": \"sDepot1\", \"normalized\": 1.0, \"end\": \"B\"}, \"lower\": {\"segmentId\": \"sDepot1\", \"normalized\": 0.0, \"end\": \"A\"}}}}}"
+  },
+  "fuse.track.span.sameSegment.sameDirection": {
+    "title": "Same-segment span endpoints face same direction",
+    "why": "Both span endpoints sit on the same segment and resolve to the same end (end defaults to \"A\" when omitted), so the authored span direction is ambiguous. The validator warns; the runtime will re-anchor this legacy-compatible span if the physical positions are valid, but the document should state the intent explicitly.",
+    "fix": "Give the two endpoints opposite ends: set one to \"A\" (or \"Start\") and the other to \"B\" (or \"End\").",
+    "example": "{\"tracks\": {\"spans\": {\"spanYard\": {\"upper\": {\"segmentId\": \"sYard1\", \"distance\": 120.0, \"end\": \"B\"}, \"lower\": {\"segmentId\": \"sYard1\", \"distance\": 40.0, \"end\": \"A\"}}}}}"
+  },
+  "fuse.track.span.upper.distance": {
+    "title": "Upper span endpoint outside segment length",
+    "why": "Both span endpoints sit on a segment defined in this document, and the upper endpoint's computed position (distance, or normalized times the segment length, plus offset) falls outside the segment's estimated straight-line length. The estimate ignores curvature, so this is a warning — runtime graph validation uses the actual curved length — but a position genuinely off the segment will not land where you intend.",
+    "fix": "Adjust the upper location's distance, normalized, or offset so the resulting position lies between 0 and the segment's length.",
+    "example": "{\"tracks\": {\"nodes\": {\"nSide1\": {\"position\": {\"x\": 0, \"y\": 0, \"z\": 0}}, \"nSide2\": {\"position\": {\"x\": 0, \"y\": 0, \"z\": 100}}}, \"segments\": {\"sSiding1\": {\"startNodeId\": \"nSide1\", \"endNodeId\": \"nSide2\"}}, \"spans\": {\"spanSiding\": {\"upper\": {\"segmentId\": \"sSiding1\", \"distance\": 85.0, \"end\": \"B\"}, \"lower\": {\"segmentId\": \"sSiding1\", \"distance\": 5.0, \"end\": \"A\"}}}}}"
+  },
+  "fuse.track.speedLimit": {
+    "title": "Speed limit out of range",
+    "why": "A segment's speedLimit is below 0 or above 80; the validator only accepts values from 0 to 80. This is an error and the document fails validation until corrected.",
+    "fix": "Set speedLimit to a value between 0 and 80, or omit the field to use the default of 45.",
+    "example": "{\"tracks\": {\"segments\": {\"sMain1\": {\"startNodeId\": \"nA\", \"endNodeId\": \"nB\", \"speedLimit\": 45}}}}"
+  },
+  "fuse.turntable.radius": {
+    "title": "Turntable radius not positive",
+    "why": "A turntable's radius is 0 or negative. The field has no default, so leaving radius out of the definition also triggers this error — the turntable must declare a positive radius.",
+    "fix": "Add a radius greater than 0 to the turntable definition.",
+    "example": "{\"operations\": {\"turntables\": {\"ttSylva\": {\"radius\": 11.5, \"subdivisions\": 16}}}}"
+  },
+  "fuse.turntable.roundhouse.trackLength": {
+    "title": "Roundhouse track length not positive",
+    "why": "A turntable's roundhouse declares stalls (stalls greater than 0) but its trackLength is explicitly set to 0 or negative. Stall tracks need a positive length; this is an error and fails validation.",
+    "fix": "Set roundhouse.trackLength to a value greater than 0, or remove the field to use the default of 46.",
+    "example": "{\"operations\": {\"turntables\": {\"ttSylva\": {\"radius\": 11.5, \"roundhouse\": {\"stalls\": 6, \"trackLength\": 46}}}}}"
+  },
+  "fuse.turntable.subdivisions": {
+    "title": "Turntable subdivisions out of range",
+    "why": "Error: the turntable's subdivisions value is below 4 or above 32, outside the range the validator allows. The document fails validation, so the turntable definition is rejected.",
+    "fix": "Set subdivisions to a whole number between 4 and 32 (inclusive) under operations.turntables.<id>. The default is 16 if you have no specific need.",
+    "example": "{\"operations\": {\"turntables\": {\"ewh-turntable\": {\"radius\": 12.5, \"subdivisions\": 16}}}}"
+  },
+  "fuse.world.removal.blank": {
+    "title": "Blank world removal ID",
+    "why": "Error: an entry in a world.removals list (scenery, splineys, telegraphPoles, mapLabels, mapMasks, or sceneClones) is empty or whitespace. A blank ID cannot identify any world object to remove.",
+    "fix": "Delete the empty entry (often left behind by a trailing comma) or replace it with the real ID of the object you want removed.",
+    "example": "{\"world\": {\"removals\": {\"scenery\": [\"old-water-tower\"]}}}"
+  },
+  "fuse.world.removal.conflict": {
+    "title": "World object both defined and removed",
+    "why": "Error: an ID in a world.removals list is also a definition key in the matching world section of the same document (compared case-insensitively). A world object cannot be defined and removed in the same FUSE document — the two instructions contradict each other.",
+    "fix": "Remove the ID from one side: drop the removals entry if you mean to keep your definition, or delete the definition if you mean to remove a base-game object. If they are different objects, rename yours.",
+    "example": "{\"world\": {\"scenery\": {\"new-depot\": {\"assetIdentifier\": \"depot\"}}, \"removals\": {\"scenery\": [\"old-depot\"]}}}"
+  },
+  "fuse.world.removal.duplicate": {
+    "title": "World removal ID listed twice",
+    "why": "Warning: the same ID appears more than once in a world.removals list (compared case-insensitively). The repeated entry is redundant.",
+    "fix": "Keep one occurrence of the ID and delete the duplicates.",
+    "example": "{\"world\": {\"removals\": {\"mapLabels\": [\"label-sylva\", \"label-dillsboro\"]}}}"
+  },
+  "fuse.world.scenery.anchorSpan.empty": {
+    "title": "Blank scenery anchor span ID",
+    "why": "Warning: an entry in world.scenery.<id>.anchorSpanIds is empty or whitespace. A blank entry cannot reference any track span, so it contributes nothing to anchoring the scenery.",
+    "fix": "Delete the blank entry from anchorSpanIds, or replace it with the ID of the track span the scenery should anchor to.",
+    "example": "{\"world\": {\"scenery\": {\"depot-shed\": {\"assetIdentifier\": \"shed\", \"anchorSpanIds\": [\"yard-span-1\"]}}}}"
+  },
+  "fuse.world.scenery.assetIdentifier.required": {
+    "title": "Scenery missing asset identifier",
+    "why": "Error: this scenery entry has neither assetIdentifier nor the legacy model field set. Without one FUSE cannot resolve a PrefabStore asset, so there is nothing to place in the world.",
+    "fix": "Add an assetIdentifier naming the PrefabStore asset to place. Prefer it over the legacy model field, which is only a display label and never used as the asset key.",
+    "example": "{\"world\": {\"scenery\": {\"water-tower-1\": {\"assetIdentifier\": \"watertower\", \"position\": {\"x\": 1200.0, \"y\": 560.0, \"z\": -340.0}}}}}"
+  },
+  "fuse.world.spawnPoint.duplicate": {
+    "title": "Duplicate spawn point name",
+    "why": "Error: two spawn points in this package share the same name (compared trimmed and case-insensitively). Spawn point names must be unique within a package so each one can be addressed unambiguously.",
+    "fix": "Give every entry in world.spawnPoints a distinct name; rename or delete the duplicate.",
+    "example": "{\"world\": {\"spawnPoints\": [{\"name\": \"Ela Yard\", \"position\": {\"x\": 100.0, \"y\": 560.0, \"z\": 200.0}}, {\"name\": \"Wilmot Siding\", \"position\": {\"x\": 800.0, \"y\": 590.0, \"z\": -50.0}}]}}"
+  },
+  "fuse.world.spawnPoint.radius": {
+    "title": "Spawn point radius not positive",
+    "why": "Error: the spawn point sets a radius of 0 or less. When present, radius must be greater than 0.",
+    "fix": "Set radius to a positive number, or omit the field entirely since it is optional.",
+    "example": "{\"world\": {\"spawnPoints\": [{\"name\": \"Ela Yard\", \"position\": {\"x\": 100.0, \"y\": 560.0, \"z\": 200.0}, \"radius\": 25.0}]}}"
+  },
+  "fuse.world.spawnPoint.required": {
+    "title": "Null spawn point entry",
+    "why": "Error: an entry in the world.spawnPoints array is null, so there is no spawn point definition at that index. This is usually a stray null or trailing-comma artifact in the JSON array.",
+    "fix": "Remove the null entry, or replace it with a spawn point object that has at least a name.",
+    "example": "{\"world\": {\"spawnPoints\": [{\"name\": \"Ela Yard\", \"position\": {\"x\": 100.0, \"y\": 560.0, \"z\": 200.0}}]}}"
+  },
+  "fuse.world.suppression.area.empty": {
+    "title": "Empty area suppression ID",
+    "why": "Warning: an entry in world.suppressBaseAreas is empty or whitespace. A blank ID cannot match any base-game area, so the entry suppresses nothing.",
+    "fix": "Delete the blank entry, or fill in the ID of the base-game area you want suppressed.",
+    "example": "{\"world\": {\"suppressBaseAreas\": [\"sylva\"]}}"
+  },
+  "fuse.world.suppression.scenePath.empty": {
+    "title": "Empty scene suppression path",
+    "why": "Warning: an entry in world.suppressBaseScenePaths is empty or whitespace. A blank path cannot match any base-game scene object, so the entry suppresses nothing.",
+    "fix": "Delete the blank entry, or fill in the scene path of the base-game object you want suppressed.",
+    "example": "{\"world\": {\"suppressBaseScenePaths\": [\"Scenery/Sylva/Old Depot\"]}}"
+  },
+  "fuse.world.suppression.trackGroup.empty": {
+    "title": "Empty track group suppression ID",
+    "why": "Warning: an entry in world.suppressBaseTrackGroups is empty or whitespace. A blank ID cannot match any base-game track group, so the entry suppresses nothing.",
+    "fix": "Delete the blank entry, or fill in the ID of the base-game track group you want suppressed.",
+    "example": "{\"world\": {\"suppressBaseTrackGroups\": [\"tg-whittier\"]}}"
+  }
+}

--- a/FUSE.Editor/FUSE.Editor.csproj
+++ b/FUSE.Editor/FUSE.Editor.csproj
@@ -181,6 +181,7 @@
     <!-- FUSE.Converter depends on FUSE.Core (unified diagnostics), so the
          editor mod has to carry FUSE.Core.dll alongside it. -->
     <Copy SourceFiles="$(TargetDir)FUSE.Core.dll" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="true" Condition="Exists('$(TargetDir)FUSE.Core.dll')" />
+    <Copy SourceFiles="$(TargetDir)FUSE.Core.pdb" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="false" Condition="Exists('$(TargetDir)FUSE.Core.pdb') and '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
     <!-- Icon PNGs land alongside the DLL so FuseEditorIcons can find
          them via Assembly.GetExecutingAssembly().Location + /Icons/. -->
     <ItemGroup>

--- a/FUSE.Editor/FUSE.Editor.csproj
+++ b/FUSE.Editor/FUSE.Editor.csproj
@@ -178,6 +178,9 @@
          runtime. Match the pdb pattern of FUSE.Editor itself. -->
     <Copy SourceFiles="$(TargetDir)FUSE.Converter.dll" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="true" Condition="Exists('$(TargetDir)FUSE.Converter.dll')" />
     <Copy SourceFiles="$(TargetDir)FUSE.Converter.pdb" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="false" Condition="Exists('$(TargetDir)FUSE.Converter.pdb') and '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+    <!-- FUSE.Converter depends on FUSE.Core (unified diagnostics), so the
+         editor mod has to carry FUSE.Core.dll alongside it. -->
+    <Copy SourceFiles="$(TargetDir)FUSE.Core.dll" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="true" Condition="Exists('$(TargetDir)FUSE.Core.dll')" />
     <!-- Icon PNGs land alongside the DLL so FuseEditorIcons can find
          them via Assembly.GetExecutingAssembly().Location + /Icons/. -->
     <ItemGroup>

--- a/FUSE.Tests/Validation/FuseDefinitionValidatorDeeperTests.CarTypeFilter.cs
+++ b/FUSE.Tests/Validation/FuseDefinitionValidatorDeeperTests.CarTypeFilter.cs
@@ -1,0 +1,142 @@
+using FUSE.Authoring.Data;
+using Xunit;
+
+namespace FUSE.Tests.Validation
+{
+    public partial class FuseDefinitionValidatorDeeperTests
+    {
+        /// <summary>
+        /// Mirror of the FUSE.Core carTypeFilter tests for the shipping
+        /// validator: the filter is matched verbatim per comma-separated
+        /// token at runtime, so surrounding whitespace is an error and an
+        /// empty token from a doubled/edge comma is a warning.
+        /// </summary>
+        public class CarTypeFilterRules
+        {
+            private const string MalformedCode = "fuse.operations.component.carTypeFilter.malformed";
+            private const string EmptyTokenCode = "fuse.operations.component.carTypeFilter.emptyToken";
+
+            private static FuseModDefinition WithComponentFilter(string filter)
+            {
+                var definition = MinimalValid();
+                definition.Operations.Industries["mill"] = new FuseIndustry
+                {
+                    Name = "Mill",
+                    Components =
+                    {
+                        ["dock"] = new FuseIndustryComponent { Partial = true, CarTypeFilter = filter },
+                    },
+                };
+                return definition;
+            }
+
+            [Fact]
+            public void Component_Filter_With_Surrounding_Whitespace_Is_An_Error()
+            {
+                var result = NewValidator().Validate(WithComponentFilter("FB, XM"));
+
+                Assert.Contains(
+                    result.Errors,
+                    e => e.Code == MalformedCode && e.Field == "operations.industries.mill.components.dock.carTypeFilter");
+            }
+
+            [Fact]
+            public void Component_Filter_With_Doubled_Comma_Is_A_Warning()
+            {
+                var result = NewValidator().Validate(WithComponentFilter("FB,,XM"));
+
+                Assert.Contains(result.Warnings, w => w.Code == EmptyTokenCode);
+                Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
+            }
+
+            [Theory]
+            [InlineData("FB,XM")]
+            [InlineData("*")]
+            [InlineData("FB*")]
+            [InlineData("")]
+            [InlineData(null)]
+            public void Component_Filter_Valid_Values_Stay_Silent(string filter)
+            {
+                var result = NewValidator().Validate(WithComponentFilter(filter));
+
+                Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
+                Assert.DoesNotContain(result.Warnings, w => w.Code == EmptyTokenCode);
+            }
+
+            [Fact]
+            public void TeamProfile_Filter_Is_Validated()
+            {
+                var definition = MinimalValid();
+                definition.Operations.Industries["mill"] = new FuseIndustry
+                {
+                    Name = "Mill",
+                    Components =
+                    {
+                        ["team"] = new FuseIndustryComponent
+                        {
+                            Partial = true,
+                            TeamProfiles =
+                            {
+                                ["lumber"] = new FuseTeamTrackEntry { LoadId = "lumber", CarTypeFilter = "FB, GB" },
+                            },
+                        },
+                    },
+                };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.Contains(
+                    result.Errors,
+                    e => e.Code == MalformedCode &&
+                         e.Field == "operations.industries.mill.components.team.teamProfiles.lumber.carTypeFilter");
+            }
+
+            [Fact]
+            public void Load_Filter_Is_Validated()
+            {
+                var definition = MinimalValid();
+                definition.Operations.Loads["coal"] = new FuseLoad { Name = "Coal", CarTypeFilter = "HM ,HT" };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.Contains(
+                    result.Errors,
+                    e => e.Code == MalformedCode && e.Field == "operations.loads.coal.carTypeFilter");
+            }
+
+            [Fact]
+            public void Delivery_Filter_Is_Validated()
+            {
+                var definition = MinimalValid();
+                definition.Progression.Progressions["main"] = new FuseProgression
+                {
+                    Sections =
+                    {
+                        ["s1"] = new FuseSection
+                        {
+                            DisplayName = "Section 1",
+                            DeliveryPhases = new[]
+                            {
+                                new FuseDeliveryPhase
+                                {
+                                    IndustryComponentId = "mill.dock",
+                                    Deliveries = new[]
+                                    {
+                                        new FuseDelivery { Count = 1, CarTypeFilter = "FB, XM" },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.Contains(
+                    result.Errors,
+                    e => e.Code == MalformedCode &&
+                         e.Field == "progression.progressions.main.sections.s1.deliveryPhases[0].deliveries[0].carTypeFilter");
+            }
+        }
+    }
+}

--- a/FUSE.slnx
+++ b/FUSE.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Project Path="FUSE.Converter/FUSE.Converter.csproj" />
+  <Project Path="FUSE.ConverterCli/FUSE.ConverterCli.csproj" />
   <Project Path="FUSE.Core/FUSE.Core.csproj" />
   <Project Path="FUSE.Core.Tests/FUSE.Core.Tests.csproj" />
   <Project Path="FUSE.Editor/FUSE.Editor.csproj" />

--- a/FUSE/Authoring/Validation/FuseDefinitionValidator.cs
+++ b/FUSE/Authoring/Validation/FuseDefinitionValidator.cs
@@ -438,6 +438,7 @@ namespace FUSE.Authoring.Validation
                         result.AddError($"{path}.unitWeightInPounds", "Load unitWeightInPounds must be greater than or equal to 0.", "fuse.operations.loads.unitWeightInPounds", load.Value.UnitWeightInPounds.Value);
                     }
 
+                    ValidateCarTypeFilter(result, $"{path}.carTypeFilter", load.Value.CarTypeFilter);
                 }
             }
 
@@ -940,6 +941,8 @@ namespace FUSE.Authoring.Validation
                             result.AddError($"{deliveryPath}.direction", "Delivery direction must be loadToIndustry or loadFromIndustry.", "fuse.progression.delivery.direction", delivery.Direction);
                         }
                     }
+
+                    ValidateCarTypeFilter(result, $"{deliveryPath}.carTypeFilter", delivery.CarTypeFilter);
                 }
             }
         }
@@ -969,6 +972,32 @@ namespace FUSE.Authoring.Validation
                 }
 
                 index++;
+            }
+        }
+
+        private static void ValidateCarTypeFilter(ValidationResult result, string path, string filter)
+        {
+            // Empty and "*" both mean "any car type" at runtime, so only a
+            // filter with real tokens needs checking. The game splits the
+            // expression on ',' without trimming, so a token with surrounding
+            // whitespace can never match a car type.
+            if (string.IsNullOrWhiteSpace(filter) || filter == "*")
+            {
+                return;
+            }
+
+            var tokens = filter.Split(',');
+            for (var index = 0; index < tokens.Length; index++)
+            {
+                var token = tokens[index];
+                if (string.IsNullOrWhiteSpace(token))
+                {
+                    result.AddWarning(path, "Car type filter contains an empty entry (doubled, leading, or trailing comma); the game ignores it.", "fuse.operations.component.carTypeFilter.emptyToken", filter);
+                }
+                else if (token.Trim().Length != token.Length)
+                {
+                    result.AddError(path, $"Car type filter entry '{token}' has surrounding whitespace and can never match a car type; write the filter without spaces (e.g. \"FB,XM\").", "fuse.operations.component.carTypeFilter.malformed", filter);
+                }
             }
         }
 
@@ -1065,6 +1094,15 @@ namespace FUSE.Authoring.Validation
             if (component.CarTransferRate.HasValue && component.CarTransferRate.Value < 0f)
             {
                 result.AddError($"{path}.carTransferRate", "Car transfer rate must be greater than or equal to 0.", "fuse.operations.component.carTransferRate", component.CarTransferRate.Value);
+            }
+
+            ValidateCarTypeFilter(result, $"{path}.carTypeFilter", component.CarTypeFilter);
+            if (component.TeamProfiles != null)
+            {
+                foreach (var profile in component.TeamProfiles)
+                {
+                    ValidateCarTypeFilter(result, $"{path}.teamProfiles.{profile.Key}.carTypeFilter", profile.Value?.CarTypeFilter);
+                }
             }
 
             if (!partial &&

--- a/docs/FUSE_CONVERTER.md
+++ b/docs/FUSE_CONVERTER.md
@@ -56,6 +56,46 @@ If that folder does not exist, it writes to `converted` under the current workin
 python tools\fuse_converter.py "C:\Path\To\LegacyMod" --out "C:\Steam\steamapps\common\Railroader\Mods" --clean
 ```
 
+## fuse-convert (.NET CLI)
+
+`FUSE.ConverterCli` builds the `fuse-convert` binary: the C# converter
+(`FUSE.Converter`) plus the FUSE.Core validator in one convert → validate →
+report pipeline. Every validation finding is rendered with a fix-hint from the
+catalog embedded in FUSE.Core — what's wrong, why it matters, and exactly how
+to fix it.
+
+```powershell
+dotnet run --project FUSE.ConverterCli -- "C:\Path\To\LegacyMod" --out "C:\Steam\steamapps\common\Railroader\Mods" --clean
+```
+
+```text
+fuse-convert <inputs...> [--out <dir>] [--kind auto|route|audio|asset] [--clean] [--batch]
+             [--no-validate] [--strict] [--format console|json|markdown|all] [--quiet]
+```
+
+| Option | Meaning |
+| --- | --- |
+| `--out <dir>` | Output root; each mod converts into `<dir>\<ModFolder>.FUSE`. Default: `.\FUSEConverted`. |
+| `--kind <kind>` | Force a package kind instead of auto-detection. |
+| `--clean` | Replace an existing `.FUSE` output folder. |
+| `--batch` | Treat each input as a container and convert every recognized child folder. |
+| `--no-validate` | Skip validation (it is on by default). |
+| `--strict` | Validation warnings also fail the run (exit 2), not just errors. |
+| `--format <fmt>` | `console` (default) prints to stdout; `json` / `markdown` also write `conversion-report.json` / `conversion-report.md` into each output folder; `all` writes both. |
+| `--quiet` | Suppress per-diagnostic output; print only summaries. |
+
+Exit codes (CI can gate conversion and validation separately):
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success — validation warnings allowed unless `--strict`. |
+| `1` | Conversion failed. |
+| `2` | Validation errors (or `--strict` with validation warnings). |
+| `64` | Usage error. |
+
+Unlike the Python tool, `fuse-convert` takes mod **folders** only — extract a
+zip (or place a bare JSON in a mod folder) before converting.
+
 ## Linux / Folder Batch Mode
 
 For Linux or anyone who wants to convert a whole folder at once:

--- a/schemas/fuse-mod.schema.json
+++ b/schemas/fuse-mod.schema.json
@@ -701,7 +701,8 @@
                     "default": 0
                 },
                 "carTypeFilter": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Comma-delimited car-type filter expression, matched verbatim per token at runtime — write \"FB,XM\", not \"FB, XM\" (a token with surrounding whitespace can never match). Tokens support a trailing * prefix wildcard; bare * (or omitting the field) matches any car type."
                 },
                 "emptyCarType": {
                     "type": "string"
@@ -843,7 +844,8 @@
                     "description": "Compatibility list patch for component track spans. Replaces, prepends, appends/inserts, or removes span ids without flattening operation semantics."
                 },
                 "carTypeFilter": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Comma-delimited car-type filter expression, matched verbatim per token at runtime — write \"FB,XM\", not \"FB, XM\" (a token with surrounding whitespace can never match). Tokens support a trailing * prefix wildcard; bare * (or omitting the field) matches any car type."
                 },
                 "loadId": {
                     "$ref": "#/$defs/idRef"
@@ -992,7 +994,8 @@
                     "default": 1
                 },
                 "carTypeFilter": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Comma-delimited car-type filter expression, matched verbatim per token at runtime — write \"FB,XM\", not \"FB, XM\" (a token with surrounding whitespace can never match). Tokens support a trailing * prefix wildcard; bare * (or omitting the field) matches any car type."
                 }
             }
         },
@@ -2273,7 +2276,8 @@
             ],
             "properties": {
                 "carTypeFilter": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Comma-delimited car-type filter expression, matched verbatim per token at runtime — write \"FB,XM\", not \"FB, XM\" (a token with surrounding whitespace can never match). Tokens support a trailing * prefix wildcard; bare * (or omitting the field) matches any car type."
                 },
                 "loadId": {
                     "$ref": "#/$defs/idRef"

--- a/schemas/fuse-mod.schema.json
+++ b/schemas/fuse-mod.schema.json
@@ -702,7 +702,7 @@
                 },
                 "carTypeFilter": {
                     "type": "string",
-                    "description": "Comma-delimited car-type filter expression, matched verbatim per token at runtime — write \"FB,XM\", not \"FB, XM\" (a token with surrounding whitespace can never match). Tokens support a trailing * prefix wildcard; bare * (or omitting the field) matches any car type."
+                    "description": "Comma-delimited car-type filter expression, matched verbatim per token at runtime — write \"FB,XM\", not \"FB, XM\" (a token with surrounding whitespace can never match). A token may end with * to match any car type whose code starts with that prefix; a bare * (or omitting the field) matches any car type."
                 },
                 "emptyCarType": {
                     "type": "string"
@@ -845,7 +845,7 @@
                 },
                 "carTypeFilter": {
                     "type": "string",
-                    "description": "Comma-delimited car-type filter expression, matched verbatim per token at runtime — write \"FB,XM\", not \"FB, XM\" (a token with surrounding whitespace can never match). Tokens support a trailing * prefix wildcard; bare * (or omitting the field) matches any car type."
+                    "description": "Comma-delimited car-type filter expression, matched verbatim per token at runtime — write \"FB,XM\", not \"FB, XM\" (a token with surrounding whitespace can never match). A token may end with * to match any car type whose code starts with that prefix; a bare * (or omitting the field) matches any car type."
                 },
                 "loadId": {
                     "$ref": "#/$defs/idRef"
@@ -995,7 +995,7 @@
                 },
                 "carTypeFilter": {
                     "type": "string",
-                    "description": "Comma-delimited car-type filter expression, matched verbatim per token at runtime — write \"FB,XM\", not \"FB, XM\" (a token with surrounding whitespace can never match). Tokens support a trailing * prefix wildcard; bare * (or omitting the field) matches any car type."
+                    "description": "Comma-delimited car-type filter expression, matched verbatim per token at runtime — write \"FB,XM\", not \"FB, XM\" (a token with surrounding whitespace can never match). A token may end with * to match any car type whose code starts with that prefix; a bare * (or omitting the field) matches any car type."
                 }
             }
         },
@@ -2277,7 +2277,7 @@
             "properties": {
                 "carTypeFilter": {
                     "type": "string",
-                    "description": "Comma-delimited car-type filter expression, matched verbatim per token at runtime — write \"FB,XM\", not \"FB, XM\" (a token with surrounding whitespace can never match). Tokens support a trailing * prefix wildcard; bare * (or omitting the field) matches any car type."
+                    "description": "Comma-delimited car-type filter expression, matched verbatim per token at runtime — write \"FB,XM\", not \"FB, XM\" (a token with surrounding whitespace can never match). A token may end with * to match any car type whose code starts with that prefix; a bare * (or omitting the field) matches any car type."
                 },
                 "loadId": {
                     "$ref": "#/$defs/idRef"


### PR DESCRIPTION
Closes #82.

Makes `FUSE.Converter` runnable from a CLI now (and reusable from the coming `FUSE.ExternalEditor` GUI) so pointing it at a mod runs **convert → validate → report**, with every validation problem rendered as a specific *"what''s wrong & how to fix it"* message from a full fix-hint catalog covering all validation codes. Adds the motivating `carTypeFilter` rule.

## What''s in this PR

**1. `carTypeFilter` validation rule (both validators)**
Added `ValidateCarTypeFilter` to the FUSE.Core mirror **and** the in-game `FUSE/Authoring/Validation` copy, called at all four `string CarTypeFilter` model sites (industry component, team profile, delivery, load). The game''s `CarTypeFilter` splits the expression on `,` verbatim **without trimming**, so:
- a token with **surrounding whitespace** (`"FB, XM"`) can never match a car type → **error** `fuse.operations.component.carTypeFilter.malformed`
- a **doubled / leading / trailing comma** yields an ignored empty token → **warning** `fuse.operations.component.carTypeFilter.emptyToken`
- empty and `"*"` mean *any* and are skipped.

**Runtime parsing is unchanged** — existing `"FB,XM"` mods stay byte-for-byte identical; we validate and warn instead.

**2. Full fix-hint catalog**
`FUSE.Core/Validation/Help/fuse-validation-help.json` — embedded resource (one copy shared by CLI + editors + tests), **108 entries** keyed by code with `{title, why, fix, example}`. `FuseValidationHelp.For/TryGet/AllCodes` lazy-loads it; unknown codes degrade to message-only.

**3. Shared diagnostic renderer**
`FuseDiagnostic` + `FuseValidationRenderer` in FUSE.Core (`FromValidation` + `ToConsole/ToMarkdown/ToJson`). Converter report types made `public` + `FuseConversionDiagnostics.FromConversion` adapter so conversion findings flow through the same render path **without** FUSE.Core referencing the converter layer. One render path for CLI and (future) GUI.

**4. `FUSE.ConverterCli` → `fuse-convert`**
`net10.0`, `FuseIsGameFree=true`, references FUSE.Core + FUSE.Converter, added to `FUSE.slnx`.
Args: `<inputs...> --out --kind auto|route|audio|asset --clean --batch --validate/--no-validate --strict --format console|json|markdown|all --quiet`.
Exit codes: `0` ok / `1` conversion failed / `2` validation errors (or `--strict` + warnings) / `64` usage — lets CI gate conversion vs. validation separately. Writes `conversion-report.json` / `conversion-report.md`.

**5. Tests, schema, docs**
- `ValidationHelpCoverageTests` **source-scans both validator files** for `"fuse.*"` literals and asserts every emitted code has a non-empty catalog entry, no orphan keys — catches drift in either validator copy.
- `carTypeFilter` rule tests in `FUSE.Core.Tests` and `FUSE.Tests/Validation`.
- `description` annotations on the four `carTypeFilter` schema sites (tooltip-only).
- `fuse-convert` documented in `docs/FUSE_CONVERTER.md`.

## Decisions (the issue''s open questions)
1. **Gate/branch** — built on this branch cut from `main`; `alex/charming-kilby-5137fe` (FUSE.Core/Converter/ExternalEditor) is already merged into `main`, so no re-port needed. ✅
2. **`carTypeFilter` severity** — **whitespace = error** (it actually breaks matching at graph load, so the CLI fails by default), **empty token = warning** (the game silently ignores it).
3. **CLI name** — `FUSE.ConverterCli`, binary `fuse-convert`.

## Verification
- `FUSE.Core.Tests` **48/48**, `FUSE.Tests` **1310/1310**.
- Solution builds clean (0 errors); FUSE.Core + CLI build `net10` **without** a game dir (`FuseIsGameFree=true`).
- Ran `fuse-convert` against a broken mod (`carTypeFilter: "FB, XM"` + `"FB,,XM"`): converted, flagged both with rendered fix-hints, exit `2`. Clean mod (`"FB,XM"`) under `--strict`: exit `0`. `conversion-report.json/.md` written.
- slopwatch: 0 issues.

## Notes / follow-up
- The `FUSE.ExternalEditor` wiring (bind `FuseValidationRenderer` in the GUI) is the issue''s step 8 follow-up, not in this PR.
- The two-validator divergence is a standing hazard; the coverage test scanning **both** files is the guard.
- FUSE.Converter now depends on FUSE.Core, so `FUSE.Editor` deploy copies `FUSE.Core.dll` alongside `FUSE.Converter.dll` (in-game runtime layout unverified — out of scope here).
