### PR TITLE
fix(audio): publish FUSE whistles to the picker via a generated direct store

### DIFF
--- a/FUSE.Tests/Runtime/FuseWhistleDefinitionStoreTests.cs
+++ b/FUSE.Tests/Runtime/FuseWhistleDefinitionStoreTests.cs
@@ -1,0 +1,136 @@
+using System.Linq;
+using FUSE.Runtime.API;
+using HarmonyLib;
+using Model.Definition;
+using Model.Definition.Data;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Runtime
+{
+    public class FuseWhistleDefinitionStoreTests
+    {
+        [Fact]
+        public void BuildDefinitionsJson_EmitsGameSchemaObjects()
+        {
+            var json = FuseWhistleDefinitionStore.BuildDefinitionsJson(new[]
+            {
+                new FuseWhistleStoreEntry(
+                    "C&O 6 Chime - Modified",
+                    "C&O 6 Chime - Modified",
+                    "audio.whistles01",
+                    "6ChimeA")
+            });
+
+            var root = JObject.Parse(json);
+            var objects = (JArray)root["objects"];
+            var entry = (JObject)Assert.Single(objects);
+
+            Assert.Equal("C&O 6 Chime - Modified", (string)entry["identifier"]);
+            Assert.Equal("C&O 6 Chime - Modified", (string)entry["metadata"]["name"]);
+            Assert.Equal("Whistle", (string)entry["definition"]["kind"]);
+            Assert.Equal("audio.whistles01", (string)entry["definition"]["model"]["assetPackIdentifier"]);
+            Assert.Equal("6ChimeA", (string)entry["definition"]["model"]["assetIdentifier"]);
+        }
+
+        [Fact]
+        public void BuildDefinitionsJson_KeepsAudioReferenceEmpty()
+        {
+            // Vanilla's WhistleController.Configure skips its async audio
+            // branch for empty references; the clip must stay FUSE-served.
+            var json = FuseWhistleDefinitionStore.BuildDefinitionsJson(new[]
+            {
+                new FuseWhistleStoreEntry("id", "name", "audio.whistles01", "3ChimeA")
+            });
+
+            var audio = JObject.Parse(json)["objects"][0]["definition"]["audio"];
+            Assert.Equal(string.Empty, (string)audio["assetPackIdentifier"]);
+            Assert.Equal(string.Empty, (string)audio["assetIdentifier"]);
+        }
+
+        [Fact]
+        public void BuildDefinitionsJson_NullModel_EmitsEmptyReference()
+        {
+            var json = FuseWhistleDefinitionStore.BuildDefinitionsJson(new[]
+            {
+                new FuseWhistleStoreEntry("no-model", "No Model", null, null)
+            });
+
+            var model = JObject.Parse(json)["objects"][0]["definition"]["model"];
+            Assert.Equal(string.Empty, (string)model["assetPackIdentifier"]);
+            Assert.Equal(string.Empty, (string)model["assetIdentifier"]);
+        }
+
+        [Fact]
+        public void BuildDefinitionsJson_SkipsBlankIds_AndFallsBackToIdForBlankNames()
+        {
+            var json = FuseWhistleDefinitionStore.BuildDefinitionsJson(new[]
+            {
+                new FuseWhistleStoreEntry(" ", "blank id is dropped", "p", "a"),
+                new FuseWhistleStoreEntry("kept", null, "p", "a")
+            });
+
+            var objects = (JArray)JObject.Parse(json)["objects"];
+            var entry = (JObject)Assert.Single(objects);
+            Assert.Equal("kept", (string)entry["identifier"]);
+            Assert.Equal("kept", (string)entry["metadata"]["name"]);
+        }
+
+        [Fact]
+        public void BuildDefinitionsJson_NullOrEmptyInput_EmitsEmptyObjectsArray()
+        {
+            foreach (var json in new[]
+                     {
+                         FuseWhistleDefinitionStore.BuildDefinitionsJson(null),
+                         FuseWhistleDefinitionStore.BuildDefinitionsJson(Enumerable.Empty<FuseWhistleStoreEntry>())
+                     })
+            {
+                var root = JObject.Parse(json);
+                Assert.Empty((JArray)root["objects"]);
+            }
+        }
+
+        [Fact]
+        public void BuildDefinitionsJson_RoundTripsThroughGameContainerSerialization()
+        {
+            // The direct-store loader deserializes the generated file with the
+            // game's own serializer settings (see FuseAssetPackRegistry's
+            // BypassDeserialize). Prove the emitted schema binds: the "kind"
+            // discriminator must resolve to WhistleDefinition, the model
+            // reference must survive, and the audio reference must stay empty
+            // so vanilla's Configure never races FUSE on the clip.
+            var json = FuseWhistleDefinitionStore.BuildDefinitionsJson(new[]
+            {
+                new FuseWhistleStoreEntry(
+                    "MTH N&W J Whistle (PS3)",
+                    "MTH N&W J Whistle (PS3)",
+                    "audio.whistles01",
+                    "3ChimeD")
+            });
+
+            var settingsMethod = AccessTools.Method(typeof(ContainerSerialization), "JsonSerializerSettings");
+            Assert.NotNull(settingsMethod);
+            var settings = (JsonSerializerSettings)settingsMethod.Invoke(null, null);
+            var container = JsonConvert.DeserializeObject<Container>(json, settings);
+
+            var item = Assert.Single(container.Objects);
+            Assert.Equal("MTH N&W J Whistle (PS3)", item.Identifier);
+            Assert.Equal("MTH N&W J Whistle (PS3)", item.Metadata.Name);
+            var whistle = Assert.IsType<WhistleDefinition>(item.Definition);
+            Assert.Equal("audio.whistles01", whistle.Model.AssetPackIdentifier);
+            Assert.Equal("3ChimeD", whistle.Model.AssetIdentifier);
+            Assert.True(whistle.Audio.IsEmpty);
+        }
+
+        [Fact]
+        public void BuildCatalogJson_DeclaresNoAssets()
+        {
+            var root = JObject.Parse(FuseWhistleDefinitionStore.BuildCatalogJson());
+
+            Assert.Equal("fuse.generated.whistles", (string)root["identifier"]);
+            Assert.False((bool)root["shared"]);
+            Assert.Empty((JObject)root["assets"]);
+        }
+    }
+}

