### PR TITLE
Diagnostics, guards, and compat rollup: spike context, threshold slider, guard retry, wrapper attribution, legacy array parity

### DIFF
--- a/FUSE.Tests/Infrastructure/FuseModAttributionHarmonyTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseModAttributionHarmonyTests.cs
@@ -26,6 +26,12 @@ namespace FUSE.Tests.Infrastructure
 
         internal static bool ProbePrefix() => true;
 
+        // The wrapper frame Mono would print for a throw inside the probe
+        // target's rewritten body — shared by every test in this class.
+        private const string ProbeWrapperTrace =
+            "at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition" +
+            ".FuseModAttributionHarmonyTests.WrapperAttributionProbeTarget_Patch1(int)";
+
         [Fact]
         public void WrapperFrame_ResolvesThroughLiveHarmonyPatchState_ToTheOwningMod()
         {
@@ -49,9 +55,7 @@ namespace FUSE.Tests.Infrastructure
                         [typeof(FuseModAttributionHarmonyTests).Assembly] = ("test.mod", "Test Mod")
                     });
 
-                var trace =
-                    "at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition" +
-                    ".FuseModAttributionHarmonyTests.WrapperAttributionProbeTarget_Patch1(int)";
+                var trace = ProbeWrapperTrace;
 
                 Assert.True(FuseModAttributionMap.TryAttributeStack(
                     trace, out var modId, out var displayName, out var frame));
@@ -86,7 +90,7 @@ namespace FUSE.Tests.Infrastructure
             // A static void no-arg method from the FUSE assembly works as a
             // Harmony prefix; the target is never invoked, so it never runs.
             var fuseOwnedPrefix = typeof(FuseModAttributionMap).GetMethod(
-                "Invalidate", BindingFlags.Static | BindingFlags.NonPublic);
+                nameof(FuseModAttributionMap.Invalidate), BindingFlags.Static | BindingFlags.NonPublic);
             Assert.NotNull(fuseOwnedPrefix);
 
             try
@@ -102,9 +106,7 @@ namespace FUSE.Tests.Infrastructure
                         [typeof(FuseModAttributionHarmonyTests).Assembly] = ("test.mod", "Test Mod")
                     });
 
-                var trace =
-                    "at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition" +
-                    ".FuseModAttributionHarmonyTests.WrapperAttributionProbeTarget_Patch1(int)";
+                var trace = ProbeWrapperTrace;
 
                 Assert.False(FuseModAttributionMap.TryAttributeStack(
                     trace, out var modId, out _, out _));
@@ -137,9 +139,7 @@ namespace FUSE.Tests.Infrastructure
                         StringComparer.OrdinalIgnoreCase),
                     assemblyMap: new Dictionary<Assembly, (string modId, string displayName)>());
 
-                var trace =
-                    "at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition" +
-                    ".FuseModAttributionHarmonyTests.WrapperAttributionProbeTarget_Patch1(int)";
+                var trace = ProbeWrapperTrace;
 
                 Assert.False(FuseModAttributionMap.TryAttributeStack(
                     trace, out var modId, out _, out _));

