### PR TITLE
fix(validation): load legacy packages with padded car type filters; contain lifecycle listener failures

### DIFF
--- a/FUSE.Core.Tests/CarTypeFilterValidationTests.cs
+++ b/FUSE.Core.Tests/CarTypeFilterValidationTests.cs
@@ -8,9 +8,9 @@ namespace Fuse.Core.Tests
     /// <summary>
     /// Exercises the carTypeFilter rule at all four model sites. The filter
     /// is matched verbatim per comma-separated token at runtime, so
-    /// surrounding whitespace is an error (the token can never match) and an
-    /// empty token from a doubled/edge comma is a warning (the game ignores
-    /// it).
+    /// surrounding whitespace can never match — but packages with padded
+    /// tokens loaded under the legacy modding stack, so both that and an
+    /// empty token from a doubled/edge comma are warnings, never errors.
     /// </summary>
     public class CarTypeFilterValidationTests
     {
@@ -37,13 +37,14 @@ namespace Fuse.Core.Tests
         }
 
         [Fact]
-        public void Component_Filter_With_Surrounding_Whitespace_Is_An_Error()
+        public void Component_Filter_With_Surrounding_Whitespace_Is_A_Warning()
         {
             var result = Validate(WithComponentFilter("FB, XM"));
 
-            var issue = Assert.Single(result.Errors, e => e.Code == MalformedCode);
+            var issue = Assert.Single(result.Warnings, w => w.Code == MalformedCode);
             Assert.Equal("operations.industries.mill.components.dock.carTypeFilter", issue.Field);
             Assert.Equal("FB, XM", issue.Value);
+            Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
         }
 
         [Fact]
@@ -53,7 +54,7 @@ namespace Fuse.Core.Tests
 
             var issue = Assert.Single(result.Warnings, w => w.Code == EmptyTokenCode);
             Assert.Equal("operations.industries.mill.components.dock.carTypeFilter", issue.Field);
-            Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
+            Assert.DoesNotContain(result.Warnings, w => w.Code == MalformedCode);
         }
 
         [Theory]
@@ -66,27 +67,27 @@ namespace Fuse.Core.Tests
         {
             var result = Validate(WithComponentFilter(filter));
 
-            Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
+            Assert.DoesNotContain(result.Warnings, w => w.Code == MalformedCode);
             Assert.DoesNotContain(result.Warnings, w => w.Code == EmptyTokenCode);
         }
 
         [Fact]
-        public void Trailing_Comma_Is_A_Warning_Not_An_Error()
+        public void Trailing_Comma_Is_An_Empty_Token_Warning_Not_Malformed()
         {
             var result = Validate(WithComponentFilter("FB,XM,"));
 
             Assert.Contains(result.Warnings, w => w.Code == EmptyTokenCode);
-            Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
+            Assert.DoesNotContain(result.Warnings, w => w.Code == MalformedCode);
         }
 
         [Fact]
-        public void Whitespace_Padded_Wildcard_Is_An_Error()
+        public void Whitespace_Padded_Wildcard_Is_A_Warning()
         {
             // " * " is not the bare "any" wildcard: the runtime keeps the
             // padding and the token can never match.
             var result = Validate(WithComponentFilter(" * "));
 
-            Assert.Contains(result.Errors, e => e.Code == MalformedCode);
+            Assert.Contains(result.Warnings, w => w.Code == MalformedCode);
         }
 
         [Fact]
@@ -111,7 +112,7 @@ namespace Fuse.Core.Tests
 
             var result = Validate(definition);
 
-            var issue = Assert.Single(result.Errors, e => e.Code == MalformedCode);
+            var issue = Assert.Single(result.Warnings, w => w.Code == MalformedCode);
             Assert.Equal("operations.industries.mill.components.team.teamProfiles.lumber.carTypeFilter", issue.Field);
         }
 
@@ -123,7 +124,7 @@ namespace Fuse.Core.Tests
 
             var result = Validate(definition);
 
-            var issue = Assert.Single(result.Errors, e => e.Code == MalformedCode);
+            var issue = Assert.Single(result.Warnings, w => w.Code == MalformedCode);
             Assert.Equal("operations.loads.coal.carTypeFilter", issue.Field);
         }
 
@@ -155,7 +156,7 @@ namespace Fuse.Core.Tests
 
             var result = Validate(definition);
 
-            var issue = Assert.Single(result.Errors, e => e.Code == MalformedCode);
+            var issue = Assert.Single(result.Warnings, w => w.Code == MalformedCode);
             Assert.Equal(
                 "progression.progressions.main.sections.s1.deliveryPhases[0].deliveries[0].carTypeFilter",
                 issue.Field);
@@ -166,7 +167,20 @@ namespace Fuse.Core.Tests
         {
             var result = Validate(WithComponentFilter(" FB , XM "));
 
-            Assert.Equal(2, result.Errors.Count(e => e.Code == MalformedCode));
+            Assert.Equal(2, result.Warnings.Count(w => w.Code == MalformedCode));
+        }
+
+        [Fact]
+        public void Legacy_Padded_Filter_Stays_Valid()
+        {
+            // Padded filters shipped in legacy packages and loaded fine
+            // there, so the definition must stay loadable: warning, not
+            // error.
+            var result = Validate(WithComponentFilter("HM, HT"));
+
+            Assert.Contains(result.Warnings, w => w.Code == MalformedCode);
+            Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
+            Assert.True(result.IsValid);
         }
     }
 }

--- a/FUSE.Core/Validation/FuseDefinitionValidator.cs
+++ b/FUSE.Core/Validation/FuseDefinitionValidator.cs
@@ -982,7 +982,11 @@ namespace Fuse.Core.Validation
             // Empty and "*" both mean "any car type" at runtime, so only a
             // filter with real tokens needs checking. The game splits the
             // expression on ',' without trimming, so a token with surrounding
