### PR TITLE
Enhanced loading screen: staged progress + current step (#83)

### DIFF
--- a/FUSE.Tests/Interface/FuseLoadingLabelsTests.cs
+++ b/FUSE.Tests/Interface/FuseLoadingLabelsTests.cs
@@ -1,0 +1,108 @@
+using FUSE.Interface;
+using Xunit;
+
+namespace FUSE.Tests.Interface
+{
+    // Pins the game-flavor-string -> friendly-step mapping and the count formatter
+    // for the enhanced loading screen (issue #83). Both are Unity-free, so the
+    // contract is assertable without the engine or a live load.
+    public class FuseLoadingLabelsTests
+    {
+        [Fact]
+        public void MapProgressFlavor_SnapshotMarker_MapsToRestoringSavedGame()
+        {
+            var step = FuseLoadingLabels.MapProgressFlavor("Half a car...", 0.95f);
+            Assert.Equal("Restoring saved game", step.Title);
+            Assert.Equal("Reading world snapshot", step.Detail);
+        }
+
+        [Fact]
+        public void MapProgressFlavor_SnapshotMarker_FlagsTheSyncHandoff()
+        {
+            // The 95% hand-off is the boundary into the blocking save restore, so
+            // the bar must switch to its static band here rather than stay a fill.
+            Assert.True(FuseLoadingLabels.MapProgressFlavor("Half a car...", 0.95f).SyncHandoff);
+        }
+
+        [Theory]
+        [InlineData("Two cars to a couple...", 0.5f)] // async scene load is determinate
+        [InlineData("Tyin' down...", 0f)]
+        [InlineData("Brewing coffee", 0.5f)]          // unknown fallback
+        public void MapProgressFlavor_NonSnapshotPhases_AreNotSyncHandoff(string gameText, float fraction)
+        {
+            Assert.False(FuseLoadingLabels.MapProgressFlavor(gameText, fraction).SyncHandoff);
+        }
+
+        [Theory]
+        [InlineData("Tyin' down...")]
+        [InlineData("Tying down")] // tolerate a spelling/apostrophe fix in a game update
+        public void MapProgressFlavor_UnloadSpellings_MapToReturningToMainMenu(string gameText)
+        {
+            Assert.Equal("Returning to main menu", FuseLoadingLabels.MapProgressFlavor(gameText, 0f).Title);
+        }
+
+        [Theory]
+        [InlineData(0.0f, "Loading world")]   // early menu/UI hand-off
+        [InlineData(0.19f, "Loading world")]
+        [InlineData(0.2f, "Loading terrain")] // long terrain/environment stream
+        [InlineData(0.85f, "Loading terrain")]
+        public void MapProgressFlavor_SceneLoad_SplitsByProgress(float fraction, string expectedTitle)
+        {
+            var step = FuseLoadingLabels.MapProgressFlavor("Two cars to a couple...", fraction);
+            Assert.Equal(expectedTitle, step.Title);
+        }
+
+        [Fact]
+        public void MapProgressFlavor_Unload_MapsToReturningToMainMenu()
+        {
+            var step = FuseLoadingLabels.MapProgressFlavor("Tyin' down...", 0f);
+            Assert.Equal("Returning to main menu", step.Title);
+            Assert.Null(step.Detail);
+        }
+
+        [Fact]
+        public void MapProgressFlavor_UnknownString_FallsBackToRawTextAsDetail()
+        {
+            var step = FuseLoadingLabels.MapProgressFlavor("Brewing coffee", 0.5f);
+            Assert.Equal("Loading world", step.Title);
+            Assert.Equal("Brewing coffee", step.Detail);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void MapProgressFlavor_NullOrEmpty_FallsBackWithoutDetail(string gameText)
+        {
+            var step = FuseLoadingLabels.MapProgressFlavor(gameText, 0.5f);
+            Assert.Equal("Loading world", step.Title);
+            Assert.Null(step.Detail);
+        }
+
+        [Fact]
+        public void MapProgressFlavor_IsCaseAndWhitespaceInsensitive()
+        {
+            var step = FuseLoadingLabels.MapProgressFlavor("  HALF A CAR...  ", 0.95f);
+            Assert.Equal("Restoring saved game", step.Title);
+        }
+
+        [Theory]
+        [InlineData(0, "car", "cars", "0 cars")]
+        [InlineData(1, "car", "cars", "1 car")]
+        [InlineData(2, "car", "cars", "2 cars")]
+        [InlineData(1432, "car", "cars", "1,432 cars")]
+        [InlineData(1, "turntable", "turntables", "1 turntable")]
+        [InlineData(3, "turntable", "turntables", "3 turntables")]
+        public void DescribeCount_FormatsWithThousandsAndPluralization(int count, string singular, string plural, string expected)
+        {
+            Assert.Equal(expected, FuseLoadingLabels.DescribeCount(count, singular, plural));
+        }
+
+        [Fact]
+        public void DescribeCount_NegativeSentinel_ReturnsNull()
+        {
+            // -1 means "couldn't read the snapshot collection" — show the title alone.
+            Assert.Null(FuseLoadingLabels.DescribeCount(-1, "car", "cars"));
+        }
+    }
+}

--- a/FUSE.Tests/Interface/FuseLoadingScreenStateTests.cs
+++ b/FUSE.Tests/Interface/FuseLoadingScreenStateTests.cs
@@ -1,0 +1,234 @@
+using FUSE.Interface;
+using Xunit;
+
+namespace FUSE.Tests.Interface
+{
+    // Pins the show/hide gate of the enhanced loading screen (issue #83). The state
+    // machine is Unity-free and takes an injected monotonic "now", so the two-flag
+    // gate, the abort path, and the watchdog backstop are all assertable without the
+    // engine. The two-flag gate is the crux: FUSE's post-load pipeline can finish
+    // after the game hides its own screen, so hiding on either signal alone would
+    // expose a still-assembling world.
+    public class FuseLoadingScreenStateTests
+    {
+        [Fact]
+        public void UpdateVisibility_BeforeBeginLoad_IsHidden()
+        {
+            var state = new FuseLoadingScreenState();
+            Assert.False(state.Active);
+            Assert.False(state.UpdateVisibility(0f));
+        }
+
+        [Fact]
+        public void UpdateVisibility_AfterBeginLoad_IsVisible()
+        {
+            var state = new FuseLoadingScreenState();
+            state.BeginLoad(0f);
+            Assert.True(state.Active);
+            Assert.True(state.UpdateVisibility(1f));
+        }
+
+        [Fact]
+        public void UpdateVisibility_GameHiddenThenPipelineDone_Hides()
+        {
+            var state = new FuseLoadingScreenState();
+            state.BeginLoad(0f);
+            state.SetProgress(0.5f, 1f);
+            state.NotifyGameScreenHidden(2f);
+            Assert.True(state.UpdateVisibility(2f)); // pipeline not yet done -> still up
+            state.NotifyFusePipelineComplete(3f);
+            Assert.False(state.UpdateVisibility(3f)); // both flags -> hide
+            Assert.False(state.Active);
+        }
+
+        [Fact]
+        public void UpdateVisibility_PipelineDoneThenGameHidden_AlsoHides()
+        {
+            // The opposite ordering — pipeline finishes before the game hides its
+            // screen — must also release the gate.
+            var state = new FuseLoadingScreenState();
+            state.BeginLoad(0f);
+            state.NotifyFusePipelineComplete(1f);
+            Assert.True(state.UpdateVisibility(1f)); // game screen still up -> stay
+            state.NotifyGameScreenHidden(2f);
+            Assert.False(state.UpdateVisibility(2f));
+        }
+
+        [Fact]
+        public void UpdateVisibility_GameHiddenAlone_StaysVisible()
+        {
+            var state = new FuseLoadingScreenState();
+            state.BeginLoad(0f);
+            state.NotifyGameScreenHidden(1f);
+            Assert.True(state.UpdateVisibility(1f));
+        }
+
+        [Fact]
+        public void UpdateVisibility_PipelineDoneAlone_StaysVisible()
+        {
+            var state = new FuseLoadingScreenState();
+            state.BeginLoad(0f);
+            state.NotifyFusePipelineComplete(1f);
+            Assert.True(state.UpdateVisibility(1f));
+        }
+
+        [Fact]
+        public void Abort_HidesImmediatelyRegardlessOfFlags()
+        {
+            var state = new FuseLoadingScreenState();
+            state.BeginLoad(0f);
+            state.Abort();
+            Assert.False(state.Active);
+            Assert.False(state.UpdateVisibility(1f));
+        }
+
+        [Fact]
+        public void Abort_ThenBeginLoad_ReArmsTheScreen()
+        {
+            // A load aborted (failure / return-to-menu) must not poison the next
+            // load: BeginLoad has to clear the abort latch.
+            var state = new FuseLoadingScreenState();
+            state.BeginLoad(0f);
+            state.Abort();
+            Assert.False(state.UpdateVisibility(1f));
+
+            state.BeginLoad(2f);
+            Assert.True(state.Active);
+            Assert.True(state.UpdateVisibility(3f));
+        }
+
+        [Fact]
+        public void UpdateVisibility_WatchdogExpiry_Hides()
+        {
+            var state = new FuseLoadingScreenState(watchdogSeconds: 60f);
+            state.BeginLoad(0f);
+            Assert.True(state.UpdateVisibility(59f));
+            Assert.False(state.UpdateVisibility(60f)); // 60s since last signal -> backstop
+            Assert.False(state.Active);
+        }
+
+        [Theory]
+        [InlineData("progress")]
+        [InlineData("step")]
+        [InlineData("game-hidden")]
+        [InlineData("pipeline-done")]
+        public void UpdateVisibility_WatchdogResets_OnEverySignalKind(string signal)
+        {
+            // Every signal must push the watchdog deadline out, or a long load that
+            // legitimately keeps emitting signals would still be torn down early.
+            var state = new FuseLoadingScreenState(watchdogSeconds: 60f);
+            state.BeginLoad(0f);
+
+            switch (signal)
+            {
+                case "progress": state.SetProgress(0.5f, 50f); break;
+                case "step": state.SetStep("Restoring rail cars", "1,432 cars", syncPhase: true, 50f); break;
+                case "game-hidden": state.NotifyGameScreenHidden(50f); break;
+                case "pipeline-done": state.NotifyFusePipelineComplete(50f); break;
+            }
+
+            Assert.True(state.UpdateVisibility(100f));  // only 50s since the 50f signal
+            Assert.False(state.UpdateVisibility(110f)); // now 60s since the 50f signal
+        }
+
+        [Theory]
+        [InlineData("progress")]
+        [InlineData("game-hidden")]
+        [InlineData("pipeline-done")]
+        public void Signals_BeforeBeginLoad_AreIgnored(string signal)
+        {
+            // A stray signal before a load starts must not latch state that would
+            // mis-fire the gate on the next BeginLoad.
+            var state = new FuseLoadingScreenState();
+            switch (signal)
+            {
+                case "progress": state.SetProgress(0.9f, 0f); break;
+                case "game-hidden": state.NotifyGameScreenHidden(0f); break;
+                case "pipeline-done": state.NotifyFusePipelineComplete(0f); break;
+            }
+
+            Assert.False(state.GameScreenHidden);
+            Assert.False(state.FusePipelineDone);
+            Assert.Equal(0f, state.Progress);
+        }
+
+        [Fact]
+        public void SetStep_SyncPhase_IsAOneWayLatchWithinALoad()
+        {
+            // The host issues SetStep(syncPhase:false) on every async progress tick.
+            // Once a blocking phase has set the latch, a later determinate tick must
+            // NOT clear it, or the bar would flip back to a fill mid-freeze and read
+            // as "hung". Only BeginLoad clears it.
+            var state = new FuseLoadingScreenState();
+            state.BeginLoad(0f);
+            state.SetStep("Restoring rail cars", "1,432 cars", syncPhase: true, 1f);
+            Assert.True(state.InSyncPhase);
+            state.SetStep("Loading terrain", "Streaming map", syncPhase: false, 2f);
+            Assert.True(state.InSyncPhase);
+        }
+
+        [Fact]
+        public void SetStep_WhenInactive_IsIgnored()
+        {
+            var state = new FuseLoadingScreenState();
+            state.SetStep("ghost", "ghost", syncPhase: true, 0f);
+            Assert.Null(state.StepTitle);
+            Assert.False(state.InSyncPhase);
+        }
+
+        [Theory]
+        [InlineData(1.5f, 1f)]
+        [InlineData(-0.3f, 0f)]
+        [InlineData(0.42f, 0.42f)]
+        [InlineData(float.NaN, 0f)]                 // a divide-by-zero progress must not poison the bar
+        [InlineData(float.PositiveInfinity, 1f)]
+        [InlineData(float.NegativeInfinity, 0f)]
+        public void SetProgress_ClampsToUnitRange(float input, float expected)
+        {
+            var state = new FuseLoadingScreenState();
+            state.BeginLoad(0f);
+            state.SetProgress(input, 1f);
+            Assert.Equal(expected, state.Progress);
+        }
+
+        [Fact]
+        public void SetStep_SyncPhase_FlipsInSyncPhase()
+        {
+            var state = new FuseLoadingScreenState();
+            state.BeginLoad(0f);
+            state.SetProgress(0.5f, 1f);
+            Assert.False(state.InSyncPhase);
+            state.SetStep("Restoring rail cars", null, syncPhase: true, 2f);
+            Assert.True(state.InSyncPhase);
+        }
+
+        [Fact]
+        public void BeginLoad_FullyResetsForRepeatedLoads()
+        {
+            var state = new FuseLoadingScreenState();
+            state.BeginLoad(0f);
+            state.SetProgress(0.7f, 1f);
+            state.SetStep("Restoring rail cars", "1,432 cars", syncPhase: true, 2f);
+            state.NotifyGameScreenHidden(3f);
+            state.NotifyFusePipelineComplete(4f);
+            Assert.False(state.UpdateVisibility(4f)); // first load hides
+            Assert.False(state.Active);
+
+            state.BeginLoad(10f); // a second load in the same session
+            Assert.True(state.Active);
+            Assert.False(state.InSyncPhase);
+            Assert.Equal(0f, state.Progress);
+            Assert.Equal("Loading world", state.StepTitle);
+            Assert.Null(state.StepDetail);
+            // Gate flags must have reset too: completing only the pipeline must NOT
+            // hide (proving _gameScreenHidden didn't leak true from the prior load),
+            // and the watchdog clock restarted at 10f.
+            Assert.False(state.GameScreenHidden);
+            Assert.False(state.FusePipelineDone);
+            state.NotifyFusePipelineComplete(11f);
+            Assert.True(state.UpdateVisibility(12f));
+            state.NotifyGameScreenHidden(13f);
+            Assert.False(state.UpdateVisibility(13f));
+        }
+    }
+}

--- a/FUSE/FusePlugin.cs
+++ b/FUSE/FusePlugin.cs
@@ -83,6 +83,7 @@ namespace FUSE
                 FuseTrackDebugOverlay.Ensure();
                 FuseSceneryDebugOverlay.Ensure();
                 FuseWorldLabelsOverlay.Ensure();
+                FuseLoadingScreen.Ensure();
                 FuseUmmInjector.ScheduleInjection(modEntry.Path, ReadInfoJsonString(Path.Combine(modEntry.Path ?? string.Empty, "Info.json"), "Version"));
                 FuseLegacyAssemblyHost.EnsureStartupHost();
 
@@ -227,6 +228,7 @@ namespace FUSE
             FuseTrackDebugOverlay.Shutdown();
             FuseSceneryDebugOverlay.Shutdown();
             FuseWorldLabelsOverlay.Shutdown();
+            FuseLoadingScreen.Shutdown();
 
             if (_isLoaded)
             {

--- a/FUSE/Info.json
+++ b/FUSE/Info.json
@@ -16,6 +16,7 @@
     "BlockNonHostMultiplayerClientWorldApply": false,
     "ShowAdvancedHealthDetails": false,
     "ShowLegacyModsInUmm": true,
+    "EnableEnhancedLoadingScreen": true,
     "DecoupleVisualConditionLimits": false
   }
 }

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -32,6 +32,11 @@ namespace FUSE.Infrastructure
         public const bool DefaultWorldLabelsShowTrackNodes = false;
         public const bool DefaultWorldLabelsShowTrackSegments = false;
         public const bool DefaultShowLegacyModsInUmm = true;
+        // FUSE-owned enhanced loading screen (issue #83): replaces the bare stock
+        // "Loading…" screen with staged progress + a current-step label that stays
+        // up until FUSE's own post-load pipeline finishes. On by default; one switch
+        // falls the whole feature back to the untouched stock screen.
+        public const bool DefaultEnableEnhancedLoadingScreen = true;
         // When off (default), the per-car Visual Condition slider can only make
         // a car look more worn than its mechanical condition; when on, the
         // visual override applies verbatim so worn cars can look fresh.
@@ -89,6 +94,8 @@ namespace FUSE.Infrastructure
 
         public static bool ShowLegacyModsInUmm { get; private set; } = DefaultShowLegacyModsInUmm;
 
+        public static bool EnableEnhancedLoadingScreen { get; private set; } = DefaultEnableEnhancedLoadingScreen;
+
         public static bool DecoupleVisualConditionLimits { get; private set; } = DefaultDecoupleVisualConditionLimits;
 
         public static bool RandomizeVisualConditionOnSpawn { get; private set; } = DefaultRandomizeVisualConditionOnSpawn;
@@ -118,6 +125,7 @@ namespace FUSE.Infrastructure
             WorldLabelsShowTrackNodes = DefaultWorldLabelsShowTrackNodes;
             WorldLabelsShowTrackSegments = DefaultWorldLabelsShowTrackSegments;
             ShowLegacyModsInUmm = DefaultShowLegacyModsInUmm;
+            EnableEnhancedLoadingScreen = DefaultEnableEnhancedLoadingScreen;
             DecoupleVisualConditionLimits = DefaultDecoupleVisualConditionLimits;
             RandomizeVisualConditionOnSpawn = DefaultRandomizeVisualConditionOnSpawn;
             RandomVisualConditionMin = DefaultRandomVisualConditionMin;
@@ -173,6 +181,8 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, "WorldLabelsShowTrackSegments", DefaultWorldLabelsShowTrackSegments);
                 ShowLegacyModsInUmm =
                     ReadBool(settings, "ShowLegacyModsInUmm", DefaultShowLegacyModsInUmm);