--- a/FUSE.Tests/Infrastructure/FuseModAttributionHarmonyTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseModAttributionHarmonyTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Xunit;
+
+namespace FUSE.Tests.Infrastructure
+{
+    /// <summary>
+    /// Integration coverage for the Harmony half of dynamic-method wrapper
+    /// attribution: a REAL Harmony patch applied inside the test process,
+    /// resolved through the same <c>TryAttributeStack</c> entry the log-hook
+    /// drain uses. The pure wrapper parsing and merge rules live in
+    /// FuseModAttributionMapTests; this class proves the production resolver
+    /// walks Harmony's live patch state and maps the patch assembly through
+    /// the published assembly map. Joins the registry test collection because
+    /// it publishes/reset the attribution map's static state.
+    /// </summary>
+    [Collection(FuseModExceptionRegistryTestCollection.Name)]
+    public class FuseModAttributionHarmonyTests
+    {
+        // A method name unlikely to collide with anything else Harmony has
+        // patched in this test process.
+        internal static int WrapperAttributionProbeTarget(int value) => value + 1;
+
+        internal static bool ProbePrefix() => true;
+
+        [Fact]
+        public void WrapperFrame_ResolvesThroughLiveHarmonyPatchState_ToTheOwningMod()
+        {
+            var harmony = new Harmony("fuse.tests.wrapper-attribution");
+            var target = typeof(FuseModAttributionHarmonyTests).GetMethod(
+                nameof(WrapperAttributionProbeTarget), BindingFlags.Static | BindingFlags.NonPublic);
+            var prefix = typeof(FuseModAttributionHarmonyTests).GetMethod(
+                nameof(ProbePrefix), BindingFlags.Static | BindingFlags.NonPublic);
+
+            try
+            {
+                harmony.Patch(target, prefix: new HarmonyMethod(prefix));
+
+                // Publish this test assembly as a known mod so the resolver's
+                // assembly-map lookup lands on it.
+                FuseModAttributionMap.SetMapsForTests(
+                    tokenMap: new Dictionary<string, (string modId, string displayName)>(
+                        StringComparer.OrdinalIgnoreCase),
+                    assemblyMap: new Dictionary<Assembly, (string modId, string displayName)>
+                    {
+                        [typeof(FuseModAttributionHarmonyTests).Assembly] = ("test.mod", "Test Mod")
+                    });
+
+                var trace =
+                    "at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition" +
+                    ".FuseModAttributionHarmonyTests.WrapperAttributionProbeTarget_Patch1(int)";
+
+                Assert.True(FuseModAttributionMap.TryAttributeStack(
+                    trace, out var modId, out var displayName, out var frame));
+                Assert.Equal("test.mod", modId);
+                Assert.Equal("Test Mod", displayName);
+                Assert.Equal(
+                    "FuseModAttributionHarmonyTests.WrapperAttributionProbeTarget [via Harmony patch]",
+                    frame);
+            }
+            finally
+            {
+                harmony.UnpatchAll(harmony.Id);
+                FuseModAttributionMap.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void WrapperFrame_WithAnUnmappedCoPatch_StaysUnattributed()
+        {
+            // The wrong-blame guard: the probe method carries one patch from
+            // this (mapped) assembly and one from the FUSE assembly, which is
+            // never in the map — exactly the shape of a game method co-patched
+            // by FUSE and one third-party mod. The unknown owner must poison
+            // the method: blaming the mapped mod would pin FUSE's own faults
+            // (or the game's) on an innocent bystander.
+            var harmony = new Harmony("fuse.tests.wrapper-attribution-copatch");
+            var target = typeof(FuseModAttributionHarmonyTests).GetMethod(
+                nameof(WrapperAttributionProbeTarget), BindingFlags.Static | BindingFlags.NonPublic);
+            var prefix = typeof(FuseModAttributionHarmonyTests).GetMethod(
+                nameof(ProbePrefix), BindingFlags.Static | BindingFlags.NonPublic);
+
+            // A static void no-arg method from the FUSE assembly works as a
+            // Harmony prefix; the target is never invoked, so it never runs.
+            var fuseOwnedPrefix = typeof(FuseModAttributionMap).GetMethod(
+                "Invalidate", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(fuseOwnedPrefix);
+
+            try
+            {
+                harmony.Patch(target, prefix: new HarmonyMethod(prefix));
+                harmony.Patch(target, prefix: new HarmonyMethod(fuseOwnedPrefix));
+
+                FuseModAttributionMap.SetMapsForTests(
+                    tokenMap: new Dictionary<string, (string modId, string displayName)>(
+                        StringComparer.OrdinalIgnoreCase),
+                    assemblyMap: new Dictionary<Assembly, (string modId, string displayName)>
+                    {
+                        [typeof(FuseModAttributionHarmonyTests).Assembly] = ("test.mod", "Test Mod")
+                    });
+
+                var trace =
+                    "at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition" +
+                    ".FuseModAttributionHarmonyTests.WrapperAttributionProbeTarget_Patch1(int)";
+
+                Assert.False(FuseModAttributionMap.TryAttributeStack(
+                    trace, out var modId, out _, out _));
+                Assert.Null(modId);
+            }
+            finally
+            {
+                harmony.UnpatchAll(harmony.Id);
+                FuseModAttributionMap.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void WrapperFrame_WithAnEmptyAssemblyMap_StaysUnattributed()
+        {
+            var harmony = new Harmony("fuse.tests.wrapper-attribution-unmapped");
+            var target = typeof(FuseModAttributionHarmonyTests).GetMethod(
+                nameof(WrapperAttributionProbeTarget), BindingFlags.Static | BindingFlags.NonPublic);
+            var prefix = typeof(FuseModAttributionHarmonyTests).GetMethod(
+                nameof(ProbePrefix), BindingFlags.Static | BindingFlags.NonPublic);
+
+            try
+            {
+                harmony.Patch(target, prefix: new HarmonyMethod(prefix));
+
+                // No assembly map entries: the patch exists but belongs to no
+                // known mod (FUSE's own patches take this path in production).
+                FuseModAttributionMap.SetMapsForTests(
+                    tokenMap: new Dictionary<string, (string modId, string displayName)>(
+                        StringComparer.OrdinalIgnoreCase),
+                    assemblyMap: new Dictionary<Assembly, (string modId, string displayName)>());
+
+                var trace =
+                    "at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition" +
+                    ".FuseModAttributionHarmonyTests.WrapperAttributionProbeTarget_Patch1(int)";
+
+                Assert.False(FuseModAttributionMap.TryAttributeStack(
+                    trace, out var modId, out _, out _));
+                Assert.Null(modId);
+            }
+            finally
+            {
+                harmony.UnpatchAll(harmony.Id);
+                FuseModAttributionMap.ResetForTests();
+            }
+        }
+    }
+}

--- a/FUSE.Tests/Infrastructure/FuseModAttributionHarmonyTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseModAttributionHarmonyTests.cs
@@ -28,6 +28,12 @@ namespace FUSE.Tests.Infrastructure
 
         // The wrapper frame Mono would print for a throw inside the probe
         // target's rewritten body — shared by every test in this class.
+        // Deliberately a fixture (captured verbatim from a field log), NOT a
+        // stack recorded from throwing through the patched probe: this suite
+        // runs on the .NET Framework CLR, whose dynamic-method frames never
+        // use Mono's "(wrapper dynamic-method) MonoMod..." shape, so a live
+        // throw here cannot produce the production format these tests exist
+        // to cover.
         private const string ProbeWrapperTrace =
             "at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition" +
             ".FuseModAttributionHarmonyTests.WrapperAttributionProbeTarget_Patch1(int)";

--- a/FUSE.Tests/Infrastructure/FuseModAttributionMapTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseModAttributionMapTests.cs
@@ -293,6 +293,259 @@ namespace FUSE.Tests.Infrastructure
             Assert.Equal("mapenhancer", modId);
         }
 
+        // ---- Harmony dynamic-method wrapper frames ----
+
+        private const string ObservedWrapperLine =
+            "  at (wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition" +
+            ".TrainController.AddCarInternal_Patch1(TrainController,Game.Messages.Snapshot/Car," +
+            "System.Collections.Generic.Dictionary`2<string, Game.Messages.IPropertyValue>,int)";
+
+        [Fact]
+        public void ParseDynamicMethodFrame_ObservedFieldLine_YieldsTypeAndMethod()
+        {
+            Assert.True(FuseModAttributionMap.TryParseDynamicMethodFrame(
+                ObservedWrapperLine, out var typeName, out var methodName));
+            Assert.Equal("TrainController", typeName);
+            Assert.Equal("AddCarInternal", methodName);
+        }
+
+        [Fact]
+        public void ParseDynamicMethodFrame_NamespacedType_KeepsTheFullTypePath()
+        {
+            var line =
+                "(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition" +
+                ".Game.State.StateManager.ApplyStateChange_Patch2(Game.State.StateManager,bool)";
+
+            Assert.True(FuseModAttributionMap.TryParseDynamicMethodFrame(
+                line, out var typeName, out var methodName));
+            Assert.Equal("Game.State.StateManager", typeName);
+            Assert.Equal("ApplyStateChange", methodName);
+        }
+
+        [Fact]
+        public void ParseDynamicMethodFrame_WithoutDmdPrefix_StillParses()
+        {
+            Assert.True(FuseModAttributionMap.TryParseDynamicMethodFrame(
+                "(wrapper dynamic-method) TrainController.AddCarInternal_Patch1(TrainController)",
+                out var typeName, out var methodName));
+            Assert.Equal("TrainController", typeName);
+            Assert.Equal("AddCarInternal", methodName);
+        }
+
+        [Fact]
+        public void ParseDynamicMethodFrame_UnderscoredMethodName_SurvivesTheSuffixCut()
+        {
+            Assert.True(FuseModAttributionMap.TryParseDynamicMethodFrame(
+                "(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition" +
+                ".CarPrototype.get_Custom_Length_Patch10(CarPrototype)",
+                out var typeName, out var methodName));
+            Assert.Equal("CarPrototype", typeName);
+            Assert.Equal("get_Custom_Length", methodName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("MapEnhancer.MapEnhancer.Rebuild () (at <a>:0)")]                       // ordinary frame
+        [InlineData("(wrapper managed-to-native) UnityEngine.Object.Internal_Clone(x)")]   // not dynamic-method
+        [InlineData("(wrapper dynamic-method) Some.Type.Method(int)")]                     // no _PatchN suffix
+        [InlineData("(wrapper dynamic-method) Some.Type.Method_PatchX(int)")]              // non-digit suffix
+        [InlineData("(wrapper dynamic-method) Some.Type.Method_Patch(int)")]               // no digits at all
+        [InlineData("(wrapper dynamic-method) NoTypeDot_Patch1(int)")]                     // no type separator
+        public void ParseDynamicMethodFrame_NonHarmonyShapes_AreRejected(string line)
+        {
+            Assert.False(FuseModAttributionMap.TryParseDynamicMethodFrame(line, out var typeName, out var methodName));
+            Assert.Null(typeName);
+            Assert.Null(methodName);
+        }
+
+        [Fact]
+        public void WrapperFrame_ResolvedOwner_WinsAtTheInnermostPosition()
+        {
+            var map = Map(("ModB", "mod.b", "Mod B"));
+            var trace =
+                ObservedWrapperLine + "\n" +
+                "ModB.Outer.Caller () (at <b>:0)";
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                trace, map, out var modId, out var displayName, out var frame,
+                (type, method) => type == "TrainController" && method == "AddCarInternal"
+                    ? ("mod.a", "Mod A")
+                    : ((string, string)?)null));
+
+            Assert.Equal("mod.a", modId);
+            Assert.Equal("Mod A", displayName);
+            Assert.Equal("TrainController.AddCarInternal [via Harmony patch]", frame);
+        }
+
+        [Fact]
+        public void WrapperFrame_UnresolvedOwner_FallsThroughToDeeperFrames()
+        {
+            var map = Map(("ModB", "mod.b", "Mod B"));
+            var trace =
+                ObservedWrapperLine + "\n" +
+                "ModB.Outer.Caller () (at <b>:0)";
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                trace, map, out var modId, out _, out var frame, (type, method) => null));
+            Assert.Equal("mod.b", modId);
+            Assert.Equal("ModB.Outer.Caller", frame);
+        }
+
+        [Fact]
+        public void WrapperFrame_WithoutAResolver_IsSkippedLikeAnyPlumbingLine()
+        {
+            var trace =
+                ObservedWrapperLine + "\n" +
+                "MapEnhancer.MapEnhancer.Rebuild () (at <b>:0)";
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                trace, MapEnhancerMap, out var modId, out _, out var frame));
+            Assert.Equal("mapenhancer", modId);
+            Assert.Equal("MapEnhancer.MapEnhancer.Rebuild", frame);
+        }
+
+        [Fact]
+        public void WrapperFrame_ThrowingResolver_DegradesToASkippedLine()
+        {
+            var trace =
+                ObservedWrapperLine + "\n" +
+                "MapEnhancer.MapEnhancer.Rebuild () (at <b>:0)";
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                trace, MapEnhancerMap, out var modId, out _, out _,
+                (type, method) => throw new InvalidOperationException("resolver fault")));
+            Assert.Equal("mapenhancer", modId);
+        }
+
+        [Fact]
+        public void WrapperFrames_DoNotConsumeTheFrameBudget()
+        {
+            // Five wrapper lines, then eleven game frames, then the mod frame:
+            // the mod frame is the twelfth COUNTED frame, so it still matches.
+            var trace = new StringBuilder();
+            for (var i = 0; i < 5; i++)
+            {
+                trace.AppendLine("(wrapper managed-to-native) UnityEngine.Object.Internal_Clone(x)");
+            }
+
+            for (var i = 0; i < 11; i++)
+            {
+                trace.AppendLine($"Game.Events.Frame{i}.Method (System.Int32 x) (at <a>:0)");
+            }
+
+            trace.AppendLine("MapEnhancer.MapEnhancer.Rebuild () (at <b>:0)");
+
+            Assert.True(FuseModAttributionMap.TryAttributeStackCore(
+                trace.ToString(), MapEnhancerMap, out var modId, out _, out _));
+            Assert.Equal("mapenhancer", modId);
+        }
+
+        [Fact]
+        public void WrapperResolutions_AreCappedPerScan()
+        {
+            // Six resolvable wrapper lines; the resolver answers null so the
+            // scan keeps going, but only the first four lines may invoke it.
+            var trace = new StringBuilder();
+            for (var i = 0; i < 6; i++)
+            {
+                trace.AppendLine(
+                    $"(wrapper dynamic-method) MonoMod.Utils.DynamicMethodDefinition.Type{i}.Method_Patch1(int)");
+            }
+
+            var calls = 0;
+            Assert.False(FuseModAttributionMap.TryAttributeStackCore(
+                trace.ToString(), MapEnhancerMap, out _, out _, out _,
+                (type, method) => { calls++; return null; }));
+            Assert.Equal(4, calls);
+        }
+
+        [Fact]
+        public void IsExactTypeMatch_RequiresTheFullTypePath()
+        {
+            var method = typeof(MatchTarget).GetMethod(nameof(MatchTarget.Plain));
+            var nested = typeof(MatchTarget.Nested).GetMethod(nameof(MatchTarget.Nested.Inner));
+
+            Assert.True(FuseModAttributionMap.IsExactTypeMatch(
+                method, "FUSE.Tests.Infrastructure.FuseModAttributionMapTests.MatchTarget"));
+            Assert.True(FuseModAttributionMap.IsExactTypeMatch(
+                nested, "FUSE.Tests.Infrastructure.FuseModAttributionMapTests/MatchTarget/Nested"));
+
+            // The loose arms of MatchesPatchedMethod are NOT exact.
+            Assert.False(FuseModAttributionMap.IsExactTypeMatch(method, "MatchTarget"));
+            Assert.False(FuseModAttributionMap.IsExactTypeMatch(
+                method, "FuseModAttributionMapTests.MatchTarget"));
+            Assert.False(FuseModAttributionMap.IsExactTypeMatch(null, "MatchTarget"));
+        }
+
+        [Fact]
+        public void MergeOwnerCandidates_EmptyOrNull_YieldsNoOwner()
+        {
+            Assert.Null(FuseModAttributionMap.MergeOwnerCandidates(null));
+            Assert.Null(FuseModAttributionMap.MergeOwnerCandidates(
+                Array.Empty<(string, string)>()));
+            Assert.Null(FuseModAttributionMap.MergeOwnerCandidates(
+                new (string, string)[] { (null, "No Id"), ("  ", "Blank Id") }));
+        }
+
+        [Fact]
+        public void MergeOwnerCandidates_AgreeingOwners_MergeToTheSingleMod()
+        {
+            var merged = FuseModAttributionMap.MergeOwnerCandidates(new[]
+            {
+                ("mod.a", "Mod A"),
+                ("MOD.A", "Mod A (other patch)")   // same id, case-insensitive
+            });
+
+            Assert.NotNull(merged);
+            Assert.Equal("mod.a", merged.Value.modId);
+        }
+
+        [Fact]
+        public void MergeOwnerCandidates_ConflictingOwners_YieldNoOwner()
+        {
+            Assert.Null(FuseModAttributionMap.MergeOwnerCandidates(new[]
+            {
+                ("mod.a", "Mod A"),
+                ("mod.b", "Mod B")
+            }));
+        }
+
+        private static class MatchTarget
+        {
+            public static void Plain() { }
+
+            public static class Nested
+            {
+                public static void Inner() { }
+            }
+        }
+
+        [Fact]
+        public void MatchesPatchedMethod_FullPath_TrailingSegment_AndBareName_AllMatch()
+        {
+            var method = typeof(MatchTarget).GetMethod(nameof(MatchTarget.Plain));
+            var fullPath = "FUSE.Tests.Infrastructure.FuseModAttributionMapTests.MatchTarget";
+
+            Assert.True(FuseModAttributionMap.MatchesPatchedMethod(method, fullPath, "Plain"));
+            Assert.True(FuseModAttributionMap.MatchesPatchedMethod(method, "FuseModAttributionMapTests.MatchTarget", "Plain"));
+            Assert.True(FuseModAttributionMap.MatchesPatchedMethod(method, "MatchTarget", "Plain"));
+            Assert.False(FuseModAttributionMap.MatchesPatchedMethod(method, "MatchTarget", "SomethingElse"));
+            Assert.False(FuseModAttributionMap.MatchesPatchedMethod(method, "SomeOtherType", "Plain"));
+            Assert.False(FuseModAttributionMap.MatchesPatchedMethod(null, "MatchTarget", "Plain"));
+        }
+
+        [Fact]
+        public void MatchesPatchedMethod_NestedTypeSeparators_NormalizeBothWays()
+        {
+            var method = typeof(MatchTarget.Nested).GetMethod(nameof(MatchTarget.Nested.Inner));
+
+            // Runtime FullName uses '+'; Mono wrapper text may print '/'.
+            Assert.True(FuseModAttributionMap.MatchesPatchedMethod(method, "MatchTarget/Nested", "Inner"));
+            Assert.True(FuseModAttributionMap.MatchesPatchedMethod(method, "MatchTarget+Nested", "Inner"));
+            Assert.True(FuseModAttributionMap.MatchesPatchedMethod(method, "MatchTarget.Nested", "Inner"));
+        }
+
         [Fact]
         public void DeniedGameToken_NeverAttributes_EvenWhenAModClaimedIt()
         {

--- a/FUSE.Tests/Infrastructure/FuseSettingsReadFloatTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseSettingsReadFloatTests.cs
@@ -74,6 +74,9 @@ namespace FUSE.Tests.Infrastructure
         [InlineData(5f, FuseSettings.MinFrameSpikeThresholdMs)]     // below floor clamps up
         [InlineData(50f, 50f)]                                       // in-range passes through
         [InlineData(9999f, FuseSettings.MaxFrameSpikeThresholdMs)]   // above ceiling clamps down
+        [InlineData(float.NaN, FuseSettings.DefaultFrameSpikeThresholdMs)]           // NaN degrades to default
+        [InlineData(float.PositiveInfinity, FuseSettings.MaxFrameSpikeThresholdMs)]  // +Inf clamps down
+        [InlineData(float.NegativeInfinity, FuseSettings.MinFrameSpikeThresholdMs)]  // -Inf clamps up
         public void PreviewFrameSpikeThresholdMs_ClampsToDocumentedRange(float input, float expected)
         {
             var original = FuseSettings.FrameSpikeThresholdMs;

--- a/FUSE.Tests/Infrastructure/FuseSettingsReadFloatTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseSettingsReadFloatTests.cs
@@ -62,4 +62,29 @@ namespace FUSE.Tests.Infrastructure
             Assert.Equal(0.6f, FuseSettings.ReadFloat(settings, null, 0.6f));
         }
     }