-            // whitespace can never match a car type.
+            // whitespace can never match a car type. That is still only a
+            // warning, not an error: packages with padded tokens loaded and
+            // ran under the legacy modding stack, so FUSE must load them
+            // too — the warning plus its fix hint tells the author how to
+            // repair the filter.
             if (string.IsNullOrWhiteSpace(filter) || filter == "*")
             {
                 return;
@@ -998,7 +1002,7 @@ namespace Fuse.Core.Validation
                 }
                 else if (token.Trim().Length != token.Length)
                 {
-                    result.AddError(path, $"Car type filter entry '{token}' has surrounding whitespace and can never match a car type; write the filter without spaces (e.g. \"FB,XM\").", "fuse.operations.component.carTypeFilter.malformed", filter);
+                    result.AddWarning(path, $"Car type filter entry '{token}' has surrounding whitespace and can never match a car type; write the filter without spaces (e.g. \"FB,XM\").", "fuse.operations.component.carTypeFilter.malformed", filter);
                 }
             }
         }

--- a/FUSE.Core/Validation/Help/fuse-validation-help.json
+++ b/FUSE.Core/Validation/Help/fuse-validation-help.json
@@ -109,7 +109,7 @@
   },
   "fuse.operations.component.carTypeFilter.malformed": {
     "title": "Whitespace inside car type filter entry",
-    "why": "A carTypeFilter entry has surrounding whitespace (e.g. \"FB, XM\"). The game splits the expression on commas without trimming and matches each token verbatim, so a padded token can never match any car type; the validator rejects this as an error that must be fixed.",
+    "why": "A carTypeFilter entry has surrounding whitespace (e.g. \"FB, XM\"). The game splits the expression on commas without trimming and matches each token verbatim, so a padded token can never match any car type. The validator reports this as a warning rather than an error — packages with padded tokens still load, as they did under the legacy modding stack — but the filter will not work until it is fixed.",
     "fix": "Write the filter as a single comma-delimited string with no spaces around the commas; tokens match verbatim, with optional * suffix wildcards or a bare * for any car.",
     "example": "{\"components\": {\"loader\": {\"carTypeFilter\": \"FB,XM\"}}}"
   },

--- a/FUSE.Tests/Patches/FuseMessengerIsolationPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseMessengerIsolationPatchTests.cs
@@ -179,9 +179,49 @@ namespace FUSE.Tests.Patches
             Assert.Null(result);
         }
 
+        [Fact]
+        public void Finalizer_LogsNewOffender_ThenThrottlesTheRepeat()
+        {
+            // The throttle promise: a previously-unseen offender is always surfaced
+            // (even after the global first-5 budget is spent), but the SAME offender
+            // on a later, non-heartbeat suppression is counted yet not logged.
+            // SuppressedExceptions is a process-global counter the other tests also
+            // advance, so drive it to a known residue first: residue 50 puts the two
+            // calls below at xx51/xx52, clear of both the "<= 5" and "% 100 == 0"
+            // branches no matter what order xUnit ran the suite in.
+            while (FuseMessengerIsolationPatch.SuppressedExceptions % 100 != 50)
+            {
+                FuseMessengerIsolationPatch.Finalizer(new InvalidOperationException("warmup"), new object());
+            }
+
+            // A recipient type unique to this test, so its description is guaranteed
+            // absent from the remembered-offender set (i.e. genuinely "new").
+            var probe = new ThrottleProbe();
+            var weakAction = new WeakAction<MapDidLoadEvent>(probe, probe.Handler);
+
+            var loggedBeforeNew = FuseMessengerIsolationPatch.LoggedExceptions;
+            FuseMessengerIsolationPatch.Finalizer(new InvalidOperationException("first sighting"), weakAction);
+            var loggedAfterNew = FuseMessengerIsolationPatch.LoggedExceptions;
+
+            FuseMessengerIsolationPatch.Finalizer(new InvalidOperationException("repeat"), weakAction);
+            var loggedAfterRepeat = FuseMessengerIsolationPatch.LoggedExceptions;
+
+            Assert.Equal(loggedBeforeNew + 1, loggedAfterNew);   // new offender surfaced
+            Assert.Equal(loggedAfterNew, loggedAfterRepeat);     // repeat throttled away
+        }
+
         private void OnMapDidLoadThatThrows(MapDidLoadEvent message)
         {
             throw new InvalidOperationException("listener exploded");
+        }
+
+        // Distinct recipient type so its DescribeListener output is unique to this
+        // test and never collides with another test's remembered offender.
+        private sealed class ThrottleProbe
+        {
+            public void Handler(MapDidLoadEvent message)
+            {
+            }
         }
     }
 }

