### PR TITLE
test: make terrain region progress assertion deterministic (fix build-net10 flake)

### DIFF
--- a/FUSE.ExternalEditor.UiTests/TerrainGenerationServiceTests.cs
+++ b/FUSE.ExternalEditor.UiTests/TerrainGenerationServiceTests.cs
@@ -112,11 +112,16 @@ public class TerrainGenerationServiceTests
         var svc = new TerrainGenerationService(new HttpClient(handler), new TerrainTileService());
         var tiles = Enumerable.Range(0, 6).Select(i => (i, 0)).ToList();
         var reports = new List<int>();
+        var allReported = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var progress = new Progress<TerrainGenProgress>(p =>
         {
             lock (reports)
             {
                 reports.Add(p.Completed);
+                if (reports.Count == 6)
+                {
+                    allReported.TrySetResult();
+                }
             }
         });
 
@@ -125,7 +130,12 @@ public class TerrainGenerationServiceTests
         Assert.Equal(6, done);
         Assert.True(handler.MaxConcurrent >= 2, $"expected parallel fetches, got {handler.MaxConcurrent}");
         Assert.True(handler.MaxConcurrent <= 3, $"expected bounded by MaxConcurrency, got {handler.MaxConcurrent}");
-        await Task.Delay(50); // let the last Progress callbacks post
+
+        // Progress<T> posts its callbacks asynchronously to the thread pool (no SynchronizationContext
+        // in headless xUnit), so they can trail GenerateRegionAsync's completion. Await their delivery
+        // with a bounded timeout instead of a fixed delay that a loaded CI runner can outrun.
+        var delivered = await Task.WhenAny(allReported.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+        Assert.True(delivered == allReported.Task, "expected all 6 Progress<T> callbacks to be delivered");
         lock (reports)
         {
             Assert.Equal(6, reports.Count);


### PR DESCRIPTION
## 🔗 Related Issue

No tracked issue — this fixes a pre-existing, intermittent CI flake in the recently-added `FUSE.ExternalEditor.UiTests` suite that was occasionally failing the `build-net10` check. Unrelated to any feature work.

## 📝 Description of the Change

`TerrainGenerationServiceTests.GenerateRegion_Reports_Progress_And_Runs_Bounded_Parallel` exercises `TerrainGenerationService.GenerateRegionAsync`, which reports per-tile progress through `System.Progress<TerrainGenProgress>`. In headless xUnit there is **no `SynchronizationContext`**, so `Progress<T>` marshals each callback **asynchronously onto the thread pool** — callbacks can (and do) arrive *after* `GenerateRegionAsync` has already returned.

The test asserted `reports.Count == 6` after a fixed `await Task.Delay(50)` whose comment was "let the last Progress callbacks post." 50 ms is not a guaranteed delivery window: on a loaded CI runner only some callbacks land in time, so the assertion intermittently failed (observed `Actual: 1 vs Expected: 6`). The concurrency assertions (`MaxConcurrent` between 2 and 3 with `MaxConcurrency = 3`) and the `done == 6` return value are correct and were never the problem — only the progress **callback count** was racy.

The fix makes progress delivery deterministic instead of time-based:

- A `TaskCompletionSource` (`RunContinuationsAsynchronously`) is signaled from the progress handler the moment the 6th report is recorded.
- The test awaits `Task.WhenAny(allReported.Task, Task.Delay(2s))` and asserts the completion source won the race.

This returns the instant the last callback arrives (no fixed wait) and only trips the 2 s ceiling on a *genuine* delivery stall — which now surfaces as a clear, deterministic failure rather than a flake. The bounded-parallelism assertions and the final `reports.Count == 6` check are unchanged. **No production code is touched** — the service behavior was already correct; this was purely a test-synchronization bug.

## 🔄 Alternatives Considered

- **Poll-loop on `reports.Count` with a timeout** — works, but busy-waits and resolves on a polling tick rather than on the actual event.
- **Assert on the final reported `Completed` value instead of raw callback count** — narrows what the test verifies (drops the "every tile reports" guarantee).
- **Flush/await progress delivery inside `GenerateRegionAsync`** — changes production code to accommodate a test; rejected since the service is correct as-is.

The `TaskCompletionSource` + `Task.WhenAny` approach was chosen because it is event-driven (returns exactly when delivery completes), keeps the original assertion intent, and requires no production changes.

## ⚠️ Possible Drawbacks

- Test-only change; no runtime, API, or save-compatibility impact.
- Worst-case the test now waits up to 2 s before failing if progress delivery genuinely stalls — an intentional, deterministic failure that replaces a misleading flaky one.
- Pre-existing `xUnit1051` analyzer suggestions (`TestContext.Current.CancellationToken` on `Task.Delay`) elsewhere in this file are left as-is for consistency with the surrounding tests; they are unrelated to this flake.

## ✅ Verification Process

- `dotnet test FUSE.ExternalEditor.UiTests/FUSE.ExternalEditor.UiTests.csproj -c Release` — builds clean; full suite **87/87 pass**.
- Target test looped **40× sequentially** → 0 failures.
- **48 concurrent runs** (8 instances × 6 rounds) under deliberate CPU/thread-pool saturation — the closest local proxy for the loaded-CI condition that delayed callback delivery → 0 failures.
- Branch rebased onto the latest `main` (the test file was untouched upstream); **rebuilt and re-ran the target test on the rebased tree** → pass.

## 💡 Additional Information

The 2 s ceiling is a safety net, not the expected path — under normal delivery the wait resolves in single-digit milliseconds as soon as the final callback posts.