--- a/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
@@ -18,6 +18,75 @@ namespace FUSE.Loading
 {
     internal static partial class FuseAssetPackRegistry
     {
+        private static readonly FieldInfo PrefabStoreStoresField =
+            AccessTools.Field(typeof(PrefabStore), "_stores");
+
+        /// <summary>
+        /// Mounts a FUSE-generated definitions folder (e.g. the whistle
+        /// picker store) as a fuseasset:// direct store on the supplied
+        /// PrefabStore, or refreshes it when already mounted. Unlike the
+        /// discovery-driven <see cref="AddDirectAssetPackStores"/> path this
+        /// targets a single known folder, so it skips the collision scan:
+        /// the folder is FUSE-owned and its identifier can belong to nothing
+        /// else. With <paramref name="invalidateContainer"/> the mounted
+        /// store's cached container is dropped so the next <c>Container()</c>
+        /// call re-reads a rewritten Definitions.json.
+        /// </summary>
+        internal static bool EnsureGeneratedDirectStore(
+            PrefabStore prefabStore,
+            string sourcePath,
+            bool invalidateContainer)
+        {
+            if (prefabStore == null || string.IsNullOrWhiteSpace(sourcePath))
+            {
+                return false;
+            }
+
+            var identifier = ToDirectStoreIdentifier(sourcePath);
+            try
+            {
+                if (PrefabStoreStoresField?.GetValue(prefabStore) is System.Collections.IEnumerable stores)
+                {
+                    foreach (var item in stores)
+                    {
+                        if (item is AssetPackRuntimeStore store &&
+                            string.Equals(store.Identifier, identifier, StringComparison.Ordinal))
+                        {
+                            if (invalidateContainer)
+                            {
+                                RuntimeStoreContainerField?.SetValue(store, null);
+                            }
+
+                            return true;
+                        }
+                    }
+                }
+
+                var addStore = AccessTools.Method(
+                    prefabStore.GetType(),
+                    "AddStore",
+                    new[] { typeof(string), typeof(AssetPackRuntimeStore.StoreLocation) });
+                if (addStore == null)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not locate PrefabStore.AddStore to mount generated store '{sourcePath}'.");
+                    return false;
+                }
+
+                addStore.Invoke(prefabStore, new object[]
+                {
+                    identifier,
+                    AssetPackRuntimeStore.StoreLocation.External
+                });
+                DirectAssetPackStoreIdentifiers.Add(identifier);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception($"FUSE could not mount generated direct store '{sourcePath}'", ex);
+                return false;
+            }
+        }
 
         internal static void AddDirectAssetPackStores(PrefabStore prefabStore)
         {
@@ -144,6 +213,24 @@ namespace FUSE.Loading
                 {
                     FuseLog.Exception($"FUSE verbose asset-pack resolution diagnostics failed softly", ex);
                 }
+            }
+
+            // Warm-mount the generated whistle picker store left by the last
+            // audio registration. A brand-new PrefabStore only knows the
+            // discovery-driven mod folders above; without this, FUSE whistles
+            // would stay invisible until the next RegisterDefinition re-syncs
+            // (which also refreshes the file if the whistle set changed).
+            try
+            {
+                var generatedWhistleFolder = FUSE.Runtime.API.FuseWhistleDefinitionStore.StoreFolderPath;
+                if (Directory.Exists(generatedWhistleFolder))
+                {
+                    EnsureGeneratedDirectStore(prefabStore, generatedWhistleFolder, invalidateContainer: false);
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE could not warm-mount the generated whistle store", ex);
             }
 
             FusePerformanceMetrics.RecordTiming("direct asset pack stores", stopwatch.ElapsedMilliseconds);

--- a/FUSE/Patches/FuseAudioPatches.cs
+++ b/FUSE/Patches/FuseAudioPatches.cs
@@ -43,12 +43,13 @@ namespace FUSE.Patches
         // patched IL still corrupts the return value of every other T
         // (~2k scenery skips across 20+ packages in the regression run).
         //
-        // For now we accept that FUSE-converted legacy whistles play
-        // their custom audio but render the loco's vanilla 3D whistle
-        // model. Restoring the FUSE whistle model needs a non-generic
-        // patch surface or an in-FUSE async asset-load that writes
-        // <c>WhistleController._whistleModel</c> by reflection without
-        // ever calling <c>DefinitionForIdentifier</c>.
+        // The 3D whistle model is handled inside FUSE:
+        // <see cref="FuseAudioAPI.TryConfigureWhistle"/> loads and attaches
+        // it by CALLING the generic PrefabStore load (calling is safe; only
+        // PATCHING a closed generic is hazardous). Picker visibility is
+        // likewise patch-free: FuseWhistleDefinitionStore publishes the
+        // registered whistles as a generated direct asset-pack store that
+        // vanilla's AllDefinitionInfosOfType enumeration lists natively.
         public static bool Prefix(WhistleController __instance, WhistleCustomizationSettings settings)
         {
             try

--- a/FUSE/Runtime/API/FuseAudioAPI.cs
+++ b/FUSE/Runtime/API/FuseAudioAPI.cs
@@ -97,6 +97,7 @@ namespace FUSE.Runtime.API
             FuseLog.Info(
                 $"FUSE audio package='{packageId}' operation='register audio' " +
                 $"whistles={CountPackage(Whistles, packageId)} horns={CountPackage(Horns, packageId)} bells={CountPackage(Bells, packageId)}.");
+            FuseWhistleDefinitionStore.Sync(SnapshotWhistleStoreEntries());
         }
 
         public static void ReleasePackage(string packageId)
@@ -114,6 +115,11 @@ namespace FUSE.Runtime.API
                 FuseLog.Info(
                     $"FUSE audio package='{packageId}' operation='release audio definitions' " +
                     $"whistles={whistles} horns={horns} bells={bells}.");
+            }
+
+            if (whistles > 0)
+            {
+                FuseWhistleDefinitionStore.Sync(SnapshotWhistleStoreEntries());
             }
         }
 