--- a/FUSE.Tests/Patches/FuseMessengerIsolationPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseMessengerIsolationPatchTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FUSE.Patches;
+using GalaSoft.MvvmLight.Helpers;
+using Game.Events;
+using HarmonyLib;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    /// <summary>
+    /// Targeting and direct-invocation tests for
+    /// <see cref="FuseMessengerIsolationPatch"/>.
+    ///
+    /// The patch closes <c>WeakAction&lt;T&gt;</c> over each map lifecycle
+    /// event struct and finalizes both dispatch entries
+    /// (<c>ExecuteWithObject(object)</c> and <c>Execute(T)</c>) so a
+    /// throwing listener is contained at its own boundary instead of
+    /// surfacing into the Messenger dispatch loop. Because the targets
+    /// are CONSTRUCTED generic methods, the highest-value regression
+    /// net here is target resolution against the real game DLLs: a
+    /// game update that renames an event struct, turns it into a
+    /// class, or reshapes WeakAction would silently detach the patch
+    /// at runtime — these tests fail instead.
+    ///
+    /// FUSE.Tests never applies Harmony patches (no Harmony instance,
+    /// no .Patch() calls — see FusePatchTargetingTests), so there is
+    /// deliberately no "apply + Send + assert listener B still ran"
+    /// integration test; the finalizer is exercised the same way
+    /// FusePrefabStoreMaterialDefinitionsPatchTests exercises its
+    /// patch bodies — as a plain static method.
+    /// </summary>
+    public class FuseMessengerIsolationPatchTests
+    {
+        // ---- target resolution against the real game assemblies ----
+
+        [Fact]
+        public void TargetMethods_ResolvesMapDidLoadEventInstantiation()
+        {
+            // The minimum guarantee: the event observed breaking in the
+            // wild stays guarded. typeof(MapDidLoadEvent) is a
+            // compile-time reference, so a game rename fails this test
+            // (and the build) rather than silently detaching the patch.
+            var targets = FuseMessengerIsolationPatch.TargetMethods().ToList();
+
+            var executeWithObject = AccessTools.Method(
+                typeof(WeakAction<MapDidLoadEvent>), "ExecuteWithObject", new[] { typeof(object) });
+            var execute = AccessTools.Method(
+                typeof(WeakAction<MapDidLoadEvent>), "Execute", new[] { typeof(MapDidLoadEvent) });
+
+            Assert.NotNull(executeWithObject);
+            Assert.NotNull(execute);
+            Assert.Contains(executeWithObject, targets);
+            Assert.Contains(execute, targets);
+        }
+
+        [Fact]
+        public void TargetMethods_CoverAllFourLifecycleEvents_WithBothDispatchEntries()
+        {
+            // Full expected surface: four lifecycle structs, two dispatch
+            // entries each. Compile-time typeofs again so any single
+            // event going missing or changing shape raises an alarm here
+            // instead of a runtime "stays unguarded" warning nobody reads.
+            var eventTypes = new[]
+            {
+                typeof(MapWillLoadEvent),
+                typeof(MapDidLoadEvent),
+                typeof(MapWillUnloadEvent),
+                typeof(MapDidUnloadEvent)
+            };
+
+            var expected = new HashSet<MethodBase>();
+            foreach (var eventType in eventTypes)
+            {
+                var weakActionType = typeof(WeakAction<>).MakeGenericType(eventType);
+                expected.Add(AccessTools.Method(weakActionType, "ExecuteWithObject", new[] { typeof(object) }));
+                expected.Add(AccessTools.Method(weakActionType, "Execute", new[] { eventType }));
+            }
+
+            var targets = new HashSet<MethodBase>(FuseMessengerIsolationPatch.TargetMethods());
+
+            Assert.DoesNotContain((MethodBase)null, expected);
+            Assert.Equal(expected.Count, targets.Count);
+            Assert.Subset(expected, targets);
+        }
+
+        [Fact]
+        public void TargetMethods_OnlyTargetValueTypeInstantiations()
+        {
+            // Pins the generic-method caveat the patch documents: the
+            // constructed-method approach is only sound for value-type
+            // arguments (unshared bodies). If a lifecycle event ever
+            // becomes a class, the patch must drop it — and this test
+            // makes that conversation happen at test time.
+            foreach (var target in FuseMessengerIsolationPatch.TargetMethods())
+            {
+                var declaringType = target.DeclaringType;
+                Assert.NotNull(declaringType);
+                Assert.True(declaringType.IsGenericType, $"{target} is not on a constructed generic type");
+                Assert.Equal(typeof(WeakAction<>), declaringType.GetGenericTypeDefinition());
+                Assert.True(
+                    declaringType.GetGenericArguments()[0].IsValueType,
+                    $"{target} closes WeakAction<T> over a reference type — shared canonical bodies make that patch unreliable");
+            }
+        }
+
+        // ---- finalizer contract (direct invocation, no Harmony apply) ----
+
+        [Fact]
+        public void Finalizer_NullException_ReturnsNull_AndDoesNotCount()
+        {
+            var before = FuseMessengerIsolationPatch.SuppressedExceptions;
+            var weakAction = new WeakAction<MapDidLoadEvent>(this, _ => { });
+
+            var result = FuseMessengerIsolationPatch.Finalizer(null, weakAction);
+
+            Assert.Null(result);
+            Assert.Equal(before, FuseMessengerIsolationPatch.SuppressedExceptions);
+        }
+
+        [Fact]
+        public void Finalizer_SuppressesListenerException_AndCountsIt()
+        {
+            var before = FuseMessengerIsolationPatch.SuppressedExceptions;
+            var weakAction = new WeakAction<MapDidLoadEvent>(this, OnMapDidLoadThatThrows);
+
+            var result = FuseMessengerIsolationPatch.Finalizer(
+                new InvalidOperationException("listener exploded"), weakAction);
+
+            // Returning null is what tells Harmony to swallow the
+            // exception so the dispatch loop never sees it.
+            Assert.Null(result);
+            Assert.Equal(before + 1, FuseMessengerIsolationPatch.SuppressedExceptions);
+        }
+
+        [Fact]
+        public void Finalizer_SurvivesNullInstance()
+        {
+            // __instance should never be null for an instance-method
+            // finalizer, but the diagnostics must hold up anyway — a
+            // throw from the finalizer would be strictly worse than the
+            // listener exception it replaces.
+            var result = FuseMessengerIsolationPatch.Finalizer(
+                new InvalidOperationException("listener exploded"), null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void DescribeListener_NamesRecipientTypeAndHandlerMethod()
+        {
+            // Pins the offender-naming promise against the REAL game type shape:
+            // WeakAction<T> hides the base 'Action' property with a same-named
+            // property of a different type, so a base-walking property lookup is
+            // an ambiguous match and would collapse every description to the
+            // fallback — the log would contain the suppression but never name
+            // who threw, which is the patch's entire reason to exist.
+            var weakAction = new WeakAction<MapDidLoadEvent>(this, OnMapDidLoadThatThrows);
+
+            var description = FuseMessengerIsolationPatch.DescribeListener(weakAction);
+
+            Assert.Contains(nameof(FuseMessengerIsolationPatchTests), description);
+            Assert.Contains(nameof(OnMapDidLoadThatThrows), description);
+            Assert.Contains(nameof(MapDidLoadEvent), description);
+            Assert.DoesNotContain("undescribable", description);
+        }
+
+        [Fact]
+        public void Finalizer_SurvivesForeignInstance()
+        {
+            // Defensive: DescribeListener reflects over the instance's
+            // actual type, so hand it something that is not a WeakAction
+            // at all and make sure suppression still happens cleanly.
+            var result = FuseMessengerIsolationPatch.Finalizer(
+                new InvalidOperationException("listener exploded"), new object());
+
+            Assert.Null(result);
+        }
+
+        private void OnMapDidLoadThatThrows(MapDidLoadEvent message)
+        {
+            throw new InvalidOperationException("listener exploded");
+        }
+    }
+}

--- a/FUSE.Tests/Validation/FuseDefinitionValidatorDeeperTests.CarTypeFilter.cs
+++ b/FUSE.Tests/Validation/FuseDefinitionValidatorDeeperTests.CarTypeFilter.cs
@@ -8,8 +8,10 @@ namespace FUSE.Tests.Validation
         /// <summary>
         /// Mirror of the FUSE.Core carTypeFilter tests for the shipping
         /// validator: the filter is matched verbatim per comma-separated
-        /// token at runtime, so surrounding whitespace is an error and an
-        /// empty token from a doubled/edge comma is a warning.
+        /// token at runtime, so surrounding whitespace can never match —
+        /// but legacy packages with padded tokens still loaded, so both
+        /// that and an empty token from a doubled/edge comma are warnings,
+        /// never errors.
         /// </summary>
         public class CarTypeFilterRules
         {
@@ -31,13 +33,14 @@ namespace FUSE.Tests.Validation
             }
 
             [Fact]
-            public void Component_Filter_With_Surrounding_Whitespace_Is_An_Error()
+            public void Component_Filter_With_Surrounding_Whitespace_Is_A_Warning()
             {
                 var result = NewValidator().Validate(WithComponentFilter("FB, XM"));
 
                 Assert.Contains(
-                    result.Errors,
-                    e => e.Code == MalformedCode && e.Field == "operations.industries.mill.components.dock.carTypeFilter");
+                    result.Warnings,
+                    w => w.Code == MalformedCode && w.Field == "operations.industries.mill.components.dock.carTypeFilter");
+                Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
             }
 
             [Fact]