+                EnableEnhancedLoadingScreen =
+                    ReadBool(settings, "EnableEnhancedLoadingScreen", DefaultEnableEnhancedLoadingScreen);
                 DecoupleVisualConditionLimits =
                     ReadBool(settings, "DecoupleVisualConditionLimits", DefaultDecoupleVisualConditionLimits);
                 RandomizeVisualConditionOnSpawn =
@@ -205,6 +215,7 @@ namespace FUSE.Infrastructure
                     $"WorldLabelsShowTrackNodes={WorldLabelsShowTrackNodes} " +
                     $"WorldLabelsShowTrackSegments={WorldLabelsShowTrackSegments} " +
                     $"ShowLegacyModsInUmm={ShowLegacyModsInUmm} " +
+                    $"EnableEnhancedLoadingScreen={EnableEnhancedLoadingScreen} " +
                     $"DecoupleVisualConditionLimits={DecoupleVisualConditionLimits} " +
                     $"RandomizeVisualConditionOnSpawn={RandomizeVisualConditionOnSpawn} " +
                     $"RandomVisualConditionMin={RandomVisualConditionMin} " +
@@ -232,6 +243,7 @@ namespace FUSE.Infrastructure
                 WorldLabelsShowTrackNodes = DefaultWorldLabelsShowTrackNodes;
                 WorldLabelsShowTrackSegments = DefaultWorldLabelsShowTrackSegments;
                 ShowLegacyModsInUmm = DefaultShowLegacyModsInUmm;
