### PR TITLE
ci: bound Actions artifact storage so editor publishes stay tiny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,17 @@ jobs:
       - name: Run tests
         run: dotnet test FUSE.Tests/FUSE.Tests.csproj -c Debug --verbosity minimal --logger "trx;LogFileName=test-results.trx" --results-directory FUSE.Tests/TestResults
 
+      # continue-on-error: a storage-quota or transient upload hiccup must never
+      # fail the job after the build + tests have already passed. Short retention
+      # keeps debug artifacts from accumulating against the Actions storage quota.
       - name: Upload test results
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results
           path: FUSE.Tests/TestResults/test-results.trx
-          retention-days: 7
+          retention-days: 3
 
       # --- EditMode Unity tests (FUSE.UnityTests/) ---
       # These exercise SceneCloneAPI.ApplyDefinition,
@@ -220,11 +224,12 @@ jobs:
 
       - name: Upload EditMode test results
         if: always() && steps.editmode_gate.outputs.enabled == 'true' && steps.unity_probe.outputs.available == 'true'
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unity-editmode-results
           path: FUSE.UnityTests/TestResults/editmode-results.xml
-          retention-days: 7
+          retention-days: 3
 
       # --- Build a stamped Release zip and attach it as a workflow artifact.
       # Runs on both PR and push events; PR runs additionally get a sticky comment.
@@ -336,7 +341,7 @@ jobs:
         with:
           name: ${{ steps.build_id.outputs.archive }}
           path: ${{ steps.build_id.outputs.archive }}
-          retention-days: 30
+          retention-days: 14
           if-no-files-found: error
 
       # Posts (or updates, on re-runs) a single PR comment with the download link.
@@ -365,7 +370,7 @@ jobs:
             2. Replace `Railroader/Mods/FUSE/` with the extracted `FUSE/` folder
             3. Launch Railroader; verify with `/fuse.report`
 
-            > Artifact retention: 30 days. This comment refreshes automatically on each push to the PR.
+            > Artifact retention: 14 days. This comment refreshes automatically on each push to the PR.
 
   # Cross-platform editor lane. Builds the game-free net10 projects (FUSE.Core,
   # FUSE.ExternalEditor, the converter's net10 facet) on a STOCK GitHub runner —
@@ -410,18 +415,28 @@ jobs:
             dotnet publish FUSE.ExternalEditor/FUSE.ExternalEditor.csproj -c Release -r $rid --self-contained false -o publish/$rid
           done
 
+      # Keep this artifact's storage footprint tiny. It is ~60 MB per run (three
+      # framework-dependent RID publishes), so retaining a copy for every PR push
+      # is what exhausts the Actions storage quota. The publish STEP above still
+      # runs on PRs as a build smoke test; we just don't retain its output there
+      # (skip the upload on pull_request events). On main/manual runs we keep a
+      # short-lived copy for grabbing the latest editor build. continue-on-error
+      # so a quota/transient upload failure can never fail this job after the
+      # build + tests have passed.
       - name: Upload editor publish artifacts
-        if: always()
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuse-external-editor
           path: publish/
