### PR TITLE
NarrowGauge

### DIFF
--- a/FUSE.Tests/API/TrackApiCompanionExtensionTests.cs
+++ b/FUSE.Tests/API/TrackApiCompanionExtensionTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Reflection;
+using FUSE.Authoring.Data;
+using FUSE.Runtime.API;
+using FUSE.Runtime.Events;
+using Xunit;
+
+namespace FUSE.Tests.API
+{
+    public sealed class TrackApiCompanionExtensionTests
+    {
+        [Fact]
+        public void TrackGraphApplying_PublishesContextToCompanionModules()
+        {
+            FuseTrackGraphApplyingContext received = null;
+            Action<FuseTrackGraphApplyingContext> handler = context => received = context;
+            FuseEvents.TrackGraphApplying += handler;
+
+            try
+            {
+                FuseEvents.RaiseTrackGraphApplying(null);
+                Assert.NotNull(received);
+                Assert.Null(received.Graph);
+            }
+            finally
+            {
+                FuseEvents.TrackGraphApplying -= handler;
+            }
+        }
+
+        [Fact]
+        public void CloneSegmentDefinition_PreservesCompanionMetadata()
+        {
+            var source = new FuseSegment
+            {
+                StartNodeId = "a",
+                EndNodeId = "b",
+                Gauge = "DualGauge",
+                Partial = true,
+                PreserveStyle = true,
+                PreserveTrackClass = true,
+                PreserveSpeedLimit = true,
+                PreservePriority = true,
+                PreserveGroupId = true
+            };
+
+            MethodInfo cloneMethod = typeof(TrackAPI).GetMethod(
+                "CloneSegmentDefinition",
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+            Assert.NotNull(cloneMethod);
+            var clone = Assert.IsType<FuseSegment>(cloneMethod.Invoke(null, new object[] { source }));
+
+            Assert.Equal("DualGauge", clone.Gauge);
+            Assert.True(clone.Partial);
+            Assert.True(clone.PreserveStyle);
+            Assert.True(clone.PreserveTrackClass);
+            Assert.True(clone.PreserveSpeedLimit);
+            Assert.True(clone.PreservePriority);
+            Assert.True(clone.PreserveGroupId);
+        }
+    }
+}

--- a/FUSE/Runtime/API/TrackAPI.Helpers.cs
+++ b/FUSE/Runtime/API/TrackAPI.Helpers.cs
@@ -67,7 +67,14 @@ namespace FUSE.Runtime.API
                 SpeedLimit = definition.SpeedLimit,
                 Priority = definition.Priority,
                 GroupId = definition.GroupId,
-                Tags = definition.Tags?.ToArray()
+                Tags = definition.Tags?.ToArray(),
+                Gauge = definition.Gauge,
+                Partial = definition.Partial,
+                PreserveStyle = definition.PreserveStyle,
+                PreserveTrackClass = definition.PreserveTrackClass,
+                PreserveSpeedLimit = definition.PreserveSpeedLimit,
+                PreservePriority = definition.PreservePriority,
+                PreserveGroupId = definition.PreserveGroupId
             };
         }
 