+
+    /// <summary>
+    /// Clamp contract for the spike-floor slider preview (visible via
+    /// InternalsVisibleTo). Preview mutates the live static value without
+    /// persisting, so each test restores the default afterwards.
+    /// </summary>
+    public class FuseSettingsFrameSpikeThresholdTests
+    {
+        [Theory]
+        [InlineData(5f, FuseSettings.MinFrameSpikeThresholdMs)]     // below floor clamps up
+        [InlineData(50f, 50f)]                                       // in-range passes through
+        [InlineData(9999f, FuseSettings.MaxFrameSpikeThresholdMs)]   // above ceiling clamps down
+        public void PreviewFrameSpikeThresholdMs_ClampsToDocumentedRange(float input, float expected)
+        {
+            try
+            {
+                FuseSettings.PreviewFrameSpikeThresholdMs(input);
+                Assert.Equal(expected, FuseSettings.FrameSpikeThresholdMs);
+            }
+            finally
+            {
+                FuseSettings.PreviewFrameSpikeThresholdMs(FuseSettings.DefaultFrameSpikeThresholdMs);
+            }
+        }
+    }
 }

--- a/FUSE.Tests/Infrastructure/FuseSettingsReadFloatTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseSettingsReadFloatTests.cs
@@ -76,6 +76,7 @@ namespace FUSE.Tests.Infrastructure
         [InlineData(9999f, FuseSettings.MaxFrameSpikeThresholdMs)]   // above ceiling clamps down
         public void PreviewFrameSpikeThresholdMs_ClampsToDocumentedRange(float input, float expected)
         {
+            var original = FuseSettings.FrameSpikeThresholdMs;
             try
             {
                 FuseSettings.PreviewFrameSpikeThresholdMs(input);
@@ -83,7 +84,7 @@ namespace FUSE.Tests.Infrastructure
             }
             finally
             {
-                FuseSettings.PreviewFrameSpikeThresholdMs(FuseSettings.DefaultFrameSpikeThresholdMs);
+                FuseSettings.PreviewFrameSpikeThresholdMs(original);
             }
         }
     }

--- a/FUSE.Tests/Loading/FuseLegacyJsonPatchTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyJsonPatchTests.cs
@@ -237,6 +237,61 @@ namespace FUSE.Tests.Loading
             }
         }
 