-          retention-days: 14
+          retention-days: 2
 
       - name: Upload net10 test results
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: net10-test-results
           path: TestResults/*.trx
-          retention-days: 7
+          retention-days: 3


### PR DESCRIPTION
## 🔗 Related Issue

No tracked issue — follow-up to the artifact-storage-quota exhaustion that began failing the `build-net10` check on open PRs (e.g. #129, #131). The build and all tests pass; only the artifact *upload* steps fail with "Artifact storage quota has been hit."

## 📝 Description of the Change

The org's GitHub Actions storage quota was full (≈4.8 GB used), and `actions/upload-artifact` targets GitHub's storage — there is no separate build server in the loop. The footprint is dominated by the **`fuse-external-editor`** publish artifact: ~60 MB per run (three framework-dependent RID publishes: win/linux/osx) uploaded on **every push to every PR/branch** with 14-day retention. That accumulated to ~4.7 GB (74 live copies), which exhausts the quota and fails the upload steps in `build-net10` even though the build + tests succeed.

This bounds the storage so the editor artifacts use only a small slice of quota, and makes the upload steps non-fatal:

- **Editor publish (`fuse-external-editor`) — the dominant fix:** skip the **upload** on `pull_request` events (the *publish step* still runs on PRs as a build smoke test — it just doesn't retain the ~60 MB output); keep a short-lived copy only on `main`/manual runs; retention **14 → 2 days**. This removes the vast majority of copies (PR pushes) and expires the rest quickly.
- **Other artifacts — stop retaining things for long:** `test-results` and `net10-test-results` and the EditMode results retention **7 → 3 days**; the PR mod zip **30 → 14 days** (the sticky PR-comment text was updated to match).
- **Robustness:** added `continue-on-error: true` to the artifact **upload** steps so a storage-quota or transient upload failure can never red a job whose build + tests already passed. The PR mod zip deliberately keeps its strict `if-no-files-found: error` because it is the downloadable deliverable, not a debug artifact.

## 🔄 Alternatives Considered

- **Just delete artifacts periodically / free quota by hand:** done once already to unblock, but GitHub recalculates the enforcement figure only every 6–12h, so it doesn't take effect immediately and the quota simply refills on the next pushes. This change fixes the accumulation at the source.
- **Upload editor publishes to a self-hosted/build server instead of GitHub storage:** `actions/upload-artifact` can't target an external server, and there's no artifact server wired up; that would be a larger infra change. Out of scope here.
- **Drop the editor publish entirely on PRs (no publish step):** rejected — the publish step is a useful smoke test that the Avalonia editor publishes cleanly per RID; only the *upload* (retention) is unnecessary on PRs.
- **Self-contained per-RID publishes:** would be far larger; the framework-dependent publish is already the small variant (release.yml builds the real self-contained bundles).

## ⚠️ Possible Drawbacks

- PR runs no longer produce a downloadable `fuse-external-editor` artifact (the build still verifies it publishes). If a per-PR editor download is ever needed, we can re-enable it for PRs with a 1-day retention. The latest editor build remains available from `main`/manual runs.
- Shorter retention means older test-result/PR-zip artifacts expire sooner (3 / 14 days). These are debug/build conveniences, not releases — release assets live on GitHub Releases (`release.yml`) and are unaffected.
- `continue-on-error` on the upload steps means a genuine upload failure won't fail the job; it surfaces as a step annotation instead. Acceptable: the build + tests are the gate, not artifact upload. The deliverable PR zip stays strict.
- No save/runtime/code impact — CI-only change.

## ✅ Verification Process

- `ci.yml` parses as valid YAML (`yaml.safe_load`).
- Reviewed the rendered diff hunk-by-hunk: only the five `actions/upload-artifact` steps + the sticky-comment retention text changed; no job/runner/build/test step altered. `build`, `cs-lint`, `json-lint`, and `build-net10`'s build/test steps are untouched.
- Confirmed the GitHub Actions `if:` semantics: `if: github.event_name != 'pull_request'` still carries the implicit `success()` (no status function present), so the editor upload runs on push/manual only when prior steps succeeded — matching intent.
- Footprint math: editor publish drops from "every push × 14 days" to "main/manual only × 2 days," i.e. from ~4.7 GB to well under a few hundred MB; the rest are ≤6 MB each at 3-day retention.

## 💡 Additional Information

This is the durable fix for the recurring `build-net10` red. Note it only addresses the **GitHub-hosted** lane — the separate, current blocker on open PRs is that the self-hosted runner **`CCNET-BUILD-VM1` is offline**, which gates `build`/`cs-lint`/`json-lint` (those all run on it). That requires bringing the runner back online and is independent of this change.
