### PR TITLE
fix(progression): re-bind map-feature industry gates to live instances on refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,12 @@ jobs:
 
       - name: Upload build artifact
         id: build_upload
+        # continue-on-error: a storage-quota or transient upload hiccup must never
+        # fail the job after the build, tests, and package validation have already
+        # passed (same rationale as the other upload steps in this workflow). A
+        # genuinely missing archive is still caught upstream by the Package mod zip
+        # and Validate mod package steps, so this only tolerates upload-side failures.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.build_id.outputs.archive }}

--- a/FUSE/Runtime/API/ProgressionAPI.Apply.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.Apply.cs
@@ -114,6 +114,12 @@ namespace FUSE.Runtime.API
                     definition.UnlockIncludeIndustryComponents.ApplyTo(existingIds));
             }
             SanitizeMapFeature(feature);
+            // Capture the resolved gate identifiers so the progression refresh can
+            // re-bind them to live instances if an industry is later Remove+Add'd
+            // (otherwise the unlock toggles ProgressionDisabled on a destroyed
+            // reference and the live industry stays gated — e.g. a progression-gated
+            // interchange that shows a panel but is excluded from EnabledInterchanges).
+            RememberMapFeatureReferenceIds(feature);
 
             if (FuseSettings.VerboseApplyReportDetails)
             {

--- a/FUSE/Runtime/API/ProgressionAPI.FeatureState.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.FeatureState.cs
@@ -292,6 +292,11 @@ namespace FUSE.Runtime.API
             // required for correctness.
             var initialized = InitializeMissingMapFeatureStates(manager);
             var inferredIndustryIncludes = InferMapFeatureIndustryIncludes(manager, reason);
+            // Re-bind each feature's industry/component gate arrays to live instances
+            // BEFORE re-applying the feature state, so the gate toggles
+            // ProgressionDisabled on the live industry rather than a destroyed
+            // reference left behind by a Remove+Add re-apply.
+            var reboundLiveReferences = ReResolveMapFeatureLiveReferences(manager, reason);
             var forcedFeatureState = ForceApplyCurrentMapFeatureState(manager, reason);
             var invokedCurrentProgressionAfterFeatureState = TryRefreshCurrentProgression(reason, "after map feature replay");
             var restoredTrackGroups = RestoreDisabledTrackGroups(manager, reason);
@@ -302,7 +307,7 @@ namespace FUSE.Runtime.API
                 $"currentProgressionRefreshedBeforeFeatureState={invokedCurrentProgressionBeforeFeatureState} " +
                 $"currentProgressionRefreshedAfterFeatureState={invokedCurrentProgressionAfterFeatureState} " +
                 $"initializedFeatureStates={initialized} " +
-                $"inferredIndustryIncludes={inferredIndustryIncludes} forcedFeatureState={forcedFeatureState} " +
+                $"inferredIndustryIncludes={inferredIndustryIncludes} reboundLiveReferences={reboundLiveReferences} forcedFeatureState={forcedFeatureState} " +
                 $"restoredDisabledTrackGroups={restoredTrackGroups} " +
                 $"finalisedOrphanTrackGroups={finalisedOrphans}.");
 

