### PR TITLE
Retry third-party guard install on map load (guards never engaged in the field)

### DIFF
--- a/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
+++ b/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
@@ -263,6 +263,13 @@ namespace FUSE.Runtime.Lifecycle
                 var consoleStopwatch = Stopwatch.StartNew();
                 FuseConsoleRegistrar.TryRegisterAll();
                 FuseLegacyAssemblyHost.RetryPendingConsoleCommands();
+                // Second attempt for the third-party guards: FUSE loads before
+                // MapEnhancer and the rebill mod in UMM's order, so the
+                // plugin-load attempt resolves neither ("idle (not present)")
+                // and the guards never engaged in the field. By map load every
+                // mod assembly is up; the installer re-resolves absent targets
+                // and latches anything already installed.
+                FUSE.Patches.FuseThirdPartyGuardInstaller.EnsureInstalled();
                 FusePerformanceMetrics.RecordTiming("console registration", consoleStopwatch.ElapsedMilliseconds);
                 FuseLog.Info($"FUSE load timing phase='console registration' elapsedMs={consoleStopwatch.ElapsedMilliseconds}.");
             }


### PR DESCRIPTION
## Bug

`FuseThirdPartyGuardInstaller.EnsureInstalled()` was only called from `FusePlugin.Load`. FUSE loads before MapEnhancer and `us.dchn.railroader.rebillindustrycars` in UMM's load order, so `AccessTools.TypeByName` resolved neither target at that moment and both guards reported `idle (not present)` — **on every machine, always**. Observed live on two field machines today; a session with rrRIC 0.2.2 installed ran its config-retry storm completely unsuppressed despite the guard code shipping in 0.17.0.

## Fix

One wiring line: call the installer again from the map-load pipeline, right beside `FuseConsoleRegistrar.TryRegisterAll()` — which exists for exactly the same load-order reason. The installer was already built for re-entry (absent targets re-resolve per call, installs latch, one summary line per state change); the second call had simply never been wired.

Expected field log change: `FUSE third-party guards: ... 'idle (not present)'` at plugin load, followed at map load by `mapEnhancerCulling='installed' rebillIndustryCars='installed'` (version-gated) on machines carrying those mods.

1,561 tests passing.