### PR TITLE
Legacy-mod health monitor, switch-geometry rail backfill, MapEnhancer/rrRIC containment guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,6 @@ jobs:
     env:
       DOTNET_NOLOGO: "true"
       DOTNET_CLI_TELEMETRY_OPTOUT: "1"
-      # setup-dotnet installs into C:\Program Files\dotnet by default, which
-      # the self-hosted runner service account cannot write to — the install
-      # step fails and every downstream step skips. The tool cache lives under
-      # the runner's own _work tree, so it is always writable and persists
-      # between runs (no re-download per build).
-      DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet
 
     steps:
       - name: Checkout repository
@@ -55,6 +49,16 @@ jobs:
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: "10.0.x"
+        env:
+          # setup-dotnet installs into C:\Program Files\dotnet by default,
+          # which the self-hosted runner service account cannot write to — the
+          # install fails and every downstream step skips. The tool cache lives
+          # under the runner's own _work tree: always writable, and persistent
+          # between runs so the SDK is not re-downloaded per build. Set here
+          # rather than on the job because the runner context is only in scope
+          # for steps; the action exports DOTNET_ROOT and PATH from it, so the
+          # later build/test steps resolve this SDK.
+          DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet
 
       # JSON lint and .NET format checks are split out into dedicated
       # workflows (.github/workflows/json-lint.yml and dotnet-lint.yml)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
     env:
       DOTNET_NOLOGO: "true"
       DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+      # setup-dotnet installs into C:\Program Files\dotnet by default, which
+      # the self-hosted runner service account cannot write to — the install
+      # step fails and every downstream step skips. The tool cache lives under
+      # the runner's own _work tree, so it is always writable and persists
+      # between runs (no re-download per build).
+      DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,6 @@ jobs:
     env:
       DOTNET_NOLOGO: "true"
       DOTNET_CLI_TELEMETRY_OPTOUT: "1"
-      # See the matching note in ci.yml: the default install root is not
-      # writable by the self-hosted runner service account, so pin the SDK
-      # install to the runner-owned tool cache. Without this the release lane
-      # fails at SDK setup before it ever builds an artifact.
-      DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet
 
     steps:
       - name: Checkout repository
@@ -41,6 +36,12 @@ jobs:
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: "10.0.x"
+        env:
+          # See the matching note in ci.yml: the default install root is not
+          # writable by the self-hosted runner service account, so pin the SDK
+          # install to the runner-owned tool cache. Without this the release
+          # lane fails at SDK setup before it ever builds an artifact.
+          DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
     env:
       DOTNET_NOLOGO: "true"
       DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+      # See the matching note in ci.yml: the default install root is not
+      # writable by the self-hosted runner service account, so pin the SDK
+      # install to the runner-owned tool cache. Without this the release lane
+      # fails at SDK setup before it ever builds an artifact.
+      DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet
 
     steps:
       - name: Checkout repository

--- a/FUSE.Tests/Infrastructure/FuseModAttributionMapTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseModAttributionMapTests.cs
@@ -216,6 +216,35 @@ namespace FUSE.Tests.Infrastructure
         }
 
         [Fact]
+        public void BuildTokenMapCore_DropsTwoSegmentTokensUnderADeniedRoot()
+        {
+            // Mods routinely ship polyfill/generated types under BCL roots
+            // (System.Runtime.CompilerServices.IsExternalInit and friends).
+            // Harvesting those as two-segment tokens would attribute every
+            // engine/BCL frame to whichever mod happened to embed the
+            // polyfill — the denied root has to cover its children too.
+            var map = FuseModAttributionMap.BuildTokenMapCore(
+                new[]
+                {
+                    ("System.Runtime", "mod.a", "Mod A"),
+                    ("System.Diagnostics", "mod.a", "Mod A"),
+                    ("Microsoft.CodeAnalysis", "mod.b", "Mod B"),
+                    ("ModA.Internals", "mod.a", "Mod A")
+                },
+                new[] { "System", "Microsoft" },
+                out var dropped);
+
+            Assert.Equal(3, dropped);
+            Assert.False(map.ContainsKey("System.Runtime"));
+            Assert.False(map.ContainsKey("System.Diagnostics"));
+            Assert.False(map.ContainsKey("Microsoft.CodeAnalysis"));
+
+            // A mod-owned two-segment token still attributes normally.
+            Assert.True(map.ContainsKey("ModA.Internals"));
+            Assert.Equal("mod.a", map["ModA.Internals"].modId);
+        }
+
+        [Fact]
         public void BuildTokenMapCore_DropsTokensClaimedByTwoMods()
         {
             var map = FuseModAttributionMap.BuildTokenMapCore(

--- a/FUSE.Tests/Infrastructure/FuseModAttributionMapTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseModAttributionMapTests.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using FUSE.Infrastructure;
+using Xunit;
+
+namespace FUSE.Tests.Infrastructure
+{
+    /// <summary>
+    /// Tests for the attribution map's pure cores: the stack-trace token
+    /// parser (TryAttributeStackCore) and the token-map assembly with its
+    /// denylist/ambiguity rules (BuildTokenMapCore). Both are static pure
+    /// functions over caller-supplied data, so these tests run without
+    /// Unity, UMM, or any live mod population — the runtime harvesting
+    /// paths stay in-game-only by design.
+    /// </summary>
+    public class FuseModAttributionMapTests
+    {
+        private static Dictionary<string, (string modId, string displayName)> Map(
+            params (string token, string modId, string displayName)[] entries)
+        {
+            var map = new Dictionary<string, (string modId, string displayName)>(StringComparer.OrdinalIgnoreCase);
+            foreach (var entry in entries)
+            {
+                map[entry.token] = (entry.modId, entry.displayName);
+            }
+
+            return map;
+        }
+
+        private static readonly Dictionary<string, (string modId, string displayName)> MapEnhancerMap =
+            Map(("MapEnhancer", "mapenhancer", "Map Enhancer"));
+
+        [Fact]
+        public void UnityTraceLine_Parses_AndReturnsTheFrame()
+        {
+            var trace =
+                "MapEnhancer.MapEnhancer.UpdateCullingSpheres (Game.Events.WorldDidMoveEvent evt) (at <abc123>:0)\n" +
+                "Game.Events.Messenger.SendToList (Game.Events.WorldDidMoveEvent evt) (at <def456>:0)";
+
+            var matched = FuseModAttributionMap.TryAttributeStackCore(
+                trace, MapEnhancerMap, out var modId, out var displayName, out var frame);
+
+            Assert.True(matched);
+            Assert.Equal("mapenhancer", modId);
+            Assert.Equal("Map Enhancer", displayName);
+            Assert.Equal("MapEnhancer.MapEnhancer.UpdateCullingSpheres", frame);
+        }
+
+        [Fact]
+        public void InnermostMatchingFrame_Wins_OverALaterMatch()
+        {
+            var map = Map(
+                ("ModA", "mod.a", "Mod A"),
+                ("ModB", "mod.b", "Mod B"));
+            var trace =
+                "ModA.Deep.Thrower (System.String s) (at <a>:0)\n" +
+                "ModB.Outer.Caller () (at <b>:0)";
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                trace, map, out var modId, out _, out var frame));
+            Assert.Equal("mod.a", modId);
+            Assert.Equal("ModA.Deep.Thrower", frame);
+        }
+
+        [Fact]
+        public void UnmatchedInnerFrames_FallThrough_ToTheFirstModFrame()
+        {
+            var trace =
+                "Game.Events.Messenger.SendToList (Game.Events.WorldDidMoveEvent evt) (at <a>:0)\n" +
+                "UnityEngine.Events.UnityEvent.Invoke () (at <b>:0)\n" +
+                "MapEnhancer.MapEnhancer.Rebuild () (at <c>:0)";
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                trace, MapEnhancerMap, out var modId, out _, out var frame));
+            Assert.Equal("mapenhancer", modId);
+            Assert.Equal("MapEnhancer.MapEnhancer.Rebuild", frame);
+        }
+
+        [Fact]
+        public void TwoSegmentToken_MatchesDeepReverseDomainNamespaces()
+        {
+            var map = Map(("Us.Dchn", "us.dchn.rebill", "Rebill Industry Cars"));
+            var trace = "Us.Dchn.Railroader.RebillIndustryCars.RebillSystem.AutoConfigUnloaders () (at <a>:0)";
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                trace, map, out var modId, out _, out var frame));
+            Assert.Equal("us.dchn.rebill", modId);
+            Assert.Equal("Us.Dchn.Railroader.RebillIndustryCars.RebillSystem.AutoConfigUnloaders", frame);
+        }
+
+        [Fact]
+        public void TwoSegmentToken_IsPreferredOverAOneSegmentToken()
+        {
+            var map = Map(
+                ("Us", "wrong.mod", "Wrong"),
+                ("Us.Dchn", "right.mod", "Right"));
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                "Us.Dchn.Railroader.RebillSystem.Tick () (at <a>:0)",
+                map, out var modId, out _, out _));
+            Assert.Equal("right.mod", modId);
+        }
+
+        [Fact]
+        public void MonoStyleFrames_WithAtPrefixAndIlOffset_Parse()
+        {
+            var trace =
+                "  at MapEnhancer.MapEnhancer.Rebuild () [0x0001d] in <hash>:0 \n" +
+                "  at MapEnhancer.MapEnhancer.OnMapDidLoad (Map.Runtime.MapDidLoadEvent evt) [0x001bb] in <hash>:0";
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                trace, MapEnhancerMap, out var modId, out _, out var frame));
+            Assert.Equal("mapenhancer", modId);
+            Assert.Equal("MapEnhancer.MapEnhancer.Rebuild", frame);
+        }
+
+        [Fact]
+        public void DebugLogStyleFrames_WithColonSeparator_Parse()
+        {
+            var trace = "MapEnhancer.MapEnhancer:Rebuild()";
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                trace, MapEnhancerMap, out var modId, out _, out var frame));
+            Assert.Equal("mapenhancer", modId);
+            // The frame keeps the method tail; only token lookup cuts at ':'.
+            Assert.Equal("MapEnhancer.MapEnhancer:Rebuild()", frame);
+        }
+
+        [Fact]
+        public void MalformedLines_AreSkipped_NotFatal()
+        {
+            var trace =
+                "----\n" +
+                "Rethrow as TargetInvocationException\n" +
+                "\n" +
+                "no dots on this line\n" +
+                "MapEnhancer.MapEnhancer.CreateSwitches () (at <a>:0)";
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                trace, MapEnhancerMap, out var modId, out _, out var frame));
+            Assert.Equal("mapenhancer", modId);
+            Assert.Equal("MapEnhancer.MapEnhancer.CreateSwitches", frame);
+        }
+
+        [Fact]
+        public void NoMatchingFrame_ReturnsFalse_WithNullOuts()
+        {
+            var trace =
+                "Game.Events.Messenger.SendToList (Game.Events.WorldDidMoveEvent evt) (at <a>:0)\n" +
+                "UnityEngine.Events.UnityEvent.Invoke () (at <b>:0)";
+
+            Assert.False(FuseModAttributionMap.TryAttributeStackCore(
+                trace, MapEnhancerMap, out var modId, out var displayName, out var frame));
+            Assert.Null(modId);
+            Assert.Null(displayName);
+            Assert.Null(frame);
+        }
+
+        [Fact]
+        public void EmptyStack_NullMap_EmptyMap_AllReturnFalse()
+        {
+            Assert.False(FuseModAttributionMap.TryAttributeStackCore(
+                null, MapEnhancerMap, out _, out _, out _));
+            Assert.False(FuseModAttributionMap.TryAttributeStackCore(
+                string.Empty, MapEnhancerMap, out _, out _, out _));
+            Assert.False(FuseModAttributionMap.TryAttributeStackCore(
+                "MapEnhancer.MapEnhancer.Rebuild () (at <a>:0)", null, out _, out _, out _));
+            Assert.False(FuseModAttributionMap.TryAttributeStackCore(
+                "MapEnhancer.MapEnhancer.Rebuild () (at <a>:0)", Map(), out _, out _, out _));
+        }
+
+        [Fact]
+        public void FrameCap_StopsAfterTwelveFrames()
+        {
+            var beyondCap = new StringBuilder();
+            for (var i = 0; i < 12; i++)
+            {
+                beyondCap.AppendLine($"Game.Events.Frame{i}.Method (System.Int32 x) (at <a>:0)");
+            }
+
+            beyondCap.AppendLine("MapEnhancer.MapEnhancer.Rebuild () (at <b>:0)");
+
+            Assert.False(FuseModAttributionMap.TryAttributeStackCore(
+                beyondCap.ToString(), MapEnhancerMap, out _, out _, out _));
+
+            var withinCap = new StringBuilder();
+            for (var i = 0; i < 11; i++)
+            {
+                withinCap.AppendLine($"Game.Events.Frame{i}.Method (System.Int32 x) (at <a>:0)");
+            }
+
+            withinCap.AppendLine("MapEnhancer.MapEnhancer.Rebuild () (at <b>:0)");
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                withinCap.ToString(), MapEnhancerMap, out var modId, out _, out _));
+            Assert.Equal("mapenhancer", modId);
+        }
+
+        [Fact]
+        public void BuildTokenMapCore_DropsDenylistedTokens()
+        {
+            var map = FuseModAttributionMap.BuildTokenMapCore(
+                new[]
+                {
+                    ("Game", "mod.a", "Mod A"),          // shadows a game root: dropped
+                    ("ModA", "mod.a", "Mod A")
+                },
+                new[] { "Game" },
+                out var dropped);
+
+            Assert.Equal(1, dropped);
+            Assert.False(map.ContainsKey("Game"));
+            Assert.True(map.ContainsKey("ModA"));
+            Assert.Equal("mod.a", map["ModA"].modId);
+        }
+
+        [Fact]
+        public void BuildTokenMapCore_DropsTokensClaimedByTwoMods()
+        {
+            var map = FuseModAttributionMap.BuildTokenMapCore(
+                new[]
+                {
+                    ("Shared", "mod.a", "Mod A"),
+                    ("Shared", "mod.b", "Mod B"),   // conflict: token removed + denied
+                    ("Shared", "mod.c", "Mod C")    // now denied
+                },
+                Array.Empty<string>(),
+                out var dropped);
+
+            Assert.Equal(2, dropped);
+            Assert.False(map.ContainsKey("Shared"));
+        }
+
+        [Fact]
+        public void BuildTokenMapCore_IgnoresDuplicatesFromTheSameMod_AndBlankTokens()
+        {
+            var map = FuseModAttributionMap.BuildTokenMapCore(
+                new[]
+                {
+                    ("ModA", "mod.a", "Mod A"),
+                    ("ModA", "mod.a", "Mod A"),
+                    ("  ", "mod.a", "Mod A"),
+                    ((string)null, "mod.a", "Mod A")
+                },
+                Array.Empty<string>(),
+                out var dropped);
+
+            Assert.Equal(0, dropped);
+            Assert.Single(map);
+        }
+
+        [Fact]
+        public void BuildTokenMapCore_Output_IsCaseInsensitive_ForCoreLookups()
+        {
+            var map = FuseModAttributionMap.BuildTokenMapCore(
+                new[] { ("mapenhancer", "mapenhancer", "Map Enhancer") },
+                Array.Empty<string>(),
+                out _);
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                "MapEnhancer.MapEnhancer.Rebuild () (at <a>:0)",
+                map, out var modId, out _, out _));
+            Assert.Equal("mapenhancer", modId);
+        }
+
+        [Fact]
+        public void DeniedGameToken_NeverAttributes_EvenWhenAModClaimedIt()
+        {
+            // A mod claiming "Game" loses the token to the denylist, so a
+            // stack whose inner frames are game code still attributes to the
+            // mod's own namespace further out — never the other way around.
+            var map = FuseModAttributionMap.BuildTokenMapCore(
+                new[]
+                {
+                    ("Game", "greedy.mod", "Greedy Mod"),
+                    ("GreedyMod", "greedy.mod", "Greedy Mod")
+                },
+                new[] { "Game" },
+                out _);
+
+            var trace =
+                "Game.Messages.Handler.Dispatch () (at <a>:0)\n" +
+                "GreedyMod.Listener.OnMessage () (at <b>:0)";
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                trace, map, out var modId, out _, out var frame));
+            Assert.Equal("greedy.mod", modId);
+            Assert.Equal("GreedyMod.Listener.OnMessage", frame);
+        }
+    }
+}

