### PR TITLE
fix(ops): retire passenger stops with their orphaned base-game industries

### DIFF
--- a/FUSE/Patches/FusePassengerCarPanelPatch.cs
+++ b/FUSE/Patches/FusePassengerCarPanelPatch.cs
@@ -79,7 +79,7 @@ namespace FUSE.Patches
             {
                 try
                 {
-                    var passed = allStopsRaw.Count(s => !s.ProgressionDisabled);
+                    var passed = allStopsRaw.Count(s => !s.ProgressionDisabled && !IsParentIndustryProgressionDisabled(s));
                     var filtered = allStopsRaw.Length - passed;
                     FuseLog.Info(
                         $"FUSE diag passenger panel populate car='{car?.id ?? "<null>"}' " +
@@ -87,11 +87,12 @@ namespace FUSE.Patches
                     foreach (var s in allStopsRaw.OrderBy(x => x.identifier, StringComparer.OrdinalIgnoreCase))
                     {
                         var industry = s.GetComponentInParent<Model.Ops.Industry>(true);
+                        var industryDisabled = industry != null && industry.ProgressionDisabled;
                         FuseLog.Info(
                             $"  panel diag id='{s.identifier}' progressionDisabled={s.ProgressionDisabled} " +
                             $"industry='{(industry != null ? industry.identifier : "<none>")}' " +
-                            $"industryProgDisabled={(industry != null && industry.ProgressionDisabled)} " +
-                            $"willShow={!s.ProgressionDisabled}.");
+                            $"industryProgDisabled={industryDisabled} " +
+                            $"willShow={!s.ProgressionDisabled && !industryDisabled}.");
                     }
                 }
                 catch (Exception ex)
@@ -101,7 +102,7 @@ namespace FUSE.Patches
             }
 
             var allStops = allStopsRaw
-                .Where(stop => !stop.ProgressionDisabled)
+                .Where(stop => !stop.ProgressionDisabled && !IsParentIndustryProgressionDisabled(stop))
                 .ToArray();
 
             var stopsById = allStops
@@ -198,6 +199,25 @@ namespace FUSE.Patches
 
             var count = marker.Value.CountPassengersForStop(stop.identifier);
             return count != 0 ? $"{stop.name} ({count})" : stop.name;
+        }
+
+        // A stop inside a progression-disabled industry cannot be served no
+        // matter what its own flag says — the game's feature pass only reaches
+        // stops through intact area wiring, and FUSE's orphan pass may disable
+        // the industry when track replacement severs that wiring. Filtering on
+        // the parent keeps the picker honest for the whole failure class
+        // instead of only the writes FUSE itself performs.
+        private static bool IsParentIndustryProgressionDisabled(PassengerStop stop)
+        {
+            try
+            {
+                var industry = stop != null ? stop.GetComponentInParent<Model.Ops.Industry>(true) : null;
+                return industry != null && industry.ProgressionDisabled;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private static int GetPassengerStopAreaOrder(PassengerStop stop)

--- a/FUSE/Runtime/API/IndustryAPI.Cache.cs
+++ b/FUSE/Runtime/API/IndustryAPI.Cache.cs
@@ -220,6 +220,27 @@ namespace FUSE.Runtime.API
                         }
                     }
 
+                    // PassengerStop is not an IndustryComponent, so the loop
+                    // above never reaches it — and the game's own feature pass
+                    // cannot either, because the orphaned industry's area
+                    // wiring was severed by the same track replacement that
+                    // orphaned it. Left enabled, the stop keeps appearing in
+                    // the destination picker and keeps being generated FOR by
+                    // every other station (seen in the field: 'almond' and
+                    // 'nantahala' on the EWH map). Everything downstream —
+                    // picker filter, ActiveAvailableDestinations, the spawn
+                    // loop — keys off ProgressionDisabled, so setting it here
+                    // retires the stop everywhere at once.
+                    foreach (var stop in industry.GetComponentsInChildren<PassengerStop>(true))
+                    {
+                        if (stop != null && !stop.ProgressionDisabled)
+                        {
+                            stop.ProgressionDisabled = true;
+                            FuseLog.Info(
+                                $"FUSE disabled passenger stop '{stop.identifier}' with orphaned base-game industry '{id}'.");
+                        }
+                    }
+
                     industry.gameObject.SetActive(false);
                     FuseIndustryRuntimeIndex.Instance.Remove(id);
                     disabled++;


### PR DESCRIPTION
## Summary

On maps where FUSE track replacement severs base-game industries from the rails (seen on the EWH map: `almond-depot`, `nantahala-station`), the affected passenger stations kept appearing in the passenger car destination checklist and kept generating passengers — even though they can never be served.

**Root cause (proven with the verbose diagnostics built for this hunt):**

- FUSE's `DisableOrphanedBaseGameIndustries` correctly disables the orphaned `Industry` and its `IndustryComponent`s — but `PassengerStop` is not an `IndustryComponent`, so the station's stop stayed enabled.
- The game's own section pass can't catch it either: the same track surgery empties the area wiring `MapFeatureManager.UpdateFeatureForUnlocked` walks. Diag showed the locked `fo-na` feature finding `almond(ind=0,stops=0) ... nantahala(ind=0,stops=0)` while the intact `na-an` areas disabled topton/rhodo/andrews correctly.
- An enabled stop feeds everything: the picker filter, every other station's `ActiveAvailableDestinations` pool, and the spawn loop all key off `PassengerStop.ProgressionDisabled`.

## Fix

- `DisableOrphanedBaseGameIndustries` now also sets `ProgressionDisabled` on every `PassengerStop` under an industry it disables — retiring the stop from the picker, destination pools, and spawning in one write.
- The passenger panel filter additionally hides stops whose parent `Industry` is progression-disabled, so this failure class cannot render even if a future path disables an industry without reaching its stop. The verbose panel diag reports the same combined predicate.

## Testing

- Full suite: 1467/1467 passing; slopwatch clean.
- Verified in-game on the EWH sandbox save: load logs `FUSE disabled passenger stop 'almond' with orphaned base-game industry 'almond-depot'` (and `nantahala`), panel diag flips both to `willShow=False` (passedFilter 16 → 14), and the stations no longer appear in the checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
