### PR TITLE
refactor(authoring): consolidate id allocation onto shared AuthoringIds core

### DIFF
--- a/FUSE.Core.Tests/OperationsOpsTests.cs
+++ b/FUSE.Core.Tests/OperationsOpsTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using Fuse.Core.Authoring;
+using Fuse.Core.Model;
+using Xunit;
+
+namespace Fuse.Core.Tests;
+
+public class OperationsOpsTests
+{
+    [Fact]
+    public void New_Load_Single_Shot_Fills_First_Free_Slot()
+    {
+        var operations = new FuseOperationsDefinition();
+
+        var id1 = OperationsOps.NewLoadId(operations);
+        OperationsOps.AddLoad(operations, id1, "Coal");
+        var id2 = OperationsOps.NewLoadId(operations);
+
+        Assert.Equal("load_0001", id1);
+        Assert.Equal("load_0002", id2);
+        Assert.False(operations.Loads.ContainsKey(id2));
+    }
+
+    [Fact]
+    public void Batch_Industry_Ids_Match_Repeated_Single_Shot_Calls()
+    {
+        var single = new FuseOperationsDefinition();
+        var batch = new FuseOperationsDefinition();
+        foreach (var id in new[] { "ind_0001", "ind_0003", "ind_0004", "unrelated" })
+        {
+            OperationsOps.AddIndustry(single, id, "Mine");
+            OperationsOps.AddIndustry(batch, id, "Mine");
+        }
+
+        var takenIds = new HashSet<string>(batch.Industries.Keys);
+        var nextIndex = 1;
+        var minted = new List<string>();
+        for (var i = 0; i < 5; i++)
+        {
+            var expected = OperationsOps.NewIndustryId(single);
+            OperationsOps.AddIndustry(single, expected, "Mine");
+
+            var actual = OperationsOps.NewIndustryId(takenIds, ref nextIndex);
+            OperationsOps.AddIndustry(batch, actual, "Mine");
+
+            Assert.Equal(expected, actual);
+            minted.Add(actual);
+        }
+
+        // Gap at ind_0002 is filled first, then the sequence continues past the taken ids.
+        Assert.Equal(new[] { "ind_0002", "ind_0005", "ind_0006", "ind_0007", "ind_0008" }, minted);
+    }
+
+    [Fact]
+    public void Batch_Load_Ids_Use_Prefix_And_Update_Set()
+    {
+        var takenIds = new HashSet<string> { "load_0001" };
+        var nextIndex = 1;
+
+        var first = OperationsOps.NewLoadId(takenIds, ref nextIndex);
+        var second = OperationsOps.NewLoadId(takenIds, ref nextIndex);
+
+        Assert.Equal("load_0002", first);
+        Assert.Equal("load_0003", second);
+        Assert.Contains("load_0002", takenIds);
+        Assert.Contains("load_0003", takenIds);
+    }
+}

--- a/FUSE.Core.Tests/WorldOpsTests.cs
+++ b/FUSE.Core.Tests/WorldOpsTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using Fuse.Core.Authoring;
+using Fuse.Core.Model;
+using Xunit;
+
+namespace Fuse.Core.Tests;
+
+public class WorldOpsTests
+{
+    [Fact]
+    public void New_Scenery_Single_Shot_Fills_First_Free_Slot()
+    {
+        var world = new FuseWorldDefinition();
+
+        var id1 = WorldOps.NewSceneryId(world);
+        WorldOps.AddScenery(world, id1, "asset", default, default);
+        var id2 = WorldOps.NewSceneryId(world);
+
+        Assert.Equal("scn_0001", id1);
+        Assert.Equal("scn_0002", id2);
+        Assert.False(world.Scenery.ContainsKey(id2));
+    }
+
+    [Fact]
+    public void Batch_Scenery_Ids_Match_Repeated_Single_Shot_Calls()
+    {
+        var single = new FuseWorldDefinition();
+        var batch = new FuseWorldDefinition();
+        foreach (var id in new[] { "scn_0001", "scn_0003", "scn_0004", "unrelated" })
+        {
+            WorldOps.AddScenery(single, id, "asset", default, default);
+            WorldOps.AddScenery(batch, id, "asset", default, default);
+        }
+
+        var takenIds = new HashSet<string>(batch.Scenery.Keys);
+        var nextIndex = 1;
+        var minted = new List<string>();
+        for (var i = 0; i < 5; i++)
+        {
+            var expected = WorldOps.NewSceneryId(single);
+            WorldOps.AddScenery(single, expected, "asset", default, default);
+
+            var actual = WorldOps.NewSceneryId(takenIds, ref nextIndex);
+            WorldOps.AddScenery(batch, actual, "asset", default, default);
+
+            Assert.Equal(expected, actual);
+            minted.Add(actual);
+        }
+
+        // Gap at scn_0002 is filled first, then the sequence continues past the taken ids.
+        Assert.Equal(new[] { "scn_0002", "scn_0005", "scn_0006", "scn_0007", "scn_0008" }, minted);
+    }
+
+    [Fact]
+    public void Batch_Spliney_Ids_Use_Prefix_And_Update_Set()
+    {
+        var takenIds = new HashSet<string> { "spl_0001" };
+        var nextIndex = 1;
+
+        var first = WorldOps.NewSplineyId(takenIds, ref nextIndex);
+        var second = WorldOps.NewSplineyId(takenIds, ref nextIndex);
+
+        Assert.Equal("spl_0002", first);
+        Assert.Equal("spl_0003", second);
+        Assert.Contains("spl_0002", takenIds);
+        Assert.Contains("spl_0003", takenIds);
+    }
+}

