### PR TITLE
ci: harden workflows against zizmor template-injection (env-block pattern)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,17 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write    # needed by the sticky comment step on PR builds
 
 jobs:
   build:
     runs-on: self-hosted
+    # pull-requests: write is scoped to this job rather than the whole workflow
+    # because only the sticky PR-comment step below needs it. The build-net10
+    # job inherits the read-only workflow default. (Job-level permissions
+    # replace the workflow default for this job, so contents:read is repeated.)
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       DOTNET_NOLOGO: "true"
       DOTNET_CLI_TELEMETRY_OPTOUT: "1"
@@ -101,9 +107,15 @@ jobs:
       - name: Decide EditMode-gate
         id: editmode_gate
         shell: powershell
+        env:
+          # Pass the gate inputs through the environment rather than ${{ }}
+          # template expansion so they can't inject into the script. Mirrors
+          # the TAG_NAME hardening in release.yml.
+          MANUAL_GATE: ${{ github.event_name == 'workflow_dispatch' && inputs.run_unity_editmode == true }}
+          REPO_VAR: ${{ vars.RUN_UNITY_EDITMODE_TESTS }}
         run: |
-          $manual = "${{ github.event_name == 'workflow_dispatch' && inputs.run_unity_editmode == true }}"
-          $repoVar = "${{ vars.RUN_UNITY_EDITMODE_TESTS }}"
+          $manual = $env:MANUAL_GATE
+          $repoVar = $env:REPO_VAR
           $enabled = ($manual -eq 'True') -or ($repoVar -eq 'true')
           if ($enabled) {
             Write-Host "EditMode tests ENABLED (manual=$manual, repo-var=$repoVar)"
@@ -173,6 +185,10 @@ jobs:
         if: steps.editmode_gate.outputs.enabled == 'true' && steps.unity_probe.outputs.available == 'true'
         continue-on-error: true
         shell: powershell
+        env:
+          # Pass the probed editor path through the environment rather than
+          # ${{ }} template expansion. Mirrors the TAG_NAME hardening in release.yml.
+          UNITY_PATH: ${{ steps.unity_probe.outputs.path }}
         run: |
           # -batchmode -nographics: no GUI, no GPU needed.
           # -runTests: invokes the Test Runner against -testPlatform.
@@ -181,7 +197,7 @@ jobs:
           # An exit code of 0/2 means tests passed (2 = "all tests
           # passed but Unity wanted to be picky about something else").
           # Anything else fails the job.
-          $unity = "${{ steps.unity_probe.outputs.path }}"
+          $unity = $env:UNITY_PATH
           $project = "$PWD\FUSE.UnityTests"
           $results = "$PWD\FUSE.UnityTests\TestResults\editmode-results.xml"
           New-Item -ItemType Directory -Force -Path (Split-Path $results) | Out-Null
@@ -212,16 +228,26 @@ jobs:
       - name: Compute build identity
         id: build_id
         shell: powershell
+        env:
+          # Pass attacker-influenceable context (branch name via ref_name, plus
+          # PR metadata and commit SHAs) through the environment rather than
+          # ${{ }} template expansion, so a crafted branch name can't inject into
+          # the script. Mirrors the TAG_NAME hardening in release.yml.
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMIT_SHA: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if ("${{ github.event_name }}" -eq "pull_request") {
-            $sha = "${{ github.event.pull_request.head.sha }}".Substring(0, 7)
-            $prNumber = "${{ github.event.pull_request.number }}"
+          if ($env:EVENT_NAME -eq "pull_request") {
+            $sha = $env:PR_HEAD_SHA.Substring(0, 7)
+            $prNumber = $env:PR_NUMBER
             $version = "0.0.0-pr$prNumber.$sha"
             $archive = "FUSE-pr$prNumber-$sha.zip"
           }
           else {
-            $sha = "${{ github.sha }}".Substring(0, 7)
-            $branch = "${{ github.ref_name }}" -replace '[^A-Za-z0-9.-]', '-'
+            $sha = $env:COMMIT_SHA.Substring(0, 7)
+            $branch = $env:REF_NAME -replace '[^A-Za-z0-9.-]', '-'
             $version = "0.0.0-$branch.$sha"
             $archive = "FUSE-$branch-$sha.zip"
           }
@@ -230,14 +256,23 @@ jobs:
           "short_sha=$sha" >> $env:GITHUB_OUTPUT
 
       - name: Rebuild Release with stamped version
-        run: dotnet build FUSE.Editor/FUSE.Editor.csproj -c Release -p:ModVersion=${{ steps.build_id.outputs.version }}
+        shell: powershell
+        env:
+          # Read the computed version from the environment rather than ${{ }}
+          # template expansion. Mirrors the TAG_NAME hardening in release.yml.
+          MOD_VERSION: ${{ steps.build_id.outputs.version }}
+        run: dotnet build FUSE.Editor/FUSE.Editor.csproj -c Release "-p:ModVersion=$env:MOD_VERSION"
 
       - name: Package mod zip
         shell: powershell
+        env:
+          # Read the computed archive name from the environment rather than
+          # ${{ }} template expansion. Mirrors the TAG_NAME hardening in release.yml.
+          ARCHIVE_NAME: ${{ steps.build_id.outputs.archive }}
         run: |
           $stagingRoot = Join-Path $PWD "staging-ci"
           $modFolder = Join-Path $stagingRoot "FUSE"
-          $archivePath = Join-Path $PWD "${{ steps.build_id.outputs.archive }}"
+          $archivePath = Join-Path $PWD "$env:ARCHIVE_NAME"
 
           if (Test-Path $stagingRoot) { Remove-Item $stagingRoot -Recurse -Force }
           if (Test-Path $archivePath) { Remove-Item $archivePath -Force }

--- a/.github/workflows/sync-info-json.yml
+++ b/.github/workflows/sync-info-json.yml
@@ -32,8 +32,13 @@ jobs:
       - name: Parse semantic version from release tag
         id: version
         shell: powershell
+        env:
+          # Pass the tag via the environment, not template expansion, so a
+          # crafted release tag name can't inject into the script before
+          # validation. Mirrors the TAG_NAME hardening in release.yml.
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          $tag = "${{ github.event.release.tag_name }}"
+          $tag = $env:TAG_NAME
           if ($tag -notmatch '^mod-v(?<version>[0-9]+\.[0-9]+\.[0-9]+)$') {
             Write-Host "Release tag '$tag' is not a 3-part GA mod-v semver; skipping sync."
             "skip=true" >> $env:GITHUB_OUTPUT
@@ -45,19 +50,24 @@ jobs:
       - name: Stamp FUSE/Info.json
         if: steps.version.outputs.skip == 'false'
         shell: powershell
+        env:
+          MOD_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          .\scripts\stamp-info-version.ps1 -Path FUSE\Info.json -Version ${{ steps.version.outputs.version }}
+          .\scripts\stamp-info-version.ps1 -Path FUSE\Info.json -Version "$env:MOD_VERSION"
 
       - name: Commit and push
         if: steps.version.outputs.skip == 'false'
         shell: powershell
+        env:
+          MOD_VERSION: ${{ steps.version.outputs.version }}
         run: |
+          $version = $env:MOD_VERSION
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           $status = git status --porcelain FUSE/Info.json
           if (-not $status) {
-            Write-Host "FUSE/Info.json already at v${{ steps.version.outputs.version }}; nothing to commit."
+            Write-Host "FUSE/Info.json already at v$version; nothing to commit."
             exit 0
           }
 
@@ -65,5 +75,5 @@ jobs:
           # [skip ci] keeps this metadata bump from re-running the full CI
           # build matrix; the verify-stamping check is exercised on every
           # other push so we don't lose coverage.
-          git commit -m "Sync FUSE/Info.json Version to ${{ steps.version.outputs.version }} [skip ci]"
+          git commit -m "Sync FUSE/Info.json Version to $version [skip ci]"
           git push origin main


### PR DESCRIPTION
## 🔗 Related Issue

Refs #87 — extends the workflow-hardening pass from #119, which fixed `release.yml` but left the same `template-injection` pattern unaddressed in `ci.yml` and `sync-info-json.yml`.

## 📝 Description of the Change

`zizmor` (v1.25.2, default persona) flagged high-confidence `template-injection` findings where attacker-influenceable context was interpolated via `${{ }}` directly into PowerShell `run:` blocks. A crafted branch name or release-tag name could break out of the intended string and inject script.

This PR applies the established fix — pass the value through a step-level `env:` block and read `$env:NAME` inside the script — to every remaining site. It mirrors the `TAG_NAME` hardening #119 added to `release.yml`.

**`.github/workflows/ci.yml`**
- **Compute build identity** (high-confidence `github.ref_name`): moved all five contexts — `github.event_name`, `github.event.pull_request.head.sha`, `github.event.pull_request.number`, `github.sha`, `github.ref_name` — into `env:`.
- **Decide EditMode-gate** → `MANUAL_GATE` / `REPO_VAR`.
- **Run EditMode tests** → `UNITY_PATH`.
- **Rebuild Release** and **Package mod zip** (low-confidence `steps.build_id.outputs.*`) → `MOD_VERSION` / `ARCHIVE_NAME`, so the result is a clean zero rather than just "no high-confidence".
- **`excessive-permissions`**: removed workflow-level `pull-requests: write` and scoped it to the `build` job (the only job whose sticky PR-comment step needs it). `build-net10` inherits the read-only workflow default.

**`.github/workflows/sync-info-json.yml`**
- **Parse semantic version from release tag** (high-confidence `github.event.release.tag_name`) → `TAG_NAME`.
- **Stamp Info.json** and **Commit and push** (`steps.version.outputs.version`) → `MOD_VERSION`.

New env-var names deliberately avoid the `GITHUB_` prefix so they don't shadow built-ins, and `UNITY_PATH` doesn't collide with the probe step's operator-supplied `UNITY_EDITOR_PATH`.

## 🔄 Alternatives Considered

- **`zizmor`'s auto-fix / inline `# zizmor: ignore` suppressions** — rejected; suppressing leaves the actual injection vector in place. The `env:` indirection is the real fix and is already the repo's house style (#119).
- **Leaving the low-confidence `steps.*.outputs.*` sites alone** — the task allows low-confidence findings with a justification comment, but those outputs derive from `github.ref_name` upstream, so hardening them costs nothing and gets the report to a true zero.

## ⚠️ Possible Drawbacks

- Behavior-only-preserving refactor of CI scripts — no product/runtime code changes, no save-format impact, fully backwards compatible.
- `Rebuild Release` gains an explicit `shell: powershell` (it previously relied on the runner default). `dotnet build` is shell-agnostic, so this only fixes the variable syntax (`$env:MOD_VERSION`); output is identical.
- The `GITHUB_OUTPUT` contract consumed by downstream steps (`version` / `archive` / `short_sha` / `skip`) is byte-for-byte unchanged.

## ✅ Verification Process

- **`zizmor --offline` at the default persona** on both edited files: `template-injection` **0** (was 2 high + 7 low across the two files), `excessive-permissions` **0** (was 1 high). Only 3 pre-existing, out-of-scope `artipacked` (low, `persist-credentials` on `checkout`) remain.
- **YAML parses** — all three workflows via `yaml.safe_load`.
- **Structural check** — a YAML-structural walk (not regex) confirms **zero `${{ }}` expansions remain in any `run:` block**.
- **PowerShell semantics pre-tested** against the string-literal originals: `$env:X.Substring(0,7)`, `-replace`, case-insensitive `-eq`, double-quoted interpolation, and — critically — `-notmatch` still populating `$Matches.version` when the tag regex matches. All identical.

## 💡 Additional Information

- `release.yml` is intentionally untouched — it's the reference for the good pattern and its remaining findings are low-confidence step-output sites out of this PR's scope.
- `sync-info-json.yml`'s workflow-level `contents: write` is also left as-is: it only surfaces at the stricter *pedantic* persona, is genuinely needed (the `sync` job pushes to `main`), and is outside this PR's scope.
