### PR TITLE
Make the frame-spike floor configurable from the Settings page

### DIFF
--- a/FUSE.Tests/Infrastructure/FuseSettingsReadFloatTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseSettingsReadFloatTests.cs
@@ -62,4 +62,29 @@ namespace FUSE.Tests.Infrastructure
             Assert.Equal(0.6f, FuseSettings.ReadFloat(settings, null, 0.6f));
         }
     }
+
+    /// <summary>
+    /// Clamp contract for the spike-floor slider preview (visible via
+    /// InternalsVisibleTo). Preview mutates the live static value without
+    /// persisting, so each test restores the default afterwards.
+    /// </summary>
+    public class FuseSettingsFrameSpikeThresholdTests
+    {
+        [Theory]
+        [InlineData(5f, FuseSettings.MinFrameSpikeThresholdMs)]     // below floor clamps up
+        [InlineData(50f, 50f)]                                       // in-range passes through
+        [InlineData(9999f, FuseSettings.MaxFrameSpikeThresholdMs)]   // above ceiling clamps down
+        public void PreviewFrameSpikeThresholdMs_ClampsToDocumentedRange(float input, float expected)
+        {
+            try
+            {
+                FuseSettings.PreviewFrameSpikeThresholdMs(input);
+                Assert.Equal(expected, FuseSettings.FrameSpikeThresholdMs);
+            }
+            finally
+            {
+                FuseSettings.PreviewFrameSpikeThresholdMs(FuseSettings.DefaultFrameSpikeThresholdMs);
+            }
+        }
+    }
 }

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -458,6 +458,36 @@ namespace FUSE.Infrastructure
                 $"(threshold {FrameSpikeThresholdMs:F0}ms). Takes effect immediately.");
         }
 
+        // The spike-floor clamp: 20ms matches the read-time floor applied to
+        // Info.json values (below that, ordinary frames at low fps would log
+        // as spikes); 500ms is far past anything worth calling a "spike"
+        // rather than a stall.
+        internal const float MinFrameSpikeThresholdMs = 20f;
+        internal const float MaxFrameSpikeThresholdMs = 500f;
+
+        /// <summary>
+        /// Live preview while the settings slider is being dragged: updates
+        /// the running value (the spike logger reads it per frame) without
+        /// persisting, so a drag does not write the override file once per
+        /// slider tick. <see cref="SetFrameSpikeThresholdMs"/> persists on
+        /// release.
+        /// </summary>
+        internal static void PreviewFrameSpikeThresholdMs(float thresholdMs)
+        {
+            FrameSpikeThresholdMs = Mathf.Clamp(
+                thresholdMs, MinFrameSpikeThresholdMs, MaxFrameSpikeThresholdMs);
+        }
+
+        public static void SetFrameSpikeThresholdMs(float thresholdMs)
+        {
+            FrameSpikeThresholdMs = Mathf.Clamp(
+                thresholdMs, MinFrameSpikeThresholdMs, MaxFrameSpikeThresholdMs);
+            SaveUserOverride(nameof(FrameSpikeThresholdMs), FrameSpikeThresholdMs);
+            FuseLog.Info(
+                $"FUSE setting changed: {nameof(FrameSpikeThresholdMs)}={FrameSpikeThresholdMs:F0}ms. " +
+                "Takes effect immediately.");
+        }
+
         public static void SetEnableNativeLeakStackTraces(bool enabled)
         {
             EnableNativeLeakStackTraces = enabled;

--- a/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
@@ -118,6 +118,24 @@ namespace FUSE.Interface.MenuWindow
                     ? $"Logging adaptive hitches to FUSE.log (absolute floor {FuseSettings.FrameSpikeThresholdMs:F0}ms; spikes so far: {FuseRuntimeGuardCounters.FrameSpikes}, worst {FuseRuntimeGuardCounters.FrameSpikeWorstMs:F0}ms)."
                     : "For stutter reports: logs frames that exceed both the configured floor and the rolling frame-time baseline, with memory and queue context. Takes effect immediately.");
 
+            builder.AddField("Spike Floor", control: builder.AddSliderQuantized(
+                () => FuseSettings.FrameSpikeThresholdMs,
+                () => $"{FuseSettings.FrameSpikeThresholdMs:F0}ms",
+                FuseSettings.PreviewFrameSpikeThresholdMs,
+                5f,
+                FuseSettings.MinFrameSpikeThresholdMs,
+                250f,
+                value =>
+                {
+                    FuseSettings.SetFrameSpikeThresholdMs(value);
+                    builder.Rebuild();
+                }));
+
+            builder.AddLabel(
+                "Frames shorter than the floor never log as spikes, even when they exceed the rolling " +
+                "baseline. 50ms suits subtle-stutter hunts; the 100ms default keeps only severe hitches. " +
+                "Takes effect immediately.");
+
             builder.AddField("Native Allocation Stacks", control: BuildToggleBoxWithButton(
                 builder,
                 FuseSettings.EnableNativeLeakStackTraces,


### PR DESCRIPTION
## What

The frame-spike diagnostic's absolute floor (`FrameSpikeThresholdMs`) was only settable by hand-editing the `Settings` block in `Info.json` — against the standing rule that field testers never edit config files. This adds a quantized slider (5ms steps, 20–250ms) to the menu window's **Settings → Performance Diagnostics** section, right beside the Frame Spike Log toggle.

## Why now

0.17.0 ships the floor at its 100ms default, which is right for severe-hitch hunts (Sam's sub-5-FPS episodes) but misses subtle 30–60ms stutter. The hand-built diag zips that ran the earlier field investigations used 50ms to good effect; with the slider, each tester picks per-hunt without anyone touching JSON or waiting on a rebuilt zip.

## Design notes

- **Drag = preview, release = persist**: `PreviewFrameSpikeThresholdMs` updates the live value only (the spike logger reads the setting per frame, so the effect is immediate); the standard `SetFrameSpikeThresholdMs` runs on editing-end, persisting via the existing user-override path and logging the change. This keeps a slider drag from writing the override file once per tick.
- Clamp is 20–500ms in the setter (20ms matches the existing read-time floor; the slider itself tops at 250ms), documented as constants and pinned by tests.
- **Default unchanged** (100ms). Dropping it to 50 is a one-line follow-up if we decide the field default should favor sensitivity — deliberately not bundled here.

1,561 tests passing; slopwatch clean.