### PR TITLE
Fix CheckForCarsAtPoint transpiler hang: wrong continue-label harvest

### DIFF
--- a/FUSE/Patches/TrainControllerPatches.cs
+++ b/FUSE/Patches/TrainControllerPatches.cs
@@ -70,17 +70,34 @@ namespace FUSE.Patches
                     codes[i - 1].Calls(getCenterPos) &&
                     codes[i].opcode == OpCodes.Stloc_3)
                 {
+                    // Harvest the loop's real continue target from the radius
+                    // early-out that immediately follows (a bgt-family branch:
+                    // "sqrMagnitude > radius*radius -> skip this car"). The
+                    // method's only brtrue is the foreach loop-back test, whose
+                    // TARGET is the loop head — branching there re-enters the
+                    // iteration without advancing the enumerator and hangs the
+                    // main thread, so brtrue must never be harvested here.
                     Label continueLabel = default;
-
-                    // Find the existing continue target (IL_010d)
-                    for (int j = i; j < codes.Count; j++)
+                    var foundContinue = false;
+                    for (int j = i + 1; j < codes.Count; j++)
                     {
-                        if (codes[j].opcode == OpCodes.Brtrue ||
-                            codes[j].opcode == OpCodes.Brtrue_S)
+                        var op = codes[j].opcode;
+                        if (op == OpCodes.Bgt || op == OpCodes.Bgt_S ||
+                            op == OpCodes.Bgt_Un || op == OpCodes.Bgt_Un_S)
                         {
                             continueLabel = (Label)codes[j].operand;
+                            foundContinue = true;
                             break;
                         }
+                    }
+
+                    if (!foundContinue)
+                    {
+                        // Fail open: no injection beats a wrong branch target.
+                        FuseLog.Warning(
+                            "FUSE CheckForCarsAtPoint height-skip not installed: the radius early-out " +
+                            "branch was not found after GetCenterPosition (game loop shape changed).");
+                        continue;
                     }
 
                     yield return new CodeInstruction(OpCodes.Ldarg_1); // point

--- a/FUSE/Patches/TrainControllerPatches.cs
+++ b/FUSE/Patches/TrainControllerPatches.cs
@@ -82,13 +82,23 @@ namespace FUSE.Patches
                     for (int j = i + 1; j < codes.Count; j++)
                     {
                         var op = codes[j].opcode;
+                        // Bind to the radius early-out specifically: it is the
+                        // FIRST branch after the stloc, so any other branch
+                        // opcode appearing first means the loop shape changed
+                        // and we must not guess.
+                        if (op.FlowControl != FlowControl.Cond_Branch &&
+                            op.FlowControl != FlowControl.Branch)
+                        {
+                            continue;
+                        }
+
                         if (op == OpCodes.Bgt || op == OpCodes.Bgt_S ||
                             op == OpCodes.Bgt_Un || op == OpCodes.Bgt_Un_S)
                         {
                             continueLabel = (Label)codes[j].operand;
                             foundContinue = true;
-                            break;
                         }
+                        break;
                     }
 
                     if (!foundContinue)


### PR DESCRIPTION
## Bug

`CheckForCarsAtPointPatch.Transpiler` injects a 4m height early-skip into the car foreach in `TrainController.CheckForCarsAtPoint`. To find the "continue" label it scanned forward for the first `brtrue` — but in the compiled loop the **only** `brtrue` is the trailing MoveNext test, whose *target* is the **loop head** (`get_Current`), not the continue point. The game's own early-outs use `bgt.s`/`brfalse.s`, which the scan ignored.

Result: the injected `brfalse` jumps back into the same iteration **without advancing the enumerator**. The first time a car inside the query radius fails the height check — a car on/under a bridge, the exact scenario the patch targets — the main thread spins forever and the game hard-hangs. Latent in every build carrying this patch; it only needs the geometry to line up once.

## Fix

- Harvest the continue label from the **radius early-out** instead: the `bgt`-family branch immediately following `GetCenterPosition`/`stloc.3` (`sqrMagnitude > radius² → skip car`), which targets the real per-iteration continuation.
- **Fail open**: if that pattern is ever absent (game update reshapes the loop), log a warning and skip the injection entirely.

## Evidence

IL dump of the shipped `TrainController.CheckForCarsAtPoint`: branches after the injection point are `bgt.s IL_010d`, `brfalse.s IL_010d`, `brfalse.s IL_0105`, `brfalse.s IL_010d`; the sole `brtrue` is `IL_0114: brtrue IL_0035` (loop-back to `get_Current`). The old scan harvested `IL_0035`; the correct continue target is `IL_010d`.

## Tests

Full suite: 1,518 passed / 0 failed. Patch class remains covered by `FusePatchTargetingTests` / `HarmonyPatchInstallationTests`.