+                EnableEnhancedLoadingScreen = DefaultEnableEnhancedLoadingScreen;
                 DecoupleVisualConditionLimits = DefaultDecoupleVisualConditionLimits;
                 RandomizeVisualConditionOnSpawn = DefaultRandomizeVisualConditionOnSpawn;
                 RandomVisualConditionMin = DefaultRandomVisualConditionMin;
@@ -365,6 +377,13 @@ namespace FUSE.Infrastructure
             FuseLog.Info($"FUSE setting changed: {nameof(WorldLabelsShowTrackSegments)}={enabled}.");
         }
 
+        public static void SetEnableEnhancedLoadingScreen(bool enabled)
+        {
+            EnableEnhancedLoadingScreen = enabled;
+            SaveUserOverride(nameof(EnableEnhancedLoadingScreen), enabled);
+            FuseLog.Info($"FUSE setting changed: {nameof(EnableEnhancedLoadingScreen)}={enabled}. Takes effect on the next map load.");
+        }
+
         public static void SetDecoupleVisualConditionLimits(bool enabled)
         {
             DecoupleVisualConditionLimits = enabled;
@@ -493,6 +512,8 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, nameof(WorldLabelsShowTrackSegments), WorldLabelsShowTrackSegments);
                 ShowLegacyModsInUmm =
                     ReadBool(settings, nameof(ShowLegacyModsInUmm), ShowLegacyModsInUmm);
+                EnableEnhancedLoadingScreen =
+                    ReadBool(settings, nameof(EnableEnhancedLoadingScreen), EnableEnhancedLoadingScreen);
                 DecoupleVisualConditionLimits =
                     ReadBool(settings, nameof(DecoupleVisualConditionLimits), DecoupleVisualConditionLimits);
                 RandomizeVisualConditionOnSpawn =

--- a/FUSE/Interface/FuseHealthUi.SettingsTab.cs
+++ b/FUSE/Interface/FuseHealthUi.SettingsTab.cs
@@ -66,6 +66,16 @@ namespace FUSE.Interface
                     FuseVisualConditionAPI.RefreshAllOverriddenCars();
                     RebuildWindow();
                 });
+            AddSettingToggle(
+                builder,
+                "Loading Screen",
+                FuseSettings.EnableEnhancedLoadingScreen ? "enhanced (FUSE)" : "stock game screen",
+                FuseSettings.EnableEnhancedLoadingScreen ? "Use Stock" : "Use Enhanced",
+                () =>
+                {
+                    FuseSettings.SetEnableEnhancedLoadingScreen(!FuseSettings.EnableEnhancedLoadingScreen);
+                    RebuildWindow();
+                });
             builder.Spacer(4f);
 
             builder.AddSection("Reporting");