--- a/FUSE.Core/Authoring/AuthoringIds.cs
+++ b/FUSE.Core/Authoring/AuthoringIds.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+
+namespace Fuse.Core.Authoring
+{
+    /// <summary>
+    /// Shared <c>prefix_NNNN</c> id minting for the authoring ops helpers
+    /// (<see cref="TrackOps"/>, <see cref="WorldOps"/>, <see cref="OperationsOps"/>).
+    /// Fills the first free slot (gaps included) and widens past 9999 once the D4
+    /// range is exhausted. The cursor overload lets a bulk caller mint many ids in
+    /// one pass without rebuilding the taken-set and rescanning from 1 per id.
+    /// </summary>
+    internal static class AuthoringIds
+    {
+        /// <summary>
+        /// Single-shot: the first free <c>prefix_NNNN</c> slot not already present in
+        /// <paramref name="existing"/>. Builds a one-off set, so repeated calls are O(n) each.
+        /// </summary>
+        internal static string UniqueId(IEnumerable<string> existing, string prefix)
+        {
+            var set = new HashSet<string>(existing);
+            var i = 1;
+            return UniqueId(set, prefix, ref i);
+        }
+
+        // Ids are only added while a batch runs, so the first free slot never moves backwards
+        // and the cursor can resume where the previous call stopped instead of rescanning from 1.
+        internal static string UniqueId(ISet<string> takenIds, string prefix, ref int nextIndex)
+        {
+            if (nextIndex < 1)
+            {
+                nextIndex = 1;
+            }
+
+            var id = $"{prefix}_{nextIndex:D4}";
+            while (!takenIds.Add(id))
+            {
+                nextIndex++;
+                id = $"{prefix}_{nextIndex:D4}";
+            }
+
+            // Leave the cursor past the minted slot so the next call doesn't re-test it.
+            nextIndex++;
+            return id;
+        }
+    }
+}

--- a/FUSE.Core/Authoring/OperationsOps.cs
+++ b/FUSE.Core/Authoring/OperationsOps.cs
@@ -24,20 +24,21 @@ namespace Fuse.Core.Authoring
 
         public static bool DeleteLoad(FuseOperationsDefinition operations, string id) => operations.Loads.Remove(id);
 
-        public static string NewIndustryId(FuseOperationsDefinition operations) => UniqueId(operations.Industries.Keys, "ind");
+        public static string NewIndustryId(FuseOperationsDefinition operations) => AuthoringIds.UniqueId(operations.Industries.Keys, "ind");
 
-        public static string NewLoadId(FuseOperationsDefinition operations) => UniqueId(operations.Loads.Keys, "load");
+        public static string NewLoadId(FuseOperationsDefinition operations) => AuthoringIds.UniqueId(operations.Loads.Keys, "load");
 
-        private static string UniqueId(IEnumerable<string> existing, string prefix)
-        {
-            var set = new HashSet<string>(existing);
-            var i = 1;
-            while (set.Contains($"{prefix}_{i:D4}"))
-            {
-                i++;
-            }
+        /// <summary>
+        /// Batch variant of <see cref="NewIndustryId(FuseOperationsDefinition)"/> for callers minting
+        /// many ids in one operation: build <paramref name="takenIds"/> from <c>operations.Industries.Keys</c>
+        /// once, start <paramref name="nextIndex"/> at 1, and reuse both across calls. Each returned
+        /// id is added to <paramref name="takenIds"/>, so as long as no ids are removed mid-batch the
+        /// sequence matches repeated single-shot calls (first free slot, gaps filled) without
+        /// rescanning every key per id.
+        /// </summary>
+        public static string NewIndustryId(ISet<string> takenIds, ref int nextIndex) => AuthoringIds.UniqueId(takenIds, "ind", ref nextIndex);
 
-            return $"{prefix}_{i:D4}";
-        }
+        /// <summary>Batch variant of <see cref="NewLoadId(FuseOperationsDefinition)"/>; see <see cref="NewIndustryId(ISet{string}, ref int)"/>.</summary>
+        public static string NewLoadId(ISet<string> takenIds, ref int nextIndex) => AuthoringIds.UniqueId(takenIds, "load", ref nextIndex);
     }
 }

