### PR TITLE
Frame-spike log: always log session-worst, add streaming context to spike lines

### DIFF
--- a/FUSE.Tests/Runtime/FuseFrameSpikeShouldLogTests.cs
+++ b/FUSE.Tests/Runtime/FuseFrameSpikeShouldLogTests.cs
@@ -1,0 +1,36 @@
+using FUSE.Runtime.Lifecycle;
+using Xunit;
+
+namespace FUSE.Tests.Runtime
+{
+    /// <summary>
+    /// Pins the spike-log throttle contract (visible via InternalsVisibleTo):
+    /// early spikes and the heartbeat cadence log as before, and a session
+    /// worst ALWAYS breaks through — a field capture lost its single biggest
+    /// stall because it fell between heartbeats, leaving only the aggregate
+    /// with no timestamp to correlate.
+    /// </summary>
+    public class FuseFrameSpikeShouldLogTests
+    {
+        [Theory]
+        [InlineData(1, false, true)]    // early spikes log individually
+        [InlineData(10, false, true)]
+        [InlineData(11, false, false)]  // then the heartbeat takes over
+        [InlineData(25, false, true)]
+        [InlineData(26, false, false)]
+        [InlineData(100, false, true)]
+        public void HeartbeatCadence_IsUnchanged(long count, bool isNewWorst, bool expected)
+        {
+            Assert.Equal(expected, FuseFrameSpikeDiagnostic.ShouldLogSpike(count, isNewWorst));
+        }
+
+        [Theory]
+        [InlineData(11)]
+        [InlineData(26)]
+        [InlineData(9999)]
+        public void SessionWorst_AlwaysBreaksThroughTheThrottle(long offCadenceCount)
+        {
+            Assert.True(FuseFrameSpikeDiagnostic.ShouldLogSpike(offCadenceCount, isNewWorst: true));
+        }
+    }
+}

--- a/FUSE/Runtime/Lifecycle/FuseFrameSpikeDiagnostic.cs
+++ b/FUSE/Runtime/Lifecycle/FuseFrameSpikeDiagnostic.cs
@@ -83,10 +83,14 @@ namespace FUSE.Runtime.Lifecycle
 
         // First few hitches individually (enough to align with nearby logs),
         // then a heartbeat so persistent stutter stays visible without a line
-        // for every slow frame.
-        private static bool ShouldLog(long count)
+        // for every slow frame — but a session-worst spike ALWAYS logs: in a
+        // field capture the single biggest stall was invisible because it fell
+        // between heartbeats, leaving only the "worst" aggregate with no
+        // timestamp to correlate against. Worst is monotone, so break-through
+        // lines are self-limiting.
+        internal static bool ShouldLogSpike(long count, bool isNewWorst)
         {
-            return count <= 10 || count % 25 == 0;
+            return isNewWorst || count <= 10 || count % 25 == 0;
         }
 
         private sealed class FuseFrameSpikeRunner : MonoBehaviour
@@ -190,17 +194,28 @@ namespace FUSE.Runtime.Lifecycle
                     var observation = _hitchDetector.Observe(frameMs, absoluteFloorMs);
                     if (observation.IsHitch)
                     {
+                        var isNewWorst = frameMs > FuseRuntimeGuardCounters.FrameSpikeWorstMs;
                         var spikeCount = FuseRuntimeGuardCounters.RecordFrameSpike(frameMs);
-                        if (ShouldLog(spikeCount))
+                        if (ShouldLogSpike(spikeCount, isNewWorst))
                         {
+                            // Streaming context at spike time: a spike with a
+                            // deep scenery queue or a decal-registry jump is a
+                            // streaming wave, not a sim/GC problem — the exact
+                            // split a field capture needs one line to answer.
+                            var decalRegistry = FuseDecalCullingScrubPatch.TryGetRegistryCount(out var registryCount)
+                                ? registryCount.ToString()
+                                : "n/a";
                             FuseLog.Warning(
-                                $"FUSE frame spike #{spikeCount}: {frameMs:F0}ms " +
+                                $"FUSE frame spike #{spikeCount}: {frameMs:F0}ms{(isNewWorst ? " (session worst)" : string.Empty)} " +
                                 $"(adaptive baseline {observation.BaselineMs:F1}ms, absolute floor {absoluteFloorMs:F0}ms, " +
                                 $"effective threshold {observation.EffectiveThresholdMs:F1}ms, " +
                                 $"worst {FuseRuntimeGuardCounters.FrameSpikeWorstMs:F0}ms) frame={Time.frameCount} " +
-                                $"gcDelta0={gen0 - _gen0} gcDelta1={gen1 - _gen1} gcDelta2={gen2 - _gen2}. " +
+                                $"gcDelta0={gen0 - _gen0} gcDelta1={gen1 - _gen1} gcDelta2={gen2 - _gen2} " +
+                                $"sceneryLoadQueue={FuseSceneryLoadThrottlePatch.QueueDepth} " +
+                                $"decalRegistry={decalRegistry}. " +
                                 "Correlate this timestamp with surrounding FUSE.log/Player.log activity; " +
-                                "a positive GC delta with no nearby activity points at allocation pressure.");
+                                "a positive GC delta points at allocation pressure, a deep scenery queue " +
+                                "or decal-registry jump at a streaming wave.");
                         }
                     }
                 }


### PR DESCRIPTION
## What

Two diagnostic gaps exposed by a fresh field capture (Sam, 0.17.0 + census enabled):

1. **The single biggest stall of the session was never logged.** A 4,936ms frame fell between the spike log's every-25th heartbeat; only `worst=4936` survived in later lines, with no timestamp to correlate against Player.log. A new session-worst now always breaks through the throttle, tagged `(session worst)`. Worst is monotone, so break-through lines are inherently self-limiting.

2. **Spike lines carried GC deltas but no streaming context.** In the same capture, the fps collapse minute (12 avg fps, 314ms adaptive baseline) had `gcDelta 0/0/0` on every spike — GC exonerated — while the census showed `decalRegistry` jumping 29→129 as the one metric climbing during the fall (a post-teleport streaming wave registering car decals). Spike lines now include `sceneryLoadQueue` depth and the decal-registry count at spike time, so a single line distinguishes allocation pressure (GC deltas) from a streaming wave (queue depth / registry jump).

## Notes

- The throttle contract moved to an internal pure helper (`ShouldLogSpike`) with tests pinning both the unchanged heartbeat cadence and the new worst-breakthrough rule.
- Per-spike cost of the new fields: one static int read (queue depth) + one compiled-FieldRef read (registry count) — only on frames already classified as hitches.
- No overlap with #154 (different files); both are independent of each other.

1,567 tests passing; slopwatch clean.