--- a/FUSE/Interface/FuseLoadingLabels.cs
+++ b/FUSE/Interface/FuseLoadingLabels.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Globalization;
+
+namespace FUSE.Interface
+{
+    // Maps the game's loading-progress flavor strings to FUSE's friendly
+    // "current step" labels for the enhanced loading screen (issue #83). Pure and
+    // Unity-free so the mapping table is unit-testable.
+    //
+    // The game emits only a handful of distinct flavor strings during a load (the
+    // text passed to PersistentLoader.ShowProgress): one constant string for the
+    // whole async scene-load phase and another at the ~95% hand-off to the
+    // synchronous save restore, plus an unload string. We match on a stable
+    // substring rather than the exact text so trailing punctuation changes don't
+    // matter, and an unknown/renamed string degrades to a generic-but-honest label
+    // (raw text as detail) instead of breaking — if the game renames these, FUSE
+    // still drives step labels from the snapshot/pipeline patches.
+    internal static class FuseLoadingLabels
+    {
+        internal readonly struct Step
+        {
+            internal Step(string title, string detail, bool syncHandoff = false)
+            {
+                Title = title;
+                Detail = detail;
+                SyncHandoff = syncHandoff;
+            }
+
+            internal string Title { get; }
+
+            internal string Detail { get; }
+
+            // True for the game's ~95% hand-off into the synchronous save restore.
+            // The controller marks the sync phase from here so the determinate bar
+            // switches to its static band going into the freeze instead of sitting
+            // as a partial fill that reads as "stuck at 95%".
+            internal bool SyncHandoff { get; }
+        }
+
+        internal static Step MapProgressFlavor(string gameText, float fraction)
+        {
+            var text = gameText == null ? string.Empty : gameText.Trim();
+
+            // ~95% hand-off marker, emitted immediately before the synchronous
+            // ApplyGameSetup save restore.
+            if (Contains(text, "Half a car"))
+            {
+                return new Step("Restoring saved game", "Reading world snapshot", syncHandoff: true);
+            }
+
+            // Return-to-menu unload. FUSE does not own the unload screen (it aborts
+            // on MapWillUnloadEvent), but the mapping is kept honest for completeness.
+            if (Contains(text, "Tyin'") || Contains(text, "Tying"))
+            {
+                return new Step("Returning to main menu", null);
+            }
+
+            // The constant string across the whole async scene-load phase. Split by
+            // progress so the early menu/UI hand-off reads differently from the long
+            // terrain/environment stream.
+            if (Contains(text, "Two cars"))
+            {
+                return fraction < 0.2f
+                    ? new Step("Loading world", "Preparing interface")
+                    : new Step("Loading terrain", "Streaming map & environment");
+            }
+
+            // Unknown / renamed flavor string: stay honest and resilient.
+            return new Step("Loading world", string.IsNullOrEmpty(text) ? null : text);
+        }
+
+        // Formats a snapshot-element count into a step detail line, e.g.
+        // (1432, "car", "cars") -> "1,432 cars". A negative count (the sentinel for
+        // "couldn't read the collection") yields null so the caller shows the title
+        // alone rather than a wrong number.
+        internal static string DescribeCount(int count, string singular, string plural)
+        {
+            if (count < 0)
+            {
+                return null;
+            }
+
+            var noun = count == 1 ? singular : plural;
+            return count.ToString("N0", CultureInfo.InvariantCulture) + " " + noun;
+        }
+
+        private static bool Contains(string haystack, string needle)
+        {
+            return haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+    }
+}

--- a/FUSE/Interface/FuseLoadingScreen.cs
+++ b/FUSE/Interface/FuseLoadingScreen.cs
@@ -1,0 +1,437 @@
+using System;
+using FUSE.Infrastructure;
+using UnityEngine;
+
+namespace FUSE.Interface
+{
+    // FUSE-owned enhanced loading screen (issue #83). A DontDestroyOnLoad host
+    // MonoBehaviour created from FusePlugin.Load (mirroring FuseTrackDebugOverlay /
+    // FuseWorldLabelsOverlay), it replaces the bare stock "Loading…" screen with a
+    // staged progress bar and a human-readable "current step" label, and stays up
+    // until FUSE's own post-load pipeline finishes.
+    //
+    // Driving signals arrive from FuseLoadingScreenPatches (Harmony) and
+    // FuseLifecycle; this class only owns the visuals and the show/hide gate (the
+    // gate itself lives in the Unity-free FuseLoadingScreenState so it is testable).
+    //
+    // THE HARD CONSTRAINT — read before "fixing" the missing animation: Unity UI
+    // repaints only between frames on the main thread. The heaviest load phases
+    // (the save restore and FUSE's mod-apply) block the main thread for their whole
+    // duration, so the screen CANNOT animate or update *during* a phase — only
+    // *between* phases. That is why the progress bar deliberately switches to a
+    // static full band (not a spinner) once a synchronous phase begins: a frozen
+    // frame must look intentional, never "hung". Do not add motion that implies
+    // progress during a synchronous phase; it will appear broken.
+    //
+    // Phase 1 here is the IMGUI (OnGUI) renderer, alive from the persistent scene
+    // onward with no dependency on game UI internals (same rationale as
+    // FuseLegacyInstallAlert). Phase 2 (a code-built uGUI/TMP canvas) can replace
+    // the renderer without touching the controller API or any driver patch.
+    internal sealed class FuseLoadingScreen : MonoBehaviour
+    {
+        private const float ContentWidth = 720f;
+        private const float TipIntervalSeconds = 6f;
+
+        private static GameObject _host;
+        private static FuseLoadingScreen _instance;
+
+        private readonly FuseLoadingScreenState _state = new FuseLoadingScreenState();
+
+        private GameObject _stockLoadingScreen;
+        private bool _renderedOnce;
+        private bool _renderingDisabled;
+        private bool _renderFailureLogged;
+
+        private bool _stylesReady;
+        private Texture2D _backgroundTexture;
+        private Texture2D _barTrackTexture;
+        private Texture2D _barFillTexture;
+        private Texture2D _barSyncTexture;
+        private GUIStyle _brandStyle;
+        private GUIStyle _stepStyle;
+        private GUIStyle _detailStyle;
+        private GUIStyle _percentStyle;
+        private GUIStyle _tipStyle;
+
+        private static readonly string[] Tips =
+        {
+            "FUSE keeps the screen up until every mod has finished applying.",
+            "A frozen step label is normal: the world is being assembled on the main thread.",
+            "Larger railroads take longer to restore — every car is rebuilt individually.",
+            "Mods, track, scenery, and terrain are all reapplied after the save loads.",
+            "You can turn this screen off in the FUSE settings to fall back to the stock one.",
+        };
+
+        public static void Ensure()
+        {
+            if (_host != null)
+            {
+                return;
+            }
+
+            _host = new GameObject("FUSE Loading Screen");
+            DontDestroyOnLoad(_host);
+            _host.hideFlags = HideFlags.HideAndDontSave;
+            _instance = _host.AddComponent<FuseLoadingScreen>();
+            FuseLog.Info("FUSE enhanced loading screen initialized.");
+        }
+
+        public static void Shutdown()
+        {
+            if (_host != null)
+            {
+                Destroy(_host);
+                _host = null;
+            }
+
+            _instance = null;
+        }
+
+        // MapWillLoadEvent → begin a fresh load. Gated here so a single switch falls
+        // the whole feature back to the untouched stock screen.
+        public static void BeginLoad(string reason)
+        {
+            if (_instance == null || !FuseSettings.EnableEnhancedLoadingScreen)
+            {
+                return;
+            }
+
+            _instance.BeginLoadInstance(reason);
+        }
+
+        // Captured from the PersistentLoader.ShowLoadingScreen postfix so we can hide
+        // the stock visuals once — and only once — our own first frame has drawn.
+        public static void CaptureStockLoadingScreen(GameObject stockLoadingScreen)
+        {
+            if (_instance == null)
+            {
+                return;
+            }
+
+            _instance._stockLoadingScreen = stockLoadingScreen;
+        }
+
+        // PersistentLoader.ShowProgress postfix. Drives the determinate bar and the
+        // async-phase step label (mapped from the game's flavor string).
+        public static void SetProgressFromGame(int intProgress, string gameText)
+        {
+            if (_instance == null)
+            {
+                return;
+            }
+
+            var fraction = intProgress / 100f;
+            _instance._state.SetProgress(fraction, Now);
+            var step = FuseLoadingLabels.MapProgressFlavor(gameText, fraction);
+            // The async scene-load ticks are determinate (syncPhase:false); only the
+            // ~95% hand-off into the blocking save restore flips the bar to its band.
+            _instance._state.SetStep(step.Title, step.Detail, step.SyncHandoff, Now);
+        }
+
+        // Set the label for a synchronous (main-thread-blocking) phase. Every caller
+        // is at the boundary of a blocking call, so this always marks the sync phase
+        // (which switches the bar to its static treatment).
+        public static void SetStep(string title, string detail = null)
+        {
+            if (_instance == null)
+            {
+                return;
+            }
+
+            _instance._state.SetStep(title, detail, syncPhase: true, Now);
+        }
+
+        // PersistentLoader.ShowLoadingScreen(false).
+        public static void NotifyGameScreenHidden()
+        {
+            if (_instance == null)
+            {
+                return;
+            }
+
+            _instance._state.NotifyGameScreenHidden(Now);
+        }
+
+        // End of FuseLifecycle.OnMapDidLoad (runs on all paths, including non-host
+        // multiplayer clients, via its finally block).
+        public static void NotifyFusePipelineComplete()
+        {
+            if (_instance == null)
+            {
+                return;
+            }
+
+            _instance._state.NotifyFusePipelineComplete(Now);
+        }
+
+        // Load failure / return-to-menu: hide immediately rather than waiting on the
+        // FUSE-pipeline flag (which never fires on those paths).
+        public static void Abort(string reason)
+        {
+            if (_instance == null)
+            {
+                return;
+            }
+
+            _instance.AbortInstance(reason);
+        }
+
+        private static float Now => Time.realtimeSinceStartup;
+
+        private void BeginLoadInstance(string reason)
+        {
+            _state.BeginLoad(Now);
+            _renderedOnce = false;
+            FuseLog.Info($"FUSE enhanced loading screen shown ({reason}).");
+        }
+
+        private void AbortInstance(string reason)
+        {
+            if (!_state.Active)
+            {
+                return;
+            }
+
+            _state.Abort();
+            RestoreStockLoadingScreenIfHidden();
+            FuseLog.Info($"FUSE enhanced loading screen aborted ({reason}).");
+        }
+
+        private void Update()
+        {
+            if (!_state.UpdateVisibility(Now))
+            {
+                // Either still hidden, or the gate just closed. We never re-show the
+                // stock screen on a normal hide — the game has already hidden it.
+                return;
+            }
+
+            // Hide the stock screen only after our own first frame has drawn, so a
+            // render failure leaves the stock screen visible instead of a blank one.
+            if (!_renderingDisabled && _renderedOnce && _stockLoadingScreen != null && _stockLoadingScreen.activeSelf)
+            {
+                try
+                {
+                    _stockLoadingScreen.SetActive(false);
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning("FUSE enhanced loading screen could not hide the stock screen: " + ex.GetBaseException().Message);
+                }
+            }
+        }
+
+        private void OnGUI()
+        {
+            if (_renderingDisabled || !_state.Active)
+            {
+                return;
+            }
+
+            var evt = Event.current;
+            if (evt == null || evt.type != EventType.Repaint)
+            {
+                return;
+            }
+
+            try
+            {
+                EnsureStyles();
+                DrawScreen();
+                _renderedOnce = true;
+            }
+            catch (Exception ex)
+            {
+                HandleRenderFailure(ex);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            DestroyTexture(ref _backgroundTexture);
+            DestroyTexture(ref _barTrackTexture);
+            DestroyTexture(ref _barFillTexture);
+            DestroyTexture(ref _barSyncTexture);
+        }
+
+        private void HandleRenderFailure(Exception ex)
+        {
+            _renderingDisabled = true;
+            if (_state.GameScreenHidden)
+            {
+                // The game has already torn down its own screen and our renderer is
+                // dead — nothing is left to cover the world, so stop gating and let
+                // it show rather than holding a blank screen until the watchdog.
+                _state.Abort();
+            }
+            else
+            {
+                // The game still wants a loading screen up; restore the stock one.
+                RestoreStockLoadingScreenIfHidden();
+            }
+
+            if (!_renderFailureLogged)
+            {
+                _renderFailureLogged = true;
+                FuseLog.Warning(
+                    "FUSE enhanced loading screen OnGUI failed; falling back to the stock screen for this session: "
+                    + ex.GetBaseException().Message);
+            }
+        }
+
+        private void RestoreStockLoadingScreenIfHidden()
+        {
+            if (_stockLoadingScreen == null || _state.GameScreenHidden)
+            {
+                return;
+            }
+
+            try
+            {
+                if (!_stockLoadingScreen.activeSelf)
+                {
+                    _stockLoadingScreen.SetActive(true);
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning("FUSE enhanced loading screen could not restore the stock screen: " + ex.GetBaseException().Message);
+            }
+        }
+
+        private void DrawScreen()
+        {
+            var width = Screen.width;
+            var height = Screen.height;
+
+            GUI.depth = -1000;
+            GUI.DrawTexture(new Rect(0f, 0f, width, height), _backgroundTexture);
+
+            var columnWidth = Mathf.Min(ContentWidth, width - 80f);
+            var columnX = (width - columnWidth) * 0.5f;
+            var centerY = height * 0.5f;
+
+            GUI.Label(new Rect(columnX, centerY - 132f, columnWidth, 26f), "FUSE", _brandStyle);
+
+            var title = string.IsNullOrEmpty(_state.StepTitle) ? "Loading…" : _state.StepTitle;
+            GUI.Label(new Rect(columnX, centerY - 96f, columnWidth, 48f), title, _stepStyle);
+
+            if (!string.IsNullOrEmpty(_state.StepDetail))
+            {
+                GUI.Label(new Rect(columnX, centerY - 46f, columnWidth, 28f), _state.StepDetail, _detailStyle);
+            }
+
+            DrawBar(new Rect(columnX, centerY + 8f, columnWidth, 12f), centerY, columnX, columnWidth);
+
+            GUI.Label(new Rect(columnX, centerY + 64f, columnWidth, 24f), CurrentTip(), _tipStyle);
+        }
+
+        private void DrawBar(Rect rect, float centerY, float columnX, float columnWidth)
+        {
+            GUI.DrawTexture(rect, _barTrackTexture);
+
+            if (_state.InSyncPhase)
+            {
+                // Synchronous phase: the main thread is blocked. A partial fill would
+                // read as "stuck at N%", so show a full muted band — intentional, not
+                // stalled — and let the step label carry the meaning. No percentage.
+                GUI.DrawTexture(rect, _barSyncTexture);
+            }
+            else
+            {
+                var fillWidth = rect.width * Mathf.Clamp01(_state.Progress);
+                if (fillWidth > 0f)
+                {
+                    GUI.DrawTexture(new Rect(rect.x, rect.y, fillWidth, rect.height), _barFillTexture);
+                }
+
+                var percent = Mathf.RoundToInt(Mathf.Clamp01(_state.Progress) * 100f);
+                GUI.Label(new Rect(columnX, centerY + 24f, columnWidth, 22f), percent + "%", _percentStyle);
+            }
+        }
+
+        private static string CurrentTip()
+        {
+            if (Tips.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var index = Mathf.Abs((int)(Time.realtimeSinceStartup / TipIntervalSeconds)) % Tips.Length;
+            return Tips[index];
+        }
+
+        private void EnsureStyles()
+        {
+            if (_stylesReady)
+            {
+                return;
+            }
+
+            _backgroundTexture = SolidTexture(new Color(0.06f, 0.07f, 0.09f, 1f));
+            _barTrackTexture = SolidTexture(new Color(1f, 1f, 1f, 0.10f));
+            _barFillTexture = SolidTexture(new Color(0.36f, 0.62f, 0.92f, 1f));
+            _barSyncTexture = SolidTexture(new Color(0.36f, 0.62f, 0.92f, 0.35f));
+
+            _brandStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 14,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleCenter
+            };
+            _brandStyle.normal.textColor = new Color(0.45f, 0.6f, 0.85f);
+
+            _stepStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 30,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleCenter,
+                wordWrap = false
+            };
+            _stepStyle.normal.textColor = Color.white;
+
+            _detailStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 16,
+                alignment = TextAnchor.MiddleCenter,
+                wordWrap = false
+            };
+            _detailStyle.normal.textColor = new Color(0.78f, 0.82f, 0.88f);
+
+            _percentStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 13,
+                alignment = TextAnchor.MiddleRight
+            };
+            _percentStyle.normal.textColor = new Color(0.7f, 0.76f, 0.84f);
+
+            _tipStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 13,
+                fontStyle = FontStyle.Italic,
+                alignment = TextAnchor.MiddleCenter,
+                wordWrap = true
+            };
+            _tipStyle.normal.textColor = new Color(0.55f, 0.6f, 0.68f);
+
+            _stylesReady = true;
+        }
+
+        private static Texture2D SolidTexture(Color color)
+        {
+            var texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+            texture.SetPixel(0, 0, color);
+            texture.Apply();
+            return texture;
+        }
+
+        private static void DestroyTexture(ref Texture2D texture)
+        {
+            if (texture != null)
+            {
+                Destroy(texture);
+                texture = null;
+            }
+        }
+    }
+}