@@ -133,72 +139,25 @@ namespace FUSE.Runtime.API
                 .ToArray();
         }
 
-        public static IEnumerable<TypedContainerItem<WhistleDefinition>> GetWhistleDefinitionItems()
-        {
-            foreach (var whistle in Whistles.Values.OrderBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase))
-            {
-                yield return new TypedContainerItem<WhistleDefinition>
-                {
-                    Identifier = whistle.Id,
-                    Metadata = BuildWhistleMetadata(whistle),
-                    Definition = BuildWhistleDefinition(whistle)
-                };
-            }
-        }
-
         /// <summary>
-        /// Try to fetch a FUSE-registered whistle by its in-save identifier
-        /// (the same key vanilla passes to
-        /// <see cref="Model.Database.PrefabStore.DefinitionForIdentifier{T}"/>).
-        /// Used by the <see cref="FUSE.Patches.FusePrefabStoreDefinitionForIdentifierWhistlePatch"/>
-        /// Prefix to short-circuit vanilla's asset-pack lookup, which would
-        /// otherwise throw <c>UnknownIdentifierException</c> for FUSE whistle
-        /// ids and abort the whole <c>WhistleController.Configure</c> async
-        /// method — taking the 3D model spawn down with it.
+        /// Snapshot of the registered whistles in picker order, carrying the
+        /// facts <see cref="FuseWhistleDefinitionStore"/> serializes into the
+        /// generated direct store that vanilla's whistle dropdown enumerates.
+        /// The generated definitions keep the audio reference empty on
+        /// purpose — see <see cref="FuseWhistleDefinitionStore"/> — so
+        /// vanilla never races <see cref="TryConfigureWhistle"/> +
+        /// <see cref="LoadClip"/> on the clip.
         /// </summary>