--- a/FUSE.Tests/Infrastructure/FuseModExceptionRegistryTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseModExceptionRegistryTests.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FUSE.Infrastructure;
+using Xunit;
+
+namespace FUSE.Tests.Infrastructure
+{
+    [CollectionDefinition(Name)]
+    public sealed class FuseModExceptionRegistryTestCollection
+    {
+        public const string Name = "FuseModExceptionRegistry";
+    }
+
+    /// <summary>
+    /// Tests for the legacy-mod health monitor's exception registry (visible
+    /// via InternalsVisibleTo). The registry is the single sink all three
+    /// capture sources write and the load report / Status page read, so its
+    /// dedupe, episode coalescing, caps, and summary line are the contract a
+    /// pasted /fuse.report depends on. State is static and
+    /// session-cumulative; every test resets first and the collection keeps
+    /// classes that share the statics from interleaving.
+    /// </summary>
+    [Collection(FuseModExceptionRegistryTestCollection.Name)]
+    public class FuseModExceptionRegistryTests
+    {
+        public FuseModExceptionRegistryTests()
+        {
+            FuseModExceptionRegistry.ResetForTests();
+            FuseModAttributionMap.ResetForTests();
+        }
+
+        private static void RecordDefault(
+            string modId = "mapenhancer",
+            string frame = "MapEnhancer.MapEnhancer.UpdateCullingSpheres",
+            string source = "LogHook",
+            string exceptionType = "NullReferenceException",
+            string message = "Object reference not set to an instance of an object")
+        {
+            FuseModExceptionRegistry.Record(source, modId, "Map Enhancer", exceptionType, frame, message);
+        }
+
+        [Fact]
+        public void FreshRegistry_IsIdle_AndSummarizesAllZero()
+        {
+            Assert.True(FuseModExceptionRegistry.AllIdle);
+            Assert.Equal(0, FuseModExceptionRegistry.GrandTotal);
+            Assert.Equal(0, FuseModExceptionRegistry.TotalUnattributed);
+            Assert.Equal("modErrors=0 unattributed=0 mods=0", FuseModExceptionRegistry.FormatSummary());
+            Assert.Empty(FuseModExceptionRegistry.SnapshotForReport());
+        }
+
+        [Fact]
+        public void Record_CreatesModRecordAndSignature()
+        {
+            RecordDefault();
+
+            Assert.False(FuseModExceptionRegistry.AllIdle);
+            Assert.Equal(1, FuseModExceptionRegistry.GrandTotal);
+            Assert.Equal("modErrors=1 unattributed=0 mods=1", FuseModExceptionRegistry.FormatSummary());
+
+            var snapshot = Assert.Single(FuseModExceptionRegistry.SnapshotForReport());
+            Assert.Equal("mapenhancer", snapshot.ModId);
+            Assert.Equal("Map Enhancer", snapshot.DisplayName);
+            Assert.Equal(1, snapshot.Count);
+            Assert.Equal(1, snapshot.Episodes);
+
+            var signature = Assert.Single(snapshot.Signatures);
+            Assert.Equal("NullReferenceException", signature.ExceptionType);
+            Assert.Equal("MapEnhancer.MapEnhancer.UpdateCullingSpheres", signature.TopOwnedFrame);
+            Assert.Equal("LogHook", signature.Source);
+            Assert.Equal(1, signature.Count);
+            Assert.Equal(1, signature.Episodes);
+            Assert.Equal("Object reference not set to an instance of an object", signature.SampleMessage);
+        }
+
+        [Fact]
+        public void SameSignature_Dedupes_DistinctSignature_GetsOwnRow()
+        {
+            RecordDefault();
+            RecordDefault();
+            RecordDefault(frame: "MapEnhancer.MapEnhancer.CreateSwitches");
+
+            var snapshot = Assert.Single(FuseModExceptionRegistry.SnapshotForReport());
+            Assert.Equal(3, snapshot.Count);
+            Assert.Equal(2, snapshot.Signatures.Length);
+
+            // Worst signature first.
+            Assert.Equal("MapEnhancer.MapEnhancer.UpdateCullingSpheres", snapshot.Signatures[0].TopOwnedFrame);
+            Assert.Equal(2, snapshot.Signatures[0].Count);
+            Assert.Equal(1, snapshot.Signatures[1].Count);
+        }
+
+        [Fact]
+        public void EpisodeCoalescing_MergesOccurrencesWithinOneSecond()
+        {
+            long tick = 0;
+            FuseModExceptionRegistry.TickSource = () => tick;
+
+            RecordDefault();          // tick 0    -> episode 1
+            tick = 400;
+            RecordDefault();          // +400ms    -> same episode
+            tick = 900;
+            RecordDefault();          // +500ms    -> same episode (sliding window)
+            tick = 2000;
+            RecordDefault();          // +1100ms   -> episode 2
+            tick = 2100;
+            RecordDefault();          // +100ms    -> same episode
+            tick = 3500;
+            RecordDefault();          // +1400ms   -> episode 3
+
+            var snapshot = Assert.Single(FuseModExceptionRegistry.SnapshotForReport());
+            Assert.Equal(6, snapshot.Count);
+            Assert.Equal(3, snapshot.Episodes);
+
+            var signature = Assert.Single(snapshot.Signatures);
+            Assert.Equal(6, signature.Count);
+            Assert.Equal(3, signature.Episodes);
+        }
+
+        [Fact]
+        public void Episodes_AreTrackedPerSignature()
+        {
+            long tick = 0;
+            FuseModExceptionRegistry.TickSource = () => tick;
+
+            RecordDefault(frame: "ModA.First");
+            tick = 100;
+            RecordDefault(frame: "ModA.Second");
+            tick = 200;
+            RecordDefault(frame: "ModA.First");
+            RecordDefault(frame: "ModA.Second");
+
+            var snapshot = Assert.Single(FuseModExceptionRegistry.SnapshotForReport());
+            // Each signature stays one episode; the mod aggregates both.
+            Assert.Equal(2, snapshot.Episodes);
+            Assert.All(snapshot.Signatures, signature => Assert.Equal(1, signature.Episodes));
+        }
+
+        [Fact]
+        public void SignatureCap_KeepsEight_AndCountsOverflowIntoModTotals()
+        {
+            long tick = 0;
+            FuseModExceptionRegistry.TickSource = () => tick;
+
+            for (var i = 0; i < 10; i++)
+            {
+                RecordDefault(frame: $"MapEnhancer.MapEnhancer.Method{i}");
+            }
+
+            var snapshot = Assert.Single(FuseModExceptionRegistry.SnapshotForReport());
+            Assert.Equal(8, snapshot.Signatures.Length);
+            Assert.Equal(10, snapshot.Count);
+            // 8 tracked signatures (1 episode each) + the two overflow
+            // occurrences at the same tick coalescing into one episode.
+            Assert.Equal(9, snapshot.Episodes);
+            Assert.Equal(2, FuseModExceptionRegistry.SignatureOverflowDropped);
+            Assert.Equal(10, FuseModExceptionRegistry.GrandTotal);
+        }
+
+        [Fact]
+        public void ModCap_FoldsLaterModsIntoTheOverflowBucket()
+        {
+            for (var i = 0; i < 40; i++)
+            {
+                FuseModExceptionRegistry.Record(
+                    "LogHook", $"mod{i}", $"Mod {i}", "NullReferenceException", $"Mod{i}.Type.Method", "boom");
+            }
+
+            var snapshots = FuseModExceptionRegistry.SnapshotForReport();
+            Assert.Equal(33, snapshots.Length); // 32 named + "<other>"
+
+            var overflow = snapshots.Single(s => s.ModId == FuseModExceptionRegistry.OverflowModId);
+            Assert.Equal(8, overflow.Count);
+            Assert.Equal("(other mods)", overflow.DisplayName);
+
+            // Sentinel buckets stay out of the mods= count; overflow means it is a floor.
+            Assert.Equal("modErrors=40 unattributed=0 mods=32", FuseModExceptionRegistry.FormatSummary());
+        }
+
+        [Fact]
+        public void NullOrSentinelModId_LandsInTheUnattributedBucket()
+        {
+            FuseModExceptionRegistry.Record("LogHook", null, null, "NullReferenceException", "Game.Foo.Bar", "boom");
+            FuseModExceptionRegistry.Record(
+                "LogHook", FuseModExceptionRegistry.UnattributedModId, null, "NullReferenceException", "Game.Foo.Bar", "boom");
+
+            Assert.Equal(2, FuseModExceptionRegistry.TotalUnattributed);
+            Assert.Equal("modErrors=2 unattributed=2 mods=0", FuseModExceptionRegistry.FormatSummary());
+
+            var snapshot = Assert.Single(FuseModExceptionRegistry.SnapshotForReport());
+            Assert.Equal(FuseModExceptionRegistry.UnattributedModId, snapshot.ModId);
+            Assert.Equal("(unattributed)", snapshot.DisplayName);
+            Assert.Equal(2, snapshot.Count);
+        }
+
+        [Fact]
+        public void RecordContained_ByModId_UsesTheLegacyHostSource()
+        {
+            FuseModExceptionRegistry.RecordContained(
+                new InvalidOperationException("plugin blew up"), "legacy.pack", "legacy host OnEnable");
+
+            var snapshot = Assert.Single(FuseModExceptionRegistry.SnapshotForReport());
+            Assert.Equal("legacy.pack", snapshot.ModId);
+
+            var signature = Assert.Single(snapshot.Signatures);
+            Assert.Equal("LegacyHost", signature.Source);
+            Assert.Equal("InvalidOperationException", signature.ExceptionType);
+            Assert.Equal("legacy host OnEnable", signature.TopOwnedFrame);
+            Assert.Equal("plugin blew up", signature.SampleMessage);
+        }
+
+        [Fact]
+        public void RecordContained_ByType_AttributesThroughTheAttributionMap()
+        {
+            FuseModAttributionMap.SetMapsForTests(
+                tokenMap: null,
+                assemblyMap: new Dictionary<Assembly, (string modId, string displayName)>
+                {
+                    [typeof(FuseModExceptionRegistryTests).Assembly] = ("test.mod", "Test Mod")
+                });
+
+            FuseModExceptionRegistry.RecordContained(
+                new NullReferenceException("boom"), typeof(FuseModExceptionRegistryTests), "map lifecycle listener");
+
+            var snapshot = Assert.Single(FuseModExceptionRegistry.SnapshotForReport());
+            Assert.Equal("test.mod", snapshot.ModId);
+            Assert.Equal("Test Mod", snapshot.DisplayName);
+
+            var signature = Assert.Single(snapshot.Signatures);
+            Assert.Equal("Messenger", signature.Source);
+            Assert.Contains("FuseModExceptionRegistryTests", signature.TopOwnedFrame);
+            Assert.Contains("[map lifecycle listener]", signature.TopOwnedFrame);
+        }
+
+        [Fact]
+        public void RecordContained_ByType_FallsBackToUnattributed_WhenTheMapDoesNotKnowTheAssembly()
+        {
+            FuseModAttributionMap.SetMapsForTests(tokenMap: null, assemblyMap: null);
+
+            FuseModExceptionRegistry.RecordContained(
+                new NullReferenceException("boom"), typeof(FuseModExceptionRegistryTests), "map lifecycle listener");
+
+            Assert.Equal(1, FuseModExceptionRegistry.TotalUnattributed);
+            var snapshot = Assert.Single(FuseModExceptionRegistry.SnapshotForReport());
+            Assert.Equal(FuseModExceptionRegistry.UnattributedModId, snapshot.ModId);
+            // The recipient identity is preserved even without attribution.
+            Assert.Contains("FuseModExceptionRegistryTests", snapshot.Signatures[0].TopOwnedFrame);
+        }
+
+        [Fact]
+        public void RecordContained_NullException_IsANoOp()
+        {
+            FuseModExceptionRegistry.RecordContained(null, "some.mod", "context");
+            FuseModExceptionRegistry.RecordContained(null, typeof(FuseModExceptionRegistryTests), "context");
+
+            Assert.True(FuseModExceptionRegistry.AllIdle);
+            Assert.Empty(FuseModExceptionRegistry.SnapshotForReport());
+        }
+
+        [Fact]
+        public void SampleMessage_IsTruncatedTo200Characters()
+        {
+            RecordDefault(message: new string('x', 300));
+
+            var snapshot = Assert.Single(FuseModExceptionRegistry.SnapshotForReport());
+            Assert.Equal(200, snapshot.Signatures[0].SampleMessage.Length);
+        }
+
+        [Fact]
+        public void FirstAndLastSeen_TrackTheInjectedClock()
+        {
+            var now = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            FuseModExceptionRegistry.UtcNowSource = () => now;
+            long tick = 0;
+            FuseModExceptionRegistry.TickSource = () => tick;
+
+            RecordDefault();
+            now = now.AddMinutes(5);
+            tick = 5 * 60 * 1000;
+            RecordDefault();
+
+            var snapshot = Assert.Single(FuseModExceptionRegistry.SnapshotForReport());
+            Assert.Equal(new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc), snapshot.FirstSeenUtc);
+            Assert.Equal(new DateTime(2026, 1, 1, 12, 5, 0, DateTimeKind.Utc), snapshot.LastSeenUtc);
+        }
+
+        [Fact]
+        public void ResetForTests_ClearsAllStateAndRestoresDefaultClocks()
+        {
+            long tick = 0;
+            FuseModExceptionRegistry.TickSource = () => tick;
+            RecordDefault();
+            FuseModExceptionRegistry.Record("LogHook", null, null, "Exception", "X.Y", "m");
+            Assert.NotEqual(0, FuseModExceptionRegistry.GrandTotal);
+
+            FuseModExceptionRegistry.ResetForTests();
+
+            Assert.True(FuseModExceptionRegistry.AllIdle);
+            Assert.Equal(0, FuseModExceptionRegistry.TotalUnattributed);
+            Assert.Equal(0, FuseModExceptionRegistry.SignatureOverflowDropped);
+            Assert.Empty(FuseModExceptionRegistry.SnapshotForReport());
+            Assert.Equal("modErrors=0 unattributed=0 mods=0", FuseModExceptionRegistry.FormatSummary());
+
+            // Recording still works against the restored default clocks.
+            RecordDefault();
+            Assert.Equal(1, FuseModExceptionRegistry.GrandTotal);
+        }
+
+        [Fact]
+        public void Snapshot_OrdersModsWorstFirst()
+        {
+            RecordDefault(modId: "quiet.mod", frame: "Quiet.Type.Method");
+            for (var i = 0; i < 3; i++)
+            {
+                RecordDefault(modId: "noisy.mod", frame: "Noisy.Type.Method");
+            }
+
+            var snapshots = FuseModExceptionRegistry.SnapshotForReport();
+            Assert.Equal(2, snapshots.Length);
+            Assert.Equal("noisy.mod", snapshots[0].ModId);
+            Assert.Equal(3, snapshots[0].Count);
+            Assert.Equal("quiet.mod", snapshots[1].ModId);
+        }
+    }
+}

--- a/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
@@ -87,15 +87,17 @@ namespace FUSE.Tests.Infrastructure
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordMapEnhancerCullingGuarded());
             Assert.Equal(2, FuseRuntimeGuardCounters.RecordMapEnhancerCullingGuarded());
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordRebillAutoConfigSuppressed());
+            Assert.Equal(1, FuseRuntimeGuardCounters.RecordSwitchGeometryRailsBackfilled());
 
             // Third-party containment must surface as guard activity: an
             // active suppression storm reading as "guards idle" would hide
             // the offender from every report surface.
             Assert.False(FuseRuntimeGuardCounters.AllIdle);
-            Assert.Equal(3, FuseRuntimeGuardCounters.GuardTotal);
+            Assert.Equal(4, FuseRuntimeGuardCounters.GuardTotal);
             var summary = FuseRuntimeGuardCounters.FormatSummary();
             Assert.Contains("mapEnhancerCullingGuarded=2", summary);
             Assert.Contains("rebillAutoConfigSuppressed=1", summary);
+            Assert.Contains("switchRailsBackfilled=1", summary);
         }
     }
 }

--- a/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
@@ -30,6 +30,8 @@ namespace FUSE.Tests.Infrastructure
                 "decalRegistrationsRejected=0 " +
                 "curveMesh=0 sceneryCarDecalsDisabled=0 sceneryLoadFailures=0 sceneryQuarantined=0 " +
                 "sceneryLoadWatch=0 " +
+                "mapEnhancerCullingGuarded=0 " +
+                "rebillAutoConfigSuppressed=0 " +
                 "flares=0 switchRailsBackfilled=0 frameSpikes=0",
                 FuseRuntimeGuardCounters.FormatSummary());
         }
@@ -77,6 +79,23 @@ namespace FUSE.Tests.Infrastructure
             Assert.Contains("sceneryCarDecalsDisabled=1", summary);
             Assert.Contains("sceneryLoadFailures=1", summary);
             Assert.Equal(5, FuseRuntimeGuardCounters.GuardTotal);
+        }
+
+        [Fact]
+        public void ThirdPartyGuardCounters_FeedTheTotal_AndTheSummary()
+        {
+            Assert.Equal(1, FuseRuntimeGuardCounters.RecordMapEnhancerCullingGuarded());
+            Assert.Equal(2, FuseRuntimeGuardCounters.RecordMapEnhancerCullingGuarded());
+            Assert.Equal(1, FuseRuntimeGuardCounters.RecordRebillAutoConfigSuppressed());
+
+            // Third-party containment must surface as guard activity: an
+            // active suppression storm reading as "guards idle" would hide
+            // the offender from every report surface.
+            Assert.False(FuseRuntimeGuardCounters.AllIdle);
+            Assert.Equal(3, FuseRuntimeGuardCounters.GuardTotal);
+            var summary = FuseRuntimeGuardCounters.FormatSummary();
+            Assert.Contains("mapEnhancerCullingGuarded=2", summary);
+            Assert.Contains("rebillAutoConfigSuppressed=1", summary);
         }
     }
 }

--- a/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
@@ -30,7 +30,7 @@ namespace FUSE.Tests.Infrastructure
                 "decalRegistrationsRejected=0 " +
                 "curveMesh=0 sceneryCarDecalsDisabled=0 sceneryLoadFailures=0 sceneryQuarantined=0 " +
                 "sceneryLoadWatch=0 " +
-                "flares=0 frameSpikes=0",
+                "flares=0 switchRailsBackfilled=0 frameSpikes=0",
                 FuseRuntimeGuardCounters.FormatSummary());
         }
 