--- a/FUSE/Interface/FuseLoadingScreenState.cs
+++ b/FUSE/Interface/FuseLoadingScreenState.cs
@@ -1,0 +1,178 @@
+using System;
+
+namespace FUSE.Interface
+{
+    // Pure, Unity-free show/hide + current-step state for the enhanced loading
+    // screen (issue #83). Deliberately separated from the FuseLoadingScreen
+    // MonoBehaviour so the two-flag hide gate and the watchdog backstop can be
+    // unit-tested without the engine: nothing here touches UnityEngine, and every
+    // method takes a monotonic "now" in seconds (the host passes
+    // Time.realtimeSinceStartup). The host calls UpdateVisibility() each frame and
+    // tears down when it returns false.
+    //
+    // Hide gate (the reason this is two flags, not one): FUSE's post-load pipeline
+    // (FuseLifecycle.OnMapDidLoad) can finish AFTER the game hides its own loading
+    // screen, so hiding the moment ShowLoadingScreen(false) fires would expose a
+    // still-assembling world. We hide only when BOTH the game screen has hidden and
+    // the FUSE pipeline has signalled complete — with a watchdog so a missed signal
+    // can never trap the player behind the screen.
+    internal sealed class FuseLoadingScreenState
+    {
+        // Absolute backstop: if no signal (progress, step, or completion) arrives
+        // for this long, tear the screen down regardless of the flags. Sized well
+        // above the heaviest single synchronous load phase so a legitimately long
+        // freeze never trips it; only a genuinely missed terminal signal does.
+        internal const float DefaultWatchdogSeconds = 120f;
+
+        private readonly float _watchdogSeconds;
+
+        private bool _active;
+        private bool _gameScreenHidden;
+        private bool _fusePipelineDone;
+        private bool _aborted;
+        private float _progress;
+        private string _stepTitle;
+        private string _stepDetail;
+        private bool _inSyncPhase;
+        private float _lastSignalAt;
+
+        internal FuseLoadingScreenState(float watchdogSeconds = DefaultWatchdogSeconds)
+        {
+            _watchdogSeconds = watchdogSeconds > 0f ? watchdogSeconds : DefaultWatchdogSeconds;
+        }
+
+        internal bool Active => _active;
+
+        internal bool GameScreenHidden => _gameScreenHidden;
+
+        internal bool FusePipelineDone => _fusePipelineDone;
+
+        internal float Progress => _progress;
+
+        internal string StepTitle => _stepTitle;
+
+        internal string StepDetail => _stepDetail;
+
+        // True once a synchronous (main-thread-blocking) phase has been entered.
+        // The host switches the progress bar from a determinate fill to a static
+        // "deep in the load" treatment so a frozen frame never reads as a stalled
+        // partial bar.
+        internal bool InSyncPhase => _inSyncPhase;
+
+        internal void BeginLoad(float now)
+        {
+            _active = true;
+            _gameScreenHidden = false;
+            _fusePipelineDone = false;
+            _aborted = false;
+            _progress = 0f;
+            _stepTitle = "Loading world";
+            _stepDetail = null;
+            _inSyncPhase = false;
+            _lastSignalAt = now;
+        }
+
+        internal void SetProgress(float fraction, float now)
+        {
+            if (!_active)
+            {
+                return;
+            }
+
+            _progress = Clamp01(fraction);
+            _lastSignalAt = now;
+        }
+
+        internal void SetStep(string title, string detail, bool syncPhase, float now)
+        {
+            if (!_active)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(title))
+            {
+                _stepTitle = title;
+            }
+
+            _stepDetail = detail;
+            if (syncPhase)
+            {
+                _inSyncPhase = true;
+            }
+
+            _lastSignalAt = now;
+        }
+
+        internal void NotifyGameScreenHidden(float now)
+        {
+            if (!_active)
+            {
+                return;
+            }
+
+            _gameScreenHidden = true;
+            _lastSignalAt = now;
+        }
+
+        internal void NotifyFusePipelineComplete(float now)
+        {
+            if (!_active)
+            {
+                return;
+            }
+
+            _fusePipelineDone = true;
+            _lastSignalAt = now;
+        }
+
+        // Immediate hide, used for load failure / return-to-menu. Distinct from the
+        // gated hide so an aborted load never waits on the FUSE-pipeline flag.
+        internal void Abort()
+        {
+            _aborted = true;
+            _active = false;
+        }
+
+        // Returns whether the screen should remain visible. Flips the screen off
+        // exactly once when the hide gate is satisfied so the host can run teardown
+        // on the transition.
+        internal bool UpdateVisibility(float now)
+        {
+            if (!_active)
+            {
+                return false;
+            }
+
+            if (_aborted)
+            {
+                _active = false;
+                return false;
+            }
+
+            if (now - _lastSignalAt >= _watchdogSeconds)
+            {
+                _active = false;
+                return false;
+            }
+
+            if (_gameScreenHidden && _fusePipelineDone)
+            {
+                _active = false;
+                return false;
+            }
+
+            return true;
+        }
+
+        private static float Clamp01(float value)
+        {
+            if (float.IsNaN(value) || value < 0f)
+            {
+                return 0f;
+            }
+
+            return value > 1f ? 1f : value;
+        }
+    }
+}