@@ -46,7 +49,7 @@ namespace FUSE.Tests.Validation
                 var result = NewValidator().Validate(WithComponentFilter("FB,,XM"));
 
                 Assert.Contains(result.Warnings, w => w.Code == EmptyTokenCode);
-                Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
+                Assert.DoesNotContain(result.Warnings, w => w.Code == MalformedCode);
             }
 
             [Theory]
@@ -59,7 +62,7 @@ namespace FUSE.Tests.Validation
             {
                 var result = NewValidator().Validate(WithComponentFilter(filter));
 
-                Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
+                Assert.DoesNotContain(result.Warnings, w => w.Code == MalformedCode);
                 Assert.DoesNotContain(result.Warnings, w => w.Code == EmptyTokenCode);
             }
 
@@ -86,9 +89,9 @@ namespace FUSE.Tests.Validation
                 var result = NewValidator().Validate(definition);
 
                 Assert.Contains(
-                    result.Errors,
-                    e => e.Code == MalformedCode &&
-                         e.Field == "operations.industries.mill.components.team.teamProfiles.lumber.carTypeFilter");
+                    result.Warnings,
+                    w => w.Code == MalformedCode &&
+                         w.Field == "operations.industries.mill.components.team.teamProfiles.lumber.carTypeFilter");
             }
 
             [Fact]
@@ -100,8 +103,8 @@ namespace FUSE.Tests.Validation
                 var result = NewValidator().Validate(definition);
 
                 Assert.Contains(
-                    result.Errors,
-                    e => e.Code == MalformedCode && e.Field == "operations.loads.coal.carTypeFilter");
+                    result.Warnings,
+                    w => w.Code == MalformedCode && w.Field == "operations.loads.coal.carTypeFilter");
             }
 
             [Fact]
@@ -133,9 +136,22 @@ namespace FUSE.Tests.Validation
                 var result = NewValidator().Validate(definition);
 
                 Assert.Contains(
-                    result.Errors,
-                    e => e.Code == MalformedCode &&
-                         e.Field == "progression.progressions.main.sections.s1.deliveryPhases[0].deliveries[0].carTypeFilter");
+                    result.Warnings,
+                    w => w.Code == MalformedCode &&
+                         w.Field == "progression.progressions.main.sections.s1.deliveryPhases[0].deliveries[0].carTypeFilter");
+            }
+
+            [Fact]
+            public void Legacy_Padded_Filter_Stays_Valid()
+            {
+                // Padded filters shipped in legacy packages and loaded fine
+                // there, so the definition must stay loadable: warning, not
+                // error.
+                var result = NewValidator().Validate(WithComponentFilter("HM, HT"));
+
+                Assert.Contains(result.Warnings, w => w.Code == MalformedCode);
+                Assert.DoesNotContain(result.Errors, e => e.Code == MalformedCode);
+                Assert.True(result.IsValid);
             }
         }
     }