-        public static bool TryBuildWhistleDefinition(string whistleId, out WhistleDefinition definition, out ObjectMetadata metadata)
+        internal static IReadOnlyList<FuseWhistleStoreEntry> SnapshotWhistleStoreEntries()
         {
-            definition = null;
-            metadata = null;
-            if (string.IsNullOrWhiteSpace(whistleId))
-            {
-                return false;
-            }
-            if (!Whistles.TryGetValue(whistleId, out var whistle))
-            {
-                return false;
-            }
-            definition = BuildWhistleDefinition(whistle);
-            metadata = BuildWhistleMetadata(whistle);
-            return true;
-        }
-
-        private static WhistleDefinition BuildWhistleDefinition(RegisteredWhistle whistle)
-        {
-            return new WhistleDefinition
-            {
-                // Leave Audio with an empty AssetIdentifier on purpose.
-                // <see cref="Model.Definition.Data.AssetReference.IsEmpty"/>
-                // is <c>string.IsNullOrEmpty(AssetIdentifier)</c>, and
-                // <see cref="RollingStock.Steam.WhistleController.Configure"/>
-                // skips its async <c>LoadAssetAsync&lt;AudioClip&gt;</c> branch
-                // when <c>!whistleDefinition.Audio.IsEmpty</c> is false.
-                // FUSE serves the actual clip from disk via
-                // <see cref="TryConfigureWhistle"/> + <see cref="LoadClip"/>,
-                // so we want vanilla to not race against us on the audio side
-                // while still running its Model branch to spawn the 3D whistle.
-                Audio = new AssetReference(),
-                Model = ToAssetReference(whistle.Model)
-            };
-        }
-
-        private static ObjectMetadata BuildWhistleMetadata(RegisteredWhistle whistle)
-        {
-            return new ObjectMetadata
-            {
-                Name = string.IsNullOrWhiteSpace(whistle.Name) ? whistle.Id : whistle.Name,
-                Description = "FUSE loose-file whistle"
-            };
+            return Whistles.Values
+                .OrderBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(entry => new FuseWhistleStoreEntry(
+                    entry.Id,
+                    entry.Name,
+                    entry.Model?.AssetPackIdentifier,
+                    entry.Model?.AssetIdentifier))
+                .ToArray();
         }
 
         public static bool TryConfigureWhistle(WhistleController controller, string whistleId)