+        public class PlainArrayReplacement
+        {
+            // The field shape behind the five 'legacy game-graph
+            // compatibility' faults: a spliney's directive-free "points"
+            // array re-applied while the spliney already exists in the
+            // runtime state. The literal array is the author's complete
+            // value and must replace, not fault.
+            [Fact]
+            public void PlainObjectArray_OnExistingArray_ReplacesWholesale()
+            {
+                var target = Obj(
+                    "{\"points\":[{\"x\":1,\"width\":7.0},{\"x\":2,\"width\":7.0},{\"x\":3,\"width\":7.0}]}");
+                var patch = Obj("{\"points\":[{\"x\":10,\"width\":5.0},{\"x\":20,\"width\":5.0}]}");
+
+                FuseLegacyJsonPatch.Apply(target, patch, "source");
+
+                Assert.Equal(2, target["points"].Count());
+                Assert.Equal(10, (int)target["points"][0]["x"]);
+                Assert.Equal(5.0, (double)target["points"][1]["width"]);
+            }
+
+            [Fact]
+            public void PlainObjectArray_OnMissingKey_SetsTheArray()
+            {
+                var target = Obj("{}");
+                var patch = Obj("{\"points\":[{\"x\":1},{\"x\":2}]}");
+
+                FuseLegacyJsonPatch.Apply(target, patch, "source");
+
+                Assert.Equal(2, target["points"].Count());
+            }
+
+            [Fact]
+            public void PrimitiveOnlyArray_KeepsAppendSemantics()
+            {
+                var target = Obj("{\"tags\":[\"a\",\"b\"]}");
+                var patch = Obj("{\"tags\":[\"c\"]}");
+
+                FuseLegacyJsonPatch.Apply(target, patch, "source");
+
+                Assert.Equal(3, target["tags"].Count());
+                Assert.Equal("c", (string)target["tags"][2]);
+            }
+
+            [Fact]
+            public void MixedArray_WithADirective_KeepsStrictMergeAndStillRejectsPlainObjects()
+            {
+                var target = Obj("{\"items\":[{\"id\":\"a\"}]}");
+                var patch = Obj("{\"items\":[{\"$append\":[{\"id\":\"b\"}]},{\"id\":\"plain\"}]}");
+
+                Assert.Throws<InvalidOperationException>(
+                    () => FuseLegacyJsonPatch.Apply(target, patch, "source"));
+            }
+        }
+
         public class ArrayElementDirectives
         {
             [Fact]

--- a/FUSE.Tests/Runtime/FuseFrameSpikeShouldLogTests.cs
+++ b/FUSE.Tests/Runtime/FuseFrameSpikeShouldLogTests.cs
@@ -1,0 +1,36 @@
+using FUSE.Runtime.Lifecycle;
+using Xunit;
+
+namespace FUSE.Tests.Runtime
+{
+    /// <summary>
+    /// Pins the spike-log throttle contract (visible via InternalsVisibleTo):
+    /// early spikes and the heartbeat cadence log as before, and a session
+    /// worst ALWAYS breaks through — a field capture lost its single biggest
+    /// stall because it fell between heartbeats, leaving only the aggregate
+    /// with no timestamp to correlate.
+    /// </summary>
+    public class FuseFrameSpikeShouldLogTests
+    {
+        [Theory]
+        [InlineData(1, false, true)]    // early spikes log individually
+        [InlineData(10, false, true)]
+        [InlineData(11, false, false)]  // then the heartbeat takes over
+        [InlineData(25, false, true)]
+        [InlineData(26, false, false)]
+        [InlineData(100, false, true)]
+        public void HeartbeatCadence_IsUnchanged(long count, bool isNewWorst, bool expected)
+        {
+            Assert.Equal(expected, FuseFrameSpikeDiagnostic.ShouldLogSpike(count, isNewWorst));
+        }
+
+        [Theory]
+        [InlineData(11)]
+        [InlineData(26)]
+        [InlineData(9999)]
+        public void SessionWorst_AlwaysBreaksThroughTheThrottle(long offCadenceCount)
+        {
+            Assert.True(FuseFrameSpikeDiagnostic.ShouldLogSpike(offCadenceCount, isNewWorst: true));
+        }
+    }
+}

--- a/FUSE/Infrastructure/FuseModAttributionMap.cs
+++ b/FUSE/Infrastructure/FuseModAttributionMap.cs
@@ -30,9 +30,27 @@ namespace FUSE.Infrastructure
     /// (everything unattributed) and one warning, never a throw into the
     /// recording path.
     ///
+    /// Harmony dynamic-method wrappers get one extra resolution step: a
+    /// frame like "(wrapper dynamic-method) MonoMod.Utils
+    /// .DynamicMethodDefinition.TrainController.AddCarInternal_Patch1(...)"
+    /// names the patched method but never the mod, because the throw came
+    /// from inside the rewritten body (transpiled code, or an inlined
+    /// accessor) with no mod-owned frame beneath it. For those frames the
+    /// patched method is looked up in Harmony's patch state and the
+    /// exception attributes to the patch's owning mod — but only when EVERY
+    /// patch on that method belongs to ONE mapped mod. A second mod owner,
+    /// or any patch whose owner cannot be mapped (FUSE's own patches, a mod
+    /// the harvest missed), resolves to nobody, because the wrapper alone
+    /// cannot say whose patch threw — and the original method body also
+    /// runs inside the wrapper, so even a sole-owner attribution is a
+    /// candidate, marked "[via Harmony patch]" in the frame text.
+    /// Wrapper frames never count against the frame-scan budget; the scan
+    /// continues past them into ordinary frames either way.
+    ///
     /// The parsing core (<see cref="TryAttributeStackCore"/>) and the token
     /// map assembly (<see cref="BuildTokenMapCore"/>) are pure so tests run
-    /// them without Unity or UMM present.
+    /// them without Unity or UMM present; the Harmony lookup enters through
+    /// an injectable resolver so the core stays Harmony-free too.
     /// </summary>
     internal static class FuseModAttributionMap
     {
@@ -40,6 +58,20 @@ namespace FUSE.Infrastructure
         // not a FUSE/game frame that hosted the call. Deep traces past this
         // cap are almost certainly engine plumbing; stop rather than scan.
         private const int MaxFramesExamined = 12;
+
+        // Wrapper frames are budget-exempt, so a degenerate trace of stacked
+        // dynamic-method wrappers must not turn into unbounded patch-state
+        // walks: only this many wrapper resolutions run per scan.
+        private const int MaxWrapperResolutionsPerScan = 4;
+
+        // Patch-owner memoization: one full GetAllPatchedMethods walk per
+        // distinct wrapped (type, method) per map generation. Cleared with
+        // the maps; on overflow the whole cache drops (64 distinct wrapped
+        // methods throwing in one session means something far worse than
+        // cache churn is happening).
+        private const int MaxResolverCacheEntries = 64;
+        private static readonly Dictionary<(string typeName, string methodName), (string modId, string displayName)?> ResolverCache =
+            new Dictionary<(string typeName, string methodName), (string modId, string displayName)?>();
 
         private static readonly object Gate = new object();
 
@@ -59,7 +91,7 @@ namespace FUSE.Infrastructure
         // assemblies too large to scan (System.*, UnityEngine.*).
         private static readonly string[] DenylistSeedTokens =
         {
-            "System", "Microsoft", "Mono", "mscorlib", "netstandard",
+            "System", "Microsoft", "Mono", "MonoMod", "mscorlib", "netstandard",
             "Unity", "UnityEngine", "UnityEngineInternal", "UnityModManagerNet",
             "TMPro", "Newtonsoft", "Serilog", "JetBrains",
             "FUSE", "HarmonyLib", "Harmony", "GalaSoft"
@@ -68,13 +100,15 @@ namespace FUSE.Infrastructure
         /// <summary>
         /// Attribute a Unity stack-trace string to a known mod. Innermost
         /// matching frame wins; returns false (outs null) when no frame in
-        /// the first 12 belongs to a mapped mod.
+        /// the first 12 belongs to a mapped mod. Harmony dynamic-method
+        /// wrapper frames resolve through the live Harmony patch state.
         /// </summary>
         internal static bool TryAttributeStack(
             string stackTrace, out string modId, out string displayName, out string topOwnedFrame)
         {
             EnsureBuilt();
-            return TryAttributeStackCore(stackTrace, _tokenMap, out modId, out displayName, out topOwnedFrame);
+            return TryAttributeStackCore(
+                stackTrace, _tokenMap, out modId, out displayName, out topOwnedFrame, ResolveHarmonyPatchOwner);
         }
 
         /// <summary>
@@ -126,6 +160,7 @@ namespace FUSE.Infrastructure
             lock (Gate)
             {
                 _built = false;
+                ResolverCache.Clear();
             }
         }
 
@@ -138,23 +173,35 @@ namespace FUSE.Infrastructure
         /// <paramref name="tokenMap"/> (two-segment first, so "Us.Dchn" style
         /// roots win over a generic first word), and the first — innermost —
         /// matching frame is returned.
+        ///
+        /// Mono wrapper frames ("(wrapper dynamic-method) ...", "(wrapper
+        /// managed-to-native) ...") carry no mod namespace and never count
+        /// against the frame budget. Dynamic-method wrappers additionally
+        /// consult <paramref name="patchOwnerResolver"/> (patched type +
+        /// method name → owning mod, or null when unknown/ambiguous); a
+        /// resolved owner wins at the wrapper's — innermost — position with
+        /// the frame text marked "[via Harmony patch]". A null or throwing
+        /// resolver degrades to skipping the wrapper line.
         /// </summary>
         internal static bool TryAttributeStackCore(
             string stackTrace,
             IReadOnlyDictionary<string, (string modId, string displayName)> tokenMap,
             out string modId,
             out string displayName,
-            out string topOwnedFrame)
+            out string topOwnedFrame,
+            Func<string, string, (string modId, string displayName)?> patchOwnerResolver = null)
         {
             modId = null;
             displayName = null;
             topOwnedFrame = null;
-            if (string.IsNullOrEmpty(stackTrace) || tokenMap == null || tokenMap.Count == 0)
+            var hasTokens = tokenMap != null && tokenMap.Count > 0;
+            if (string.IsNullOrEmpty(stackTrace) || (!hasTokens && patchOwnerResolver == null))
             {
-                return false;
+                return false; // nothing could ever match; with a resolver, wrapper frames still can
             }
 
             var examined = 0;
+            var resolutions = 0;
             var position = 0;
             while (position < stackTrace.Length && examined < MaxFramesExamined)
             {
@@ -167,12 +214,41 @@ namespace FUSE.Infrastructure
                     continue;
                 }
 
-                examined++;
                 if (line.StartsWith("at ", StringComparison.Ordinal))
                 {
                     line = line.Substring(3).TrimStart();
                 }
 
+                if (line.StartsWith("(wrapper ", StringComparison.Ordinal))
+                {
+                    if (patchOwnerResolver != null &&
+                        resolutions < MaxWrapperResolutionsPerScan &&
+                        TryParseDynamicMethodFrame(line, out var patchedType, out var patchedMethod))
+                    {
+                        resolutions++;
+                        (string modId, string displayName)? owner;
+                        try
+                        {
+                            owner = patchOwnerResolver(patchedType, patchedMethod);
+                        }
+                        catch
+                        {
+                            owner = null; // resolver faults degrade to a skipped line
+                        }
+
+                        if (owner != null)
+                        {
+                            modId = owner.Value.modId;
+                            displayName = owner.Value.displayName;
+                            topOwnedFrame = patchedType + "." + patchedMethod + " [via Harmony patch]";
+                            return true;
+                        }
+                    }
+
+                    continue; // wrapper plumbing: no namespace, no budget cost
+                }
+
+                examined++;
                 var argumentsStart = line.IndexOf(" (", StringComparison.Ordinal);
                 var framePath = argumentsStart >= 0 ? line.Substring(0, argumentsStart) : line;
                 framePath = framePath.TrimEnd();
@@ -195,6 +271,11 @@ namespace FUSE.Infrastructure
                 if (firstDot <= 0)
                 {
                     continue; // no namespace-qualified identifier on this line
+                }
+
+                if (!hasTokens)
+                {
+                    continue; // resolver-only scan: ordinary frames can't match
                 }
 
                 var secondDot = tokenSource.IndexOf('.', firstDot + 1);
@@ -285,6 +366,325 @@ namespace FUSE.Infrastructure
         }
 
         /// <summary>
+        /// Parse a Mono dynamic-method wrapper frame into the patched type
+        /// path and method name. Accepts an optional "at " prefix, requires
+        /// the "(wrapper dynamic-method) " marker, tolerates a missing
+        /// "MonoMod.Utils.DynamicMethodDefinition." prefix, and requires
+        /// Harmony's "_Patch&lt;digits&gt;" suffix — a dynamic method
+        /// without it is some other codegen, not a Harmony rewrite. Nested
+        /// types keep whatever separator the runtime printed ('/' or '+');
+        /// <see cref="MatchesPatchedMethod"/> normalizes at compare time.
+        /// Pure; unit-tested.
+        /// </summary>
+        internal static bool TryParseDynamicMethodFrame(string line, out string typeName, out string methodName)
+        {
+            typeName = null;
+            methodName = null;
+            if (string.IsNullOrEmpty(line))
+            {
+                return false;
+            }
+
+            var path = line.Trim();
+            if (path.StartsWith("at ", StringComparison.Ordinal))
+            {
+                path = path.Substring(3).TrimStart();
+            }
+
+            const string wrapperMarker = "(wrapper dynamic-method) ";
+            if (!path.StartsWith(wrapperMarker, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            path = path.Substring(wrapperMarker.Length).TrimStart();
+
+            const string dmdPrefix = "MonoMod.Utils.DynamicMethodDefinition.";
+            if (path.StartsWith(dmdPrefix, StringComparison.Ordinal))
+            {
+                path = path.Substring(dmdPrefix.Length);
+            }
+
+            // The argument list opens with '(' directly after the name (no
+            // space, unlike ordinary Mono frames); identifiers cannot
+            // contain '(' so the first one is always the cut point.
+            var argumentsStart = path.IndexOf('(');
+            if (argumentsStart >= 0)
+            {
+                path = path.Substring(0, argumentsStart);
+            }
+
+            path = path.TrimEnd();
+
+            const string patchSuffixMarker = "_Patch";
+            var suffixStart = path.LastIndexOf(patchSuffixMarker, StringComparison.Ordinal);
+            if (suffixStart <= 0 || suffixStart + patchSuffixMarker.Length >= path.Length)
+            {
+                return false;
+            }
+
+            for (var i = suffixStart + patchSuffixMarker.Length; i < path.Length; i++)
+            {
+                if (!char.IsDigit(path[i]))
+                {
+                    return false;
+                }
+            }
+
+            path = path.Substring(0, suffixStart);
+            var lastDot = path.LastIndexOf('.');
+            if (lastDot <= 0 || lastDot >= path.Length - 1)
+            {
+                return false;
+            }
+
+            typeName = path.Substring(0, lastDot);
+            methodName = path.Substring(lastDot + 1);
+            return true;
+        }
+
+        /// <summary>
+        /// Collapse the mod owners of every patch found on a wrapped method
+        /// into one attribution: null for no mapped owner, the single owner
+        /// when every candidate agrees (id compare, case-insensitive), and
+        /// null again the moment two mods disagree — the wrapper frame alone
+        /// cannot say whose patch threw, so an ambiguous method attributes
+        /// to nobody, exactly like an ambiguous namespace token. Pure;
+        /// unit-tested.
+        /// </summary>
+        internal static (string modId, string displayName)? MergeOwnerCandidates(
+            IEnumerable<(string modId, string displayName)> candidates)
+        {
+            if (candidates == null)
+            {
+                return null;
+            }
+
+            (string modId, string displayName)? merged = null;
+            foreach (var candidate in candidates)
+            {
+                if (string.IsNullOrWhiteSpace(candidate.modId))
+                {
+                    continue;
+                }
+
+                if (merged == null)
+                {
+                    merged = candidate;
+                    continue;
+                }
+
+                if (!string.Equals(merged.Value.modId, candidate.modId, StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+            }
+
+            return merged;
+        }
+
+        /// <summary>
+        /// Whether a runtime method is the one a wrapper frame named. Method
+        /// names compare exactly; the declaring type matches on its full
+        /// dotted path, a trailing path segment, or its bare name — the
+        /// wrapper text may carry any of those depending on how the type was
+        /// namespaced — with '/' and '+' nested-type separators normalized
+        /// to '.' on both sides. Pure reflection; unit-tested.
+        /// </summary>
+        internal static bool MatchesPatchedMethod(MethodBase method, string typeName, string methodName)
+        {
+            if (method == null || string.IsNullOrEmpty(typeName) || string.IsNullOrEmpty(methodName))
+            {
+                return false;
+            }
+
+            if (!string.Equals(method.Name, methodName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var declaring = method.DeclaringType;
+            if (declaring == null)
+            {
+                return false;
+            }
+
+            var declaredPath = (declaring.FullName ?? declaring.Name).Replace('+', '.').Replace('/', '.');
+            var wantedPath = typeName.Replace('+', '.').Replace('/', '.');
+            return string.Equals(declaredPath, wantedPath, StringComparison.Ordinal) ||
+                declaredPath.EndsWith("." + wantedPath, StringComparison.Ordinal) ||
+                string.Equals(declaring.Name, wantedPath, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// True when the runtime method's declaring type equals the wrapper
+        /// frame's type path exactly (separators normalized) — the strongest
+        /// arm of <see cref="MatchesPatchedMethod"/>. When any exact match
+        /// exists, the resolver ignores the looser suffix/bare-name matches
+        /// so a same-named type elsewhere cannot pollute the owner set.
+        /// Pure reflection; unit-tested.
+        /// </summary>
+        internal static bool IsExactTypeMatch(MethodBase method, string typeName)
+        {
+            var declaring = method?.DeclaringType;
+            if (declaring == null || string.IsNullOrEmpty(typeName))
+            {
+                return false;
+            }
+
+            var declaredPath = (declaring.FullName ?? declaring.Name).Replace('+', '.').Replace('/', '.');
+            var wantedPath = typeName.Replace('+', '.').Replace('/', '.');
+            return string.Equals(declaredPath, wantedPath, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Production patch-owner resolver: find the wrapped method in
+        /// Harmony's patch state and map its patches' assemblies through the
+        /// assembly map. The rules err toward no attribution: exact
+        /// declaring-type matches are preferred over suffix/bare-name ones,
+        /// and ANY patch whose owner cannot be mapped — FUSE's own patches,
+        /// a mod whose harvesting failed, unreadable patch info — poisons
+        /// the whole method to "nobody", because the wrapper frame cannot
+        /// say whose patch (or whether the original body) threw. Only a
+        /// method whose every visible patch belongs to one mapped mod
+        /// attributes. Results are memoized per (type, method) — the walk of
+        /// Harmony's full patch state is not per-exception cheap — and the
+        /// cache drops with the maps on <see cref="Invalidate"/>. Fail-open:
+        /// any Harmony absence or shape drift returns null and counts a
+        /// self-fault.
+        /// </summary>
+        private static (string modId, string displayName)? ResolveHarmonyPatchOwner(string typeName, string methodName)
+        {
+            try
+            {
+                var key = (typeName, methodName);
+                lock (Gate)
+                {
+                    if (ResolverCache.TryGetValue(key, out var cached))
+                    {
+                        return cached;
+                    }
+                }
+
+                var resolved = ResolveHarmonyPatchOwnerCore(typeName, methodName);
+                lock (Gate)
+                {
+                    if (ResolverCache.Count >= MaxResolverCacheEntries)
+                    {
+                        ResolverCache.Clear();
+                    }
+
+                    ResolverCache[key] = resolved;
+                }
+
+                return resolved;
+            }
+            catch
+            {
+                FuseModExceptionRegistry.CountSelfFault();
+                return null;
+            }
+        }
+
+        // Kept in its own method so a missing 0Harmony assembly surfaces as
+        // a JIT failure at this call site, inside the caller's catch — same
+        // isolation pattern as HarvestUmmMods.
+        private static (string modId, string displayName)? ResolveHarmonyPatchOwnerCore(string typeName, string methodName)
+        {
+            var map = _assemblyMap;
+            if (map == null || map.Count == 0)
+            {
+                return null;
+            }
+
+            List<MethodBase> exactMatches = null;
+            List<MethodBase> looseMatches = null;
+            foreach (var method in HarmonyLib.Harmony.GetAllPatchedMethods())
+            {
+                if (!MatchesPatchedMethod(method, typeName, methodName))
+                {
+                    continue;
+                }
+
+                if (IsExactTypeMatch(method, typeName))
+                {
+                    exactMatches = exactMatches ?? new List<MethodBase>();
+                    exactMatches.Add(method);
+                }
+                else
+                {
+                    looseMatches = looseMatches ?? new List<MethodBase>();
+                    looseMatches.Add(method);
+                }
+            }
+
+            var selected = exactMatches ?? looseMatches;
+            if (selected == null)
+            {
+                return null;
+            }
+
+            List<(string modId, string displayName)> owners = null;
+            foreach (var method in selected)
+            {
+                var patches = HarmonyLib.Harmony.GetPatchInfo(method);
+                if (patches == null)
+                {
+                    return null; // a patched method with unreadable info is an unknown owner
+                }
+
+                foreach (var patch in EnumerateAllPatches(patches))
+                {
+                    var assembly = patch?.PatchMethod?.DeclaringType?.Assembly;
+                    if (assembly == null || !map.TryGetValue(assembly, out var candidate))
+                    {
+                        return null; // unknown owner poisons the whole method
+                    }
+
+                    owners = owners ?? new List<(string modId, string displayName)>();
+                    owners.Add(candidate);
+                }
+            }
+
+            return MergeOwnerCandidates(owners);
+        }
+
+        private static IEnumerable<HarmonyLib.Patch> EnumerateAllPatches(HarmonyLib.Patches patches)
+        {
+            if (patches.Prefixes != null)
+            {
+                foreach (var patch in patches.Prefixes)
+                {
+                    yield return patch;
+                }
+            }
+
+            if (patches.Postfixes != null)
+            {
+                foreach (var patch in patches.Postfixes)
+                {
+                    yield return patch;
+                }
+            }
+
+            if (patches.Transpilers != null)
+            {
+                foreach (var patch in patches.Transpilers)
+                {
+                    yield return patch;
+                }
+            }
+
+            if (patches.Finalizers != null)
+            {
+                foreach (var patch in patches.Finalizers)
+                {
+                    yield return patch;
+                }
+            }
+        }
+
+        /// <summary>
         /// Test seam: publish maps directly so registry/attribution wiring is
         /// testable without a live UMM/legacy-host population.
         /// </summary>
@@ -297,6 +697,7 @@ namespace FUSE.Infrastructure
                 _tokenMap = tokenMap ??
                     new Dictionary<string, (string modId, string displayName)>(StringComparer.OrdinalIgnoreCase);
                 _assemblyMap = assemblyMap ?? new Dictionary<Assembly, (string modId, string displayName)>();
+                ResolverCache.Clear();
                 _built = true;
             }
         }
@@ -308,6 +709,7 @@ namespace FUSE.Infrastructure
             {
                 _tokenMap = null;
                 _assemblyMap = null;
+                ResolverCache.Clear();
                 _built = false;
                 _loggedBuildFailure = false;
                 _loggedDroppedTokens = false;
@@ -412,6 +814,7 @@ namespace FUSE.Infrastructure
 
             _tokenMap = BuildTokenMapCore(tokenCandidates, denylist, out var droppedTokens);
             _assemblyMap = assemblyMap;
+            ResolverCache.Clear();
 
             if (droppedTokens > 0 && !_loggedDroppedTokens)
             {

--- a/FUSE/Infrastructure/FuseModAttributionMap.cs
+++ b/FUSE/Infrastructure/FuseModAttributionMap.cs
@@ -549,9 +549,12 @@ namespace FUSE.Infrastructure
         /// method whose every visible patch belongs to one mapped mod
         /// attributes. Results are memoized per (type, method) — the walk of
         /// Harmony's full patch state is not per-exception cheap — and the
-        /// cache drops with the maps on <see cref="Invalidate"/>. Fail-open:
-        /// any Harmony absence or shape drift returns null and counts a
-        /// self-fault.
+        /// cache drops with the maps on <see cref="Invalidate"/>. A cached
+        /// null therefore outlives patches installed AFTER the first wrapper
+        /// fault on that method until the next map invalidation; accepted,
+        /// since staleness here can only cost an attribution, never invent
+        /// one. Fail-open: any Harmony absence or shape drift returns null
+        /// and counts a self-fault.
         /// </summary>
         private static (string modId, string displayName)? ResolveHarmonyPatchOwner(string typeName, string methodName)
         {

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -458,6 +458,36 @@ namespace FUSE.Infrastructure
                 $"(threshold {FrameSpikeThresholdMs:F0}ms). Takes effect immediately.");
         }
 
+        // The spike-floor clamp: 20ms matches the read-time floor applied to
+        // Info.json values (below that, ordinary frames at low fps would log
+        // as spikes); 500ms is far past anything worth calling a "spike"
+        // rather than a stall.
+        internal const float MinFrameSpikeThresholdMs = 20f;
+        internal const float MaxFrameSpikeThresholdMs = 500f;
+
+        /// <summary>
+        /// Live preview while the settings slider is being dragged: updates
+        /// the running value (the spike logger reads it per frame) without
+        /// persisting, so a drag does not write the override file once per
+        /// slider tick. <see cref="SetFrameSpikeThresholdMs"/> persists on
+        /// release.
+        /// </summary>
+        internal static void PreviewFrameSpikeThresholdMs(float thresholdMs)
+        {
+            FrameSpikeThresholdMs = Mathf.Clamp(
+                thresholdMs, MinFrameSpikeThresholdMs, MaxFrameSpikeThresholdMs);
+        }
+
+        public static void SetFrameSpikeThresholdMs(float thresholdMs)
+        {
+            FrameSpikeThresholdMs = Mathf.Clamp(
+                thresholdMs, MinFrameSpikeThresholdMs, MaxFrameSpikeThresholdMs);
+            SaveUserOverride(nameof(FrameSpikeThresholdMs), FrameSpikeThresholdMs);
+            FuseLog.Info(
+                $"FUSE setting changed: {nameof(FrameSpikeThresholdMs)}={FrameSpikeThresholdMs:F0}ms. " +
+                "Takes effect immediately.");
+        }
+
         public static void SetEnableNativeLeakStackTraces(bool enabled)
         {
             EnableNativeLeakStackTraces = enabled;

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -468,8 +468,15 @@ namespace FUSE.Infrastructure
         // Every path that writes FrameSpikeThresholdMs — Info.json load, user
         // override apply, slider preview, and persist — funnels through this
         // clamp so no source can smuggle a value outside the documented range.
+        // NaN would sail through Mathf.Clamp (ReadFloat accepts the string
+        // "NaN"), so it degrades to the default; infinities clamp normally.
         private static float ClampFrameSpikeThresholdMs(float thresholdMs)
         {
+            if (float.IsNaN(thresholdMs))
+            {
+                return DefaultFrameSpikeThresholdMs;
+            }
+
             return Mathf.Clamp(thresholdMs, MinFrameSpikeThresholdMs, MaxFrameSpikeThresholdMs);
         }
 

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -216,7 +216,7 @@ namespace FUSE.Infrastructure
                     ReadFloat(settings, "RandomVisualConditionMax", DefaultRandomVisualConditionMax));
                 EnableFrameSpikeDiagnostics =
                     ReadBool(settings, "EnableFrameSpikeDiagnostics", DefaultEnableFrameSpikeDiagnostics);
-                FrameSpikeThresholdMs = Mathf.Max(20f,
+                FrameSpikeThresholdMs = ClampFrameSpikeThresholdMs(
                     ReadFloat(settings, "FrameSpikeThresholdMs", DefaultFrameSpikeThresholdMs));
                 EnableNativeLeakStackTraces =
                     ReadBool(settings, "EnableNativeLeakStackTraces", DefaultEnableNativeLeakStackTraces);
@@ -465,6 +465,14 @@ namespace FUSE.Infrastructure
         internal const float MinFrameSpikeThresholdMs = 20f;
         internal const float MaxFrameSpikeThresholdMs = 500f;
 
+        // Every path that writes FrameSpikeThresholdMs — Info.json load, user
+        // override apply, slider preview, and persist — funnels through this
+        // clamp so no source can smuggle a value outside the documented range.
+        private static float ClampFrameSpikeThresholdMs(float thresholdMs)
+        {
+            return Mathf.Clamp(thresholdMs, MinFrameSpikeThresholdMs, MaxFrameSpikeThresholdMs);
+        }
+
         /// <summary>
         /// Live preview while the settings slider is being dragged: updates
         /// the running value (the spike logger reads it per frame) without
@@ -474,14 +482,12 @@ namespace FUSE.Infrastructure
         /// </summary>
         internal static void PreviewFrameSpikeThresholdMs(float thresholdMs)
         {
-            FrameSpikeThresholdMs = Mathf.Clamp(
-                thresholdMs, MinFrameSpikeThresholdMs, MaxFrameSpikeThresholdMs);
+            FrameSpikeThresholdMs = ClampFrameSpikeThresholdMs(thresholdMs);
         }
 
         public static void SetFrameSpikeThresholdMs(float thresholdMs)
         {
-            FrameSpikeThresholdMs = Mathf.Clamp(
-                thresholdMs, MinFrameSpikeThresholdMs, MaxFrameSpikeThresholdMs);
+            FrameSpikeThresholdMs = ClampFrameSpikeThresholdMs(thresholdMs);
             SaveUserOverride(nameof(FrameSpikeThresholdMs), FrameSpikeThresholdMs);
             FuseLog.Info(
                 $"FUSE setting changed: {nameof(FrameSpikeThresholdMs)}={FrameSpikeThresholdMs:F0}ms. " +
@@ -706,7 +712,7 @@ namespace FUSE.Infrastructure
                     ReadFloat(settings, nameof(RandomVisualConditionMax), RandomVisualConditionMax));
                 EnableFrameSpikeDiagnostics =
                     ReadBool(settings, nameof(EnableFrameSpikeDiagnostics), EnableFrameSpikeDiagnostics);
-                FrameSpikeThresholdMs = Mathf.Max(20f,
+                FrameSpikeThresholdMs = ClampFrameSpikeThresholdMs(
                     ReadFloat(settings, nameof(FrameSpikeThresholdMs), FrameSpikeThresholdMs));
                 EnableNativeLeakStackTraces =
                     ReadBool(settings, nameof(EnableNativeLeakStackTraces), EnableNativeLeakStackTraces);

--- a/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
@@ -118,6 +118,24 @@ namespace FUSE.Interface.MenuWindow
                     ? $"Logging adaptive hitches to FUSE.log (absolute floor {FuseSettings.FrameSpikeThresholdMs:F0}ms; spikes so far: {FuseRuntimeGuardCounters.FrameSpikes}, worst {FuseRuntimeGuardCounters.FrameSpikeWorstMs:F0}ms)."
                     : "For stutter reports: logs frames that exceed both the configured floor and the rolling frame-time baseline, with memory and queue context. Takes effect immediately.");
 
+            builder.AddField("Spike Floor", control: builder.AddSliderQuantized(
+                () => FuseSettings.FrameSpikeThresholdMs,
+                () => $"{FuseSettings.FrameSpikeThresholdMs:F0}ms",
+                FuseSettings.PreviewFrameSpikeThresholdMs,
+                5f,
+                FuseSettings.MinFrameSpikeThresholdMs,
+                250f,
+                value =>
+                {
+                    FuseSettings.SetFrameSpikeThresholdMs(value);
+                    builder.Rebuild();
+                }));
+
+            builder.AddLabel(
+                "Frames shorter than the floor never log as spikes, even when they exceed the rolling " +
+                "baseline. 50ms suits subtle-stutter hunts; the 100ms default keeps only severe hitches. " +
+                "Takes effect immediately.");
+
             builder.AddField("Native Allocation Stacks", control: BuildToggleBoxWithButton(
                 builder,
                 FuseSettings.EnableNativeLeakStackTraces,

--- a/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
@@ -124,7 +124,7 @@ namespace FUSE.Interface.MenuWindow
                 FuseSettings.PreviewFrameSpikeThresholdMs,
                 5f,
                 FuseSettings.MinFrameSpikeThresholdMs,
-                250f,
+                FuseSettings.MaxFrameSpikeThresholdMs,
                 value =>
                 {
                     FuseSettings.SetFrameSpikeThresholdMs(value);

--- a/FUSE/Loading/FuseLegacyJsonPatch.cs
+++ b/FUSE/Loading/FuseLegacyJsonPatch.cs
@@ -274,6 +274,28 @@ namespace FUSE.Loading
 
         private static void ApplyArray(JArray target, JArray patchArray, JObject root, string source)
         {
+            // A directive-free array that contains objects is the author's
+            // complete intended value, not a merge program. The legacy loader
+            // only ever accepted such an array when the key was new (assigning
+            // it wholesale) and rejected it against an existing array — but
+            // FUSE's game-graph expansion replays patches against the live
+            // runtime state, where the package's own splineys/roads already
+            // exist, so the same file that loaded cleanly as a fresh key would
+            // fault here. Replacing reproduces the legacy end state no matter
+            // which side of that race the target is on. Arrays that mix in
+            // $-directives keep strict merge semantics below, and all-primitive
+            // arrays keep their existing append behavior.
+            if (IsPlainObjectArray(patchArray))
+            {
+                target.Clear();
+                foreach (var plainItem in patchArray)
+                {
+                    target.Add(plainItem.DeepClone());
+                }
+
+                return;
+            }
+
             foreach (var item in patchArray)
             {
                 if (!(item is JObject instruction))
@@ -330,6 +352,35 @@ namespace FUSE.Loading
                 throw new InvalidOperationException(
                     $"Legacy patch '{source}' has an array object without $add, $append, $prepend, $insert, $replace, $remove, or $find.");
             }
+        }
+
+        /// <summary>
+        /// True when the array carries at least one object and none of its
+        /// objects is a $-directive instruction — i.e. it is a literal array
+        /// value, not a merge program.
+        /// </summary>
+        private static bool IsPlainObjectArray(JArray patchArray)
+        {
+            var sawObject = false;
+            foreach (var item in patchArray)
+            {
+                if (!(item is JObject candidate))
+                {
+                    continue;
+                }
+
+                foreach (var property in candidate.Properties())
+                {
+                    if (IsDirective(property.Name))
+                    {
+                        return false;
+                    }
+                }
+
+                sawObject = true;
+            }
+
+            return sawObject;
         }
 
         private static void ApplyFindInstruction(JArray target, JObject instruction, JToken findToken, JObject root, string source)

--- a/FUSE/Runtime/Lifecycle/FuseFrameSpikeDiagnostic.cs
+++ b/FUSE/Runtime/Lifecycle/FuseFrameSpikeDiagnostic.cs
@@ -83,10 +83,14 @@ namespace FUSE.Runtime.Lifecycle
 
         // First few hitches individually (enough to align with nearby logs),
         // then a heartbeat so persistent stutter stays visible without a line
-        // for every slow frame.
-        private static bool ShouldLog(long count)
+        // for every slow frame — but a session-worst spike ALWAYS logs: in a
+        // field capture the single biggest stall was invisible because it fell
+        // between heartbeats, leaving only the "worst" aggregate with no
+        // timestamp to correlate against. Worst is monotone, so break-through
+        // lines are self-limiting.
+        internal static bool ShouldLogSpike(long count, bool isNewWorst)
         {
-            return count <= 10 || count % 25 == 0;
+            return isNewWorst || count <= 10 || count % 25 == 0;
         }
 
         private sealed class FuseFrameSpikeRunner : MonoBehaviour
@@ -190,17 +194,28 @@ namespace FUSE.Runtime.Lifecycle
                     var observation = _hitchDetector.Observe(frameMs, absoluteFloorMs);
                     if (observation.IsHitch)
                     {
+                        var isNewWorst = frameMs > FuseRuntimeGuardCounters.FrameSpikeWorstMs;
                         var spikeCount = FuseRuntimeGuardCounters.RecordFrameSpike(frameMs);
-                        if (ShouldLog(spikeCount))
+                        if (ShouldLogSpike(spikeCount, isNewWorst))
                         {
+                            // Streaming context at spike time: a spike with a
+                            // deep scenery queue or a decal-registry jump is a
+                            // streaming wave, not a sim/GC problem — the exact
+                            // split a field capture needs one line to answer.
+                            var decalRegistry = FuseDecalCullingScrubPatch.TryGetRegistryCount(out var registryCount)
+                                ? registryCount.ToString()
+                                : "n/a";
                             FuseLog.Warning(
-                                $"FUSE frame spike #{spikeCount}: {frameMs:F0}ms " +
+                                $"FUSE frame spike #{spikeCount}: {frameMs:F0}ms{(isNewWorst ? " (session worst)" : string.Empty)} " +
                                 $"(adaptive baseline {observation.BaselineMs:F1}ms, absolute floor {absoluteFloorMs:F0}ms, " +
                                 $"effective threshold {observation.EffectiveThresholdMs:F1}ms, " +
                                 $"worst {FuseRuntimeGuardCounters.FrameSpikeWorstMs:F0}ms) frame={Time.frameCount} " +
-                                $"gcDelta0={gen0 - _gen0} gcDelta1={gen1 - _gen1} gcDelta2={gen2 - _gen2}. " +
+                                $"gcDelta0={gen0 - _gen0} gcDelta1={gen1 - _gen1} gcDelta2={gen2 - _gen2} " +
+                                $"sceneryLoadQueue={FuseSceneryLoadThrottlePatch.QueueDepth} " +
+                                $"decalRegistry={decalRegistry}. " +
                                 "Correlate this timestamp with surrounding FUSE.log/Player.log activity; " +
-                                "a positive GC delta with no nearby activity points at allocation pressure.");
+                                "a positive GC delta points at allocation pressure, a deep scenery queue " +
+                                "or decal-registry jump at a streaming wave.");
                         }
                     }
                 }

--- a/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
+++ b/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
@@ -263,6 +263,13 @@ namespace FUSE.Runtime.Lifecycle
                 var consoleStopwatch = Stopwatch.StartNew();
                 FuseConsoleRegistrar.TryRegisterAll();
                 FuseLegacyAssemblyHost.RetryPendingConsoleCommands();
+                // Second attempt for the third-party guards: FUSE loads before
+                // MapEnhancer and the rebill mod in UMM's order, so the
+                // plugin-load attempt resolves neither ("idle (not present)")
+                // and the guards never engaged in the field. By map load every
+                // mod assembly is up; the installer re-resolves absent targets
+                // and latches anything already installed.
+                FUSE.Patches.FuseThirdPartyGuardInstaller.EnsureInstalled();
                 FusePerformanceMetrics.RecordTiming("console registration", consoleStopwatch.ElapsedMilliseconds);
                 FuseLog.Info($"FUSE load timing phase='console registration' elapsedMs={consoleStopwatch.ElapsedMilliseconds}.");
             }

--- a/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
+++ b/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
@@ -263,19 +263,29 @@ namespace FUSE.Runtime.Lifecycle
                 var consoleStopwatch = Stopwatch.StartNew();
                 FuseConsoleRegistrar.TryRegisterAll();
                 FuseLegacyAssemblyHost.RetryPendingConsoleCommands();
-                // Second attempt for the third-party guards: FUSE loads before
-                // MapEnhancer and the rebill mod in UMM's order, so the
-                // plugin-load attempt resolves neither ("idle (not present)")
-                // and the guards never engaged in the field. By map load every
-                // mod assembly is up; the installer re-resolves absent targets
-                // and latches anything already installed.
-                FUSE.Patches.FuseThirdPartyGuardInstaller.EnsureInstalled();
                 FusePerformanceMetrics.RecordTiming("console registration", consoleStopwatch.ElapsedMilliseconds);
                 FuseLog.Info($"FUSE load timing phase='console registration' elapsedMs={consoleStopwatch.ElapsedMilliseconds}.");
             }
             catch (Exception ex)
             {
                 FuseLog.Exception("FUSE console registration on map-load failed.", ex);
+            }
+
+            // Second attempt for the third-party guards: FUSE loads before
+            // MapEnhancer and the rebill mod in UMM's order, so the
+            // plugin-load attempt resolves neither ("idle (not present)")
+            // and the guards never engaged in the field. By map load every
+            // mod assembly is up; the installer re-resolves absent targets
+            // and latches anything already installed. Guarded separately so
+            // an installer fault can neither abort nor mislabel console
+            // registration.
+            try
+            {
+                FUSE.Patches.FuseThirdPartyGuardInstaller.EnsureInstalled();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE third-party guard install retry on map load failed.", ex);
             }
 
             // Defer the actual publish (toast + log summary +


### PR DESCRIPTION
Combined rollup of the pending diagnostics/guards work (supersedes closed #154/#155/#156/#157) plus one field-driven compat fix, per the one-big-PR plan. All components field-tested on the EFA Actual 7-12 save during the 2026-07-25 live sessions.

## Contents

### Frame-spike diagnostics (ex-#155) - live-verified
Always log the session-worst spike; add streaming context (sceneryLoadQueue, decalRegistry) to spike lines; once-per-minute runtime census (fps, scene-graph counts, managed/native memory split, queue peaks). This instrumentation produced the census evidence behind issues #158-#168.

### Configurable spike threshold (ex-#154)
Settings-page slider for the frame-spike floor (20-500ms, default 100), invariant-culture ReadFloat with contract tests.

### Third-party guard installer retry (ex-#156) - live-verified
Guards install at startup only; FUSE loads alphabetically before MapEnhancer/rrRIC, so field machines got zero containment. A second EnsureInstalled() in RunMapDidLoadPipeline fixes the ordering. Verified live: rebillAutoConfigSuppressed=3 this session, NRE storm replaced by throttled containment lines.

### Harmony dynamic-method wrapper attribution (ex-#157)
The mod-health monitor now resolves "(wrapper dynamic-method) ...Type.Method_PatchN" frames through Harmony patch state and attributes to the patch-owning mod under conservative rules: every patch on the matched method must belong to one mapped mod; any unmapped owner (FUSE itself, harvest-missed mods) poisons the method to unattributed; exact type-path matches preferred; memoized per map generation; capped per scan. Frames render as "Type.Method [via Harmony patch]" to keep the candidate nature visible. Includes an adversarial multi-agent review pass whose two confirmed wrong-blame defects are fixed here (see #157 history).

### Legacy patch array parity (new)
The five field "legacy game-graph compatibility" faults (acm-alarka, acm-little-tennessee, acm-needmore-bridges, EFA Track Pack buildings, zz_aspenscrazymap) all trace to directive-free object arrays (spliney "points") re-applied while the target key already exists in the runtime state. The legacy loader accepted such arrays only as fresh keys (wholesale assign); FUSE expansion replays against live state, so the same files faulted and their edits were dropped. A directive-free array containing objects now replaces the target wholesale - reproducing the legacy end state regardless of target state. Directive arrays keep strict merge; primitive arrays keep append.

## Tests
1,601 passing (23 new attribution incl. live-Harmony integration tests, 4 new legacy-patch parity, spike/threshold suites from the constituent branches).

## Field verification status
- Guard retry + spike context: verified live this session.
- Threshold slider: deployed, pending settings-page confirmation.
- Array parity: deployed as 0.17.1-dev-8255d4b; expected Faults 5 -> 0 on next load (pending).
- Wrapper attribution: deployed; awaits a wrapper-frame exception in the field.