--- a/FUSE/Authoring/Validation/FuseDefinitionValidator.cs
+++ b/FUSE/Authoring/Validation/FuseDefinitionValidator.cs
@@ -980,7 +980,11 @@ namespace FUSE.Authoring.Validation
             // Empty and "*" both mean "any car type" at runtime, so only a
             // filter with real tokens needs checking. The game splits the
             // expression on ',' without trimming, so a token with surrounding
-            // whitespace can never match a car type.
+            // whitespace can never match a car type. That is still only a
+            // warning, not an error: packages with padded tokens loaded and
+            // ran under the legacy modding stack, so FUSE must load them
+            // too — the warning plus its fix hint tells the author how to
+            // repair the filter.
             if (string.IsNullOrWhiteSpace(filter) || filter == "*")
             {
                 return;
@@ -996,7 +1000,7 @@ namespace FUSE.Authoring.Validation
                 }
                 else if (token.Trim().Length != token.Length)
                 {
-                    result.AddError(path, $"Car type filter entry '{token}' has surrounding whitespace and can never match a car type; write the filter without spaces (e.g. \"FB,XM\").", "fuse.operations.component.carTypeFilter.malformed", filter);
+                    result.AddWarning(path, $"Car type filter entry '{token}' has surrounding whitespace and can never match a car type; write the filter without spaces (e.g. \"FB,XM\").", "fuse.operations.component.carTypeFilter.malformed", filter);
                 }
             }
         }

--- a/FUSE/Interface/FuseLoadingScreen.cs
+++ b/FUSE/Interface/FuseLoadingScreen.cs
@@ -39,6 +39,7 @@ namespace FUSE.Interface
 
         private GameObject _stockLoadingScreen;
         private bool _renderedOnce;
+        private float _loadBeganAt;
         private bool _renderingDisabled;
         private bool _renderFailureLogged;
 
@@ -182,6 +183,7 @@ namespace FUSE.Interface
         {
             _state.BeginLoad(Now);
             _renderedOnce = false;
+            _loadBeganAt = Now;
             FuseLog.Info($"FUSE enhanced loading screen shown ({reason}).");
         }
 
@@ -199,10 +201,30 @@ namespace FUSE.Interface
 
         private void Update()
         {
+            // Capture the pre-update state: UpdateVisibility flips Active off exactly
+            // once, so wasActive distinguishes "the gate just closed" from "still
+            // hidden", and the gate flags read before the flip classify the close
+            // reason even if a future refactor resets them on close.
+            var wasActive = _state.Active;
+            var gameScreenHidden = _state.GameScreenHidden;
+            var fusePipelineDone = _state.FusePipelineDone;
+
             if (!_state.UpdateVisibility(Now))
             {
-                // Either still hidden, or the gate just closed. We never re-show the
-                // stock screen on a normal hide — the game has already hidden it.
+                // We never re-show the stock screen on a normal hide — the game has
+                // already hidden it. Abort paths close the state synchronously and
+                // log on their own, so they never surface as a transition here.
+                if (wasActive)
+                {
+                    // Both flags set means the two-flag gate released; anything else
+                    // can only be the watchdog backstop. renderFailed marks the OnGUI
+                    // fallback where the stock screen carried the load, so this line
+                    // can't read as a healthy FUSE-screen session in that case.
+                    var watchdog = !(gameScreenHidden && fusePipelineDone);
+                    FuseLog.Info(
+                        $"FUSE enhanced loading screen hidden (gameScreenHidden={gameScreenHidden}, fusePipelineDone={fusePipelineDone}, watchdog={watchdog}, renderFailed={_renderingDisabled}) after {Now - _loadBeganAt:0.0}s.");
+                }
+
                 return;
             }
 

--- a/FUSE/Loading/FuseAssetPackRegistry.LegacyAlias.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.LegacyAlias.cs
@@ -126,8 +126,11 @@ namespace FUSE.Loading
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
             {
-                FuseLog.Exception(
-                    $"FUSE could not inspect asset pack Catalog.json '{catalogPath}' for legacy aliases", ex);
+                // Warning, not error: Catalog.json is third-party data and this inspection is
+                // best-effort — the path-derived aliases were already registered above, so only
+                // the optional catalog-declared aliases are lost when the file is unreadable.
+                FuseLog.Warning(
+                    $"FUSE could not inspect asset pack Catalog.json '{catalogPath}' for legacy aliases: {ex.Message}");
             }
         }
 