--- a/FUSE.Core/Authoring/TrackOps.cs
+++ b/FUSE.Core/Authoring/TrackOps.cs
@@ -125,9 +125,9 @@ namespace Fuse.Core.Authoring
         public static int NodeValency(FuseTrackDefinition tracks, string nodeId) =>
             tracks.Segments.Values.Count(s => s != null && (s.StartNodeId == nodeId || s.EndNodeId == nodeId));
 
-        public static string NewNodeId(FuseTrackDefinition tracks) => UniqueId(tracks.Nodes.Keys, "n");
+        public static string NewNodeId(FuseTrackDefinition tracks) => AuthoringIds.UniqueId(tracks.Nodes.Keys, "n");
 
-        public static string NewSegmentId(FuseTrackDefinition tracks) => UniqueId(tracks.Segments.Keys, "s");
+        public static string NewSegmentId(FuseTrackDefinition tracks) => AuthoringIds.UniqueId(tracks.Segments.Keys, "s");
 
         /// <summary>
         /// Batch variant of <see cref="NewNodeId(FuseTrackDefinition)"/> for callers minting many
@@ -137,37 +137,9 @@ namespace Fuse.Core.Authoring
         /// mid-batch the sequence matches repeated single-shot calls (first free slot, gaps
         /// filled) without rescanning every key per id.
         /// </summary>
-        public static string NewNodeId(ISet<string> takenIds, ref int nextIndex) => UniqueId(takenIds, "n", ref nextIndex);
+        public static string NewNodeId(ISet<string> takenIds, ref int nextIndex) => AuthoringIds.UniqueId(takenIds, "n", ref nextIndex);
 
         /// <summary>Batch variant of <see cref="NewSegmentId(FuseTrackDefinition)"/>; see <see cref="NewNodeId(ISet{string}, ref int)"/>.</summary>
-        public static string NewSegmentId(ISet<string> takenIds, ref int nextIndex) => UniqueId(takenIds, "s", ref nextIndex);
-
-        private static string UniqueId(IEnumerable<string> existing, string prefix)
-        {
-            var set = new HashSet<string>(existing);
-            var i = 1;
-            return UniqueId(set, prefix, ref i);
-        }
-
-        // Ids are only added while a batch runs, so the first free slot never moves backwards
-        // and the cursor can resume where the previous call stopped instead of rescanning from 1.
-        private static string UniqueId(ISet<string> takenIds, string prefix, ref int nextIndex)
-        {
-            if (nextIndex < 1)
-            {
-                nextIndex = 1;
-            }
-
-            var id = $"{prefix}_{nextIndex:D4}";
-            while (!takenIds.Add(id))
-            {
-                nextIndex++;
-                id = $"{prefix}_{nextIndex:D4}";
-            }
-
-            // Leave the cursor past the minted slot so the next call doesn't re-test it.
-            nextIndex++;
-            return id;
-        }
+        public static string NewSegmentId(ISet<string> takenIds, ref int nextIndex) => AuthoringIds.UniqueId(takenIds, "s", ref nextIndex);
     }
 }

--- a/FUSE.Core/Authoring/WorldOps.cs
+++ b/FUSE.Core/Authoring/WorldOps.cs
@@ -30,20 +30,21 @@ namespace Fuse.Core.Authoring
 
         public static bool DeleteSpliney(FuseWorldDefinition world, string id) => world.Splineys.Remove(id);
 
-        public static string NewSceneryId(FuseWorldDefinition world) => UniqueId(world.Scenery.Keys, "scn");
+        public static string NewSceneryId(FuseWorldDefinition world) => AuthoringIds.UniqueId(world.Scenery.Keys, "scn");
 
-        public static string NewSplineyId(FuseWorldDefinition world) => UniqueId(world.Splineys.Keys, "spl");
+        public static string NewSplineyId(FuseWorldDefinition world) => AuthoringIds.UniqueId(world.Splineys.Keys, "spl");
 