--- a/FUSE/Runtime/API/ProgressionAPI.MapFeatureManager.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.MapFeatureManager.cs
@@ -19,6 +19,24 @@ namespace FUSE.Runtime.API
 {
     public static partial class ProgressionAPI
     {
+        // Captured-at-apply-time identifier lists for each MapFeature's industry /
+        // component gate arrays. A MapFeature stores its gate targets as live
+        // Object references (Industry[] / IndustryComponent[]); when FUSE later
+        // Remove+Add's one of those industries (multi-package apply, resident
+        // re-apply, reload), the array keeps the DESTROYED reference. The runtime
+        // unlock (MapFeatureManager.UpdateFeatureForUnlocked) then toggles
+        // ProgressionDisabled on the dead instance while the live one stays gated —
+        // so e.g. a progression-gated interchange shows a working panel yet is
+        // excluded from OpsController.EnabledInterchanges forever. A destroyed
+        // Unity object reads back as null and can no longer report its identifier,
+        // so we cannot recover the intended id from the array itself; we remember it
+        // here at apply time and re-resolve to the live instance on every refresh.
+        private static readonly Dictionary<string, string[]> _featureIncludeIndustryIds =
+            new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, string[]> _featureExcludeIndustryIds =
+            new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, string[]> _featureIncludeComponentIds =
+            new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
 
         private static void RefreshMapFeatureManager(MapFeatureManager manager)
         {
@@ -910,6 +928,275 @@ namespace FUSE.Runtime.API
             feature.unlockExcludeIndustries = feature.unlockExcludeIndustries ?? Array.Empty<Industry>();
             feature.unlockIncludeIndustries = feature.unlockIncludeIndustries ?? Array.Empty<Industry>();
             feature.unlockIncludeIndustryComponents = feature.unlockIncludeIndustryComponents ?? Array.Empty<IndustryComponent>();
+        }
+
+        /// <summary>
+        /// Records the identifiers currently bound into a feature's industry /
+        /// component gate arrays so <see cref="ReResolveMapFeatureLiveReferences"/>
+        /// can re-bind them to live instances after an industry is destroyed and
+        /// recreated. Called at the end of <c>ApplyMapFeatureDefinition</c>, when the
+        /// arrays hold freshly-resolved live references.
+        /// </summary>
+        internal static void RememberMapFeatureReferenceIds(MapFeature feature)
+        {
+            if (feature == null || string.IsNullOrWhiteSpace(feature.identifier))
+            {
+                return;
+            }
+
+            _featureIncludeIndustryIds[feature.identifier] = CollectIndustryIds(feature.unlockIncludeIndustries);
+            _featureExcludeIndustryIds[feature.identifier] = CollectIndustryIds(feature.unlockExcludeIndustries);
+            _featureIncludeComponentIds[feature.identifier] = CollectComponentIds(feature.unlockIncludeIndustryComponents);
+        }
+
+        private static string[] CollectIndustryIds(Industry[] industries)
+        {
+            if (industries == null || industries.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            return industries
+                .Where(industry => industry != null && !string.IsNullOrWhiteSpace(industry.identifier))
+                .Select(industry => industry.identifier)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        private static string[] CollectComponentIds(IndustryComponent[] components)
+        {
+            if (components == null || components.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            return components
+                .Where(component => component != null)
+                .Select(SafeIndustryComponentId)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Re-binds every <see cref="MapFeature"/>'s gate arrays
+        /// (<c>unlockIncludeIndustries</c>, <c>unlockExcludeIndustries</c>,
+        /// <c>unlockIncludeIndustryComponents</c>) to the LIVE scene instances for
+        /// their intended identifiers, dropping Unity-destroyed entries and
+        /// re-resolving any intended id whose live reference is missing. Runs during
+        /// the progression refresh, immediately before
+        /// <c>ForceApplyCurrentMapFeatureState</c> re-applies the gate, so the
+        /// unlock toggles <c>ProgressionDisabled</c> on the live industry rather than
+        /// a destroyed reference left over from a Remove+Add re-apply.
+        ///
+        /// Conservative by construction: it keeps every live reference already in the
+        /// array, only prunes destroyed (null) entries and adds intended-but-missing
+        /// live references. An identifier removed by a later patch is no longer in the
+        /// captured intent (or the live array), so it is not re-added.
+        /// </summary>
+        private static int ReResolveMapFeatureLiveReferences(MapFeatureManager manager, string reason)
+        {
+            if (manager == null)
+            {
+                return 0;
+            }
+
+            var changed = 0;
+            foreach (var feature in manager.AvailableFeatures ?? Enumerable.Empty<MapFeature>())
+            {
+                if (feature == null || string.IsNullOrWhiteSpace(feature.identifier))
+                {
+                    continue;
+                }
+
+                changed += RebindIndustryReferences(
+                    feature.identifier, ref feature.unlockIncludeIndustries,
+                    _featureIncludeIndustryIds, "unlockIncludeIndustries", reason);
+                changed += RebindIndustryReferences(
+                    feature.identifier, ref feature.unlockExcludeIndustries,
+                    _featureExcludeIndustryIds, "unlockExcludeIndustries", reason);
+                changed += RebindIndustryComponentReferences(
+                    feature.identifier, ref feature.unlockIncludeIndustryComponents,
+                    _featureIncludeComponentIds, "unlockIncludeIndustryComponents", reason);
+            }
+
+            return changed;
+        }
+
+        private static int RebindIndustryReferences(
+            string featureId, ref Industry[] array,
+            Dictionary<string, string[]> intentMap, string label, string reason)
+        {
+            var current = array ?? Array.Empty<Industry>();
+
+            // Live entries still in the array, keyed by id. Unity-destroyed
+            // references compare == null via the engine overload and are skipped.
+            var liveById = new Dictionary<string, Industry>(StringComparer.OrdinalIgnoreCase);
+            var hadDestroyed = false;
+            foreach (var industry in current)
+            {
+                if (industry == null)
+                {
+                    hadDestroyed = true;
+                    continue;
+                }
+
+                var id = industry.identifier;
+                if (!string.IsNullOrWhiteSpace(id) && !liveById.ContainsKey(id))
+                {
+                    liveById[id] = industry;
+                }
+            }
+
+            // Desired ids = captured apply-time intent (survives destruction) unioned
+            // with whatever live references remain (covers inference-added includes).
+            var desired = new List<string>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (intentMap.TryGetValue(featureId, out var intentIds) && intentIds != null)
+            {
+                foreach (var id in intentIds)
+                {
+                    if (!string.IsNullOrWhiteSpace(id) && seen.Add(id))
+                    {
+                        desired.Add(id);
+                    }
+                }
+            }
+
+            foreach (var id in liveById.Keys)
+            {
+                if (seen.Add(id))
+                {
+                    desired.Add(id);
+                }
+            }
+
+            if (desired.Count == 0)
+            {
+                if (!hadDestroyed)
+                {
+                    return 0;
+                }
+
+                array = Array.Empty<Industry>();
+                return 1;
+            }
+
+            var rebuilt = new List<Industry>(desired.Count);
+            var addedMissingLive = false;
+            foreach (var id in desired)
+            {
+                if (liveById.TryGetValue(id, out var existing))
+                {
+                    rebuilt.Add(existing);
+                    continue;
+                }
+
+                var live = ResolveIndustry(id);
+                if (live != null)
+                {
+                    rebuilt.Add(live);
+                    addedMissingLive = true;
+                }
+            }
+
+            if (!hadDestroyed && !addedMissingLive && rebuilt.Count == current.Length)
+            {
+                return 0;
+            }
+
+            array = rebuilt.ToArray();
+            FuseLog.Info(
+                $"FUSE progression rebound live {label} feature='{featureId}' " +
+                $"count={array.Length} droppedDestroyed={hadDestroyed} addedMissingLive={addedMissingLive} " +
+                $"reason='{reason ?? "unspecified"}'.");
+            return 1;
+        }
+
+        private static int RebindIndustryComponentReferences(
+            string featureId, ref IndustryComponent[] array,
+            Dictionary<string, string[]> intentMap, string label, string reason)
+        {
+            var current = array ?? Array.Empty<IndustryComponent>();
+
+            var liveById = new Dictionary<string, IndustryComponent>(StringComparer.OrdinalIgnoreCase);
+            var hadDestroyed = false;
+            foreach (var component in current)
+            {
+                if (component == null)
+                {
+                    hadDestroyed = true;
+                    continue;
+                }
+
+                var id = SafeIndustryComponentId(component);
+                if (!string.IsNullOrWhiteSpace(id) && !liveById.ContainsKey(id))
+                {
+                    liveById[id] = component;
+                }
+            }
+
+            var desired = new List<string>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (intentMap.TryGetValue(featureId, out var intentIds) && intentIds != null)
+            {
+                foreach (var id in intentIds)
+                {
+                    if (!string.IsNullOrWhiteSpace(id) && seen.Add(id))
+                    {
+                        desired.Add(id);
+                    }
+                }
+            }
+
+            foreach (var id in liveById.Keys)
+            {
+                if (seen.Add(id))
+                {
+                    desired.Add(id);
+                }
+            }
+
+            if (desired.Count == 0)
+            {
+                if (!hadDestroyed)
+                {
+                    return 0;
+                }
+
+                array = Array.Empty<IndustryComponent>();
+                return 1;
+            }
+
+            var rebuilt = new List<IndustryComponent>(desired.Count);
+            var addedMissingLive = false;
+            foreach (var id in desired)
+            {
+                if (liveById.TryGetValue(id, out var existing))
+                {
+                    rebuilt.Add(existing);
+                    continue;
+                }
+
+                var live = ResolveAnyIndustryComponent(id);
+                if (live != null)
+                {
+                    rebuilt.Add(live);
+                    addedMissingLive = true;
+                }
+            }
+
+            if (!hadDestroyed && !addedMissingLive && rebuilt.Count == current.Length)
+            {
+                return 0;
+            }
+
+            array = rebuilt.ToArray();
+            FuseLog.Info(
+                $"FUSE progression rebound live {label} feature='{featureId}' " +
+                $"count={array.Length} droppedDestroyed={hadDestroyed} addedMissingLive={addedMissingLive} " +
+                $"reason='{reason ?? "unspecified"}'.");
+            return 1;
         }
 
         private static void RefreshProgressionManager()

--- a/FUSE/Runtime/API/ProgressionAPI.MapFeatureManager.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.MapFeatureManager.cs
@@ -949,6 +949,20 @@ namespace FUSE.Runtime.API
             _featureIncludeComponentIds[feature.identifier] = CollectComponentIds(feature.unlockIncludeIndustryComponents);
         }
 
+        /// <summary>
+        /// Drops the captured map-feature gate identifier snapshots so the next map
+        /// load starts clean. Called from <c>FuseLifecycle.OnMapWillUnload</c>
+        /// alongside the other runtime-state resets, so the intent dictionaries do
+        /// not accumulate entries for features that no longer exist across many map
+        /// loads in a single session. Safe to call repeatedly.
+        /// </summary>
+        public static void ClearRememberedReferenceIds()
+        {
+            _featureIncludeIndustryIds.Clear();
+            _featureExcludeIndustryIds.Clear();
+            _featureIncludeComponentIds.Clear();
+        }
+
         private static string[] CollectIndustryIds(Industry[] industries)
         {
             if (industries == null || industries.Length == 0)

--- a/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
+++ b/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
@@ -324,6 +324,7 @@ namespace FUSE.Runtime.Lifecycle
                 FuseModLoader.UnloadAll(resetDiscovery: true, restoreTrackSnapshots: false);
                 FuseMapTileRegistry.ClearAll();
                 TrackAPI.ClearBaseGraphSnapshot();
+                ProgressionAPI.ClearRememberedReferenceIds();
                 FuseCacheRegistry.ClearAll();
                 FuseRuntimeRebindService.ResetUnknownKindLog();
                 FuseSplineyPluginHost.Reset();


### PR DESCRIPTION
## 🔗 Related Issue

No linked issue — reported via Discord: a community Strange-Customs mod ("Copper's Nantahala River Interchange") that gates an interchange industry behind a progression milestone. The interchange loads and shows a working, schedulable panel in-game but never actually interchanges cars in either direction.

## 📝 Description of the Change

A progression-gated industry uses `MapFeature.unlockIncludeIndustries`, which holds **live `Industry` references**. The unlock/lock transition (`MapFeatureManager.UpdateFeatureForUnlocked`) flips `Industry.ProgressionDisabled` on exactly the instances in that array.

When FUSE recreates an industry — a Remove+Add during a multi-package apply, a resident re-apply, or a reload — **after** the feature array was populated, the array keeps the **destroyed** reference. The unlock then clears the gate on the dead instance while the live industry stays `ProgressionDisabled = true`.

For an interchange this surfaces as a particularly confusing symptom:

- `unlockIncludeIndustries` only sets the flag on the **Industry**, never on its child components. So the interchange **component**'s `ProgressionDisabled` stays `false` → `IndustryComponent.IsVisible` is `true` → its panel renders and a service is schedulable.
- But `OpsController.EnabledInterchanges` filters on `!i.Industry.ProgressionDisabled`. With the Industry flag stuck true, the interchange is excluded from **all** car routing (inbound waybills and the empties the `InterchangedIndustryLoader`s need). `CheckServiceInterchanges` still *services* it (it iterates `AllInterchanges`), so there's no error — it just has nothing to move.

Net: a visible, schedulable interchange that never interchanges anything.

A destroyed Unity object reads back as `null` and can no longer report its identifier, so the stale entry can't be re-bound from the runtime array alone.

The fix:

1. `ProgressionAPI.Apply.cs` — at the end of `ApplyMapFeatureDefinition`, record each feature's resolved gate identifiers (`unlockIncludeIndustries`, `unlockExcludeIndustries`, `unlockIncludeIndustryComponents`).
2. `ProgressionAPI.MapFeatureManager.cs` — add `ReResolveMapFeatureLiveReferences`, which prunes Unity-destroyed entries and re-resolves any intended-but-missing id to its live instance via the existing `ResolveIndustry` / `ResolveAnyIndustryComponent` index lookups.
3. `ProgressionAPI.FeatureState.cs` — invoke it during the progression refresh **immediately before** `ForceApplyCurrentMapFeatureState`, so the gate is applied to the live industry. A `reboundLiveReferences=` field is added to the refresh log line.

## 🔄 Alternatives Considered

- **Re-run `ApplyMapFeatureDefinition` from cached definitions on each refresh** — heavier, re-applies track-group/scenery patches that don't need it, and couples the refresh to the definition cache.
- **Rely on `InferMapFeatureIndustryIncludes`** — it already prunes nulls and can re-add by track-group ownership, but only when the industry's groups map uniquely to one feature; it's a heuristic, not deterministic for explicit `unlockIncludeIndustries`.
- **Cascade the gate onto the interchange component** so the panel hides while locked — changes player-facing UX and doesn't address the underlying stale-reference problem.

The chosen approach is the minimal, deterministic one: re-bind the explicit gate targets to live instances, keyed by the identifiers the mod actually declared.

## ⚠️ Possible Drawbacks

- Negligible per-refresh overhead: a dictionary build per feature plus index lookups; returns early as a no-op when references are already live (the common case, including all untouched base-game features).
- **No save-format change** — this is purely runtime re-resolution of in-scene references during the progression refresh. Backwards compatible with existing saves.
- Conservative by design: it keeps every live reference already in the array and never removes one a patch intended to keep, so it cannot un-gate or re-gate anything beyond repairing a destroyed reference.

## ✅ Verification Process

- **Builds clean:** `dotnet build FUSE/FUSE.csproj -c Release` → 0 errors, 0 warnings.
- **Traced both paths against the code:**
  - *Industry live (normal):* intent id matches a live array entry, nothing destroyed, count unchanged → returns 0, no mutation, no log. Same for base-game features with no captured intent.
  - *Industry Remove+Add'd (bug):* array holds a destroyed (null) entry, the intended id is re-resolved to the live instance, the array is rebound → `ForceApplyCurrentMapFeatureState` then clears `ProgressionDisabled` on the live interchange.
- **Not yet verified in a live game.** I could not reproduce the Remove+Add in a normal single load, so this is a targeted robustness fix for the one path that produces the exact reported symptom. The new `reboundLiveReferences=N` log field (and the per-feature `rebound live unlockIncludeIndustries feature='…' addedMissingLive=True` line) make it observable in `FUSE.log` whether the fix actually fired. **Requesting an in-game check:** load the affected save, complete the gated milestone, and confirm the interchange begins moving cars; `reboundLiveReferences>0` confirms a stale reference was repaired.

## 💡 Additional Information

If the reporter simply hadn't completed the gating milestone yet, that branch is by-design (the schedulable-but-inert panel is the base game leaving the component visible while only the Industry is flagged) and this change is a safe no-op. The fix only alters behavior when a destroyed gate reference is actually found.