--- a/FUSE/Patches/FuseMessengerIsolationPatch.cs
+++ b/FUSE/Patches/FuseMessengerIsolationPatch.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using FUSE.Infrastructure;
+using GalaSoft.MvvmLight.Helpers;
+using HarmonyLib;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Contains exceptions thrown by map lifecycle event listeners so one broken
+    /// listener can never disturb delivery to anyone else — and so the offender is
+    /// actually NAMED in the log.
+    ///
+    /// The game broadcasts <c>MapWillLoadEvent</c> / <c>MapDidLoadEvent</c> /
+    /// <c>MapWillUnloadEvent</c> / <c>MapDidUnloadEvent</c> through MvvmLight's
+    /// <c>Messenger</c>, and every mod plus a number of scene components register
+    /// handlers for them — many during the load sequence itself. A handler that
+    /// throws (observed in the wild: a stale third-party mod whose MapDidLoadEvent
+    /// handler died in a TypeLoadException before its first statement ran) surfaces
+    /// as a raw exception inside the dispatch loop. The game's dispatch logs such
+    /// failures generically and moves on, but that log line does not identify which
+    /// registered recipient failed — a JIT-time type-load failure never even enters
+    /// the handler, so no mod frame appears — and nothing guards
+    /// <see cref="WeakAction"/> invocations that happen outside that one loop. As
+    /// the mod-compat layer, FUSE pins the containment to the WeakAction itself:
+    /// the exception is suppressed at the listener boundary, counted, and logged
+    /// (throttled) with the recipient type and handler method name, and dispatch
+    /// continues so later-registered listeners still receive the event.
+    ///
+    /// Deliberately scoped to the four map lifecycle events only — this is not a
+    /// blanket "never throw from Messenger" patch; every other event keeps its
+    /// stock semantics.
+    ///
+    /// Generic-method caveat: this targets the CONSTRUCTED <c>WeakAction&lt;T&gt;</c>
+    /// methods, one instantiation per event type. That is only reliable because
+    /// every lifecycle event is a struct: each value-type instantiation gets its own
+    /// unshared method body, so the patch lands on exactly that instantiation.
+    /// Reference-type arguments share one canonical body — patching it is unreliable
+    /// and can bleed into unrelated instantiations — so a class-typed event must
+    /// never be added to <see cref="LifecycleEventTypeNames"/>; TargetMethods
+    /// enforces this with an IsValueType guard.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FuseMessengerIsolationPatch
+    {
+        // Resolved by name (rather than typeof) so a game update that renames or
+        // removes one event skips that entry with a warning instead of failing the
+        // whole patch class. (If EVERY entry failed to resolve, the empty target
+        // set would make Harmony reject the class as a whole — FusePatchResilience
+        // contains that to a logged skip of this one class.)
+        private static readonly string[] LifecycleEventTypeNames =
+        {
+            "Game.Events.MapWillLoadEvent",
+            "Game.Events.MapDidLoadEvent",
+            "Game.Events.MapWillUnloadEvent",
+            "Game.Events.MapDidUnloadEvent"
+        };
+
+        private static long _suppressed;
+        private static long _diagnosticFailures;
+
+        // Offenders already named in the log, so a NEW broken listener is always
+        // reported even after the global first-5 budget is spent (otherwise a noisy
+        // mod could burn the budget and a second offender would stay anonymous until
+        // the every-100th heartbeat). Bounded so the set cannot grow without limit.
+        private const int MaxRememberedOffenders = 32;
+        private static readonly HashSet<string> _loggedOffenders = new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>Exceptions suppressed since startup (diagnostics).</summary>
+        internal static long SuppressedExceptions => _suppressed;
+
+        /// <summary>Log attempts the finalizer had to abandon (diagnostics).</summary>
+        internal static long DiagnosticFailures => _diagnosticFailures;
+
+        internal static IEnumerable<MethodBase> TargetMethods()
+        {
+            var targets = new HashSet<MethodBase>();
+            foreach (var eventTypeName in LifecycleEventTypeNames)
+            {
+                // The lifecycle events ship in the same assembly as WeakAction
+                // itself, so prefer that direct lookup; fall back to a global
+                // search in case a game update ever moves them.
+                var eventType = typeof(WeakAction<>).Assembly.GetType(eventTypeName)
+                                ?? AccessTools.TypeByName(eventTypeName);
+                if (eventType == null)
+                {
+                    FuseLog.Warning(
+                        $"FUSE messenger isolation could not resolve lifecycle event type '{eventTypeName}'; " +
+                        "listeners for that event stay unguarded. Remaining lifecycle events are still patched.");
+                    continue;
+                }
+
+                if (!eventType.IsValueType)
+                {
+                    // See the class comment: a reference-type event would patch the
+                    // shared canonical WeakAction<T> body, which is unreliable and
+                    // can affect unrelated instantiations. Refuse rather than risk it.
+                    FuseLog.Warning(
+                        $"FUSE messenger isolation skipped '{eventTypeName}' because it is not a value type; " +
+                        "listeners for that event stay unguarded.");
+                    continue;
+                }
+
+                Type weakActionType;
+                try
+                {
+                    weakActionType = typeof(WeakAction<>).MakeGenericType(eventType);
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE messenger isolation could not construct WeakAction<{eventType.Name}>: " +
+                        $"{ex.GetBaseException().Message}. Listeners for that event stay unguarded.");
+                    continue;
+                }
+
+                // ExecuteWithObject(object) is the entry the Messenger dispatch loop
+                // calls; Execute(T) sits underneath it and is also reachable directly,
+                // so guard both. When Execute(T) suppresses, ExecuteWithObject simply
+                // completes — the throttled log line fires once per failure.
+                AddTarget(targets, weakActionType, eventType, "ExecuteWithObject", new[] { typeof(object) });
+                AddTarget(targets, weakActionType, eventType, "Execute", new[] { eventType });
+            }
+
+            return targets;
+        }
+
+        private static void AddTarget(
+            HashSet<MethodBase> targets,
+            Type weakActionType,
+            Type eventType,
+            string methodName,
+            Type[] parameterTypes)
+        {
+            var method = AccessTools.Method(weakActionType, methodName, parameterTypes);
+            if (method == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE messenger isolation could not resolve WeakAction<{eventType.Name}>.{methodName}; " +
+                    "that dispatch path stays unguarded.");
+                return;
+            }
+
+            targets.Add(method);
+        }
+
+        internal static Exception Finalizer(Exception __exception, object __instance)
+        {
+            if (__exception == null)
+            {
+                return null;
+            }
+
+            _suppressed++;
+            try
+            {
+                // First few individually, every previously-unseen offender once, then
+                // heartbeat only — a permanently-broken listener re-throws on every
+                // map load/unload it survives to see. Logged with the full exception
+                // (not just the message): suppressing here also silences the game's
+                // own dispatch-loop log line, so this line must carry the stack.
+                var listener = DescribeListener(__instance);
+                var newOffender = _loggedOffenders.Count < MaxRememberedOffenders && _loggedOffenders.Add(listener);
+                if (_suppressed <= 5 || newOffender || _suppressed % 100 == 0)
+                {
+                    FuseLog.Exception(
+                        $"FUSE contained map lifecycle listener exception #{_suppressed} from {listener}; " +
+                        "the exception was suppressed and dispatch continued, so later-registered listeners " +
+                        "still received the event", __exception);
+                }
+            }
+            catch
+            {
+                // Diagnostics are best-effort; the whole point of this patch is that
+                // nothing thrown here may leak back into the dispatch loop. Count the
+                // abandoned log attempt so the readout can reveal a broken log path.
+                _diagnosticFailures++;
+            }
+
+            return null;
+        }
+
+        internal static string DescribeListener(object weakAction)
+        {
+            try
+            {
+                if (weakAction == null)
+                {
+                    return "<unknown listener>";
+                }
+
+                var type = weakAction.GetType();
+                var eventName = type.IsGenericType ? type.GetGenericArguments()[0].Name : type.Name;
+
+                // The recipient passed to Messenger.Register is what users recognise;
+                // it can already be collected (WeakReference), so fall back to the
+                // handler delegate's declaring type when it is gone.
+                var recipientType = (weakAction as WeakAction)?.Target?.GetType().FullName;
+
+                // The constructed WeakAction<T> hides the base 'Action' slot with its
+                // own typed property — same name, DIFFERENT property type — so a
+                // base-walking lookup (AccessTools.Property/GetProperty) is an
+                // ambiguous match; only the declared-property lookup resolves it.
+                // Best-effort in its own guard so the recipient/event naming above
+                // still reaches the log if the delegate lookup ever breaks.
+                string methodName = null;
+                try
+                {
+                    if (AccessTools.DeclaredProperty(type, "Action")?.GetValue(weakAction, null) is Delegate action &&
+                        action.Method != null)
+                    {
+                        methodName = action.Method.Name;
+                        recipientType = recipientType ?? action.Method.DeclaringType?.FullName;
+                    }
+                }
+                catch
+                {
+                    // Keep recipientType/eventName; only the handler name is lost.
+                    // Counted so the readout reveals a degraded delegate lookup.
+                    _diagnosticFailures++;
+                }
+
+                var handler = recipientType ?? "<collected recipient>";
+                if (methodName != null)
+                {
+                    handler = handler + "." + methodName;
+                }
+
+                return $"'{handler}' (event {eventName})";
+            }
+            catch
+            {
+                return "<undescribable listener>";
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseMessengerIsolationPatch.cs
+++ b/FUSE/Patches/FuseMessengerIsolationPatch.cs
@@ -59,6 +59,7 @@ namespace FUSE.Patches
 
         private static long _suppressed;
         private static long _diagnosticFailures;
+        private static long _logged;
 
         // Offenders already named in the log, so a NEW broken listener is always
         // reported even after the global first-5 budget is spent (otherwise a noisy
@@ -73,14 +74,21 @@ namespace FUSE.Patches
         /// <summary>Log attempts the finalizer had to abandon (diagnostics).</summary>
         internal static long DiagnosticFailures => _diagnosticFailures;
 
+        /// <summary>Suppressed exceptions actually surfaced to the log, i.e. not throttled (diagnostics).</summary>
+        internal static long LoggedExceptions => _logged;
+
         internal static IEnumerable<MethodBase> TargetMethods()
         {
             var targets = new HashSet<MethodBase>();
             foreach (var eventTypeName in LifecycleEventTypeNames)
             {
-                // The lifecycle events ship in the same assembly as WeakAction
-                // itself, so prefer that direct lookup; fall back to a global
-                // search in case a game update ever moves them.
+                // WeakAction<T> and the lifecycle event structs are defined in the
+                // SAME assembly: MvvmLight is compiled into the game's Assembly-CSharp
+                // rather than shipped as a separate DLL, so only the namespace differs
+                // (GalaSoft.MvvmLight.Helpers vs Game.Events), not the assembly. That
+                // makes typeof(WeakAction<>).Assembly.GetType the path actually taken;
+                // AccessTools.TypeByName is a cross-assembly fallback that only engages
+                // if a future game build relocates the events.
                 var eventType = typeof(WeakAction<>).Assembly.GetType(eventTypeName)
                                 ?? AccessTools.TypeByName(eventTypeName);
                 if (eventType == null)
@@ -168,6 +176,7 @@ namespace FUSE.Patches
                         $"FUSE contained map lifecycle listener exception #{_suppressed} from {listener}; " +
                         "the exception was suppressed and dispatch continued, so later-registered listeners " +
                         "still received the event", __exception);
+                    _logged++;
                 }
             }
             catch


### PR DESCRIPTION
## 🔗 Related Issue

No tracked issue — incident response to the post-merge faults observed on 2026-06-10 (six installed legacy packages failing to load after #82 landed, diagnosed from `Player.log`/`FUSE.log`). Touches behavior introduced in #82 (validation severity) and #83 (loading screen observability).

## 📝 Description of the Change

Four changes, one incident:

**1. `carTypeFilter` whitespace tokens are a warning, not a load-blocking error** (both validator twins, help catalog, both test suites). The game's car-type filter matching splits on `,` without trimming, so a padded token like `" HT"` in `"HM, HT"` can never match — the rule's premise is correct. But packages with padded tokens loaded and ran under the legacy modding stack (the dud tokens silently matched nothing), and the hard error introduced in #82 failed the **entire package** at deserialization: six installed mods (Collie Ela Revamp, Barkers Creek, Bryson Removal, ACM-Alarka, Sylva Remodel, AspenCrazyMap) vanished, and their missing industries/track cascaded into `InvalidOpsCarPositionException` waybill faults and `Segment not found` errors on every save load. The demotion restores legacy load parity; the warning (with its existing fix-hint catalog entry) still tells authors how to repair the filter, and `fuse-convert --strict` still fails on it for native authoring pipelines.

**2. Catalog.json legacy-alias inspection failures are a warning.** The inspection is best-effort over third-party data; the caller registers all path-derived aliases before it runs, so a malformed `Catalog.json` loses only the optional catalog-declared aliases. Was logging at ERROR with a full stack for ~13 third-party packs on every boot.

**3. New `FuseMessengerIsolationPatch`** — Harmony finalizers on the constructed `WeakAction<T>.ExecuteWithObject(object)`/`Execute(T)` for the four map lifecycle event structs (`MapWillLoadEvent`, `MapDidLoadEvent`, `MapWillUnloadEvent`, `MapDidUnloadEvent`). A throwing listener (observed in the wild: a stale third-party mod whose `MapDidLoadEvent` handler dies in a `TypeLoadException` before its first statement) is contained at its own boundary, counted, and logged with the **recipient type and handler method name** plus the full exception; dispatch continues. The stock dispatch log line is generic and cannot identify the offender — a JIT-time type-load failure never enters the handler, so no mod frame appears in the stack. Targeting is value-type-only (each struct instantiation has its own unshared method body, the reliable constructed-generic case; a class-typed event is refused with a warning), event types resolve by name so a game rename degrades to a logged skip, and the patch is always-on following the `FuseCurveMeshCullingGuardPatch` precedent (ungated safety finalizer, throttled logging, static counters). Registration rides the existing `FusePatchResilience.ApplyAll` assembly scan.

**4. Loading-screen hide-transition logging** (observability only, no behavior change). The enhanced loading screen's gate close was silent, which made the post-merge loading-screen behavior impossible to reconstruct from logs. The host now emits exactly one line on the visible→hidden transition with the gate flags, watchdog classification, render-failure flag, and elapsed seconds. Gate flags are captured before `UpdateVisibility` so a future refactor that resets state on close cannot mislabel the line; abort paths close synchronously and keep their existing log lines, so no double-logging.

## 🔄 Alternatives Considered

- **Trim filter tokens at load/convert time** instead of demoting: would make padded filters match as the author intended, but that *changes runtime ops behavior vs. legacy* (industries would start accepting car types they never accepted), so it was rejected in favor of exact parity. Trimming remains available to authors via the fix hint.
- **Legacy-only severity branch** (error for FUSE-native packages, warning for converted ones): rejected — a dud filter token never makes applying a definition unsafe, so warning is the right severity everywhere; `--strict` already provides the hard gate where one is wanted.
- **Transpiler on `Messenger.SendToList`** for listener isolation: rejected — `SendToList<TMessage>` is a generic method and a transpiler there is far more fragile than finalizers on the value-type `WeakAction<T>` instantiations, which Harmony detours reliably.

## ⚠️ Possible Drawbacks

- A package whose only issue is a padded filter now loads with the filter silently matching nothing (exactly the legacy behavior). The itemized warning no longer appears at definition-load time (that log loop lives in the failure branch); it still surfaces once per map load via the preflight/apply report, in the console `validate` command, and in the editor validation panel.
- Suppressing lifecycle listener exceptions means the game's own generic dispatch-loop log line no longer fires for those four events — it is replaced by FUSE's attributed line (first 5 occurrences, every previously-unseen offender, then every 100th, full stack included).
- Save compatibility: strictly improves — restores pre-#82 loading for existing installs; no save format changes.

## ✅ Verification Process

- Full solution build: 0 errors. Full test run: **1552 passed, 0 failed** across FUSE.Tests (1383, net48 against the real game assemblies), FUSE.Core.Tests (63), FUSE.LiveHarness.Tests (10), FUSE.ExternalEditor.UiTests (96). Slopwatch clean.
- The load path was traced end-to-end for the demotion: `ValidateCarTypeFilter` → `ValidationResult.IsValid` (errors-only, both twins) → `FuseModLoader.LoadDefinition` (no throw) → `RunPreflightValidation` (warnings never go Fatal) → fault registry/health UI (warnings never count as faults) → CLI exit codes (`0` default, non-zero with `--strict`). All eight padded-filter values from the incident logs were checked against the validator branches — every one is now warning-only, and the six packages' remaining findings (`fuse.track.segment.external` etc.) were already warnings.
- Adversarial review caught a real bug in the first cut of the isolation patch: the game's `WeakAction<T>` hides the base `Action` property with a same-named property of a different type, so a base-walking property lookup throws `AmbiguousMatchException` and every offender would have logged as `<undescribable listener>`. Fixed with `AccessTools.DeclaredProperty` plus an inner guard that preserves recipient/event naming, and pinned by `DescribeListener_NamesRecipientTypeAndHandlerMethod`, which runs against the real game type shape on net48 and fails if the lookup regresses.
- New targeting tests resolve all 8 constructed methods against the real game DLLs (compile-time `typeof`s, so a game rename breaks the build/test rather than silently detaching the patch) and pin the value-type-only invariant.
- **Pending in-game verification**: next session should show the six packages loading (no `carTypeFilter.malformed` faults), the `FUSE applied Harmony patch class 'FUSE.Patches.FuseMessengerIsolationPatch'` line, an attributed containment line for the stale third-party mod's `MapDidLoadEvent` handler, and the new `FUSE enhanced loading screen hidden (...)` line.

## 💡 Additional Information

The new hide-transition log line is deliberately ahead of the upcoming loading-screen behavior work — it gives the next play session the diagnostics that this round's investigation lacked. Harmony detour application to the constructed generic methods is only provable in-game (FUSE.Tests deliberately never applies patches); if application ever fails, `FusePatchResilience` contains it to a logged skip of this one patch class.