-        private static string UniqueId(IEnumerable<string> existing, string prefix)
-        {
-            var set = new HashSet<string>(existing);
-            var i = 1;
-            while (set.Contains($"{prefix}_{i:D4}"))
-            {
-                i++;
-            }
+        /// <summary>
+        /// Batch variant of <see cref="NewSceneryId(FuseWorldDefinition)"/> for callers minting many
+        /// ids in one operation: build <paramref name="takenIds"/> from <c>world.Scenery.Keys</c>
+        /// once, start <paramref name="nextIndex"/> at 1, and reuse both across calls. Each returned
+        /// id is added to <paramref name="takenIds"/>, so as long as no ids are removed mid-batch the
+        /// sequence matches repeated single-shot calls (first free slot, gaps filled) without
+        /// rescanning every key per id.
+        /// </summary>
+        public static string NewSceneryId(ISet<string> takenIds, ref int nextIndex) => AuthoringIds.UniqueId(takenIds, "scn", ref nextIndex);
 
-            return $"{prefix}_{i:D4}";
-        }
+        /// <summary>Batch variant of <see cref="NewSplineyId(FuseWorldDefinition)"/>; see <see cref="NewSceneryId(ISet{string}, ref int)"/>.</summary>
+        public static string NewSplineyId(ISet<string> takenIds, ref int nextIndex) => AuthoringIds.UniqueId(takenIds, "spl", ref nextIndex);
     }
 }


### PR DESCRIPTION
> Follow-up to #120 (now merged). Targets `main`; diff is just this consolidation.

## 🔗 Related Issue

Direct follow-up to #120 (*perf(track): batch id allocation in TrackGenerators.Commit*), merged into `main`. That PR fixed the O(n²) id-allocation pattern in `TrackOps`; this PR finishes the job by removing the two remaining verbatim copies.

## 📝 Description of the Change

`WorldOps` (`NewSceneryId`/`NewSplineyId`) and `OperationsOps` (`NewIndustryId`/`NewLoadId`) each still carried a verbatim copy of the old quadratic `UniqueId` helper — rebuild a `HashSet` from every existing key, then scan from index 1 on **every** call. PR #120 replaced that exact pattern in `TrackOps` with a cursor-based core but left these two untouched.

This change:

- **Extracts the cursor core into a shared `internal static class AuthoringIds`** (`FUSE.Core/Authoring/AuthoringIds.cs`), lifted byte-for-byte from #120's `TrackOps` implementation (clamp `nextIndex < 1` → 1, `takenIds.Add` collision loop, advance the cursor past the minted slot).
- **Routes all three ops classes** (`TrackOps`, `WorldOps`, `OperationsOps`) through it and deletes the three duplicate `UniqueId` bodies.
- **Mirrors TrackOps's batch surface** onto the other two: `NewSceneryId`/`NewSplineyId`/`NewIndustryId`/`NewLoadId(ISet<string> takenIds, ref int nextIndex)`. No bulk-mint caller exists today (only single-shot interactive tools), but the moment a bulk scenery/spliney/industry import or paste feature lands, these let it mint in O(n) instead of resurrecting the quadratic shape.

The single-shot public signatures (`NewSceneryId(FuseWorldDefinition)`, etc.) are unchanged.

## 🔄 Alternatives Considered

- **Make `TrackOps.UniqueId(ISet<string>, string, ref int)` `internal` and have `WorldOps`/`OperationsOps` call into `TrackOps`.** Rejected: it couples scenery/industry authoring to track-graph code for what is a generic string helper. A neutral `AuthoringIds` helper reads better and is the truest "one shared core."
- **Leave the duplicates as-is** (it's not a live perf bug — only single-shot callers exist). Rejected: the duplication is exactly what lets the quadratic shape silently return when a bulk caller is added, and consolidating now is cheap.

## ⚠️ Possible Drawbacks

- **Behavior is byte-identical**, so no functional risk: first free slot, gaps filled, `prefix_NNNN` with D4 formatting that widens past 9999, cursor clamped below 1 and advanced past the minted slot.
- **Public surface only grows** (new `ISet<string>, ref int` overloads); no existing caller signature changes, so editors consuming `FUSE.Core` are unaffected.
- **No serialization/save-format change** — id strings are produced identically, so existing `*.fuse.json` saves are unaffected and backwards compatible.

## ✅ Verification Process

Run with `-p:GameDir="F:\SteamLibrary\steamapps\common\Railroader"` from PowerShell (worktree).

- **`dotnet test FUSE.Core.Tests` → 45/45 pass.** This includes #120's *unchanged* `TrackOpsTests`/`TrackGeneratorsCommitTests` running against the relocated core — proving behavior is preserved — plus 6 new tests in `WorldOpsTests`/`OperationsOpsTests` covering the batch variants (gap-fill sequence matches repeated single-shot calls, correct `scn`/`spl`/`ind`/`load` prefixes, and the taken-set is mutated).
- **`FUSE.Core` builds clean on both target frameworks:** `net48` (0 warnings / 0 errors) and `net10.0` (only pre-existing CA analyzer warnings in unrelated files; none from this change).
- A repo-wide grep confirms the only remaining `new HashSet<string>(existing)` scan helper is the single shared copy in `AuthoringIds`.

## 💡 Additional Information

Net diff: `+1` new shared helper file, three ops files lose their private `UniqueId` bodies and gain delegating wrappers, `+2` test files. `TrackOps` shrinks by ~28 lines.