--- a/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
@@ -64,6 +64,19 @@ namespace FUSE.Interface.MenuWindow
 
             builder.Spacing = 6f;
 
+            builder.AddSection("Interface");
+
+            builder.AddField("Enhanced Loading Screen", control: BuildToggleBoxWithButton(
+                builder,
+                FuseSettings.EnableEnhancedLoadingScreen,
+                () =>
+                {
+                    FuseSettings.SetEnableEnhancedLoadingScreen(!FuseSettings.EnableEnhancedLoadingScreen);
+                    builder.Rebuild();
+                }));
+
+            builder.AddLabel("Staged progress and current-step labels during loading; takes effect on the next load.");
+
             builder.AddSection("Reporting");
 
             builder.AddField("Verbose Reporting", control: BuildToggleBoxWithButton(

--- a/FUSE/Patches/FuseLoadingScreenPatches.cs
+++ b/FUSE/Patches/FuseLoadingScreenPatches.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections;
+using System.Reflection;
+using Game.State;
+using HarmonyLib;
+using Model.Ops;
+using UI.Menu;
+using UnityEngine;
+using FUSE.Infrastructure;
+using FUSE.Interface;
+
+namespace FUSE.Patches
+{
+    // Drives the FUSE enhanced loading screen (issue #83) from the game's load
+    // sequence. Kept separate from FuseLoadingScreen so the feature is one cohesive
+    // unit, and deliberately implemented as INDEPENDENT patch classes on methods
+    // FUSE already patches elsewhere (PopulateFromRemoteSnapshot, HandleSnapshot*,
+    // OpsController.Awake) — Harmony allows multiple patches per method, so these
+    // coexist with the existing snapshot patches without editing those files.
+    //
+    // Every body is gated on FuseSettings.EnableEnhancedLoadingScreen and wrapped in
+    // try/catch: none of them alter game behavior or control flow — they only push a
+    // label or a progress value and return. A throw here can never wedge a load.
+    internal static class FuseLoadingScreenPatchSupport
+    {
+        internal static int CountOf(object collection)
+        {
+            return collection is ICollection countable ? countable.Count : -1;
+        }
+    }
+
+    [HarmonyPatch(typeof(PersistentLoader), "ShowLoadingScreen")]
+    internal static class FuseLoadingScreenShowPatch
+    {
+        private static readonly FieldInfo LoadingScreenField =
+            AccessTools.Field(typeof(PersistentLoader), "loadingScreen");
+
+        private static void Postfix(bool show, PersistentLoader __instance)
+        {
+            if (!FuseSettings.EnableEnhancedLoadingScreen)
+            {
+                return;
+            }
+
+            try
+            {
+                if (__instance != null && LoadingScreenField != null)
+                {
+                    FuseLoadingScreen.CaptureStockLoadingScreen(LoadingScreenField.GetValue(__instance) as GameObject);
+                }
+
+                if (!show)
+                {
+                    FuseLoadingScreen.NotifyGameScreenHidden();
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning("FUSE loading-screen ShowLoadingScreen hook failed: " + ex.GetBaseException().Message);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(PersistentLoader), "ShowProgress")]
+    internal static class FuseLoadingScreenProgressPatch
+    {
+        private static void Postfix(int intProgress, string text)
+        {
+            if (!FuseSettings.EnableEnhancedLoadingScreen)
+            {
+                return;
+            }
+
+            try
+            {
+                FuseLoadingScreen.SetProgressFromGame(intProgress, text);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning("FUSE loading-screen ShowProgress hook failed: " + ex.GetBaseException().Message);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(StateManager), "PopulateFromRemoteSnapshot")]
+    internal static class FuseLoadingScreenSnapshotPatch
+    {
+        private static void Prefix()
+        {
+            if (!FuseSettings.EnableEnhancedLoadingScreen)
+            {
+                return;
+            }
+
+            try
+            {
+                FuseLoadingScreen.SetStep("Restoring saved game", "Reading world snapshot");
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning("FUSE loading-screen snapshot hook failed: " + ex.GetBaseException().Message);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(TrainController), "HandleSnapshotTurntables")]
+    internal static class FuseLoadingScreenTurntablesPatch
+    {
+        private static void Prefix(object states)
+        {
+            if (!FuseSettings.EnableEnhancedLoadingScreen)
+            {
+                return;
+            }
+
+            try
+            {
+                var count = FuseLoadingScreenPatchSupport.CountOf(states);
+                FuseLoadingScreen.SetStep("Restoring turntables", FuseLoadingLabels.DescribeCount(count, "turntable", "turntables"));
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning("FUSE loading-screen turntables hook failed: " + ex.GetBaseException().Message);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(TrainController), "HandleSnapshotCars")]
+    internal static class FuseLoadingScreenCarsPatch
+    {
+        private static void Prefix(object snapshotCars)
+        {
+            if (!FuseSettings.EnableEnhancedLoadingScreen)
+            {
+                return;
+            }
+
+            try
+            {
+                var count = FuseLoadingScreenPatchSupport.CountOf(snapshotCars);
+                FuseLoadingScreen.SetStep("Restoring rail cars", FuseLoadingLabels.DescribeCount(count, "car", "cars"));
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning("FUSE loading-screen cars hook failed: " + ex.GetBaseException().Message);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(OpsController), "Awake")]
+    internal static class FuseLoadingScreenIndustriesPatch
+    {
+        private static void Prefix()
+        {
+            if (!FuseSettings.EnableEnhancedLoadingScreen)
+            {
+                return;
+            }
+
+            try
+            {
+                FuseLoadingScreen.SetStep("Restoring industries", null);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning("FUSE loading-screen industries hook failed: " + ex.GetBaseException().Message);
+            }
+        }
+    }
+}

--- a/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
+++ b/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
@@ -4,6 +4,7 @@ using GalaSoft.MvvmLight.Messaging;
 using Game.Events;
 using FUSE.Runtime.API;
 using FUSE.Runtime.Cache;
+using FUSE.Interface;
 using FUSE.Interface.Console;
 using FUSE.Runtime.Events;
 using FUSE.Infrastructure;
@@ -17,6 +18,7 @@ namespace FUSE.Runtime.Lifecycle
         {
             try
             {
+                Messenger.Default.Register<MapWillLoadEvent>(this, OnMapWillLoad);
                 Messenger.Default.Register<MapDidLoadEvent>(this, OnMapDidLoad);
                 Messenger.Default.Register<GraphDidRebuildCollections>(this, OnGraphDidRebuildCollections);
                 Messenger.Default.Register<MapWillUnloadEvent>(this, OnMapWillUnload);
@@ -44,7 +46,45 @@ namespace FUSE.Runtime.Lifecycle
             }
         }
 
+        // Earliest clean "load started" signal (sent at the top of
+        // GlobalGameManager._LoadMap, before any scene work). Shows the FUSE
+        // enhanced loading screen so it owns the visuals for the whole load.
+        private void OnMapWillLoad(MapWillLoadEvent message)
+        {
+            try
+            {
+                FuseLoadingScreen.BeginLoad("map load");
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE enhanced loading screen begin-load failed", ex);
+            }
+        }
+
         private void OnMapDidLoad(MapDidLoadEvent message)
+        {
+            // Run the whole FUSE post-load pipeline, then ALWAYS tell the enhanced
+            // loading screen the pipeline is done — even on a throw or a non-host
+            // multiplayer early-out — so the two-flag hide gate can release and the
+            // player is never trapped behind the screen.
+            try
+            {
+                RunMapDidLoadPipeline();
+            }
+            finally
+            {
+                try
+                {
+                    FuseLoadingScreen.NotifyFusePipelineComplete();
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception("FUSE enhanced loading screen pipeline-complete signal failed", ex);
+                }
+            }
+        }
+
+        private static void RunMapDidLoadPipeline()
         {
             var mapLoadStopwatch = Stopwatch.StartNew();
             var loadedCount = 0;
@@ -69,6 +109,7 @@ namespace FUSE.Runtime.Lifecycle
                 FusePerformanceMetrics.RecordTiming("cache rebuild before map load apply", cacheStopwatch.ElapsedMilliseconds);
                 FuseLog.Info($"FUSE load timing phase='cache rebuild before map load apply' elapsedMs={cacheStopwatch.ElapsedMilliseconds}.");
                 TrackAPI.CaptureBaseGraphSnapshot("map load before FUSE package apply");
+                FuseLoadingScreen.SetStep("Applying mods", "Loading mod packages");
                 loadedCount = FuseDataPackageDiscovery.LoadPackagesFromDisk(false);
                 if (canMutateWorld)
                 {
@@ -76,12 +117,14 @@ namespace FUSE.Runtime.Lifecycle
                     // created during apply is queued for post-load activation instead
                     // of being activated inline on the loading-screen critical path.
                     FuseDeferredSceneryActivator.OpenInitialMapLoadWave();
+                    FuseLoadingScreen.SetStep("Applying mods", "Applying definitions");
                     appliedCount = FuseDataPackageDiscovery.ApplyLoadedPackages("map load");
                     // Run the cleanup cluster inside one batch so the rebuild
                     // RemoveInvalidTrackSpans requests folds together with any
                     // rebuild industry/marker cleanup may also request. Without
                     // this, RemoveInvalidTrackSpans fires its own full rebuild
                     // while the rest of the cleanup is still running.
+                    FuseLoadingScreen.SetStep("Rebuilding track graph");
                     TrackAPI.BeginBatch();
                     try
                     {
@@ -145,6 +188,7 @@ namespace FUSE.Runtime.Lifecycle
             {
                 if (canMutateWorld)
                 {
+                    FuseLoadingScreen.SetStep("Rebaking terrain");
                     var mapRebuildStopwatch = Stopwatch.StartNew();
                     FuseRuntimeReloadService.ReloadTerrain("map-load map-mask rebuild");
                     FusePerformanceMetrics.RecordTiming("map mask rebuild", mapRebuildStopwatch.ElapsedMilliseconds);
@@ -209,6 +253,7 @@ namespace FUSE.Runtime.Lifecycle
             // registration here even if the early Load attempt missed it.
             try
             {
+                FuseLoadingScreen.SetStep("Finishing up", "Registering console");
                 var consoleStopwatch = Stopwatch.StartNew();
                 FuseConsoleRegistrar.TryRegisterAll();
                 FuseLegacyAssemblyHost.RetryPendingConsoleCommands();
@@ -262,6 +307,11 @@ namespace FUSE.Runtime.Lifecycle
         {
             try
             {
+                // FUSE does not own the unload screen (the stock "Tyin' down…"
+                // progress is fine), and the post-load pipeline never runs on an
+                // unload — so hide our screen immediately rather than letting the
+                // two-flag gate wait on a pipeline-complete signal that never comes.
+                FuseLoadingScreen.Abort("map unload");
                 // Cancel any in-flight deferred scenery wave before the scenery
                 // GameObjects it references are destroyed below.
                 FuseDeferredSceneryActivator.CancelAndClear("map unload");


### PR DESCRIPTION
Closes #83.

Replaces the bare stock "Loading…" screen with a FUSE-owned screen that shows a real progress bar during the async scene-load phase and a human-readable **current step** for every phase of the load — including FUSE''s mod-apply pipeline, which previously had zero on-screen presence. The screen stays up until FUSE''s own post-load work finishes, instead of disappearing while the world is still being assembled.

## What the player sees

| Bar | Step | Phase |
|---|---|---|
| 0–95% | Loading world → Loading terrain (animated, real progress) | async |
| ~95% | Restoring saved game / turntables / **1,432 rail cars** / industries | sync (frozen, label visible) |
| 95–100% | Applying mods → Rebuilding track graph → Rebaking terrain → Finishing up | sync (FUSE pipeline) |

## Design

- **`FuseLoadingScreen`** — `DontDestroyOnLoad` host MonoBehaviour with a Phase-1 IMGUI renderer, mirroring the existing overlay conventions (`Ensure`/`Shutdown`, `HideAndDontSave`, render-failure disables for the session). Phase-2 uGUI/TMP can swap the renderer without touching the controller API.
- **`FuseLoadingScreenState`** — pure, Unity-free **two-flag hide gate + watchdog**. Hides only once the game has hidden its own screen **and** FUSE''s pipeline has signalled complete (the pipeline can finish *after* the game hides its screen, so slaving to either alone would expose a still-assembling world). A watchdog guarantees the screen can never trap the player.
- **`FuseLoadingLabels`** — pure flavor-string → friendly-step mapping + count formatter.
- **`FuseLoadingScreenPatches`** — independent Harmony patches that *drive* the controller from the load sequence (`PersistentLoader.ShowLoadingScreen`/`ShowProgress` + the snapshot/turntable/car/industry handlers). Every body is gated on the setting, swallows its own exceptions, and never alters game control flow — a throw here cannot wedge a load.
- **`FuseLifecycle`** — step labels at each pipeline boundary; `NotifyFusePipelineComplete` in a `finally` so it fires on **every** path (success, throw, non-host multiplayer client); `Abort` on map unload.

## The hard constraint (documented in code)

Unity UI repaints only between frames on the main thread. The heaviest phases (save restore, mod-apply) block the main thread for their whole duration, so the screen changes step labels *between* phases, not *during* them. The bar deliberately switches to a static band once a synchronous phase begins, so a frozen frame reads as intentional, never "hung". No animation implies progress during a freeze.

## Resilience

- Gated behind `EnableEnhancedLoadingScreen` (default **on**); toggle in the FUSE settings panel and the Health UI. With it off, the stock screen is left completely untouched.
- First render exception logs once and falls back to the stock screen for the session; the stock child is only hidden *after* our first successful frame.
- Multiplayer / non-host paths complete via the same `OnMapDidLoad` `finally`.

## Tests

55 new unit tests (Unity-free) covering the label map, count formatting, and the full show/hide state machine: two-flag gate, ordering permutations, abort→begin re-arm, watchdog reset/expiry, inactive no-ops, the sync-phase latch, and NaN/Infinity progress clamping. The auto-discovering `FusePatchTargetingTests` validates all six new Harmony targets resolve against the current game DLLs. **Full suite: 1356 green; slopwatch clean.**

## Not yet done (Phase 2 / out of scope)

- Phase-2 UGUI/TMP renderer (additive, isolated to the renderer).
- In-game manual verification pass against a large save (the IMGUI MVP is wired end-to-end and unit-verified, but the visuals have not been confirmed in a running game yet).