@@ -733,15 +692,6 @@ namespace FUSE.Runtime.API
             UnityEngine.Object.DontDestroyOnLoad(go);
             _host = go.AddComponent<FuseAudioRuntimeHost>();
             return _host;
-        }
-
-        private static AssetReference ToAssetReference(FuseAudioAssetReference reference)
-        {
-            return new AssetReference
-            {
-                AssetPackIdentifier = reference?.AssetPackIdentifier ?? string.Empty,
-                AssetIdentifier = reference?.AssetIdentifier ?? string.Empty
-            };
         }
 
         private static string ResolveAudioPath(string packageFolder, string value)

--- a/FUSE/Runtime/API/FuseWhistleDefinitionStore.cs
+++ b/FUSE/Runtime/API/FuseWhistleDefinitionStore.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Model.Database;
+using Newtonsoft.Json.Linq;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using UnityEngine;
+
+namespace FUSE.Runtime.API
+{
+    /// <summary>
+    /// Publishes FUSE-registered loose-file whistles to the vanilla whistle
+    /// picker through a generated direct asset-pack store.
+    ///
+    /// The customize window builds its whistle dropdown from
+    /// <c>PrefabStore.AllDefinitionInfosOfType&lt;WhistleDefinition&gt;()</c>,
+    /// which enumerates asset-pack stores only. FUSE's converted legacy
+    /// whistles (whistles.json packs) live in <see cref="FuseAudioAPI"/>'s
+    /// in-memory registry, so without a store entry they never reach the
+    /// picker — that is exactly the regression left behind when the closed
+    /// generic Harmony patch on the enumeration was removed (patching one T
+    /// of a JIT-shared generic body fires for every other T; see
+    /// <see cref="FUSE.Patches.FuseWhistleControllerConfigurePatch"/>).
+    ///
+    /// Instead of any generic patch, FUSE writes the registered whistles as
+    /// a Definitions.json in the game's own container schema to a folder
+    /// under LocalLow and mounts that folder through the existing
+    /// fuseasset:// direct-store path
+    /// (<see cref="FuseAssetPackRegistry.EnsureGeneratedDirectStore"/> +
+    /// <see cref="FUSE.Patches.FuseAssetPackRuntimeStoreContainerPatch"/>).
+    /// Vanilla then lists AND resolves the whistles natively — including
+    /// <c>DefinitionForIdentifier&lt;WhistleDefinition&gt;</c>, which used to
+    /// throw <c>UnknownIdentifierException</c> for FUSE whistle ids.
+    ///
+    /// Every generated definition carries an EMPTY audio reference on
+    /// purpose: <c>WhistleController.Configure</c> skips its async audio
+    /// branch for empty references, leaving the clip to FUSE
+    /// (<see cref="FuseAudioAPI.TryConfigureWhistle"/> serves it from disk),
+    /// while the model reference stays real so the definition describes the
+    /// same 3D whistle FUSE attaches.
+    /// </summary>
+    internal static class FuseWhistleDefinitionStore
+    {
+        internal static string StoreFolderPath =>
+            Path.Combine(Application.persistentDataPath, "FUSE", "GeneratedStores", "fuse-whistles");
+
+        /// <summary>
+        /// Pure generator (unit-tested): the game-schema Definitions.json for
+        /// the supplied whistles. Matches the object shape shipping asset
+        /// packs use, which is what the direct-store loader deserializes with
+        /// the game's own serializer settings.
+        /// </summary>
+        internal static string BuildDefinitionsJson(IEnumerable<FuseWhistleStoreEntry> whistles)
+        {
+            var objects = new JArray();
+            foreach (var whistle in whistles ?? Array.Empty<FuseWhistleStoreEntry>())
+            {
+                if (string.IsNullOrWhiteSpace(whistle.Id))
+                {
+                    continue;
+                }
+
+                objects.Add(new JObject
+                {
+                    ["identifier"] = whistle.Id,
+                    ["metadata"] = new JObject
+                    {
+                        ["name"] = string.IsNullOrWhiteSpace(whistle.Name) ? whistle.Id : whistle.Name,
+                        ["description"] = "FUSE loose-file whistle",
+                        ["tags"] = new JArray(),
+                        ["credits"] = string.Empty
+                    },
+                    ["definition"] = new JObject
+                    {
+                        ["kind"] = "Whistle",
+                        ["model"] = new JObject
+                        {
+                            ["assetPackIdentifier"] = whistle.ModelAssetPackIdentifier ?? string.Empty,
+                            ["assetIdentifier"] = whistle.ModelAssetIdentifier ?? string.Empty
+                        },
+                        ["audio"] = new JObject
+                        {
+                            ["assetPackIdentifier"] = string.Empty,
+                            ["assetIdentifier"] = string.Empty
+                        },
+                        ["components"] = JValue.CreateNull()
+                    }
+                });
+            }
+
+            return new JObject { ["objects"] = objects }.ToString(Newtonsoft.Json.Formatting.Indented);
+        }
+
+        /// <summary>
+        /// Minimal catalog so the generated folder satisfies the same
+        /// file-layout invariants every other direct store does. It declares
+        /// no assets: the definitions reference models in OTHER packs and
+        /// empty audio, so nothing ever opens this store's (absent) bundle.
+        /// </summary>
+        internal static string BuildCatalogJson()
+        {
+            return new JObject
+            {
+                ["identifier"] = "fuse.generated.whistles",
+                ["name"] = "FUSE Whistles",
+                ["shared"] = false,
+                ["assets"] = new JObject()
+            }.ToString(Newtonsoft.Json.Formatting.Indented);
+        }
+
+        /// <summary>
+        /// Rewrites the generated store from the current whistle registry and
+        /// (re)mounts it on the live PrefabStore. Safe to call repeatedly —
+        /// files are only rewritten when content changed, and the mounted
+        /// store's cached container is invalidated only on a rewrite so the
+        /// next picker open re-reads the refreshed definitions.
+        /// </summary>
+        internal static void Sync(IReadOnlyList<FuseWhistleStoreEntry> whistles)
+        {
+            try
+            {
+                var folder = StoreFolderPath;
+                Directory.CreateDirectory(folder);
+                var changed = WriteIfChanged(Path.Combine(folder, "Definitions.json"), BuildDefinitionsJson(whistles));
+                WriteIfChanged(Path.Combine(folder, "Catalog.json"), BuildCatalogJson());
+
+                // PrefabStore is per-map. When none exists yet (early apply),
+                // the PrefabStore.Create postfix warm-mounts this folder on
+                // the next map load instead.
+                if (!(TrainController.Shared?.PrefabStore is PrefabStore prefabStore))
+                {
+                    return;
+                }
+
+                if (FuseAssetPackRegistry.EnsureGeneratedDirectStore(prefabStore, folder, invalidateContainer: changed) &&
+                    changed)
+                {
+                    FuseLog.Info(
+                        $"FUSE published {whistles?.Count ?? 0} whistle definition(s) to the generated picker store.");
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE could not publish whistle definitions to the generated picker store", ex);
+            }
+        }
+
+        private static bool WriteIfChanged(string path, string content)
+        {
+            try
+            {
+                if (File.Exists(path) && string.Equals(File.ReadAllText(path), content, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Info(
+                    $"FUSE could not compare generated store file '{path}' " +
+                    $"({ex.GetBaseException().Message}); rewriting it.");
+            }
+
+            File.WriteAllText(path, content);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// The registry facts <see cref="FuseWhistleDefinitionStore"/> needs from
+    /// a registered whistle, decoupled from <see cref="FuseAudioAPI"/>'s
+    /// private entry types so the JSON generation stays pure and testable.
+    /// </summary>
+    internal readonly struct FuseWhistleStoreEntry
+    {
+        internal FuseWhistleStoreEntry(string id, string name, string modelAssetPackIdentifier, string modelAssetIdentifier)
+        {
+            Id = id;
+            Name = name;
+            ModelAssetPackIdentifier = modelAssetPackIdentifier;
+            ModelAssetIdentifier = modelAssetIdentifier;
+        }
+
+        internal string Id { get; }
+
+        internal string Name { get; }
+
+        internal string ModelAssetPackIdentifier { get; }
+
+        internal string ModelAssetIdentifier { get; }
+    }
+}


### PR DESCRIPTION
## Summary

Legacy whistle packs (`whistles.json` — CollieWhistlePack's 356, CPLW's 150, WNCRR's 35, Kanawha, MTH, Dollywood, SOU154, TRR12) registered successfully on every map load but never appeared in the whistle dropdown. Only store-backed whistles (vanilla + native asset-pack mods) were listed.

**Root cause:** the customize window builds its dropdown from `PrefabStore.AllDefinitionInfosOfType<WhistleDefinition>()`, which enumerates asset-pack stores only. FUSE's converted whistles live in `FuseAudioAPI`'s in-memory registry and were fed into that enumeration by `FusePrefabStoreWhistleDefinitionsPatch` — until f53e91e ("Fix Customize tab") removed it. That removal was correct (Harmony hooks on one T of a JIT-shared closed generic fire for every other T, corrupting scenery/material/car enumerations), but no replacement was ever built, so the whistles silently vanished from the menu while `register audio` kept logging success. The dead `GetWhistleDefinitionItems`/`TryBuildWhistleDefinition` methods (whose consuming patches no longer exist) were the leftover evidence.

## Fix — no generic patches

`FuseWhistleDefinitionStore` writes the registered whistles as a game-schema `Definitions.json` under `LocalLow\...\FUSE\GeneratedStores\fuse-whistles` and mounts that folder through the **existing** `fuseasset://` direct-store machinery. Vanilla then lists *and* resolves the whistles natively — `DefinitionForIdentifier<WhistleDefinition>` no longer throws `UnknownIdentifierException` for FUSE whistle ids either.

- Generated definitions keep the **audio reference empty** so vanilla's `Configure` never races FUSE for the clip (FUSE serves it from disk via `TryConfigureWhistle`); the model reference stays real.
- `FuseAudioAPI.RegisterDefinition`/`ReleasePackage` re-sync the store; files rewrite only on content change, and the mounted store's cached container is invalidated on rewrite.
- `PrefabStore.Create` warm-mounts the folder so a fresh store population never drops the whistles.
- The dead picker-feed methods are replaced by a snapshot feed; the stale "we accept vanilla 3D whistle models" comment is corrected.

## Testing

- 7 new unit tests for the JSON generation, including a round-trip through the game's own `ContainerSerialization` serializer settings proving the emitted schema binds to `WhistleDefinition` with `Audio.IsEmpty`.
- Full suite: 1474/1474 passing; slopwatch clean.
- Verified in-game: all legacy pack whistles are back in the Whistle dropdown and play correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