--- a/FUSE.Tests/Loading/FuseLegacyModdingContextSettingsTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyModdingContextSettingsTests.cs
@@ -7,6 +7,15 @@ using Xunit;
 
 namespace FUSE.Tests.Loading
 {
+    /// <summary>
+    /// The broken-settings cases drive FuseLegacyModdingContext's
+    /// LoadSettingsData catch site, which records into the static
+    /// session-cumulative <c>FuseModExceptionRegistry</c> — so this class
+    /// shares the registry's xUnit collection (different collections run in
+    /// parallel, and stray records would race the registry/report
+    /// assertions).
+    /// </summary>
+    [Collection(FUSE.Tests.Infrastructure.FuseModExceptionRegistryTestCollection.Name)]
     public sealed class FuseLegacyModdingContextSettingsTests : IDisposable
     {
         private readonly string _modsRoot;

--- a/FUSE.Tests/Loading/FuseLoadReportModExceptionsTests.cs
+++ b/FUSE.Tests/Loading/FuseLoadReportModExceptionsTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Authoring.Data;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using FUSE.Runtime.Registry;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    /// <summary>
+    /// Pins the report surfaces for the third-party exception registry: the
+    /// summary's <c>modErrors</c> segment sits between <c>orphans</c> and the
+    /// <c>/fuse.report</c> suffix, the details section names each mod, the
+    /// JSON block rides beside <c>runtimeGuards</c>, and HasProblems only
+    /// flips for repeated faults (episodes >= 3 or count >= 10 per mod).
+    /// Uses the internal Build*ForTests seams against a hand-built snapshot
+    /// so no live capture registries are touched. The exception registry is
+    /// static session-cumulative state shared with
+    /// <see cref="FUSE.Tests.Infrastructure.FuseModExceptionRegistryTests"/>;
+    /// both classes therefore sit in the same xUnit collection (xUnit runs
+    /// different collections in parallel) and every test resets it first.
+    /// </summary>
+    [Collection(FUSE.Tests.Infrastructure.FuseModExceptionRegistryTestCollection.Name)]
+    public class FuseLoadReportModExceptionsTests
+    {
+        public FuseLoadReportModExceptionsTests()
+        {
+            FuseModExceptionRegistry.ResetForTests();
+        }
+
+        /// <summary>
+        /// Snapshot with every load-time registry surface empty and the
+        /// mod-exception fields filled from the live registry, the same way
+        /// CaptureSnapshot fills them — so whatever has been Record()ed is
+        /// the only thing that can make the report react.
+        /// </summary>
+        private static FuseLoadReport.ReportSnapshot CreateEmptySnapshot()
+        {
+            return new FuseLoadReport.ReportSnapshot
+            {
+                Reason = "test",
+                LoadedPackageIds = Array.Empty<string>(),
+                AppliedPackageIds = Array.Empty<string>(),
+                SkippedPackages = new Dictionary<string, string>(),
+                DisabledPackages = new Dictionary<string, string>(),
+                LegacyConvertedPackageIds = Array.Empty<string>(),
+                Faults = Array.Empty<FusePackageFault>(),
+                Conflicts = Array.Empty<FuseRegistryConflict>(),
+                SceneSuppressions = Array.Empty<string>(),
+                TrackGroupSuppressions = Array.Empty<string>(),
+                AreaSuppressions = Array.Empty<string>(),
+                UnknownSceneryAssets = Array.Empty<FuseLoadReport.UnknownSceneryAsset>(),
+                GraphPostBindIssues = Array.Empty<string>(),
+                ProgressionTransferSkips = Array.Empty<string>(),
+                Notices = Array.Empty<string>(),
+                SceneryLoadFailures = Array.Empty<FuseLoadReport.SceneryLoadFailure>(),
+                OrphanedCars = Array.Empty<FuseSaveCarFault>(),
+                ModExceptions = FuseModExceptionRegistry.SnapshotForReport(),
+                ModExceptionTotal = FuseModExceptionRegistry.GrandTotal,
+                ModExceptionUnattributed = FuseModExceptionRegistry.TotalUnattributed
+            };
+        }
+
+        private static void RecordMapEnhancerStyleException()
+        {
+            FuseModExceptionRegistry.Record(
+                "LogHook",
+                "mapEnhancer",
+                "Map Enhancer",
+                "NullReferenceException",
+                "MapEnhancer.MapEnhancer.UpdateCullingSpheres",
+                "Object reference not set to an instance of an object");
+        }
+
+        [Fact]
+        public void Summary_CarriesModErrorsSegment_BetweenOrphansAndReportSuffix_EvenWhenIdle()
+        {
+            var summary = FuseLoadReport.BuildSummaryForTests(CreateEmptySnapshot());
+
+            Assert.Contains("orphans 0 | modErrors 0 | /fuse.report", summary);
+        }
+
+        [Fact]
+        public void Details_OmitModExceptionSection_WhenRegistryIsIdle()
+        {
+            var details = FuseLoadReport.BuildDetailsForTests(CreateEmptySnapshot());
+
+            Assert.DoesNotContain("Third-party mod exceptions", details);
+        }
+
+        [Fact]
+        public void PopulatedRegistry_SurfacesInSummary_Details_AndJson()
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                RecordMapEnhancerStyleException();
+            }
+
+            var snapshot = CreateEmptySnapshot();
+
+            var summary = FuseLoadReport.BuildSummaryForTests(snapshot);
+            Assert.Contains($"modErrors {FuseModExceptionRegistry.GrandTotal} | /fuse.report", summary);
+
+            var details = FuseLoadReport.BuildDetailsForTests(snapshot);
+            Assert.Contains("Third-party mod exceptions observed this session:", details);
+            Assert.Contains("Map Enhancer:", details);
+            Assert.Contains("— top: NullReferenceException @ MapEnhancer.MapEnhancer.UpdateCullingSpheres", details);
+
+            var json = JObject.Parse(FuseLoadReport.BuildJsonForTests(snapshot));
+            var modExceptions = json["modExceptions"] as JObject;
+            Assert.NotNull(modExceptions);
+            Assert.Equal(FuseModExceptionRegistry.GrandTotal, (long)modExceptions["total"]);
+
+            var mods = modExceptions["mods"] as JArray;
+            Assert.NotNull(mods);
+            var entry = mods.OfType<JObject>().FirstOrDefault(item => (string)item["modId"] == "mapEnhancer");
+            Assert.NotNull(entry);
+            Assert.Equal("Map Enhancer", (string)entry["displayName"]);
+
+            var signatures = entry["signatures"] as JArray;
+            Assert.NotNull(signatures);
+            Assert.True(signatures.Count >= 1, "expected at least one signature in the JSON block");
+            var topSignature = signatures.OfType<JObject>().First();
+            Assert.Equal("NullReferenceException", (string)topSignature["type"]);
+            Assert.Equal("MapEnhancer.MapEnhancer.UpdateCullingSpheres", (string)topSignature["frame"]);
+        }
+
+        [Fact]
+        public void UnattributedBucket_RendersAsItsOwnRow_NotADuplicateFooter()
+        {
+            // The registry snapshots the "(unattributed)" bucket as a record
+            // of its own, so the details section must not append a second
+            // unattributed footer line — one mention per bucket.
+            FuseModExceptionRegistry.Record(
+                "LogHook", null, null, "InvalidOperationException", null, "boom");
+
+            var details = FuseLoadReport.BuildDetailsForTests(CreateEmptySnapshot());
+
+            Assert.Contains("Third-party mod exceptions observed this session:", details);
+            Assert.Contains("(unattributed):", details);
+            Assert.DoesNotContain("no recognizable mod frame", details);
+        }
+
+        [Fact]
+        public void HasProblems_IgnoresOneOffException_ButTripsOnRepeats()
+        {
+            RecordMapEnhancerStyleException();
+            Assert.False(CreateEmptySnapshot().HasProblems);
+
+            // Nine more of the same signature crosses the count >= 10
+            // threshold regardless of how the burst coalesces into episodes.
+            for (var i = 0; i < 9; i++)
+            {
+                RecordMapEnhancerStyleException();
+            }
+
+            Assert.True(CreateEmptySnapshot().HasProblems);
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseMessengerIsolationPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseMessengerIsolationPatchTests.cs
@@ -31,7 +31,14 @@ namespace FUSE.Tests.Patches
     /// integration test; the finalizer is exercised the same way
     /// FusePrefabStoreMaterialDefinitionsPatchTests exercises its
     /// patch bodies — as a plain static method.
+    ///
+    /// Invoking the finalizer records the contained exception into the
+    /// static session-cumulative <c>FuseModExceptionRegistry</c>, so this
+    /// class shares the registry's xUnit collection — xUnit runs different
+    /// collections in parallel, and stray records would otherwise race the
+    /// registry/report assertions.
     /// </summary>
+    [Collection(FUSE.Tests.Infrastructure.FuseModExceptionRegistryTestCollection.Name)]
     public class FuseMessengerIsolationPatchTests
     {
         // ---- target resolution against the real game assemblies ----

--- a/FUSE/FusePlugin.cs
+++ b/FUSE/FusePlugin.cs
@@ -88,6 +88,8 @@ namespace FUSE
                 FuseFrameSpikeDiagnostic.EnsureStarted();
                 FuseRuntimePump.EnsureStarted();
                 FuseSceneryLoadFailurePatch.EnsureGameLogHook();
+                FuseModExceptionLogHook.Install();
+                FuseThirdPartyGuardInstaller.EnsureInstalled();
                 FuseUmmInjector.ScheduleInjection(modEntry.Path, ReadInfoJsonString(Path.Combine(modEntry.Path ?? string.Empty, "Info.json"), "Version"));
                 FuseLegacyAssemblyHost.EnsureStartupHost();
 
@@ -226,6 +228,7 @@ namespace FUSE
 
             FuseSceneryLoadThrottlePatch.Shutdown();
             FuseSceneryLoadFailurePatch.Shutdown();
+            FuseModExceptionLogHook.Shutdown();
             FuseLegacyAssemblyHost.Shutdown();
             FuseLegacySupportAssemblyShim.Shutdown();
             FuseRuntimeRebindService.Shutdown();

--- a/FUSE/Infrastructure/FuseModAttributionMap.cs
+++ b/FUSE/Infrastructure/FuseModAttributionMap.cs
@@ -1,0 +1,667 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using FUSE.Loading;
+
+namespace FUSE.Infrastructure
+{
+    /// <summary>
+    /// Maps observed exception evidence (a Unity stack-trace string, or a
+    /// listener's recipient type) to the third-party mod that owns it, for
+    /// the legacy-mod health monitor.
+    ///
+    /// Unity stack traces carry namespace-qualified type names, never
+    /// assembly names, so stack attribution works on a token map: each known
+    /// mod assembly contributes its simple name plus the first one and two
+    /// dot-segments of every namespace it declares. Tokens that collide with
+    /// game/engine/FUSE-owned namespaces — or with another mod — attribute
+    /// to nobody (dropped into the denylist), so a wrong blame is impossible
+    /// at the cost of an occasional unattributed count.
+    ///
+    /// The map is built lazily on first use (mods are all loaded well before
+    /// the first exception can be observed) and invalidated whenever the mod
+    /// population changes. Building reflects over UMM's mod entries the same
+    /// way <see cref="FuseUmmState"/> does (per-member reflection, tolerant
+    /// of shape drift) and over FUSE's own hosted legacy plugins. All
+    /// runtime harvesting is fail-open: a build failure yields an empty map
+    /// (everything unattributed) and one warning, never a throw into the
+    /// recording path.
+    ///
+    /// The parsing core (<see cref="TryAttributeStackCore"/>) and the token
+    /// map assembly (<see cref="BuildTokenMapCore"/>) are pure so tests run
+    /// them without Unity or UMM present.
+    /// </summary>
+    internal static class FuseModAttributionMap
+    {
+        // Innermost frames are examined first — the throwing mod gets blamed,
+        // not a FUSE/game frame that hosted the call. Deep traces past this
+        // cap are almost certainly engine plumbing; stop rather than scan.
+        private const int MaxFramesExamined = 12;
+
+        private static readonly object Gate = new object();
+
+        // Both maps are immutable once published; readers take the reference
+        // without the lock. _built is volatile so the map writes are visible
+        // before the flag flips.
+        private static Dictionary<string, (string modId, string displayName)> _tokenMap;
+        private static Dictionary<Assembly, (string modId, string displayName)> _assemblyMap;
+        private static volatile bool _built;
+        private static bool _loggedBuildFailure;
+        private static bool _loggedDroppedTokens;
+
+        // Roots that must never attribute to a mod even if a mod declares
+        // them: game/engine/framework namespaces plus FUSE itself. The build
+        // additionally harvests every namespace root the game and FUSE
+        // assemblies actually declare, so this seed list only has to cover
+        // assemblies too large to scan (System.*, UnityEngine.*).
+        private static readonly string[] DenylistSeedTokens =
+        {
+            "System", "Microsoft", "Mono", "mscorlib", "netstandard",
+            "Unity", "UnityEngine", "UnityEngineInternal", "UnityModManagerNet",
+            "TMPro", "Newtonsoft", "Serilog", "JetBrains",
+            "FUSE", "HarmonyLib", "Harmony", "GalaSoft"
+        };
+
+        /// <summary>
+        /// Attribute a Unity stack-trace string to a known mod. Innermost
+        /// matching frame wins; returns false (outs null) when no frame in
+        /// the first 12 belongs to a mapped mod.
+        /// </summary>
+        internal static bool TryAttributeStack(
+            string stackTrace, out string modId, out string displayName, out string topOwnedFrame)
+        {
+            EnsureBuilt();
+            return TryAttributeStackCore(stackTrace, _tokenMap, out modId, out displayName, out topOwnedFrame);
+        }
+
+        /// <summary>
+        /// Attribute a recipient type to a known mod by its assembly — exact,
+        /// no string parsing. Used for exceptions FUSE contained itself.
+        /// </summary>
+        internal static bool TryAttributeType(Type type, out string modId, out string displayName)
+        {
+            modId = null;
+            displayName = null;
+            if (type == null)
+            {
+                return false;
+            }
+
+            EnsureBuilt();
+            var map = _assemblyMap;
+            if (map == null || map.Count == 0)
+            {
+                return false;
+            }
+
+            Assembly assembly;
+            try
+            {
+                assembly = type.Assembly;
+            }
+            catch
+            {
+                return false;
+            }
+
+            if (assembly != null && map.TryGetValue(assembly, out var owner))
+            {
+                modId = owner.modId;
+                displayName = owner.displayName;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Drop the built maps; the next attribution rebuilds. Call when the
+        /// mod population changes (UMM injection flush, legacy assembly load).
+        /// </summary>
+        internal static void Invalidate()
+        {
+            lock (Gate)
+            {
+                _built = false;
+            }
+        }
+
+        /// <summary>
+        /// Pure parsing core. Unity trace lines look like
+        /// "Namespace.Type.Method (args) (at file:line)"; Mono exception
+        /// traces prefix "at " and append IL offsets; Debug.Log context
+        /// traces use "Namespace.Type:Method()". Each line is cut before its
+        /// argument list, its first one/two dot-segments are looked up in
+        /// <paramref name="tokenMap"/> (two-segment first, so "Us.Dchn" style
+        /// roots win over a generic first word), and the first — innermost —
+        /// matching frame is returned.
+        /// </summary>
+        internal static bool TryAttributeStackCore(
+            string stackTrace,
+            IReadOnlyDictionary<string, (string modId, string displayName)> tokenMap,
+            out string modId,
+            out string displayName,
+            out string topOwnedFrame)
+        {
+            modId = null;
+            displayName = null;
+            topOwnedFrame = null;
+            if (string.IsNullOrEmpty(stackTrace) || tokenMap == null || tokenMap.Count == 0)
+            {
+                return false;
+            }
+
+            var examined = 0;
+            var position = 0;
+            while (position < stackTrace.Length && examined < MaxFramesExamined)
+            {
+                var newline = stackTrace.IndexOf('\n', position);
+                var lineEnd = newline < 0 ? stackTrace.Length : newline;
+                var line = stackTrace.Substring(position, lineEnd - position).Trim();
+                position = lineEnd + 1;
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+
+                examined++;
+                if (line.StartsWith("at ", StringComparison.Ordinal))
+                {
+                    line = line.Substring(3).TrimStart();
+                }
+
+                var argumentsStart = line.IndexOf(" (", StringComparison.Ordinal);
+                var framePath = argumentsStart >= 0 ? line.Substring(0, argumentsStart) : line;
+                framePath = framePath.TrimEnd();
+                if (framePath.Length == 0)
+                {
+                    continue;
+                }
+
+                // Tokens come from the type path only; the Debug.Log-style
+                // ":Method()" tail stays in the reported frame but not in
+                // the lookup key.
+                var tokenSource = framePath;
+                var colon = tokenSource.IndexOf(':');
+                if (colon >= 0)
+                {
+                    tokenSource = tokenSource.Substring(0, colon).TrimEnd();
+                }
+
+                var firstDot = tokenSource.IndexOf('.');
+                if (firstDot <= 0)
+                {
+                    continue; // no namespace-qualified identifier on this line
+                }
+
+                var secondDot = tokenSource.IndexOf('.', firstDot + 1);
+                var twoSegments = secondDot > 0 ? tokenSource.Substring(0, secondDot) : tokenSource;
+                if (tokenMap.TryGetValue(twoSegments, out var byTwoSegments))
+                {
+                    modId = byTwoSegments.modId;
+                    displayName = byTwoSegments.displayName;
+                    topOwnedFrame = framePath;
+                    return true;
+                }
+
+                var oneSegment = tokenSource.Substring(0, firstDot);
+                if (tokenMap.TryGetValue(oneSegment, out var byOneSegment))
+                {
+                    modId = byOneSegment.modId;
+                    displayName = byOneSegment.displayName;
+                    topOwnedFrame = framePath;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Pure token-map assembly: applies the denylist and drops tokens
+        /// claimed by more than one mod (an ambiguous token attributes to
+        /// nobody — once two mods claim it, it joins the denylist so a third
+        /// claim is also refused). Returns an OrdinalIgnoreCase map.
+        /// </summary>
+        internal static Dictionary<string, (string modId, string displayName)> BuildTokenMapCore(
+            IEnumerable<(string token, string modId, string displayName)> candidates,
+            IEnumerable<string> denylistTokens,
+            out int droppedTokens)
+        {
+            droppedTokens = 0;
+            var denied = new HashSet<string>(denylistTokens ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            var map = new Dictionary<string, (string modId, string displayName)>(StringComparer.OrdinalIgnoreCase);
+            if (candidates == null)
+            {
+                return map;
+            }
+
+            foreach (var candidate in candidates)
+            {
+                var token = candidate.token?.Trim();
+                if (string.IsNullOrEmpty(token))
+                {
+                    continue;
+                }
+
+                if (denied.Contains(token))
+                {
+                    droppedTokens++;
+                    continue;
+                }
+
+                if (map.TryGetValue(token, out var existing))
+                {
+                    if (!string.Equals(existing.modId, candidate.modId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        map.Remove(token);
+                        denied.Add(token);
+                        droppedTokens++;
+                    }
+
+                    continue;
+                }
+
+                map.Add(token, (candidate.modId, candidate.displayName));
+            }
+
+            return map;
+        }
+
+        /// <summary>
+        /// Test seam: publish maps directly so registry/attribution wiring is
+        /// testable without a live UMM/legacy-host population.
+        /// </summary>
+        internal static void SetMapsForTests(
+            Dictionary<string, (string modId, string displayName)> tokenMap,
+            Dictionary<Assembly, (string modId, string displayName)> assemblyMap)
+        {
+            lock (Gate)
+            {
+                _tokenMap = tokenMap ??
+                    new Dictionary<string, (string modId, string displayName)>(StringComparer.OrdinalIgnoreCase);
+                _assemblyMap = assemblyMap ?? new Dictionary<Assembly, (string modId, string displayName)>();
+                _built = true;
+            }
+        }
+
+        /// <summary>Test hook: forget maps and one-shot log latches.</summary>
+        internal static void ResetForTests()
+        {
+            lock (Gate)
+            {
+                _tokenMap = null;
+                _assemblyMap = null;
+                _built = false;
+                _loggedBuildFailure = false;
+                _loggedDroppedTokens = false;
+            }
+        }
+
+        private static void EnsureBuilt()
+        {
+            if (_built)
+            {
+                return;
+            }
+
+            lock (Gate)
+            {
+                if (_built)
+                {
+                    return;
+                }
+
+                try
+                {
+                    BuildLocked();
+                }
+                catch (Exception ex)
+                {
+                    _tokenMap = new Dictionary<string, (string modId, string displayName)>(StringComparer.OrdinalIgnoreCase);
+                    _assemblyMap = new Dictionary<Assembly, (string modId, string displayName)>();
+                    if (!_loggedBuildFailure)
+                    {
+                        _loggedBuildFailure = true;
+                        FuseLog.Warning(
+                            $"FUSE could not build the mod attribution map; exceptions will count as unattributed: {ex.GetBaseException().Message}");
+                    }
+                }
+
+                _built = true;
+            }
+        }
+
+        private static void BuildLocked()
+        {
+            var denylist = new HashSet<string>(DenylistSeedTokens, StringComparer.OrdinalIgnoreCase);
+
+            Assembly[] domainAssemblies;
+            try
+            {
+                domainAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+            }
+            catch
+            {
+                domainAssemblies = Array.Empty<Assembly>();
+            }
+
+            // Harvest every root the game/FUSE actually declare so mod tokens
+            // that shadow game namespaces (e.g. "Game", "Track") never win.
+            var ownAssembly = typeof(FuseModAttributionMap).Assembly;
+            foreach (var assembly in domainAssemblies)
+            {
+                if (!IsOwnedForDenylist(assembly, ownAssembly))
+                {
+                    continue;
+                }
+
+                foreach (var token in HarvestTokens(assembly))
+                {
+                    denylist.Add(token);
+                }
+            }
+
+            var candidates = new List<(Assembly assembly, string modId, string displayName)>();
+            HarvestUmmMods(candidates, domainAssemblies);
+            HarvestHostedLegacyPlugins(candidates);
+
+            var assemblyMap = new Dictionary<Assembly, (string modId, string displayName)>();
+            foreach (var candidate in candidates)
+            {
+                if (candidate.assembly == null || candidate.assembly == ownAssembly)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(candidate.modId))
+                {
+                    continue;
+                }
+
+                if (!assemblyMap.ContainsKey(candidate.assembly))
+                {
+                    assemblyMap.Add(candidate.assembly, (candidate.modId, candidate.displayName));
+                }
+            }
+
+            var tokenCandidates = new List<(string token, string modId, string displayName)>();
+            foreach (var pair in assemblyMap)
+            {
+                foreach (var token in HarvestTokens(pair.Key))
+                {
+                    tokenCandidates.Add((token, pair.Value.modId, pair.Value.displayName));
+                }
+            }
+
+            _tokenMap = BuildTokenMapCore(tokenCandidates, denylist, out var droppedTokens);
+            _assemblyMap = assemblyMap;
+
+            if (droppedTokens > 0 && !_loggedDroppedTokens)
+            {
+                _loggedDroppedTokens = true;
+                FuseLog.Info(
+                    $"FUSE mod attribution map dropped {droppedTokens} colliding namespace token(s); affected frames will count as unattributed.");
+            }
+        }
+
+        // Kept in its own method so a missing UMM assembly surfaces as a JIT
+        // failure at this call site, inside EnsureBuilt's catch — not as a
+        // type-initialization fault on the whole class.
+        private static void HarvestUmmMods(
+            List<(Assembly assembly, string modId, string displayName)> candidates,
+            Assembly[] domainAssemblies)
+        {
+            try
+            {
+                var field = typeof(UnityModManagerNet.UnityModManager)
+                    .GetField("modEntries", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                var entries = field?.GetValue(null) as IEnumerable;
+                if (entries == null)
+                {
+                    return;
+                }
+
+                // Location lookup for multi-DLL mods: any loaded assembly
+                // sitting under a mod's folder belongs to that mod.
+                var locations = new List<(Assembly assembly, string location)>();
+                foreach (var assembly in domainAssemblies)
+                {
+                    var location = SafeAssemblyLocation(assembly);
+                    if (!string.IsNullOrEmpty(location))
+                    {
+                        locations.Add((assembly, NormalizePath(location)));
+                    }
+                }
+
+                foreach (var entry in entries)
+                {
+                    if (entry == null)
+                    {
+                        continue;
+                    }
+
+                    var info = ReadObjectMember(entry, "Info");
+                    var id = ReadStringMember(entry, "Id");
+                    if (string.IsNullOrWhiteSpace(id))
+                    {
+                        id = ReadStringMember(info, "Id");
+                    }
+
+                    var displayName = ReadStringMember(entry, "DisplayName");
+                    if (string.IsNullOrWhiteSpace(displayName))
+                    {
+                        displayName = ReadStringMember(info, "DisplayName");
+                    }
+
+                    if (string.IsNullOrWhiteSpace(displayName))
+                    {
+                        displayName = id;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(id) ||
+                        string.Equals(id, "FUSE", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    var entryAssembly = ReadObjectMember(entry, "Assembly") as Assembly;
+                    if (entryAssembly != null)
+                    {
+                        candidates.Add((entryAssembly, id, displayName));
+                    }
+
+                    var path = ReadStringMember(entry, "Path");
+                    if (string.IsNullOrWhiteSpace(path))
+                    {
+                        continue;
+                    }
+
+                    var folder = NormalizePath(path) + Path.DirectorySeparatorChar;
+                    foreach (var located in locations)
+                    {
+                        if (located.location.StartsWith(folder, StringComparison.OrdinalIgnoreCase))
+                        {
+                            candidates.Add((located.assembly, id, displayName));
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // UMM absent or reshaped: the legacy-host source still works.
+                FuseModExceptionRegistry.CountSelfFault();
+            }
+        }
+
+        private static void HarvestHostedLegacyPlugins(
+            List<(Assembly assembly, string modId, string displayName)> candidates)
+        {
+            try
+            {
+                foreach (var hosted in FuseLegacyAssemblyHost.EnumerateAllHostedPlugins())
+                {
+                    var assembly = hosted.PluginType?.Assembly;
+                    var id = hosted.Manifest?.Id;
+                    if (assembly == null || string.IsNullOrWhiteSpace(id))
+                    {
+                        continue;
+                    }
+
+                    var displayName = hosted.Manifest.Name;
+                    if (string.IsNullOrWhiteSpace(displayName))
+                    {
+                        displayName = id;
+                    }
+
+                    candidates.Add((assembly, id, displayName));
+                }
+            }
+            catch
+            {
+                // Host unavailable: UMM harvesting alone still attributes.
+                FuseModExceptionRegistry.CountSelfFault();
+            }
+        }
+
+        private static bool IsOwnedForDenylist(Assembly assembly, Assembly ownAssembly)
+        {
+            if (assembly == null)
+            {
+                return false;
+            }
+
+            if (assembly == ownAssembly)
+            {
+                return true;
+            }
+
+            var name = SafeAssemblyName(assembly);
+            if (string.IsNullOrEmpty(name))
+            {
+                return false;
+            }
+
+            // Only the scannable owned assemblies: the seed list covers the
+            // huge framework/engine surfaces without a type scan.
+            return name.StartsWith("Assembly-CSharp", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(name, "0Harmony", StringComparison.OrdinalIgnoreCase) ||
+                name.StartsWith("GalaSoft", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static IEnumerable<string> HarvestTokens(Assembly assembly)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var simpleName = SafeAssemblyName(assembly);
+            if (!string.IsNullOrEmpty(simpleName) && seen.Add(simpleName))
+            {
+                yield return simpleName;
+            }
+
+            foreach (var type in SafeGetTypes(assembly))
+            {
+                var ns = type?.Namespace;
+                if (string.IsNullOrEmpty(ns))
+                {
+                    continue;
+                }
+
+                var firstDot = ns.IndexOf('.');
+                var root = firstDot < 0 ? ns : ns.Substring(0, firstDot);
+                if (seen.Add(root))
+                {
+                    yield return root;
+                }
+
+                if (firstDot > 0)
+                {
+                    var secondDot = ns.IndexOf('.', firstDot + 1);
+                    var twoSegments = secondDot < 0 ? ns : ns.Substring(0, secondDot);
+                    if (seen.Add(twoSegments))
+                    {
+                        yield return twoSegments;
+                    }
+                }
+            }
+        }
+
+        private static Type[] SafeGetTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.Types.Where(type => type != null).ToArray();
+            }
+            catch
+            {
+                return Array.Empty<Type>();
+            }
+        }
+
+        private static string SafeAssemblyName(Assembly assembly)
+        {
+            try
+            {
+                return assembly?.GetName().Name ?? string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string SafeAssemblyLocation(Assembly assembly)
+        {
+            try
+            {
+                return assembly?.Location ?? string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string NormalizePath(string path)
+        {
+            try
+            {
+                return Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+            catch
+            {
+                return path.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+        }
+
+        private static object ReadObjectMember(object instance, string name)
+        {
+            if (instance == null)
+            {
+                return null;
+            }
+
+            var type = instance.GetType();
+            var field = type.GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (field != null)
+            {
+                return field.GetValue(instance);
+            }
+
+            var property = type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            return property?.GetValue(instance, null);
+        }
+
+        private static string ReadStringMember(object instance, string name)
+        {
+            var value = ReadObjectMember(instance, name);
+            return value == null ? string.Empty : value.ToString();
+        }
+    }
+}

--- a/FUSE/Infrastructure/FuseModAttributionMap.cs
+++ b/FUSE/Infrastructure/FuseModAttributionMap.cs
@@ -253,6 +253,19 @@ namespace FUSE.Infrastructure
                     continue;
                 }
 
+                // A denied ROOT also denies its two-segment children: mods
+                // commonly embed polyfill/generated types under System.*,
+                // Microsoft.*, etc. (System.Runtime.CompilerServices
+                // .IsExternalInit and friends), and harvesting those as
+                // two-segment tokens would attribute engine/BCL frames to
+                // whichever mod shipped the polyfill.
+                var rootLength = token.IndexOf('.');
+                if (rootLength > 0 && denied.Contains(token.Substring(0, rootLength)))
+                {
+                    droppedTokens++;
+                    continue;
+                }
+
                 if (map.TryGetValue(token, out var existing))
                 {
                     if (!string.Equals(existing.modId, candidate.modId, StringComparison.OrdinalIgnoreCase))

--- a/FUSE/Infrastructure/FuseModExceptionLogHook.cs
+++ b/FUSE/Infrastructure/FuseModExceptionLogHook.cs
@@ -237,6 +237,22 @@ namespace FUSE.Infrastructure
                 catch (Exception ex)
                 {
                     FuseLog.Exception("FUSE mod health could not record an observed exception", ex);
+
+                    // Liveness: the entry must still resolve, or its repeats
+                    // ride DirtyRepeats forever and the drain never idles.
+                    var entry = item.Entry;
+                    lock (Sync)
+                    {
+                        if (!entry.Resolved)
+                        {
+                            entry.ModId = UnattributedBucket;
+                            entry.DisplayName = UnattributedBucket;
+                            entry.ExceptionType = entry.ExceptionType ?? "Exception";
+                            entry.TopOwnedFrame = entry.TopOwnedFrame ?? string.Empty;
+                            entry.SampleMessage = entry.SampleMessage ?? string.Empty;
+                            entry.Resolved = true;
+                        }
+                    }
                 }
             }
 

--- a/FUSE/Infrastructure/FuseModExceptionLogHook.cs
+++ b/FUSE/Infrastructure/FuseModExceptionLogHook.cs
@@ -236,6 +236,7 @@ namespace FUSE.Infrastructure
                 }
                 catch (Exception ex)
                 {
+                    FuseModExceptionRegistry.CountSelfFault();
                     FuseLog.Exception("FUSE mod health could not record an observed exception", ex);
 
                     // Liveness: the entry must still resolve, or its repeats
@@ -314,6 +315,7 @@ namespace FUSE.Infrastructure
                 }
                 catch (Exception ex)
                 {
+                    FuseModExceptionRegistry.CountSelfFault();
                     FuseLog.Exception("FUSE mod health could not flush repeated exception observations", ex);
                 }
             }

--- a/FUSE/Infrastructure/FuseModExceptionLogHook.cs
+++ b/FUSE/Infrastructure/FuseModExceptionLogHook.cs
@@ -1,0 +1,502 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FUSE.Infrastructure
+{
+    /// <summary>
+    /// The catch-everything net of the mod health monitor: a second subscriber
+    /// on <c>Application.logMessageReceivedThreaded</c> that observes every
+    /// exception Unity logs (world-move handlers, coroutine faults, Harmony
+    /// postfix throws surfacing through MonoBehaviour updates), attributes it
+    /// to a mod via <see cref="FuseModAttributionMap"/>, and feeds
+    /// <see cref="FuseModExceptionRegistry"/>.
+    ///
+    /// Deliberately NOT folded into FuseSceneryLoadFailurePatch's existing log
+    /// hook: that hook's per-map generation gating and reset semantics are
+    /// wrong for a session-cumulative monitor, and a second delegate costs one
+    /// extra invocation per log line. This net is disjoint from the registry's
+    /// other sources by construction — exceptions FUSE itself contains
+    /// (messenger isolation, legacy host) are suppressed before Unity ever
+    /// logs them, so they can never be double counted here.
+    ///
+    /// Threading: the hook thread must never amplify an NRE-per-frame episode.
+    /// Steady state (a signature already seen) is allocation-free: one enum
+    /// compare, one hash over the condition plus the first stack line, one
+    /// locked dictionary hit, one int increment. Only a first-seen signature
+    /// allocates and enqueues; attribution parsing, registry writes, and
+    /// throttled log lines all happen in <see cref="DrainPending"/> on the
+    /// main thread (driven per frame by FuseRuntimePump), which also keeps the
+    /// hook thread away from the UMM logger. The drain's own FuseLog lines
+    /// surface as LogType.Error at most, so the LogType.Exception filter makes
+    /// log recursion impossible.
+    ///
+    /// Never a popup or toast — the health report and Status page are the only
+    /// surfaces for what this observes.
+    /// </summary>
+    internal static class FuseModExceptionLogHook
+    {
+        /// <summary>Registry bucket for exceptions no mod token matched.</summary>
+        internal const string UnattributedBucket = "<unattributed>";
+
+        // Bounded state: past these caps, occurrences are counted into
+        // _overflowDropped instead of growing memory. 128 distinct signatures
+        // is far beyond any observed field session (the worst offenders repeat
+        // ONE signature thousands of times).
+        private const int MaxPendingQueue = 128;
+        private const int MaxTrackedSignatures = 128;
+        private const int MaxSampleMessageLength = 200;
+
+        // Mirrors FuseMessengerIsolationPatch.MaxRememberedOffenders: a NEW
+        // offender mod is always named once even after another mod spent the
+        // global first-5 budget, and the set cannot grow without limit.
+        private const int MaxLoggedMods = 32;
+
+        private static readonly object Sync = new object();
+        private static readonly Dictionary<int, SignatureEntry> Signatures = new Dictionary<int, SignatureEntry>();
+        private static readonly List<SignatureEntry> DirtyRepeats = new List<SignatureEntry>();
+        private static readonly ConcurrentQueue<PendingException> Pending = new ConcurrentQueue<PendingException>();
+        private static int _pendingCount;      // guarded by Sync
+        private static long _overflowDropped;  // guarded by Sync
+
+        private static bool _installed;
+        private static volatile bool _accepting;
+
+        // Main-thread-only drain state (never touched by the hook thread).
+        private static readonly HashSet<string> LoggedMods = new HashSet<string>(StringComparer.Ordinal);
+        private static readonly Dictionary<string, long> PerModObserved = new Dictionary<string, long>(StringComparer.Ordinal);
+
+        private sealed class SignatureEntry
+        {
+            // Attribution fields are written once by the main-thread drain
+            // (under Sync) and read thereafter; Resolved flips only after all
+            // of them are populated.
+            public bool Resolved;
+            public string ModId;
+            public string DisplayName;
+            public string ExceptionType;
+            public string TopOwnedFrame;
+            public string SampleMessage;
+
+            // Occurrences seen by the hook thread since the last drain flush
+            // (guarded by Sync). The full session totals live in the registry.
+            public int PendingRepeats;
+        }
+
+        private struct PendingException
+        {
+            public string Condition;
+            public string StackTrace;
+            public SignatureEntry Entry;
+        }
+
+        /// <summary>Occurrences dropped past the signature/queue caps (diagnostics).</summary>
+        internal static long OverflowDropped
+        {
+            get
+            {
+                lock (Sync)
+                {
+                    return _overflowDropped;
+                }
+            }
+        }
+
+        internal static void Install()
+        {
+            if (_installed)
+            {
+                _accepting = true;
+                return;
+            }
+
+            try
+            {
+                // The threaded variant sees exceptions logged from every
+                // thread; the fast path below is already thread-safe.
+                Application.logMessageReceivedThreaded += OnLogMessage;
+                _installed = true;
+                _accepting = true;
+            }
+            catch (Exception ex)
+            {
+                _accepting = false;
+                FuseLog.Exception("FUSE mod health log hook could not install", ex);
+            }
+        }
+
+        internal static void Shutdown()
+        {
+            _accepting = false;
+            if (!_installed)
+            {
+                return;
+            }
+
+            try
+            {
+                Application.logMessageReceivedThreaded -= OnLogMessage;
+                _installed = false;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE mod health log hook could not uninstall", ex);
+            }
+        }
+
+        private static void OnLogMessage(string condition, string stackTrace, LogType type)
+        {
+            // Exceptions only: mods legitimately Debug.LogError, and Error-line
+            // parsing (scenery load failures) is owned by the scenery hook.
+            // This compare is the whole per-line cost for non-exception logs.
+            if (type != LogType.Exception)
+            {
+                return;
+            }
+
+            ObserveCore(condition, stackTrace);
+        }
+
+        // Runs on whatever thread logged the exception. Split from the Unity
+        // callback so tests can drive it without loading UnityEngine's LogType
+        // dispatch (same seam shape as ObserveGameLogMessageForTests).
+        private static void ObserveCore(string condition, string stackTrace)
+        {
+            if (!_accepting)
+            {
+                return;
+            }
+
+            var hash = ComputeSignatureHash(condition, stackTrace);
+            SignatureEntry entry;
+            lock (Sync)
+            {
+                if (Signatures.TryGetValue(hash, out entry))
+                {
+                    // Steady-state path for a repeating signature: count only.
+                    if (entry.PendingRepeats == 0)
+                    {
+                        DirtyRepeats.Add(entry);
+                    }
+
+                    entry.PendingRepeats++;
+                    return;
+                }
+
+                if (Signatures.Count >= MaxTrackedSignatures || _pendingCount >= MaxPendingQueue)
+                {
+                    _overflowDropped++;
+                    return;
+                }
+
+                entry = new SignatureEntry();
+                Signatures[hash] = entry;
+                _pendingCount++;
+            }
+
+            // Enqueue outside the lock; the entry was registered above, so a
+            // racing repeat lands on the PendingRepeats path and is flushed by
+            // the drain once this item resolves.
+            Pending.Enqueue(new PendingException
+            {
+                Condition = condition,
+                StackTrace = stackTrace,
+                Entry = entry
+            });
+        }
+
+        /// <summary>
+        /// Attributes queued first-occurrences, flushes repeat counts into the
+        /// registry, and emits throttled log lines. Main thread only; driven
+        /// every frame by <see cref="FUSE.Runtime.Lifecycle.FuseRuntimePump"/>.
+        /// </summary>
+        internal static void DrainPending()
+        {
+            // Per-frame idle cost: one lock-free queue snapshot plus one plain
+            // int read (DirtyRepeats.Count is a heuristic here — the locked
+            // paths below re-check under Sync).
+            if (Pending.IsEmpty && DirtyRepeats.Count == 0)
+            {
+                return;
+            }
+
+            // First occurrences: attribution parse + registry record. Parse
+            // cost is bounded by the signature cap for the whole session.
+            while (Pending.TryDequeue(out var item))
+            {
+                lock (Sync)
+                {
+                    _pendingCount--;
+                }
+
+                try
+                {
+                    ResolveAndRecordFirst(item);
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception("FUSE mod health could not record an observed exception", ex);
+                }
+            }
+
+            List<SignatureEntry> dirty = null;
+            lock (Sync)
+            {
+                if (DirtyRepeats.Count > 0)
+                {
+                    dirty = new List<SignatureEntry>(DirtyRepeats);
+                    DirtyRepeats.Clear();
+                }
+            }
+
+            if (dirty == null)
+            {
+                return;
+            }
+
+            foreach (var entry in dirty)
+            {
+                int repeats;
+                lock (Sync)
+                {
+                    if (!entry.Resolved)
+                    {
+                        // Its first occurrence raced past the dequeue loop
+                        // above (registered but not yet enqueued when we
+                        // drained); keep the repeats and retry next frame.
+                        DirtyRepeats.Add(entry);
+                        continue;
+                    }
+
+                    repeats = entry.PendingRepeats;
+                    entry.PendingRepeats = 0;
+                }
+
+                if (repeats <= 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    // The registry coalesces episodes on its own 1s window; a
+                    // frame's worth of repeats replayed here lands inside the
+                    // window it occurred in (the pump drains every frame).
+                    for (var i = 0; i < repeats; i++)
+                    {
+                        FuseModExceptionRegistry.Record(
+                            "LogHook",
+                            entry.ModId,
+                            entry.DisplayName,
+                            entry.ExceptionType,
+                            entry.TopOwnedFrame,
+                            entry.SampleMessage);
+                    }
+
+                    NoteRecorded(entry, repeats);
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception("FUSE mod health could not flush repeated exception observations", ex);
+                }
+            }
+        }
+
+        private static void ResolveAndRecordFirst(PendingException item)
+        {
+            if (!FuseModAttributionMap.TryAttributeStack(
+                    item.StackTrace, out var modId, out var displayName, out var topOwnedFrame))
+            {
+                // Still counted: the health report's unattributed bucket is
+                // how a mod outside the token map (or a game-side fault) stays
+                // visible instead of silently vanishing.
+                modId = UnattributedBucket;
+                displayName = UnattributedBucket;
+                topOwnedFrame = ExtractFirstFrame(item.StackTrace);
+            }
+
+            var entry = item.Entry;
+            lock (Sync)
+            {
+                entry.ModId = modId;
+                entry.DisplayName = displayName;
+                entry.ExceptionType = ExtractExceptionType(item.Condition);
+                entry.TopOwnedFrame = topOwnedFrame;
+                entry.SampleMessage = Truncate(item.Condition, MaxSampleMessageLength);
+                entry.Resolved = true;
+            }
+
+            FuseModExceptionRegistry.Record(
+                "LogHook",
+                entry.ModId,
+                entry.DisplayName,
+                entry.ExceptionType,
+                entry.TopOwnedFrame,
+                entry.SampleMessage);
+            NoteRecorded(entry, 1);
+        }
+
+        // Per-mod running totals (this hook's view) drive the log throttle.
+        // Main thread only.
+        private static void NoteRecorded(SignatureEntry entry, int added)
+        {
+            var modId = entry.ModId ?? UnattributedBucket;
+            PerModObserved.TryGetValue(modId, out var before);
+            var after = before + added;
+            PerModObserved[modId] = after;
+
+            var newMod = LoggedMods.Count < MaxLoggedMods && LoggedMods.Add(modId);
+
+            // FuseGuardLog.ShouldLog generalized to batched increments: the
+            // drain adds a whole frame's repeats at once, so the every-100th
+            // heartbeat must fire when a batch CROSSES a multiple of 100, not
+            // only when it lands exactly on one.
+            if (!newMod && after > 5 && after / 100 == before / 100)
+            {
+                return;
+            }
+
+            var frame = string.IsNullOrEmpty(entry.TopOwnedFrame) ? "<no frame>" : entry.TopOwnedFrame;
+            if (newMod || after <= 5)
+            {
+                FuseLog.Warning(
+                    $"FUSE mod health observed a logged exception attributed to '{entry.DisplayName}' " +
+                    $"({modId}) #{after}: {entry.ExceptionType} at {frame} — \"{entry.SampleMessage}\". " +
+                    "Counted for the health report; repeat log lines are throttled.");
+            }
+            else
+            {
+                FuseLog.Warning(
+                    $"FUSE mod health: {after} logged exception(s) attributed to '{entry.DisplayName}' " +
+                    $"({modId}) this session (latest: {entry.ExceptionType} at {frame}).");
+            }
+        }
+
+        /// <summary>
+        /// Allocation-free signature hash: the condition string's own hash
+        /// combined with a char walk of the stack trace up to its first
+        /// newline (no Substring). Pure; unit-tested.
+        /// </summary>
+        internal static int ComputeSignatureHash(string condition, string stackTrace)
+        {
+            unchecked
+            {
+                var hash = 17;
+                hash = hash * 31 + (condition?.GetHashCode() ?? 0);
+                if (!string.IsNullOrEmpty(stackTrace))
+                {
+                    for (var i = 0; i < stackTrace.Length; i++)
+                    {
+                        var c = stackTrace[i];
+                        if (c == '\n')
+                        {
+                            break;
+                        }
+
+                        hash = hash * 31 + c;
+                    }
+                }
+
+                return hash;
+            }
+        }
+
+        /// <summary>
+        /// The exception type token from a Unity exception condition line
+        /// ("NullReferenceException: message" → "NullReferenceException").
+        /// Pure; unit-tested.
+        /// </summary>
+        internal static string ExtractExceptionType(string condition)
+        {
+            if (string.IsNullOrEmpty(condition))
+            {
+                return "<unknown exception>";
+            }
+
+            var colon = condition.IndexOf(':');
+            var type = colon > 0 ? condition.Substring(0, colon) : condition;
+            return Truncate(type.Trim(), 100);
+        }
+
+        /// <summary>
+        /// First frame of a Unity stack trace, without the argument list /
+        /// source suffix ("Ns.Type.Method (args) (at f:1)" → "Ns.Type.Method").
+        /// Pure; unit-tested.
+        /// </summary>
+        internal static string ExtractFirstFrame(string stackTrace)
+        {
+            if (string.IsNullOrEmpty(stackTrace))
+            {
+                return null;
+            }
+
+            var end = stackTrace.IndexOf('\n');
+            var line = (end >= 0 ? stackTrace.Substring(0, end) : stackTrace).TrimEnd('\r').Trim();
+            var parenthesis = line.IndexOf(" (", StringComparison.Ordinal);
+            if (parenthesis > 0)
+            {
+                line = line.Substring(0, parenthesis);
+            }
+
+            return line.Length == 0 ? null : line;
+        }
+
+        private static string Truncate(string value, int maxLength)
+        {
+            if (string.IsNullOrEmpty(value) || value.Length <= maxLength)
+            {
+                return value;
+            }
+
+            return value.Substring(0, maxLength);
+        }
+
+        /// <summary>Drives the threaded observe core without Unity's log dispatch.</summary>
+        internal static void ObserveExceptionForTests(string condition, string stackTrace)
+        {
+            ObserveCore(condition, stackTrace);
+        }
+
+        /// <summary>Controls the producer gate without installing Unity's event hook.</summary>
+        internal static void SetAcceptanceForTests(bool accept)
+        {
+            _accepting = accept;
+        }
+
+        /// <summary>Queued-but-undrained first occurrences (test hook).</summary>
+        internal static int PendingCountForTests => Pending.Count;
+
+        /// <summary>Distinct signatures registered this session (test hook).</summary>
+        internal static int TrackedSignatureCountForTests
+        {
+            get
+            {
+                lock (Sync)
+                {
+                    return Signatures.Count;
+                }
+            }
+        }
+
+        /// <summary>Test hook — the hook state is session-cumulative by design.</summary>
+        internal static void ResetForTests()
+        {
+            lock (Sync)
+            {
+                Signatures.Clear();
+                DirtyRepeats.Clear();
+                _pendingCount = 0;
+                _overflowDropped = 0;
+            }
+
+            while (Pending.TryDequeue(out _))
+            {
+            }
+
+            LoggedMods.Clear();
+            PerModObserved.Clear();
+            _accepting = false;
+        }
+    }
+}

--- a/FUSE/Infrastructure/FuseModExceptionRegistry.cs
+++ b/FUSE/Infrastructure/FuseModExceptionRegistry.cs
@@ -1,0 +1,510 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace FUSE.Infrastructure
+{
+    /// <summary>
+    /// Report-facing snapshot of one mod's observed exceptions this session.
+    /// Materialized copies only — the live registry state never escapes the
+    /// registry lock.
+    /// </summary>
+    internal sealed class FuseModExceptionSnapshot
+    {
+        public string ModId { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public long Count { get; set; }
+        public long Episodes { get; set; }
+        public DateTime FirstSeenUtc { get; set; }
+        public DateTime LastSeenUtc { get; set; }
+        public FuseModExceptionSignatureSnapshot[] Signatures { get; set; } =
+            Array.Empty<FuseModExceptionSignatureSnapshot>();
+    }
+
+    /// <summary>One distinct exception signature within a mod's snapshot.</summary>
+    internal sealed class FuseModExceptionSignatureSnapshot
+    {
+        public string ExceptionType { get; set; } = string.Empty;
+        public string TopOwnedFrame { get; set; } = string.Empty;
+        public string SampleMessage { get; set; } = string.Empty;
+        public long Count { get; set; }
+        public long Episodes { get; set; }
+        public string Source { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Session-cumulative registry of third-party mod exceptions observed by
+    /// the legacy-mod health monitor. Three producers write here — the game
+    /// log hook ("LogHook"), the messenger listener isolation ("Messenger"),
+    /// and the legacy assembly host ("LegacyHost") — and the load report /
+    /// Status page read here. Like <see cref="FuseRuntimeGuardCounters"/> it
+    /// lives in Infrastructure so patches write and Loading/UI read without
+    /// compile-time coupling, and it is never reset on map load: first/last
+    /// seen timestamps plus episode counts give per-session visibility
+    /// without the per-map generation gating the scenery patch needs.
+    ///
+    /// Everything runs under one lock because the log hook records from
+    /// Unity's logging thread while the containment sites record from the
+    /// main thread. The hot path (a repeat of an already-known signature) is
+    /// one lock, two dictionary lookups, and a handful of field writes — no
+    /// allocation beyond the value-tuple key hash — so an exception-per-frame
+    /// episode costs microseconds and cannot amplify itself.
+    ///
+    /// Bounds: at most 32 named mods (later mods coalesce into the
+    /// "&lt;other&gt;" bucket), at most 8 distinct signatures per mod (later
+    /// signatures bump per-mod totals only). Occurrences of one signature
+    /// within a 1-second window coalesce into a single "episode", so a dense
+    /// per-frame burst counts as one episode — episodes approximate
+    /// trigger events (e.g. world moves), not frames.
+    /// </summary>
+    internal static class FuseModExceptionRegistry
+    {
+        /// <summary>Bucket id for exceptions no mod could be attributed to.</summary>
+        internal const string UnattributedModId = "<unattributed>";
+
+        /// <summary>Bucket id for mods beyond the tracked-mod cap.</summary>
+        internal const string OverflowModId = "<other>";
+
+        private const string UnattributedDisplayName = "(unattributed)";
+        private const string OverflowDisplayName = "(other mods)";
+
+        private const int MaxTrackedMods = 32;
+        private const int MaxSignaturesPerMod = 8;
+        private const long EpisodeCoalesceWindowMs = 1000;
+        private const int SampleMessageMaxLength = 200;
+
+        private static readonly object Gate = new object();
+        private static readonly Stopwatch SessionClock = Stopwatch.StartNew();
+        private static readonly Dictionary<string, ModRecord> Mods =
+            new Dictionary<string, ModRecord>(StringComparer.OrdinalIgnoreCase);
+
+        private static long _totalObserved;
+        private static long _totalUnattributed;
+        private static long _signatureOverflowDropped;
+        private static int _namedModCount;
+
+        /// <summary>
+        /// Monotonic millisecond clock used for episode coalescing. Injectable
+        /// so tests can drive the window deterministically; the default is a
+        /// session stopwatch (wall-clock adjustments must not split or merge
+        /// episodes).
+        /// </summary>
+        internal static Func<long> TickSource = () => SessionClock.ElapsedMilliseconds;
+
+        /// <summary>UTC timestamp source for first/last-seen; injectable for tests.</summary>
+        internal static Func<DateTime> UtcNowSource = () => DateTime.UtcNow;
+
+        private sealed class ModRecord
+        {
+            public string ModId;
+            public string DisplayName;
+            public long Total;
+            public DateTime FirstSeenUtc;
+            public DateTime LastSeenUtc;
+
+            public readonly Dictionary<(string source, string exceptionType, string frame), SignatureRecord> Signatures =
+                new Dictionary<(string, string, string), SignatureRecord>();
+
+            // Signatures past the per-mod cap bump these instead of creating
+            // new records; the episode window still applies so overflow spam
+            // cannot inflate the mod's episode count per-frame.
+            public long OverflowCount;
+            public long OverflowEpisodes;
+            public long OverflowLastTick;
+            public bool HasOverflow;
+        }
+
+        private sealed class SignatureRecord
+        {
+            public string Source;
+            public string ExceptionType;
+            public string TopOwnedFrame;
+            public string SampleMessage;
+            public long Count;
+            public long Episodes;
+            public long LastTick;
+            public DateTime FirstSeenUtc;
+            public DateTime LastSeenUtc;
+        }
+
+        /// <summary>Total exceptions observed this session, attributed or not.</summary>
+        internal static long GrandTotal
+        {
+            get { lock (Gate) { return _totalObserved; } }
+        }
+
+        /// <summary>True when nothing has been observed — the healthy state.</summary>
+        internal static bool AllIdle => GrandTotal == 0;
+
+        /// <summary>Observed exceptions no mod token/assembly could be attributed to.</summary>
+        internal static long TotalUnattributed
+        {
+            get { lock (Gate) { return _totalUnattributed; } }
+        }
+
+        /// <summary>Signature-cap overflow occurrences (diagnostics/tests).</summary>
+        internal static long SignatureOverflowDropped
+        {
+            get { lock (Gate) { return _signatureOverflowDropped; } }
+        }
+
+        /// <summary>
+        /// Record one observed exception occurrence. A null/empty
+        /// <paramref name="modId"/> (or the sentinel itself) lands in the
+        /// unattributed bucket. Signature dedupe, episode coalescing, and all
+        /// caps are handled here; callers just describe what they saw.
+        /// Safe from any thread; never throws past its own boundary.
+        /// </summary>
+        internal static void Record(
+            string source,
+            string modId,
+            string displayName,
+            string exceptionType,
+            string topOwnedFrame,
+            string sampleMessage)
+        {
+            try
+            {
+                lock (Gate)
+                {
+                    RecordLocked(source, modId, displayName, exceptionType, topOwnedFrame, sampleMessage);
+                }
+            }
+            catch
+            {
+                // The monitor must never become the fault it exists to count;
+                // several callers sit inside the log pipeline being observed,
+                // where logging from here could recurse.
+                CountSelfFault();
+            }
+        }
+
+        /// <summary>
+        /// Record an exception FUSE contained on behalf of a listener,
+        /// attributing by the recipient's type → assembly (exact — no stack
+        /// parsing). Used by the messenger listener isolation.
+        /// </summary>
+        internal static void RecordContained(Exception ex, Type recipientType, string context)
+        {
+            if (ex == null)
+            {
+                return;
+            }
+
+            string modId = null;
+            string displayName = null;
+            try
+            {
+                FuseModAttributionMap.TryAttributeType(recipientType, out modId, out displayName);
+            }
+            catch
+            {
+                // Attribution failure degrades to the unattributed bucket.
+                CountSelfFault();
+            }
+
+            var frame = SafeTypeName(recipientType);
+            if (!string.IsNullOrEmpty(context))
+            {
+                frame = frame + " [" + context + "]";
+            }
+
+            Record("Messenger", modId, displayName, SafeExceptionTypeName(ex), frame, SafeMessage(ex));
+        }
+
+        /// <summary>
+        /// Record an exception FUSE contained for a legacy hosted plugin whose
+        /// identity is already known (the manifest id).
+        /// </summary>
+        internal static void RecordContained(Exception ex, string modId, string context)
+        {
+            if (ex == null)
+            {
+                return;
+            }
+
+            Record("LegacyHost", modId, modId, SafeExceptionTypeName(ex), context ?? string.Empty, SafeMessage(ex));
+        }
+
+        // Faults swallowed inside the monitor's own fail-open catches (never
+        // logged from those sites — several run inside the log pipeline the
+        // monitor observes, where logging could recurse). Non-zero means the
+        // monitor itself misbehaved; surfaced in FormatSummary only then.
+        private static long _selfFaults;
+
+        internal static long SelfFaults => System.Threading.Interlocked.Read(ref _selfFaults);
+
+        internal static void CountSelfFault() => System.Threading.Interlocked.Increment(ref _selfFaults);
+
+        /// <summary>
+        /// One-line breakdown for the load report summary, in the guard-counter
+        /// style. mods counts attributed mods only (the unattributed and
+        /// overflow buckets are excluded — overflow means the count is a floor).
+        /// </summary>
+        internal static string FormatSummary()
+        {
+            var selfFaults = SelfFaults;
+            lock (Gate)
+            {
+                var summary = $"modErrors={_totalObserved} unattributed={_totalUnattributed} mods={_namedModCount}";
+                return selfFaults == 0 ? summary : summary + $" selfFaults={selfFaults}";
+            }
+        }
+
+        /// <summary>
+        /// Materialized copy of every tracked bucket, worst first. Sentinel
+        /// buckets sort by their counts like any other row.
+        /// </summary>
+        internal static FuseModExceptionSnapshot[] SnapshotForReport()
+        {
+            lock (Gate)
+            {
+                return Mods.Values
+                    .OrderByDescending(record => record.Total)
+                    .ThenBy(record => record.ModId, StringComparer.OrdinalIgnoreCase)
+                    .Select(SnapshotRecordLocked)
+                    .ToArray();
+            }
+        }
+
+        /// <summary>Test hook — the registry is session-cumulative by design.</summary>
+        internal static void ResetForTests()
+        {
+            lock (Gate)
+            {
+                Mods.Clear();
+                _totalObserved = 0;
+                _totalUnattributed = 0;
+                _signatureOverflowDropped = 0;
+                _namedModCount = 0;
+                System.Threading.Interlocked.Exchange(ref _selfFaults, 0);
+                TickSource = () => SessionClock.ElapsedMilliseconds;
+                UtcNowSource = () => DateTime.UtcNow;
+            }
+        }
+
+        private static void RecordLocked(
+            string source,
+            string modId,
+            string displayName,
+            string exceptionType,
+            string topOwnedFrame,
+            string sampleMessage)
+        {
+            _totalObserved++;
+
+            var attributed = !string.IsNullOrWhiteSpace(modId) &&
+                !string.Equals(modId, UnattributedModId, StringComparison.OrdinalIgnoreCase);
+            if (!attributed)
+            {
+                _totalUnattributed++;
+                modId = UnattributedModId;
+                displayName = UnattributedDisplayName;
+            }
+
+            var nowUtc = SafeUtcNow();
+            var record = GetOrCreateRecordLocked(modId, displayName, nowUtc);
+            record.Total++;
+            record.LastSeenUtc = nowUtc;
+
+            var nowTick = SafeTick();
+            var key = (source ?? string.Empty, exceptionType ?? string.Empty, topOwnedFrame ?? string.Empty);
+            if (record.Signatures.TryGetValue(key, out var signature))
+            {
+                signature.Count++;
+                if (nowTick - signature.LastTick > EpisodeCoalesceWindowMs)
+                {
+                    signature.Episodes++;
+                }
+
+                signature.LastTick = nowTick;
+                signature.LastSeenUtc = nowUtc;
+                return;
+            }
+
+            if (record.Signatures.Count >= MaxSignaturesPerMod)
+            {
+                _signatureOverflowDropped++;
+                record.OverflowCount++;
+                if (!record.HasOverflow || nowTick - record.OverflowLastTick > EpisodeCoalesceWindowMs)
+                {
+                    record.OverflowEpisodes++;
+                }
+
+                record.HasOverflow = true;
+                record.OverflowLastTick = nowTick;
+                return;
+            }
+
+            record.Signatures.Add(key, new SignatureRecord
+            {
+                Source = source ?? string.Empty,
+                ExceptionType = exceptionType ?? string.Empty,
+                TopOwnedFrame = topOwnedFrame ?? string.Empty,
+                SampleMessage = Truncate(sampleMessage, SampleMessageMaxLength),
+                Count = 1,
+                Episodes = 1,
+                LastTick = nowTick,
+                FirstSeenUtc = nowUtc,
+                LastSeenUtc = nowUtc
+            });
+        }
+
+        private static ModRecord GetOrCreateRecordLocked(string modId, string displayName, DateTime nowUtc)
+        {
+            if (Mods.TryGetValue(modId, out var existing))
+            {
+                if (string.IsNullOrWhiteSpace(existing.DisplayName) && !string.IsNullOrWhiteSpace(displayName))
+                {
+                    existing.DisplayName = displayName;
+                }
+
+                return existing;
+            }
+
+            var isSentinel = string.Equals(modId, UnattributedModId, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(modId, OverflowModId, StringComparison.OrdinalIgnoreCase);
+            if (!isSentinel && _namedModCount >= MaxTrackedMods)
+            {
+                // Tracked-mod cap: fold this mod (and any further new mods)
+                // into the shared overflow bucket instead of growing unbounded
+                // when many mods misbehave at once.
+                if (!Mods.TryGetValue(OverflowModId, out var overflow))
+                {
+                    overflow = new ModRecord
+                    {
+                        ModId = OverflowModId,
+                        DisplayName = OverflowDisplayName,
+                        FirstSeenUtc = nowUtc,
+                        LastSeenUtc = nowUtc
+                    };
+                    Mods.Add(OverflowModId, overflow);
+                }
+
+                return overflow;
+            }
+
+            var created = new ModRecord
+            {
+                ModId = modId,
+                DisplayName = string.IsNullOrWhiteSpace(displayName) ? modId : displayName,
+                FirstSeenUtc = nowUtc,
+                LastSeenUtc = nowUtc
+            };
+            Mods.Add(modId, created);
+            if (!isSentinel)
+            {
+                _namedModCount++;
+            }
+
+            return created;
+        }
+
+        private static FuseModExceptionSnapshot SnapshotRecordLocked(ModRecord record)
+        {
+            var signatures = record.Signatures.Values
+                .OrderByDescending(signature => signature.Count)
+                .ThenBy(signature => signature.ExceptionType, StringComparer.Ordinal)
+                .Select(signature => new FuseModExceptionSignatureSnapshot
+                {
+                    ExceptionType = signature.ExceptionType,
+                    TopOwnedFrame = signature.TopOwnedFrame,
+                    SampleMessage = signature.SampleMessage,
+                    Count = signature.Count,
+                    Episodes = signature.Episodes,
+                    Source = signature.Source
+                })
+                .ToArray();
+
+            var episodes = record.OverflowEpisodes;
+            foreach (var signature in record.Signatures.Values)
+            {
+                episodes += signature.Episodes;
+            }
+
+            return new FuseModExceptionSnapshot
+            {
+                ModId = record.ModId,
+                DisplayName = record.DisplayName,
+                Count = record.Total,
+                Episodes = episodes,
+                FirstSeenUtc = record.FirstSeenUtc,
+                LastSeenUtc = record.LastSeenUtc,
+                Signatures = signatures
+            };
+        }
+
+        private static long SafeTick()
+        {
+            try
+            {
+                var source = TickSource;
+                return source != null ? source() : SessionClock.ElapsedMilliseconds;
+            }
+            catch
+            {
+                return SessionClock.ElapsedMilliseconds;
+            }
+        }
+
+        private static DateTime SafeUtcNow()
+        {
+            try
+            {
+                var source = UtcNowSource;
+                return source != null ? source() : DateTime.UtcNow;
+            }
+            catch
+            {
+                return DateTime.UtcNow;
+            }
+        }
+
+        private static string SafeExceptionTypeName(Exception ex)
+        {
+            try
+            {
+                return ex.GetType().Name;
+            }
+            catch
+            {
+                return "Exception";
+            }
+        }
+
+        private static string SafeTypeName(Type type)
+        {
+            try
+            {
+                return type != null ? (type.FullName ?? type.Name) : "(unknown recipient)";
+            }
+            catch
+            {
+                return "(unknown recipient)";
+            }
+        }
+
+        private static string SafeMessage(Exception ex)
+        {
+            try
+            {
+                return ex.Message ?? string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string Truncate(string value, int maxLength)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            return value.Length <= maxLength ? value : value.Substring(0, maxLength);
+        }
+    }
+}

--- a/FUSE/Infrastructure/FuseModExceptionRegistry.cs
+++ b/FUSE/Infrastructure/FuseModExceptionRegistry.cs
@@ -247,26 +247,43 @@ namespace FUSE.Infrastructure
             var selfFaults = SelfFaults;
             lock (Gate)
             {
-                var summary = $"modErrors={_totalObserved} unattributed={_totalUnattributed} mods={_namedModCount}";
-                return selfFaults == 0 ? summary : summary + $" selfFaults={selfFaults}";
+                return ComposeSummaryLocked(selfFaults);
+            }
+        }
+
+        private static string ComposeSummaryLocked(long selfFaults)
+        {
+            var summary = $"modErrors={_totalObserved} unattributed={_totalUnattributed} mods={_namedModCount}";
+            return selfFaults == 0 ? summary : summary + $" selfFaults={selfFaults}";
+        }
+
+        /// <summary>
+        /// Everything a report/UI render needs, captured under one lock so the
+        /// summary line, totals, and per-mod rows all describe the same
+        /// instant even while the log hook records on other threads.
+        /// </summary>
+        internal static FuseModExceptionReportState CaptureReportState()
+        {
+            var selfFaults = SelfFaults;
+            lock (Gate)
+            {
+                var mods = Mods.Values
+                    .OrderByDescending(record => record.Total)
+                    .ThenBy(record => record.ModId, StringComparer.OrdinalIgnoreCase)
+                    .Select(SnapshotRecordLocked)
+                    .ToArray();
+                return new FuseModExceptionReportState(
+                    mods, _totalObserved, _totalUnattributed, ComposeSummaryLocked(selfFaults));
             }
         }
 
         /// <summary>
         /// Materialized copy of every tracked bucket, worst first. Sentinel
-        /// buckets sort by their counts like any other row.
+        /// buckets sort by their counts like any other row. Prefer
+        /// <see cref="CaptureReportState"/> when totals are rendered beside the
+        /// rows — this overload cannot guarantee they agree.
         /// </summary>
-        internal static FuseModExceptionSnapshot[] SnapshotForReport()
-        {
-            lock (Gate)
-            {
-                return Mods.Values
-                    .OrderByDescending(record => record.Total)
-                    .ThenBy(record => record.ModId, StringComparer.OrdinalIgnoreCase)
-                    .Select(SnapshotRecordLocked)
-                    .ToArray();
-            }
-        }
+        internal static FuseModExceptionSnapshot[] SnapshotForReport() => CaptureReportState().Mods;
 
         /// <summary>Test hook — the registry is session-cumulative by design.</summary>
         internal static void ResetForTests()
@@ -506,5 +523,27 @@ namespace FUSE.Infrastructure
 
             return value.Length <= maxLength ? value : value.Substring(0, maxLength);
         }
+    }
+
+    /// <summary>
+    /// One coherent registry observation: rows, totals, and the summary line
+    /// captured under the same lock so no consumer can render totals that
+    /// disagree with the rows beside them.
+    /// </summary>
+    internal sealed class FuseModExceptionReportState
+    {
+        public FuseModExceptionReportState(
+            FuseModExceptionSnapshot[] mods, long total, long unattributed, string summaryLine)
+        {
+            Mods = mods ?? new FuseModExceptionSnapshot[0];
+            Total = total;
+            Unattributed = unattributed;
+            SummaryLine = summaryLine ?? string.Empty;
+        }
+
+        public FuseModExceptionSnapshot[] Mods { get; }
+        public long Total { get; }
+        public long Unattributed { get; }
+        public string SummaryLine { get; }
     }
 }

--- a/FUSE/Infrastructure/FuseRuntimeGuardCounters.cs
+++ b/FUSE/Infrastructure/FuseRuntimeGuardCounters.cs
@@ -3,7 +3,9 @@ namespace FUSE.Infrastructure
     /// <summary>
     /// Session-cumulative counters for every runtime guard FUSE keeps around
     /// broken content (decal culling, car-decal helpers, curve-mesh culling,
-    /// scenery decal machinery, scenery asset loads, stale flares) plus the
+    /// scenery decal machinery, scenery asset loads, stale flares, switch
+    /// geometry backfills, and the third-party containment guards for Map
+    /// Enhancer culling and Rebill Industry Cars config loads) plus the
     /// frame-spike diagnostic.
     ///
     /// Lives in Infrastructure so both ends of the dependency rule work: the
@@ -28,6 +30,8 @@ namespace FUSE.Infrastructure
         internal static long SceneryPlacementsQuarantined { get; private set; }
         internal static long FlareSuppressed { get; private set; }
         internal static long SwitchGeometryRailsBackfilled { get; private set; }
+        internal static long MapEnhancerCullingGuarded { get; private set; }
+        internal static long RebillAutoConfigSuppressed { get; private set; }
 
         internal static long FrameSpikes { get; private set; }
         internal static float FrameSpikeWorstMs { get; private set; }
@@ -55,7 +59,9 @@ namespace FUSE.Infrastructure
             SceneryLoadFailures +
             SceneryPlacementsQuarantined +
             FlareSuppressed +
-            SwitchGeometryRailsBackfilled;
+            SwitchGeometryRailsBackfilled +
+            MapEnhancerCullingGuarded +
+            RebillAutoConfigSuppressed;
 
         internal static bool AllIdle => GuardTotal == 0;
 
@@ -80,6 +86,10 @@ namespace FUSE.Infrastructure
         internal static long RecordFlareSuppressed() => ++FlareSuppressed;
 
         internal static long RecordSwitchGeometryRailsBackfilled() => ++SwitchGeometryRailsBackfilled;
+
+        internal static long RecordMapEnhancerCullingGuarded() => ++MapEnhancerCullingGuarded;
+
+        internal static long RecordRebillAutoConfigSuppressed() => ++RebillAutoConfigSuppressed;
 
         internal static long RecordFrameSpike(float frameMs)
         {
@@ -110,6 +120,8 @@ namespace FUSE.Infrastructure
                 $"curveMesh={CurveMeshSuppressed} sceneryCarDecalsDisabled={SceneryDecalComponentsDisabled} " +
                 $"sceneryLoadFailures={SceneryLoadFailures} sceneryQuarantined={SceneryPlacementsQuarantined} " +
                 $"sceneryLoadWatch={SceneryLoadWatchAttached} " +
+                $"mapEnhancerCullingGuarded={MapEnhancerCullingGuarded} " +
+                $"rebillAutoConfigSuppressed={RebillAutoConfigSuppressed} " +
                 $"flares={FlareSuppressed} switchRailsBackfilled={SwitchGeometryRailsBackfilled} " +
                 spikes;
         }
@@ -128,6 +140,8 @@ namespace FUSE.Infrastructure
             SceneryPlacementsQuarantined = 0;
             FlareSuppressed = 0;
             SwitchGeometryRailsBackfilled = 0;
+            MapEnhancerCullingGuarded = 0;
+            RebillAutoConfigSuppressed = 0;
             FrameSpikes = 0;
             FrameSpikeWorstMs = 0f;
             SceneryLoadWatchAttached = 0;

--- a/FUSE/Infrastructure/FuseRuntimeGuardCounters.cs
+++ b/FUSE/Infrastructure/FuseRuntimeGuardCounters.cs
@@ -27,6 +27,7 @@ namespace FUSE.Infrastructure
         internal static long SceneryLoadFailures { get; private set; }
         internal static long SceneryPlacementsQuarantined { get; private set; }
         internal static long FlareSuppressed { get; private set; }
+        internal static long SwitchGeometryRailsBackfilled { get; private set; }
 
         internal static long FrameSpikes { get; private set; }
         internal static float FrameSpikeWorstMs { get; private set; }
@@ -53,7 +54,8 @@ namespace FUSE.Infrastructure
             SceneryDecalComponentsDisabled +
             SceneryLoadFailures +
             SceneryPlacementsQuarantined +
-            FlareSuppressed;
+            FlareSuppressed +
+            SwitchGeometryRailsBackfilled;
 
         internal static bool AllIdle => GuardTotal == 0;
 
@@ -76,6 +78,8 @@ namespace FUSE.Infrastructure
         internal static long RecordSceneryPlacementQuarantined() => ++SceneryPlacementsQuarantined;
 
         internal static long RecordFlareSuppressed() => ++FlareSuppressed;
+
+        internal static long RecordSwitchGeometryRailsBackfilled() => ++SwitchGeometryRailsBackfilled;
 
         internal static long RecordFrameSpike(float frameMs)
         {
@@ -106,7 +110,7 @@ namespace FUSE.Infrastructure
                 $"curveMesh={CurveMeshSuppressed} sceneryCarDecalsDisabled={SceneryDecalComponentsDisabled} " +
                 $"sceneryLoadFailures={SceneryLoadFailures} sceneryQuarantined={SceneryPlacementsQuarantined} " +
                 $"sceneryLoadWatch={SceneryLoadWatchAttached} " +
-                $"flares={FlareSuppressed} " +
+                $"flares={FlareSuppressed} switchRailsBackfilled={SwitchGeometryRailsBackfilled} " +
                 spikes;
         }
 
@@ -123,6 +127,7 @@ namespace FUSE.Infrastructure
             SceneryLoadFailures = 0;
             SceneryPlacementsQuarantined = 0;
             FlareSuppressed = 0;
+            SwitchGeometryRailsBackfilled = 0;
             FrameSpikes = 0;
             FrameSpikeWorstMs = 0f;
             SceneryLoadWatchAttached = 0;

--- a/FUSE/Infrastructure/FuseUmmInjector.cs
+++ b/FUSE/Infrastructure/FuseUmmInjector.cs
@@ -55,6 +55,12 @@ namespace FUSE.Infrastructure
             _pendingFuseModEntryPath = null;
             _pendingFuseVersion = null;
             InjectLegacyEntries(path, version);
+
+            // The flush runs after UMM's _Start finished loading every real mod
+            // entry, i.e. the moment the UMM mod population is complete — drop
+            // the exception-attribution cache so its next lazy rebuild sees
+            // them all.
+            FuseModAttributionMap.Invalidate();
         }
 
         public static void InjectLegacyEntries(string fuseModEntryPath, string fuseVersion)

--- a/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
@@ -4,6 +4,7 @@ using FUSE.Authoring.Migrations;
 using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using UI.Builder;
 using UI.Common;
@@ -64,6 +65,17 @@ namespace FUSE.Interface.MenuWindow
                 FuseRuntimeGuardCounters.AllIdle,
                 "idle",
                 FuseRuntimeGuardCounters.GuardTotal + " contained event(s)");
+            // Session-cumulative third-party exception observations — same
+            // live-counter semantics as Guards, sourced from the exception
+            // registry rather than the load snapshot. Snapshotted once here
+            // and reused by the breakdown section below.
+            var modExceptions = FuseModExceptionRegistry.SnapshotForReport();
+            AddReadinessRow(
+                builder,
+                "Mod Health",
+                FuseModExceptionRegistry.AllIdle,
+                "0 exceptions observed",
+                $"{FuseModExceptionRegistry.GrandTotal} exception(s) across {modExceptions.Length} mod(s)");
             builder.Spacer(6f);
 
             // Full per-guard breakdown (this window is the only UI surface, so
@@ -77,6 +89,32 @@ namespace FUSE.Interface.MenuWindow
                 FuseRuntimeGuardCounters.AllIdle
                     ? "All idle — no broken content needed containing this session."
                     : "Non-zero counters are content problems FUSE is containing; offenders are named in FUSE.log and the health report.");
+            builder.Spacer(6f);
+
+            // Per-mod breakdown for the third-party exception registry,
+            // mirroring the Runtime Guards treatment above (this window is
+            // the only UI surface, so the observations must be readable
+            // here, not just in copied reports).
+            builder.AddSection("Mod Health");
+            builder.AddLabel(FuseModExceptionRegistry.FormatSummary());
+            if (modExceptions.Length > 0)
+            {
+                foreach (var record in modExceptions.OrderByDescending(item => item.Count).Take(5))
+                {
+                    var display = string.IsNullOrWhiteSpace(record.DisplayName) ? record.ModId : record.DisplayName;
+                    builder.AddField(display, DescribeModExceptionRecord(record));
+                }
+
+                if (modExceptions.Length > 5)
+                {
+                    builder.AddLabel($"...and {modExceptions.Length - 5} more mod(s) — full list in the health report.");
+                }
+            }
+
+            builder.AddLabel(
+                FuseModExceptionRegistry.AllIdle
+                    ? "All idle — no third-party mod exceptions were observed this session."
+                    : "Non-zero counts are third-party mod faults FUSE observed or contained; offenders are named in FUSE.log and the health report.");
             builder.Spacer(6f);
 
             builder.AddSection("Actions");
@@ -148,6 +186,24 @@ namespace FUSE.Interface.MenuWindow
         private static bool ReadBool(JToken token, bool fallback)
         {
             return token != null && bool.TryParse(token.ToString(), out var value) ? value : fallback;
+        }
+
+        /// <summary>
+        /// One-line per-mod value for the Mod Health breakdown: counts plus
+        /// the mod's top signature (by count), matching the per-mod row the
+        /// health report renders so the two surfaces read the same.
+        /// </summary>
+        private static string DescribeModExceptionRecord(FuseModExceptionSnapshot record)
+        {
+            var text = $"{record.Count} exception(s) over {record.Episodes} episode(s)";
+            var signatures = record.Signatures;
+            if (signatures != null && signatures.Length > 0)
+            {
+                var top = signatures.OrderByDescending(item => item.Count).First();
+                text += $" — top: {top.ExceptionType} @ {top.TopOwnedFrame}";
+            }
+
+            return text;
         }
 
         private static void AddReadinessRow(UIPanelBuilder builder, string label, bool ok, string okText, string problemText)

--- a/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
@@ -67,15 +67,18 @@ namespace FUSE.Interface.MenuWindow
                 FuseRuntimeGuardCounters.GuardTotal + " contained event(s)");
             // Session-cumulative third-party exception observations — same
             // live-counter semantics as Guards, sourced from the exception
-            // registry rather than the load snapshot. Snapshotted once here
-            // and reused by the breakdown section below.
-            var modExceptions = FuseModExceptionRegistry.SnapshotForReport();
+            // registry rather than the load snapshot. One atomic capture here
+            // (rows + totals + summary line under the registry's lock), reused
+            // by the readiness row and the breakdown section below so a
+            // concurrent log event can never render contradictory rows.
+            var modExceptionState = FuseModExceptionRegistry.CaptureReportState();
+            var modExceptions = modExceptionState.Mods;
             AddReadinessRow(
                 builder,
                 "Mod Health",
-                FuseModExceptionRegistry.AllIdle,
+                modExceptionState.Total == 0,
                 "0 exceptions observed",
-                $"{FuseModExceptionRegistry.GrandTotal} exception(s) across {modExceptions.Length} mod(s)");
+                $"{modExceptionState.Total} exception(s) across {modExceptions.Length} mod(s)");
             builder.Spacer(6f);
 
             // Full per-guard breakdown (this window is the only UI surface, so
@@ -96,7 +99,7 @@ namespace FUSE.Interface.MenuWindow
             // the only UI surface, so the observations must be readable
             // here, not just in copied reports).
             builder.AddSection("Mod Health");
-            builder.AddLabel(FuseModExceptionRegistry.FormatSummary());
+            builder.AddLabel(modExceptionState.SummaryLine);
             if (modExceptions.Length > 0)
             {
                 foreach (var record in modExceptions.OrderByDescending(item => item.Count).Take(5))
@@ -112,7 +115,7 @@ namespace FUSE.Interface.MenuWindow
             }
 
             builder.AddLabel(
-                FuseModExceptionRegistry.AllIdle
+                modExceptionState.Total == 0
                     ? "All idle — no third-party mod exceptions were observed this session."
                     : "Non-zero counts are third-party mod faults FUSE observed or contained; offenders are named in FUSE.log and the health report.");
             builder.Spacer(6f);

--- a/FUSE/Loading/FuseLegacyAssemblyHost.cs
+++ b/FUSE/Loading/FuseLegacyAssemblyHost.cs
@@ -134,6 +134,13 @@ namespace FUSE.Loading
                 FuseLog.Info($"FUSE legacy support hosted {hostedCount} old-loader plugin instance(s) for '{reason ?? "unspecified"}'.");
             }
 
+            // The mod population may have changed even when hostedCount is 0
+            // (LoadOrFindAssembly can pull new DLLs into the AppDomain before a
+            // plugin fails to host), so drop the attribution cache
+            // unconditionally — invalidation is a flag clear; the rebuild is
+            // lazy on the next observed exception.
+            FuseModAttributionMap.Invalidate();
+
             RetryPendingConsoleCommands();
             return hostedCount;
         }
@@ -301,6 +308,7 @@ namespace FUSE.Loading
                 }
                 catch (Exception ex)
                 {
+                    FuseModExceptionRegistry.RecordContained(ex, hosted.Manifest.Id, "legacy host plugin disable");
                     FuseLog.Exception(
                         $"FUSE legacy support failed while disabling hosted old-loader plugin '{hosted.Type.FullName}'",
                         ex);
@@ -335,6 +343,9 @@ namespace FUSE.Loading
             }
             catch (Exception ex)
             {
+                // Contained here, so Unity never logs it — feed the mod health
+                // registry directly (attribution is the manifest id itself).
+                FuseModExceptionRegistry.RecordContained(ex, manifest.Id, "legacy host plugin instantiate");
                 FuseLog.Exception(
                     $"FUSE legacy support failed to instantiate old-loader plugin '{pluginType.FullName}' from '{manifest.Id}'",
                     ex);
@@ -357,6 +368,7 @@ namespace FUSE.Loading
             }
             catch (Exception ex)
             {
+                FuseModExceptionRegistry.RecordContained(ex, manifest.Id, "legacy host plugin enable");
                 FuseLog.Exception(
                     $"FUSE legacy support failed to enable old-loader plugin '{pluginType.FullName}' from '{manifest.Id}'",
                     ex);
@@ -1288,6 +1300,10 @@ namespace FUSE.Loading
             }
             catch (Exception ex)
             {
+                // The settings identifier is the legacy mod's own id by the old
+                // loader's convention — the closest attribution available here
+                // (the shared context does not know which manifest is calling).
+                FuseModExceptionRegistry.RecordContained(ex, settingsIdentifier, "legacy host settings load");
                 FuseLog.Exception(
                     $"FUSE legacy support could not load configuration of type '{settingsType.FullName}' from '{path}'",
                     ex);

--- a/FUSE/Loading/FuseLoadReport.cs
+++ b/FUSE/Loading/FuseLoadReport.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using FUSE.Authoring.Data;
@@ -400,6 +401,15 @@ namespace FUSE.Loading
             var legacyConvertedPackageIds = FuseDataPackageDiscovery.GetLegacyConvertedPackageIds().ToArray();
             var orphanedCars = FuseSaveCarFaultRegistry.GetAll().ToArray();
 
+            // Session-cumulative third-party exception observations. Snapshotted
+            // once per capture (mirroring how the runtime-guard counters are read
+            // fresh per render) so the summary line, details section, JSON block,
+            // and HasProblems all describe the same instant even while the log
+            // hook keeps recording on other threads.
+            var modExceptions = FuseModExceptionRegistry.SnapshotForReport();
+            var modExceptionTotal = FuseModExceptionRegistry.GrandTotal;
+            var modExceptionUnattributed = FuseModExceptionRegistry.TotalUnattributed;
+
             return new ReportSnapshot
             {
                 Reason = string.IsNullOrWhiteSpace(reason) ? "map load" : reason,
@@ -421,7 +431,10 @@ namespace FUSE.Loading
                 ProgressionTransferSkips = progressionTransferSkips,
                 Notices = notices,
                 SceneryLoadFailures = sceneryLoadFailures,
-                OrphanedCars = orphanedCars
+                OrphanedCars = orphanedCars,
+                ModExceptions = modExceptions,
+                ModExceptionTotal = modExceptionTotal,
+                ModExceptionUnattributed = modExceptionUnattributed
             };
         }
 
@@ -438,7 +451,8 @@ namespace FUSE.Loading
                 $"conflicts {snapshot.Conflicts.Length} | assets {snapshot.UnknownSceneryAssets.Length} | " +
                 $"brokenAssets {snapshot.SceneryLoadFailureCount} | " +
                 $"graph {snapshot.GraphPostBindIssues.Length} | transfers {snapshot.ProgressionTransferSkips.Length} | " +
-                $"suppressions {suppressionCount} | orphans {snapshot.OrphanedCarCount} | /fuse.report";
+                $"suppressions {suppressionCount} | orphans {snapshot.OrphanedCarCount} | " +
+                $"modErrors {snapshot.ModExceptionTotal} | /fuse.report";
         }
 
         private static string BuildDetails(ReportSnapshot snapshot, string summary)
@@ -477,6 +491,8 @@ namespace FUSE.Loading
             // keeps around broken content, so a pasted report answers "did the guards
             // fire?" without the reporter having to open the Health window at all.
             sb.AppendLine("Runtime guards (session): " + FuseRuntimeGuardCounters.FormatSummary() + ".");
+
+            AppendModExceptions(sb, snapshot);
 
             sb.AppendLine(
                 $"Suppressions active: scenePaths={snapshot.SceneSuppressions.Length}; " +
@@ -523,6 +539,50 @@ namespace FUSE.Loading
             }
 
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Renders the session-cumulative third-party exception observations
+        /// (see <see cref="FuseModExceptionRegistry"/>). One row per mod,
+        /// worst first — the row itself answers "which mod, how often, since
+        /// when, what kind" so a pasted report needs no log spelunking.
+        /// Omitted entirely while the registry is idle.
+        /// </summary>
+        private static void AppendModExceptions(StringBuilder sb, ReportSnapshot snapshot)
+        {
+            // The registry's snapshot already carries the "(unattributed)" and
+            // "(other mods)" sentinel buckets as records of their own, so the
+            // per-record rows below are the complete story — no separate
+            // unattributed footer, or the bucket would be mentioned twice.
+            var records = snapshot.ModExceptions ?? Array.Empty<FuseModExceptionSnapshot>();
+            if (records.Length == 0)
+            {
+                return;
+            }
+
+            sb.AppendLine("Third-party mod exceptions observed this session:");
+            foreach (var record in records.OrderByDescending(item => item.Count))
+            {
+                var signatures = record.Signatures;
+                var signatureCount = signatures == null ? 0 : signatures.Length;
+                var display = string.IsNullOrWhiteSpace(record.DisplayName) ? record.ModId : record.DisplayName;
+                var line =
+                    $"  {display}: {record.Count} exception(s) over {record.Episodes} episode(s), " +
+                    $"{signatureCount} signature(s), " +
+                    $"first {FormatSessionTime(record.FirstSeenUtc)} last {FormatSessionTime(record.LastSeenUtc)}";
+                if (signatureCount > 0)
+                {
+                    var top = signatures.OrderByDescending(item => item.Count).First();
+                    line += $" — top: {top.ExceptionType} @ {top.TopOwnedFrame}";
+                }
+
+                sb.AppendLine(line);
+            }
+        }
+
+        private static string FormatSessionTime(DateTime timestampUtc)
+        {
+            return timestampUtc.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
         }
 
         private static string BuildJson(ReportSnapshot snapshot, string summary)
@@ -596,6 +656,9 @@ namespace FUSE.Loading
                     ["frameSpikes"] = FuseRuntimeGuardCounters.FrameSpikes,
                     ["frameSpikeWorstMs"] = FuseRuntimeGuardCounters.FrameSpikeWorstMs
                 },
+                // Session-cumulative like runtimeGuards above, sourced from the
+                // third-party exception registry snapshot taken with this capture.
+                ["modExceptions"] = BuildModExceptionsJson(snapshot),
                 ["suppressions"] = new JObject
                 {
                     ["scenePaths"] = ToArray(snapshot.SceneSuppressions),
@@ -636,6 +699,48 @@ namespace FUSE.Loading
             return root.ToString(Newtonsoft.Json.Formatting.Indented);
         }
 
+        private static JObject BuildModExceptionsJson(ReportSnapshot snapshot)
+        {
+            var records = snapshot.ModExceptions ?? Array.Empty<FuseModExceptionSnapshot>();
+            var mods = new JArray();
+            foreach (var record in records.OrderByDescending(item => item.Count))
+            {
+                var signatures = new JArray();
+                if (record.Signatures != null)
+                {
+                    foreach (var signature in record.Signatures.OrderByDescending(item => item.Count))
+                    {
+                        signatures.Add(new JObject
+                        {
+                            ["type"] = signature.ExceptionType ?? string.Empty,
+                            ["frame"] = signature.TopOwnedFrame ?? string.Empty,
+                            ["count"] = signature.Count,
+                            ["episodes"] = signature.Episodes,
+                            ["source"] = $"{signature.Source}"
+                        });
+                    }
+                }
+
+                mods.Add(new JObject
+                {
+                    ["modId"] = record.ModId ?? string.Empty,
+                    ["displayName"] = record.DisplayName ?? string.Empty,
+                    ["count"] = record.Count,
+                    ["episodes"] = record.Episodes,
+                    ["firstSeen"] = record.FirstSeenUtc.ToString("o", CultureInfo.InvariantCulture),
+                    ["lastSeen"] = record.LastSeenUtc.ToString("o", CultureInfo.InvariantCulture),
+                    ["signatures"] = signatures
+                });
+            }
+
+            return new JObject
+            {
+                ["total"] = snapshot.ModExceptionTotal,
+                ["unattributed"] = snapshot.ModExceptionUnattributed,
+                ["mods"] = mods
+            };
+        }
+
         private static void AppendList(StringBuilder sb, string label, IEnumerable<string> values)
         {
             var items = (values ?? Enumerable.Empty<string>())
@@ -667,6 +772,14 @@ namespace FUSE.Loading
                 sb.AppendLine($"  {entry.Key}: {entry.Value}");
             }
         }
+
+        // Test seams (InternalsVisibleTo): the string/JSON builders stay
+        // private because production callers must come through the capture
+        // pipeline; tests exercise the composition against a hand-built
+        // snapshot without touching the live registries CaptureSnapshot reads.
+        internal static string BuildSummaryForTests(ReportSnapshot snapshot) => BuildSummary(snapshot);
+        internal static string BuildDetailsForTests(ReportSnapshot snapshot) => BuildDetails(snapshot, BuildSummary(snapshot));
+        internal static string BuildJsonForTests(ReportSnapshot snapshot) => BuildJson(snapshot, BuildSummary(snapshot));
 
         private static void PresentToast(string summary, bool hasProblems)
         {
@@ -739,6 +852,9 @@ namespace FUSE.Loading
             public string[] Notices { get; set; }
             public SceneryLoadFailure[] SceneryLoadFailures { get; set; }
             public FuseSaveCarFault[] OrphanedCars { get; set; }
+            public FuseModExceptionSnapshot[] ModExceptions { get; set; }
+            public long ModExceptionTotal { get; set; }
+            public long ModExceptionUnattributed { get; set; }
 
             public int FaultedPackageCount =>
                 Faults == null
@@ -758,7 +874,15 @@ namespace FUSE.Loading
                 (SkippedPackages != null && SkippedPackages.Any(item => !FusePackageFaultRegistry.IsOptionalSkipReason(item.Value))) ||
                 (Notices != null && Notices.Length > 0) ||
                 SceneryLoadFailureCount > 0 ||
-                OrphanedCarCount > 0;
+                OrphanedCarCount > 0 ||
+                HasModExceptionProblem;
+
+            // A single one-off third-party exception must not flip the report
+            // red, but a per-cycle thrower (world moves, update ticks) crosses
+            // these thresholds within seconds of the fault starting.
+            public bool HasModExceptionProblem =>
+                ModExceptions != null &&
+                ModExceptions.Any(record => record.Episodes >= 3 || record.Count >= 10);
         }
 
         private static JArray ToArray(IEnumerable<string> values)

--- a/FUSE/Loading/FuseLoadReport.cs
+++ b/FUSE/Loading/FuseLoadReport.cs
@@ -401,14 +401,15 @@ namespace FUSE.Loading
             var legacyConvertedPackageIds = FuseDataPackageDiscovery.GetLegacyConvertedPackageIds().ToArray();
             var orphanedCars = FuseSaveCarFaultRegistry.GetAll().ToArray();
 
-            // Session-cumulative third-party exception observations. Snapshotted
-            // once per capture (mirroring how the runtime-guard counters are read
-            // fresh per render) so the summary line, details section, JSON block,
-            // and HasProblems all describe the same instant even while the log
-            // hook keeps recording on other threads.
-            var modExceptions = FuseModExceptionRegistry.SnapshotForReport();
-            var modExceptionTotal = FuseModExceptionRegistry.GrandTotal;
-            var modExceptionUnattributed = FuseModExceptionRegistry.TotalUnattributed;
+            // Session-cumulative third-party exception observations. One
+            // atomic capture (rows + totals under the registry's lock) so the
+            // summary line, details section, JSON block, and HasProblems all
+            // describe the same instant even while the log hook keeps
+            // recording on other threads.
+            var modExceptionState = FuseModExceptionRegistry.CaptureReportState();
+            var modExceptions = modExceptionState.Mods;
+            var modExceptionTotal = modExceptionState.Total;
+            var modExceptionUnattributed = modExceptionState.Unattributed;
 
             return new ReportSnapshot
             {
@@ -582,7 +583,9 @@ namespace FUSE.Loading
 
         private static string FormatSessionTime(DateTime timestampUtc)
         {
-            return timestampUtc.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
+            // Sortable date + explicit UTC marker: a session spanning midnight
+            // must not render a later event as an earlier time-of-day.
+            return timestampUtc.ToString("u", CultureInfo.InvariantCulture);
         }
 
         private static string BuildJson(ReportSnapshot snapshot, string summary)

--- a/FUSE/Patches/FuseMapEnhancerCullingGuardPatches.cs
+++ b/FUSE/Patches/FuseMapEnhancerCullingGuardPatches.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections;
+using System.Reflection;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Helpers;
+using Track;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Keeps Map Enhancer's junction-marker culling functional when its
+    /// marker rebuild hits a broken switch descriptor.
+    ///
+    /// Observed field failure chain: one throwing descriptor aborts the
+    /// marker rebuild BEFORE the culling-sphere array is allocated, so the
+    /// per-world-move sphere refresh then dereferences a null array on every
+    /// floating-origin shift for the rest of the session (14/14 world moves
+    /// in the captured logs), and the same rebuild throw also unwinds
+    /// through the game's deferred track-rebuild coroutine. The refresh
+    /// additionally carries a latent count-drift hazard independent of any
+    /// other mod: it loops to the LIVE switch-dictionary count while
+    /// indexing marker/sphere collections sized at rebuild time, so a
+    /// partial track-graph edit between rebuilds can push the index past
+    /// either collection.
+    ///
+    /// Two layers, installed manually by <see cref="FuseThirdPartyGuardInstaller"/>:
+    /// a replacement prefix on the sphere refresh (null state no-ops instead
+    /// of throwing; the loop is clamped to the collections it actually
+    /// indexes, fixing the count drift), and a storm-breaker finalizer on
+    /// the marker rebuild (one bad descriptor truncates the marker set
+    /// instead of killing the whole rebuild and its callers). With the
+    /// switch-geometry rail backfill (<see cref="FuseSwitchGeometryRailBackfillPatch"/>)
+    /// healing descriptors at the source, both layers should sit idle; they
+    /// exist for version skew and for the drift bug the backfill cannot
+    /// reach.
+    ///
+    /// Deliberately NOT a [HarmonyPatch] class: the target is a third-party
+    /// mod resolved by name at runtime (resolve-or-idle, same contract as
+    /// the optional-type handling in the scenery decal scrub), so the
+    /// attribute-driven apply pass and the patch-targeting smoke test must
+    /// never try to resolve it on machines where the mod is legitimately
+    /// absent. All member binding is fail-open: if the mod's internal
+    /// layout differs from the reverse-engineered runtime shape this guard
+    /// understands, the replacement prefix stays uninstalled and vanilla
+    /// behavior is untouched (the storm-breaker finalizer needs no field
+    /// access and installs whenever the method resolves).
+    /// </summary>
+    internal static class FuseMapEnhancerCullingGuardPatches
+    {
+        private static bool _prefixInstalled;
+        private static bool _finalizerInstalled;
+
+        // Bound once at install time; the prefix is only installed when every
+        // binding below succeeded, so the hot path never null-checks them.
+        private static AccessTools.FieldRef<object, IList> _junctionMarkersRef;
+        private static AccessTools.FieldRef<object, BoundingSphere[]> _cullingSpheresRef;
+        // The per-marker descriptor is a non-public struct on the game side, so
+        // these two hops stay classic reflection; the boxed cost only runs on
+        // world-origin shifts and rebuilds, which are rare by construction.
+        private static FieldInfo _entryDescriptorField;
+        private static FieldInfo _descriptorGeometryField;
+
+        /// <summary>Guard interventions since startup (diagnostics).</summary>
+        internal static long GuardedEvents => FuseRuntimeGuardCounters.MapEnhancerCullingGuarded;
+
+        internal static bool Installed => _prefixInstalled || _finalizerInstalled;
+
+        /// <summary>
+        /// Idempotent. Re-resolves on every call while the target mod is
+        /// absent (it may load after FUSE), latches once anything installed.
+        /// Returns a short status token for the installer's summary line.
+        /// </summary>
+        internal static string EnsureInstalled(Harmony harmony)
+        {
+            if (_prefixInstalled && _finalizerInstalled)
+            {
+                return "installed";
+            }
+
+            if (harmony == null)
+            {
+                return "unavailable (no harmony)";
+            }
+
+            var mapEnhancerType = AccessTools.TypeByName("MapEnhancer.MapEnhancer");
+            if (mapEnhancerType == null)
+            {
+                return "idle (not present)";
+            }
+
+            var updateCullingSpheres = AccessTools.Method(mapEnhancerType, "UpdateCullingSpheres");
+            var createSwitches = AccessTools.Method(mapEnhancerType, "CreateSwitches");
+            if (updateCullingSpheres == null && createSwitches == null)
+            {
+                // A future release that reshaped the surface gets no patch at
+                // all rather than a guard aimed at methods that no longer exist.
+                return "idle (surface changed)";
+            }
+
+            // Storm breaker first: it needs no field binding, so it protects
+            // the rebuild even when the layout drifted under the prefix.
+            if (!_finalizerInstalled && createSwitches != null)
+            {
+                harmony.Patch(
+                    createSwitches,
+                    finalizer: new HarmonyMethod(
+                        typeof(FuseMapEnhancerCullingGuardPatches),
+                        nameof(CreateSwitchesFinalizer)));
+                _finalizerInstalled = true;
+            }
+
+            if (!_prefixInstalled && updateCullingSpheres != null && TryBindFields(mapEnhancerType))
+            {
+                harmony.Patch(
+                    updateCullingSpheres,
+                    prefix: new HarmonyMethod(
+                        typeof(FuseMapEnhancerCullingGuardPatches),
+                        nameof(UpdateCullingSpheresPrefix)));
+                _prefixInstalled = true;
+            }
+
+            if (_prefixInstalled && _finalizerInstalled)
+            {
+                return "installed";
+            }
+
+            if (_finalizerInstalled)
+            {
+                return "installed (finalizer only; refresh layout unrecognized)";
+            }
+
+            return _prefixInstalled
+                ? "installed (prefix only; rebuild method unresolved)"
+                : "idle (binding failed)";
+        }
+
+        private static bool TryBindFields(Type mapEnhancerType)
+        {
+            try
+            {
+                var entryType = AccessTools.Inner(mapEnhancerType, "Entry");
+                var descriptorField = entryType != null
+                    ? AccessTools.Field(entryType, "SwitchDescriptor")
+                    : null;
+                var geometryField = descriptorField != null
+                    ? AccessTools.Field(descriptorField.FieldType, "geometry")
+                    : null;
+                if (geometryField == null || geometryField.FieldType != typeof(SwitchGeometry))
+                {
+                    return false;
+                }
+
+                _junctionMarkersRef = AccessTools.FieldRefAccess<IList>(mapEnhancerType, "junctionMarkers");
+                _cullingSpheresRef = AccessTools.FieldRefAccess<BoundingSphere[]>(mapEnhancerType, "cullingSpheres");
+                _entryDescriptorField = descriptorField;
+                _descriptorGeometryField = geometryField;
+                return _junctionMarkersRef != null && _cullingSpheresRef != null;
+            }
+            catch (Exception ex)
+            {
+                // Fail open: without bindings the prefix never installs and the
+                // refresh keeps its vanilla behavior.
+                FuseLog.Exception(
+                    "FUSE Map Enhancer culling guard could not bind the marker/sphere state; " +
+                    "the refresh replacement is unavailable",
+                    ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Replacement for the sphere refresh. Vanilla loops to the live
+        /// switch-dictionary count and would (a) throw on the null sphere
+        /// array a failed rebuild leaves behind, forever, once per world
+        /// move, and (b) overrun the rebuild-time collections after a
+        /// partial track-graph edit. The replacement no-ops on null state
+        /// and clamps to the collections it indexes; the healthy path with
+        /// matching counts is behavior-identical to a successful vanilla
+        /// run, so it records nothing.
+        /// </summary>
+        private static bool UpdateCullingSpheresPrefix(object __instance)
+        {
+            try
+            {
+                if (__instance == null)
+                {
+                    return true;
+                }
+
+                var markers = _junctionMarkersRef(__instance);
+                var spheres = _cullingSpheresRef(__instance);
+                if (markers == null || spheres == null)
+                {
+                    var guarded = FuseRuntimeGuardCounters.RecordMapEnhancerCullingGuarded();
+                    if (FuseGuardLog.ShouldLog(guarded))
+                    {
+                        FuseLog.Warning(
+                            $"FUSE skipped Map Enhancer culling-sphere refresh #{guarded}: its marker " +
+                            "state is uninitialized (a failed junction-marker rebuild leaves the sphere " +
+                            "array null, and vanilla would throw here on every world-origin shift). " +
+                            "Markers resume after the next successful rebuild.");
+                    }
+
+                    return false;
+                }
+
+                var limit = Math.Min(markers.Count, spheres.Length);
+                for (var i = 0; i < limit; i++)
+                {
+                    var entry = markers[i];
+                    var descriptor = entry != null ? _entryDescriptorField.GetValue(entry) : null;
+                    if (descriptor == null)
+                    {
+                        continue;
+                    }
+
+                    var geometry = (SwitchGeometry)_descriptorGeometryField.GetValue(descriptor);
+                    spheres[i] = new BoundingSphere(WorldTransformer.GameToWorld(geometry.switchHome), 1f);
+                }
+
+                if (markers.Count != spheres.Length)
+                {
+                    // Count drift between the rebuild-time collections: vanilla's
+                    // live-dictionary loop bound would have overrun one of them.
+                    var guarded = FuseRuntimeGuardCounters.RecordMapEnhancerCullingGuarded();
+                    if (FuseGuardLog.ShouldLog(guarded))
+                    {
+                        FuseLog.Warning(
+                            $"FUSE clamped Map Enhancer culling-sphere refresh #{guarded} to " +
+                            $"{limit} entries (markers={markers.Count} spheres={spheres.Length}); " +
+                            "the counts re-align on its next full rebuild.");
+                    }
+                }
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                // Fail open: let vanilla run rather than leave a half-written
+                // sphere set behind a suppressed replacement failure.
+                FuseLog.Exception(
+                    "FUSE Map Enhancer culling-sphere replacement failed; letting the original run",
+                    ex);
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Storm breaker on the junction-marker rebuild: suppressing lets the
+        /// caller's rebuild continue to allocate culling state for the
+        /// markers that were created before the bad descriptor, instead of
+        /// one throw producing zero markers, a null sphere array, and an
+        /// unwind through whatever game code invoked the rebuild.
+        /// </summary>
+        private static Exception CreateSwitchesFinalizer(Exception __exception)
+        {
+            if (__exception == null)
+            {
+                return null;
+            }
+
+            var guarded = FuseRuntimeGuardCounters.RecordMapEnhancerCullingGuarded();
+            if (FuseGuardLog.ShouldLog(guarded))
+            {
+                FuseLog.Exception(
+                    $"FUSE contained Map Enhancer junction-marker rebuild exception #{guarded}; the " +
+                    "marker set may be truncated at the failing switch descriptor, but culling state " +
+                    "still gets allocated and the callers above the rebuild keep running. A switch " +
+                    "descriptor with unset rail curves is the known trigger (see the switch-geometry " +
+                    "rail backfill guard)",
+                    __exception);
+            }
+
+            return null;
+        }
+    }
+}

--- a/FUSE/Patches/FuseMessengerIsolationPatch.cs
+++ b/FUSE/Patches/FuseMessengerIsolationPatch.cs
@@ -163,6 +163,13 @@ namespace FUSE.Patches
             _suppressed++;
             try
             {
+                // Suppression means Unity never logs this exception, so the mod
+                // health log hook cannot see it — feed the registry directly, and
+                // BEFORE the throttle decision so every containment is counted
+                // even when its log line below is suppressed.
+                FuseModExceptionRegistry.RecordContained(
+                    __exception, ResolveRecipientType(__instance), "map lifecycle listener");
+
                 // First few individually, every previously-unseen offender once, then
                 // heartbeat only — a permanently-broken listener re-throws on every
                 // map load/unload it survives to see. Logged with the full exception
@@ -185,6 +192,39 @@ namespace FUSE.Patches
                 // nothing thrown here may leak back into the dispatch loop. Count the
                 // abandoned log attempt so the readout can reveal a broken log path.
                 _diagnosticFailures++;
+            }
+
+            return null;
+        }
+
+        // The Type the health registry attributes by: the recipient passed to
+        // Messenger.Register when it is still alive, else the handler delegate's
+        // declaring type (same fallback order as DescribeListener, but yielding
+        // the Type itself so attribution is exact — no string parsing). May
+        // return null (collected recipient AND unresolvable delegate); the
+        // registry treats that as unattributed.
+        private static Type ResolveRecipientType(object weakAction)
+        {
+            try
+            {
+                var recipientType = (weakAction as WeakAction)?.Target?.GetType();
+                if (recipientType != null)
+                {
+                    return recipientType;
+                }
+
+                if (weakAction != null &&
+                    AccessTools.DeclaredProperty(weakAction.GetType(), "Action")?.GetValue(weakAction, null)
+                        is Delegate action)
+                {
+                    return action.Method?.DeclaringType;
+                }
+            }
+            catch
+            {
+                // Best-effort, mirroring DescribeListener: the containment must
+                // never throw over a diagnostics lookup.
+                FUSE.Infrastructure.FuseModExceptionRegistry.CountSelfFault();
             }
 
             return null;

--- a/FUSE/Patches/FuseRebillIndustryCarsGuardPatches.cs
+++ b/FUSE/Patches/FuseRebillIndustryCarsGuardPatches.cs
@@ -86,7 +86,7 @@ namespace FUSE.Patches
             {
                 // Unreadable version: fall through and install — the finalizers
                 // only ever act on an observed throw, so over-installing is inert.
-                FUSE.Infrastructure.FuseModExceptionRegistry.CountSelfFault();
+                FuseModExceptionRegistry.CountSelfFault();
             }
 
             if (!ShouldInstallForVersion(assemblyVersion))

--- a/FUSE/Patches/FuseRebillIndustryCarsGuardPatches.cs
+++ b/FUSE/Patches/FuseRebillIndustryCarsGuardPatches.cs
@@ -1,0 +1,169 @@
+using System;
+using FUSE.Infrastructure;
+using HarmonyLib;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Containment for a recurring config-load crash observed at runtime in
+    /// Rebill Industry Cars 0.2.x on custom maps: its auto-config step
+    /// throws deterministically, and because the mod only commits its
+    /// change-detection counters after a SUCCESSFUL config load, the failed
+    /// load re-arms itself on every update gate — a session-long retry loop
+    /// (observed at 74-2,286 identical six-line stack dumps per session)
+    /// during which no car is ever rebilled and even a valid hand-authored
+    /// config file is never applied.
+    ///
+    /// Finalizers on the auto-config step and, as a storm breaker, on the
+    /// config load itself suppress the throw so the rest of the load can
+    /// run: that restores the JSON-configured half of the feature and
+    /// collapses the log spam into counted, health-report-visible guard
+    /// lines. It does NOT restore the auto-config feature — only the mod's
+    /// own 0.2.3+ update can, which is why the guard message recommends it
+    /// and why the version gate leaves repaired releases unpatched. Remove
+    /// this guard once 0.2.3+ is verified fixed in the field.
+    ///
+    /// Deliberately NOT a [HarmonyPatch] class: the target is a third-party
+    /// mod resolved by name at runtime (resolve-or-idle), so the
+    /// attribute-driven apply pass and the patch-targeting smoke test never
+    /// try to resolve types that are legitimately absent. Honesty gate: if
+    /// EITHER method is missing (mod absent, or a release that renamed or
+    /// removed the surface this guard understands), nothing installs — a
+    /// half-guarded surface would claim containment it cannot deliver.
+    /// </summary>
+    internal static class FuseRebillIndustryCarsGuardPatches
+    {
+        /// <summary>
+        /// First release reported repaired upstream; assemblies at or above
+        /// this version run unpatched so the fix is observable in the field.
+        /// </summary>
+        private static readonly Version FirstFixedVersion = new Version(0, 2, 3);
+
+        private static bool _autoConfigPatched;
+        private static bool _loadConfigPatched;
+
+        /// <summary>Suppressed config-load crashes since startup (diagnostics).</summary>
+        internal static long SuppressedExceptions => FuseRuntimeGuardCounters.RebillAutoConfigSuppressed;
+
+        internal static bool Installed => _autoConfigPatched && _loadConfigPatched;
+
+        /// <summary>
+        /// Idempotent. Re-resolves on every call while the target mod is
+        /// absent (it may load after FUSE), latches once installed. Returns
+        /// a short status token for the installer's summary line.
+        /// </summary>
+        internal static string EnsureInstalled(Harmony harmony)
+        {
+            if (_autoConfigPatched && _loadConfigPatched)
+            {
+                return "installed";
+            }
+
+            if (harmony == null)
+            {
+                return "unavailable (no harmony)";
+            }
+
+            var rebillSystemType = AccessTools.TypeByName("Us.Dchn.Railroader.RebillIndustryCars.RebillSystem");
+            if (rebillSystemType == null)
+            {
+                return "idle (not present)";
+            }
+
+            var autoConfigUnloaders = AccessTools.Method(rebillSystemType, "AutoConfigUnloaders");
+            var loadConfig = AccessTools.Method(rebillSystemType, "LoadConfig");
+            if (autoConfigUnloaders == null || loadConfig == null)
+            {
+                return "idle (surface absent)";
+            }
+
+            Version assemblyVersion = null;
+            try
+            {
+                assemblyVersion = rebillSystemType.Assembly.GetName().Version;
+            }
+            catch
+            {
+                // Unreadable version: fall through and install — the finalizers
+                // only ever act on an observed throw, so over-installing is inert.
+                FUSE.Infrastructure.FuseModExceptionRegistry.CountSelfFault();
+            }
+
+            if (!ShouldInstallForVersion(assemblyVersion))
+            {
+                return $"idle (assembly {assemblyVersion} is at or past the repaired release)";
+            }
+
+            // Signature-agnostic finalizers: an (Exception) -> Exception
+            // finalizer attaches to any target signature, and a suppressed
+            // call yields the target's default return value — for the config
+            // load's boolean that reads as "load failed", which is exactly
+            // what the caller already handles.
+            if (!_autoConfigPatched)
+            {
+                harmony.Patch(
+                    autoConfigUnloaders,
+                    finalizer: new HarmonyMethod(
+                        typeof(FuseRebillIndustryCarsGuardPatches),
+                        nameof(AutoConfigUnloadersFinalizer)));
+                _autoConfigPatched = true;
+            }
+
+            if (!_loadConfigPatched)
+            {
+                harmony.Patch(
+                    loadConfig,
+                    finalizer: new HarmonyMethod(
+                        typeof(FuseRebillIndustryCarsGuardPatches),
+                        nameof(LoadConfigFinalizer)));
+                _loadConfigPatched = true;
+            }
+
+            return "installed";
+        }
+
+        /// <summary>
+        /// Version gate, kept pure for tests: install for anything below the
+        /// first repaired release, and default to installing when the
+        /// assembly version is unreadable (many mod assemblies do not stamp
+        /// their release version — the finalizers are inert on healthy code
+        /// either way, while skipping a broken build is not recoverable).
+        /// </summary>
+        internal static bool ShouldInstallForVersion(Version assemblyVersion)
+        {
+            return assemblyVersion == null || assemblyVersion < FirstFixedVersion;
+        }
+
+        private static Exception AutoConfigUnloadersFinalizer(Exception __exception)
+        {
+            return Suppress(__exception, "auto-config");
+        }
+
+        private static Exception LoadConfigFinalizer(Exception __exception)
+        {
+            return Suppress(__exception, "config-load");
+        }
+
+        private static Exception Suppress(Exception exception, string stage)
+        {
+            if (exception == null)
+            {
+                return null;
+            }
+
+            var suppressed = FuseRuntimeGuardCounters.RecordRebillAutoConfigSuppressed();
+            if (FuseGuardLog.ShouldLog(suppressed))
+            {
+                FuseLog.Exception(
+                    $"FUSE contained Rebill Industry Cars {stage} crash #{suppressed} so the rest of " +
+                    "its config load can still run (a hand-authored RICconfig.json applies again; the " +
+                    "auto-config feature itself stays down). This crash retries every update gate for " +
+                    "the whole session on affected maps — updating Rebill Industry Cars to 0.2.3 or " +
+                    "newer is the recommended fix",
+                    exception);
+            }
+
+            return null;
+        }
+    }
+}

--- a/FUSE/Patches/FuseSwitchGeometryRailBackfillPatch.cs
+++ b/FUSE/Patches/FuseSwitchGeometryRailBackfillPatch.cs
@@ -61,20 +61,24 @@ namespace FUSE.Patches
                 }
 
                 var origin = __result.switchHome;
-                var stub = new LineCurve(new[]
+
+                // One fresh curve per field: consumers may mutate a curve in
+                // place or read Hand for left/right semantics, and a shared
+                // aliased instance would leak edits across all eight rails.
+                LineCurve Stub(Hand hand) => new LineCurve(new[]
                 {
                     new LinePoint(origin, rotation),
                     new LinePoint(origin + rotation * Vector3.forward * 0.1f, rotation),
-                }, Hand.Right);
+                }, hand);
 
-                __result.aPointRail ??= stub;
-                __result.bPointRail ??= stub;
-                __result.aClosureRail ??= stub;
-                __result.bClosureRail ??= stub;
-                __result.leftStockRail ??= stub;
-                __result.rightStockRail ??= stub;
-                __result.leftGuardRail ??= stub;
-                __result.rightGuardRail ??= stub;
+                __result.aPointRail ??= Stub(Hand.Right);
+                __result.bPointRail ??= Stub(Hand.Left);
+                __result.aClosureRail ??= Stub(Hand.Right);
+                __result.bClosureRail ??= Stub(Hand.Left);
+                __result.leftStockRail ??= Stub(Hand.Left);
+                __result.rightStockRail ??= Stub(Hand.Right);
+                __result.leftGuardRail ??= Stub(Hand.Left);
+                __result.rightGuardRail ??= Stub(Hand.Right);
                 __result.frogPoints ??= new LinePoint[3];
 
                 var count = FuseRuntimeGuardCounters.RecordSwitchGeometryRailsBackfilled();

--- a/FUSE/Patches/FuseSwitchGeometryRailBackfillPatch.cs
+++ b/FUSE/Patches/FuseSwitchGeometryRailBackfillPatch.cs
@@ -1,0 +1,96 @@
+using System;
+using Core;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Track;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Backfills null rail curves on <see cref="SwitchGeometry.Calculate"/>
+    /// results before they are stored in the shared switch-descriptor
+    /// dictionary.
+    ///
+    /// The vanilla calculator either populates every rail
+    /// <see cref="LineCurve"/> or throws (and throwing switches are dropped
+    /// by the caller), so a vanilla descriptor can never carry a null rail.
+    /// Modded geometry producers can: the narrow-gauge control-shell path
+    /// substitutes a result that carries stand/frog data but leaves all
+    /// eight rail curves null. The producer's own mesh building suppresses
+    /// those hidden descriptors, so the game never notices — but the
+    /// descriptor dictionary is shared surface, and any third-party consumer
+    /// that walks it (Map Enhancer's junction markers are the known field
+    /// case) dereferences <c>geometry.aPointRail</c> and dies. In the field
+    /// that single throw aborted Map Enhancer's whole Rebuild before its
+    /// culling-sphere array was allocated, which then turned EVERY
+    /// world-origin shift into a further NRE: one poisoned descriptor became
+    /// a session-long exception stream, dead map markers, and a killed
+    /// game-side track-rebuild coroutine.
+    ///
+    /// Priority.Last puts this postfix after every producer, and Harmony
+    /// runs postfixes even when another mod's prefix skipped the original —
+    /// so the substituted result is seen too. Null rails are replaced with a
+    /// degenerate-but-valid two-point stub anchored at the switch home;
+    /// consumers get a well-formed descriptor, and the hidden descriptors
+    /// still never reach mesh building.
+    /// </summary>
+    [HarmonyPatch(typeof(SwitchGeometry), nameof(SwitchGeometry.Calculate))]
+    [HarmonyPriority(Priority.Last)]
+    internal static class FuseSwitchGeometryRailBackfillPatch
+    {
+        private static void Postfix(ref SwitchGeometry __result)
+        {
+            try
+            {
+                var needsBackfill =
+                    __result.aPointRail == null || __result.bPointRail == null ||
+                    __result.aClosureRail == null || __result.bClosureRail == null ||
+                    __result.leftStockRail == null || __result.rightStockRail == null ||
+                    __result.leftGuardRail == null || __result.rightGuardRail == null ||
+                    __result.frogPoints == null;
+                if (!needsBackfill)
+                {
+                    return;
+                }
+
+                var rotation = __result.standRotation;
+                if (rotation.x == 0f && rotation.y == 0f && rotation.z == 0f && rotation.w == 0f)
+                {
+                    rotation = Quaternion.identity;
+                }
+
+                var origin = __result.switchHome;
+                var stub = new LineCurve(new[]
+                {
+                    new LinePoint(origin, rotation),
+                    new LinePoint(origin + rotation * Vector3.forward * 0.1f, rotation),
+                }, Hand.Right);
+
+                __result.aPointRail ??= stub;
+                __result.bPointRail ??= stub;
+                __result.aClosureRail ??= stub;
+                __result.bClosureRail ??= stub;
+                __result.leftStockRail ??= stub;
+                __result.rightStockRail ??= stub;
+                __result.leftGuardRail ??= stub;
+                __result.rightGuardRail ??= stub;
+                __result.frogPoints ??= new LinePoint[3];
+
+                var count = FuseRuntimeGuardCounters.RecordSwitchGeometryRailsBackfilled();
+                if (FuseGuardLog.ShouldLog(count))
+                {
+                    FuseLog.Warning(
+                        $"FUSE backfilled null rail curves on a switch-geometry descriptor near {origin} " +
+                        $"(occurrence #{count}). A modded geometry producer left the rail curves unset; " +
+                        "without the backfill, shared-descriptor consumers such as Map Enhancer's junction " +
+                        "markers crash on the first null rail and stay broken for the whole session.");
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE switch-geometry rail backfill failed", ex);
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseSwitchGeometryRailBackfillPatch.cs
+++ b/FUSE/Patches/FuseSwitchGeometryRailBackfillPatch.cs
@@ -43,13 +43,13 @@ namespace FUSE.Patches
         {
             try
             {
-                var needsBackfill =
+                var railsNeedBackfill =
                     __result.aPointRail == null || __result.bPointRail == null ||
                     __result.aClosureRail == null || __result.bClosureRail == null ||
                     __result.leftStockRail == null || __result.rightStockRail == null ||
-                    __result.leftGuardRail == null || __result.rightGuardRail == null ||
-                    __result.frogPoints == null;
-                if (!needsBackfill)
+                    __result.leftGuardRail == null || __result.rightGuardRail == null;
+                var frogNeedsBackfill = __result.frogPoints == null;
+                if (!railsNeedBackfill && !frogNeedsBackfill)
                 {
                     return;
                 }
@@ -80,6 +80,14 @@ namespace FUSE.Patches
                 __result.leftGuardRail ??= Stub(Hand.Left);
                 __result.rightGuardRail ??= Stub(Hand.Right);
                 __result.frogPoints ??= new LinePoint[3];
+
+                // The counter and warning are specifically about rail curves —
+                // a frog-only repair (rails all present) is patched above but
+                // must not report as a rail backfill.
+                if (!railsNeedBackfill)
+                {
+                    return;
+                }
 
                 var count = FuseRuntimeGuardCounters.RecordSwitchGeometryRailsBackfilled();
                 if (FuseGuardLog.ShouldLog(count))

--- a/FUSE/Patches/FuseThirdPartyGuardInstaller.cs
+++ b/FUSE/Patches/FuseThirdPartyGuardInstaller.cs
@@ -1,0 +1,86 @@
+using System;
+using FUSE.Infrastructure;
+using HarmonyLib;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Single idempotent entry point for the guards FUSE keeps around
+    /// third-party mods it has no compile-time reference to (currently the
+    /// Map Enhancer culling guard and the Rebill Industry Cars config-load
+    /// guard). Each guard resolves its target by name and idles silently
+    /// when the mod — or the exact member surface the guard understands —
+    /// is absent.
+    ///
+    /// Kept out of the attribute-driven FusePatchResilience pass on
+    /// purpose: these guard classes carry no [HarmonyPatch] attributes, so
+    /// neither the apply pass nor the patch-targeting smoke test ever tries
+    /// to resolve third-party types that are legitimately absent from a
+    /// test or user machine.
+    ///
+    /// Safe to call more than once (plugin load, then again once the full
+    /// mod population is up): installed guards latch, absent targets are
+    /// re-resolved on each call because third-party load order relative to
+    /// FUSE is not guaranteed. One summary line is logged per state change,
+    /// never per call.
+    /// </summary>
+    internal static class FuseThirdPartyGuardInstaller
+    {
+        // FusePlugin's Harmony id, so its shutdown UnpatchAll sweep removes
+        // these manually-applied guards together with the attribute patches.
+        private const string HarmonyId = "FUSE";
+
+        private static Harmony _harmony;
+        private static string _lastSummary;
+
+        internal static void EnsureInstalled()
+        {
+            try
+            {
+                if (_harmony == null)
+                {
+                    _harmony = new Harmony(HarmonyId);
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception(
+                    "FUSE third-party guard installer could not create its Harmony instance; " +
+                    "no third-party guards are active",
+                    ex);
+                return;
+            }
+
+            string mapEnhancerStatus;
+            try
+            {
+                mapEnhancerStatus = FuseMapEnhancerCullingGuardPatches.EnsureInstalled(_harmony);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE Map Enhancer culling guard failed to install", ex);
+                mapEnhancerStatus = "failed";
+            }
+
+            string rebillStatus;
+            try
+            {
+                rebillStatus = FuseRebillIndustryCarsGuardPatches.EnsureInstalled(_harmony);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE Rebill Industry Cars guard failed to install", ex);
+                rebillStatus = "failed";
+            }
+
+            var summary =
+                $"FUSE third-party guards: mapEnhancerCulling='{mapEnhancerStatus}' " +
+                $"rebillIndustryCars='{rebillStatus}'.";
+            if (!string.Equals(summary, _lastSummary, StringComparison.Ordinal))
+            {
+                _lastSummary = summary;
+                FuseLog.Info(summary);
+            }
+        }
+    }
+}

--- a/FUSE/Runtime/Lifecycle/FuseRuntimePump.cs
+++ b/FUSE/Runtime/Lifecycle/FuseRuntimePump.cs
@@ -83,6 +83,11 @@ namespace FUSE.Runtime.Lifecycle
                 // queued from task continuations / the log hook / the bundle
                 // audit (any thread), resolved and applied here.
                 FUSE.Patches.FuseSceneryLoadFailurePatch.DrainPending();
+
+                // Mod health exception observations: first-seen signatures
+                // queued by the threaded log hook (any thread), attributed and
+                // recorded (with throttled log lines) here.
+                FuseModExceptionLogHook.DrainPending();
             }
         }
     }


### PR DESCRIPTION
## What this is

Two commits closing out the legacy-mod fault investigation:

### 1. `fix(compat)`: switch-geometry rail backfill (`e50fc77`)

Root cause of the field-observed MapEnhancer breakage (an NRE on **every** world-origin shift, all session, plus a killed game-side `DelayedRebuildTrack` coroutine each map load): FUSE.NarrowGauge's control-shell geometry path returns `SwitchGeometry` descriptors whose eight rail `LineCurve` fields are all null. The game never dereferences them (NarrowGauge suppresses mesh building for its hidden descriptors), but the descriptor dictionary is shared surface — MapEnhancer's `CreateSwitches` dereferences `aPointRail` on every entry and died on the first control shell, aborting its whole rebuild before its culling-sphere array was allocated.

A `Priority.Last` postfix on `SwitchGeometry.Calculate` (postfixes run even when a producer prefix skips the original) backfills null rails with degenerate-but-valid stubs. Vanilla results are untouched by construction — vanilla `Calculate` either fills every rail or throws, and throwing switches are dropped by the caller. Counted as `switchRailsBackfilled` in the guards line. NarrowGauge itself is fixed at source in its own repo (`90fbe55`); this patch stays as version-skew protection.

### 2. `feat(health)`: legacy-mod exception monitor + containment guards (`4d1df67`)

Per-mod exception accounting so a misbehaving third-party mod is named in one session instead of weeks of log forensics:

- **`FuseModExceptionRegistry`** — session-cumulative per-mod ledger: signature dedupe, 1s episode coalescing, caps with overflow buckets, and a `selfFaults` counter (the monitor counts its own swallowed failures instead of logging from inside the pipeline it observes; surfaced in the summary only when non-zero).
- **`FuseModExceptionLogHook`** — second `Application.logMessageReceivedThreaded` subscriber, `LogType.Exception` only, allocation-free repeat fast path, bounded first-occurrence queue drained on the runtime pump.
- **`FuseModAttributionMap`** — stack-frame→mod attribution from UMM entries + hosted legacy plugins, engine/game/FUSE tokens denylisted, pure parsing core with unit tests.
- **Precise tagging from FUSE's containment sites** (messenger isolation finalizer, legacy assembly host): exceptions FUSE swallows never reach the Unity log, so a log-only monitor would report a clean bill of health for exactly the mods FUSE babysits.
- **Surfaces**: `modErrors N` summary segment, per-mod details section + `modExceptions` JSON in the load report, Mod Health row + breakdown on the menu Status page. No popups, per the established policy.
- **Containment guards** (manual patching, resolve-or-idle, deliberately no `[HarmonyPatch]` attributes so patch-targeting tests skip third-party types): MapEnhancer culling defense layer (null-safe sphere refresh with a min-clamp that also fixes the mod's own latent count-drift bug) and Rebill Industry Cars auto-config finalizers (version-gated to the known-broken 0.2.0–0.2.2 range; a fixed 0.2.3+ runs unpatched).

## Reviewer notes

- 1,550 tests passing (38 new); slopwatch clean apart from the one pre-existing baselined warning.
- The monitor is capture-only diagnostics — no gameplay mutation. The two guards suppress only observed throws and count everything they do.
- In-game validation has not happened yet; test/inspection coverage only. Known gap (chipped separately): `FuseModExceptionLogHook` has test seams but no unit tests of its own.
- Base already contains PR #144 (merged); this PR is exactly these two commits.