--- a/FUSE/Runtime/API/TrackAPI.cs
+++ b/FUSE/Runtime/API/TrackAPI.cs
@@ -79,6 +79,20 @@ namespace FUSE.Runtime.API
         public static void RebuildGraph()
         {
             _rebuildRequested = false;
+
+            BeginBatch();
+            try
+            {
+                FuseEvents.RaiseTrackGraphApplying(RequireGraph());
+            }
+            finally
+            {
+                // Changes made by TrackGraphApplying subscribers are included in
+                // the rebuild below, so do not leave a second rebuild queued.
+                EndBatch(false);
+                _rebuildRequested = false;
+            }
+
             var manager = TrackObjectManager.Instance;
             if (manager != null)
             {

--- a/FUSE/Runtime/Events/FuseEvents.cs
+++ b/FUSE/Runtime/Events/FuseEvents.cs
@@ -1,10 +1,26 @@
 using System;
 using FUSE.Authoring.Validation;
+using FUSE.Infrastructure;
 using Model.Ops;
 using Track;
 
 namespace FUSE.Runtime.Events
 {
+    /// <summary>
+    /// Published immediately before FUSE rebuilds Railroader's native track graph.
+    /// Handlers run inside a TrackAPI batch, so companion modules may use public
+    /// TrackAPI methods without causing a nested or additional graph rebuild.
+    /// </summary>
+    public sealed class FuseTrackGraphApplyingContext
+    {
+        internal FuseTrackGraphApplyingContext(Graph graph)
+        {
+            Graph = graph;
+        }
+
+        public Graph Graph { get; }
+    }
+
     public static class FuseEvents
     {
         public static event Action FuseLoaded;
@@ -24,6 +40,7 @@ namespace FUSE.Runtime.Events
         public static event Action<IndustryComponent> IndustryComponentAdded;
         public static event Action<IndustryComponent> IndustryComponentUpdated;
         public static event Action<string> IndustryComponentRemoved;
+        public static event Action<FuseTrackGraphApplyingContext> TrackGraphApplying;
         public static event Action GraphRebuilt;
         public static event Action<string, ValidationResult> ValidationCompleted;
         public static event Action<string> ModLoaded;
@@ -112,6 +129,30 @@ namespace FUSE.Runtime.Events
         public static void RaiseIndustryComponentRemoved(string id)
         {
             IndustryComponentRemoved?.Invoke(id);
+        }
+
+        internal static void RaiseTrackGraphApplying(Graph graph)
+        {
+            var handlers = TrackGraphApplying;
+            if (handlers == null)
+            {
+                return;
+            }
+
+            var context = new FuseTrackGraphApplyingContext(graph);
+            foreach (Action<FuseTrackGraphApplyingContext> handler in handlers.GetInvocationList())
+            {
+                try
+                {
+                    handler(context);
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception(
+                        $"FUSE track-graph applying subscriber '{handler.Method?.DeclaringType?.FullName ?? "<unknown>"}.{handler.Method?.Name ?? "<unknown>"}' failed",
+                        ex);
+                }
+            }
         }
 
         public static void RaiseGraphRebuilt()


### PR DESCRIPTION
## 🔗 Related Issue

No public issue currently exists. This change implements the maintainer-endorsed FUSE extension points required by the separate `FUSE.NarrowGauge` companion module.

## 📝 Description of the Change

This PR adds generic public APIs that companion modules can use to safely extend FUSE-managed track graphs immediately before a graph rebuild.

### Track graph applying event

Adds `FuseEvents.TrackGraphApplying`, which publishes a `FuseTrackGraphApplyingContext` containing the active Railroader `Graph`.

`TrackAPI.RebuildGraph()` raises this event immediately before rebuilding the native track graph. Subscribers execute inside a `TrackAPI` batch, allowing companion modules to add or update nodes and segments without triggering nested or additional rebuilds.

Subscribers are invoked independently. Exceptions are logged and contained so one failing companion module does not prevent other subscribers or the graph rebuild from running.

### Segment metadata preservation

Updates `TrackAPI.CloneSegmentDefinition(...)` to preserve:

- `Gauge`
- `Partial`
- `PreserveStyle`
- `PreserveTrackClass`
- `PreserveSpeedLimit`
- `PreservePriority`
- `PreserveGroupId`

This ensures companion modules receive complete runtime segment definitions through `TrackAPI.GetSegmentDefinition(...)`.

### Tests

Adds unit tests confirming that:

- `TrackGraphApplying` publishes its context to subscribers.
- Cloned segment definitions preserve all companion metadata.

All narrow-gauge-specific topology, geometry, and rendering remain in the separate `FUSE.NarrowGauge` module. This PR only adds generic FUSE extension points.

## 🔄 Alternatives Considered

### Integrating Narrow Gauge directly into FUSE

This would tightly couple experimental narrow-gauge topology and special-work rendering to FUSE. Keeping the implementation in a companion module allows it to evolve independently while FUSE exposes reusable APIs.

### Modifying the graph after `GraphRebuilt`

Post-rebuild changes would require another rebuild and could create an intermediate invalid graph state. Raising the event immediately before the existing rebuild includes subscriber changes in the same operation.

### Using Harmony patches or private FUSE loader internals

This would be brittle and likely to break as FUSE internals change. The public event and existing `TrackAPI` methods provide a deliberate integration path.

### Scanning installed JSON files for gauge metadata

Installed files may not represent the final merged runtime definition. Preserving metadata through `GetSegmentDefinition(...)` lets companion modules consume FUSE’s authoritative runtime state.

## ⚠️ Possible Drawbacks

- Subscribers can modify the graph before every rebuild. Incorrect subscriber behavior could create invalid topology.
- Subscriber exceptions are contained, but changes made before an exception cannot automatically be rolled back.
- The new event and context become public API surface that FUSE must maintain.
- Existing mods require no changes.
- Existing saves remain compatible because this does not alter saved data or existing authored definitions.

## ✅ Verification Process

- Ran `git diff --check` successfully.
- Built FUSE from the `NarrowGauge` branch in Release configuration:
  - 0 warnings
  - 0 errors
- Ran the FUSE unit test suite:
  - 1,249 passed
  - 0 failed
  - 0 skipped
- Built and deployed `FUSE.NarrowGauge` against the updated FUSE API:
  - 0 warnings
  - 0 errors
- Verified the deployed FUSE DLL matched the compiled DLL byte-for-byte.
- Verified in Railroader that `FUSE.NarrowGauge` loads correctly and generated narrow-gauge and dual-gauge graph synchronization works with the updated FUSE build.

## 💡 Additional Information

`FUSE.NarrowGauge` uses `TrackGraphApplying` to synchronize generated native graph nodes and segments through public `TrackAPI` methods before FUSE performs its existing rebuild.

The companion module reads gauge metadata through `TrackAPI.GetSegmentDefinition(...)` and does not depend on FUSE private loader types, Harmony patches, or installed-file scanning.