### PR TITLE
FUSE.Profiler: in-game performance profiler (clean-room DPA-design reimplementation)

### DIFF
--- a/FUSE.Profiler/Engine/ProbeRegistry.cs
+++ b/FUSE.Profiler/Engine/ProbeRegistry.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace FUSE.Profiler.Engine
+{
+    /// <summary>
+    /// The session-wide probe table. Creation is thread-safe (instrumented
+    /// methods and the UI both race to create probes); per-cycle sampling
+    /// iterates a cached snapshot array so the hot per-frame path does not
+    /// allocate an enumerator or fight the dictionary.
+    /// </summary>
+    internal static class ProbeRegistry
+    {
+        private static readonly ConcurrentDictionary<string, ProbeRing> Probes =
+            new ConcurrentDictionary<string, ProbeRing>(StringComparer.Ordinal);
+
+        private static readonly object SnapshotLock = new object();
+        private static volatile ProbeRing[] _snapshot = Array.Empty<ProbeRing>();
+        private static volatile bool _snapshotStale;
+
+        internal static int Count => Probes.Count;
+
+        internal static ProbeRing GetOrAdd(string key, string label, ProbeCadence cadence, string groupKey = null)
+        {
+            if (Probes.TryGetValue(key, out var existing))
+            {
+                return existing;
+            }
+
+            var created = Probes.GetOrAdd(key, _ => new ProbeRing(key, label, cadence, groupKey));
+            _snapshotStale = true;
+            return created;
+        }
+
+        internal static bool TryGet(string key, out ProbeRing probe)
+        {
+            return Probes.TryGetValue(key, out probe);
+        }
+
+        /// <summary>
+        /// Close the cycle for every probe on the given clock. Main thread
+        /// only, once per frame / per sim tick.
+        /// </summary>
+        internal static void CloseCycles(ProbeCadence cadence)
+        {
+            var probes = CurrentSnapshot();
+            for (var i = 0; i < probes.Length; i++)
+            {
+                var probe = probes[i];
+                if (probe.Cadence == cadence)
+                {
+                    probe.CloseCycle();
+                }
+            }
+        }
+
+        /// <summary>Stable snapshot for the stats worker.</summary>
+        internal static ProbeRing[] SnapshotProbes()
+        {
+            return CurrentSnapshot();
+        }
+
+        internal static void Clear()
+        {
+            Probes.Clear();
+            _snapshot = Array.Empty<ProbeRing>();
+            _snapshotStale = false;
+        }
+
+        private static ProbeRing[] CurrentSnapshot()
+        {
+            // Fast path: no allocation, no lock, on every ordinary cycle.
+            if (!_snapshotStale)
+            {
+                return _snapshot;
+            }
+
+            // Rare (only after a probe was added). Claim the stale flag
+            // BEFORE enumerating: a probe added concurrently with the copy
+            // then re-marks stale and the next cycle picks it up — clearing
+            // the flag after the copy could lose that add forever.
+            lock (SnapshotLock)
+            {
+                if (_snapshotStale)
+                {
+                    _snapshotStale = false;
+                    var list = new List<ProbeRing>(Probes.Count);
+                    foreach (var pair in Probes)
+                    {
+                        list.Add(pair.Value);
+                    }
+
+                    _snapshot = list.ToArray();
+                }
+            }
+
+            return _snapshot;
+        }
+    }
+}

--- a/FUSE.Profiler/Engine/ProbeRing.cs
+++ b/FUSE.Profiler/Engine/ProbeRing.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace FUSE.Profiler.Engine
+{
+    /// <summary>
+    /// Which sampling clock closes a probe's measurement cycle: once per
+    /// rendered frame, or once per train-physics step. A probe must only be
+    /// sampled on its own clock or its buckets mix cadences.
+    /// </summary>
+    internal enum ProbeCadence
+    {
+        Frame,
+        SimTick,
+    }
+
+    /// <summary>
+    /// One profiled key's measurement state: a single stopwatch accumulating
+    /// inclusive time across all calls in the current cycle, plus fixed-size
+    /// ring buffers of per-cycle totals.
+    ///
+    /// Reentrancy: a depth counter pairs Enter/Exit, so the stopwatch runs
+    /// from the outermost Enter to the outermost Exit — recursive or
+    /// overlapping calls extend one interval (no double-counting, no lost
+    /// tail time), while the hit counter still counts every call. If an
+    /// instrumented method throws, its <see cref="Exit"/> is skipped and the
+    /// depth sticks until <see cref="CloseCycle"/> resets both watch and
+    /// depth — the damage is bounded to that one sample.
+    ///
+    /// Threading: Enter/Exit/CloseCycle run on the Unity main thread. The
+    /// stats worker reads the ring arrays concurrently from a background
+    /// thread; on x64 the aligned double/int element writes are atomic, so a
+    /// reader can at worst see a mix of cycles — acceptable for statistics,
+    /// by design.
+    /// </summary>
+    internal sealed class ProbeRing
+    {
+        internal const int SlotCount = 2000;
+
+        private readonly Stopwatch _watch = new Stopwatch();
+        private readonly double[] _milliseconds = new double[SlotCount];
+        private readonly int[] _hits = new int[SlotCount];
+        private int _hitsThisCycle;
+        private int _depth;
+        private double _externalMsThisCycle;
+        private int _cursor;
+        private int _filled;
+
+        internal ProbeRing(string key, string label, ProbeCadence cadence, string groupKey)
+        {
+            Key = key;
+            Label = string.IsNullOrEmpty(label) ? key : label;
+            Cadence = cadence;
+            GroupKey = groupKey;
+        }
+
+        internal string Key { get; }
+        internal string Label { get; }
+        internal ProbeCadence Cadence { get; }
+
+        /// <summary>
+        /// Optional grouping id for rollups (e.g. the owning mod's name for
+        /// foreign-Harmony-patch probes). Null for ungrouped probes.
+        /// </summary>
+        internal string GroupKey { get; }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void Enter()
+        {
+            _hitsThisCycle++;
+            if (_depth++ == 0)
+            {
+                _watch.Start();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void Exit()
+        {
+            if (_depth > 0 && --_depth == 0)
+            {
+                _watch.Stop();
+            }
+        }
+
+        /// <summary>
+        /// Contribute a duration measured outside the stopwatch (used by the
+        /// whole-frame baseline probe, whose duration comes from Unity's
+        /// delta time rather than an Enter/Exit pair).
+        /// </summary>
+        internal void AddExternalMilliseconds(double ms)
+        {
+            _hitsThisCycle++;
+            _externalMsThisCycle += ms;
+        }
+
+        /// <summary>
+        /// Close the current cycle: store this cycle's total and hit count
+        /// into the ring and reset for the next cycle. Called once per frame
+        /// or per sim tick (per <see cref="Cadence"/>) from the main thread.
+        /// </summary>
+        internal void CloseCycle()
+        {
+            var hits = _hitsThisCycle;
+            _hits[_cursor] = hits;
+            _milliseconds[_cursor] = hits > 0
+                ? _watch.Elapsed.TotalMilliseconds + _externalMsThisCycle
+                : 0d;
+            _watch.Reset();
+            _hitsThisCycle = 0;
+            _depth = 0;
+            _externalMsThisCycle = 0d;
+            _cursor = (_cursor + 1) % SlotCount;
+            if (_filled < SlotCount)
+            {
+                _filled++;
+            }
+        }
+
+        /// <summary>
+        /// Aggregate the most recent recorded cycles (up to
+        /// <paramref name="windowCycles"/>). Safe to call from the stats
+        /// worker thread; see the class remarks for the tearing model.
+        /// </summary>
+        internal ProbeAggregate Aggregate(int windowCycles)
+        {
+            var available = _filled;
+            var take = windowCycles < available ? windowCycles : available;
+            var index = _cursor;
+            var result = default(ProbeAggregate);
+            for (var i = 0; i < take; i++)
+            {
+                index = index == 0 ? SlotCount - 1 : index - 1;
+                var ms = _milliseconds[index];
+                var hits = _hits[index];
+                result.TotalMs += ms;
+                result.Calls += hits;
+                if (ms > result.MaxMs)
+                {
+                    result.MaxMs = ms;
+                }
+                if (hits > result.MaxCallsPerCycle)
+                {
+                    result.MaxCallsPerCycle = hits;
+                }
+            }
+
+            result.Samples = take;
+            return result;
+        }
+
+        /// <summary>
+        /// Copy the newest <paramref name="count"/> per-cycle totals into
+        /// <paramref name="destination"/>, oldest first. Returns how many
+        /// were copied (limited by what has been recorded so far).
+        /// </summary>
+        internal int CopyRecentInto(double[] destination, int count)
+        {
+            var available = _filled;
+            var take = count < available ? count : available;
+            if (take > destination.Length)
+            {
+                take = destination.Length;
+            }
+
+            var index = _cursor;
+            for (var i = take - 1; i >= 0; i--)
+            {
+                index = index == 0 ? SlotCount - 1 : index - 1;
+                destination[i] = _milliseconds[index];
+            }
+
+            return take;
+        }
+    }
+
+    internal struct ProbeAggregate
+    {
+        public double TotalMs;
+        public double MaxMs;
+        public long Calls;
+        public int MaxCallsPerCycle;
+        public int Samples;
+
+        public double AverageMs => Samples > 0 ? TotalMs / Samples : 0d;
+    }
+}

--- a/FUSE.Profiler/Engine/ProbeRow.cs
+++ b/FUSE.Profiler/Engine/ProbeRow.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+
+namespace FUSE.Profiler.Engine
+{
+    /// <summary>How the results list is ordered.</summary>
+    internal enum ProbeSortMode
+    {
+        Average,
+        Max,
+        Percent,
+        Calls,
+        Total,
+        Name,
+    }
+
+    /// <summary>
+    /// One immutable row of the rolled-up results list, produced by the stats
+    /// worker and handed to the UI as a complete replacement list.
+    /// </summary>
+    internal sealed class ProbeRow
+    {
+        internal ProbeRow(
+            string key,
+            string label,
+            string groupKey,
+            ProbeCadence cadence,
+            double averageMs,
+            double maxMs,
+            double totalMs,
+            long calls,
+            int maxCallsPerCycle,
+            double percentOfFrame)
+        {
+            Key = key;
+            Label = label;
+            GroupKey = groupKey;
+            Cadence = cadence;
+            AverageMs = averageMs;
+            MaxMs = maxMs;
+            TotalMs = totalMs;
+            Calls = calls;
+            MaxCallsPerCycle = maxCallsPerCycle;
+            PercentOfFrame = percentOfFrame;
+        }
+
+        internal string Key { get; }
+        internal string Label { get; }
+        internal string GroupKey { get; }
+        internal ProbeCadence Cadence { get; }
+        internal double AverageMs { get; }
+        internal double MaxMs { get; }
+        internal double TotalMs { get; }
+        internal long Calls { get; }
+        internal int MaxCallsPerCycle { get; }
+
+        /// <summary>
+        /// Share of the measured whole-frame time over the same window, in
+        /// percent — or a negative value when no frame baseline applies
+        /// (sim-tick probes), which the UI renders as "—".
+        /// </summary>
+        internal double PercentOfFrame { get; }
+
+        internal static Comparison<ProbeRow> ComparisonFor(ProbeSortMode mode)
+        {
+            switch (mode)
+            {
+                case ProbeSortMode.Max:
+                    return (a, b) => b.MaxMs.CompareTo(a.MaxMs);
+                case ProbeSortMode.Percent:
+                    return (a, b) => b.PercentOfFrame.CompareTo(a.PercentOfFrame);
+                case ProbeSortMode.Calls:
+                    return (a, b) => b.Calls.CompareTo(a.Calls);
+                case ProbeSortMode.Total:
+                    return (a, b) => b.TotalMs.CompareTo(a.TotalMs);
+                case ProbeSortMode.Name:
+                    return (a, b) => string.Compare(a.Label, b.Label, StringComparison.OrdinalIgnoreCase);
+                case ProbeSortMode.Average:
+                default:
+                    return (a, b) => b.AverageMs.CompareTo(a.AverageMs);
+            }
+        }
+
+        /// <summary>
+        /// Sort rows for display: pinned keys first (stable within the pinned
+        /// block), then the rest by the selected mode.
+        /// </summary>
+        internal static void SortForDisplay(List<ProbeRow> rows, ProbeSortMode mode, HashSet<string> pinnedKeys)
+        {
+            var comparison = ComparisonFor(mode);
+            if (pinnedKeys == null || pinnedKeys.Count == 0)
+            {
+                rows.Sort(comparison);
+                return;
+            }
+
+            rows.Sort((a, b) =>
+            {
+                var aPinned = pinnedKeys.Contains(a.Key);
+                var bPinned = pinnedKeys.Contains(b.Key);
+                if (aPinned != bPinned)
+                {
+                    return aPinned ? -1 : 1;
+                }
+
+                return comparison(a, b);
+            });
+        }
+    }
+}

--- a/FUSE.Profiler/Engine/ProfilerSession.cs
+++ b/FUSE.Profiler/Engine/ProfilerSession.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FUSE.Profiler.Infrastructure;
+
+namespace FUSE.Profiler.Engine
+{
+    /// <summary>
+    /// Session orchestration: the global sampling gate the instrumented code
+    /// checks, the two cycle clocks (frame and sim tick), and the throttled
+    /// background rollup that turns ring buffers into the sorted row list
+    /// the UI renders.
+    /// </summary>
+    internal static class ProfilerSession
+    {
+        internal const string FrameProbeKey = "profiler.frame";
+        internal const string FrameProbeLabel = "Whole frame";
+
+        private static volatile bool _sampling;
+        private static volatile bool _paused;
+
+        /// <summary>
+        /// The single gate the instrumented wrappers read: true only while
+        /// sampling and not paused. Kept as one volatile so pausing freezes
+        /// accumulation too — without this, probes kept measuring through a
+        /// pause and the first resumed sample contained the whole pause.
+        /// </summary>
+        internal static volatile bool Recording;
+
+        /// <summary>Master switch; flipped by open/close.</summary>
+        internal static bool Sampling
+        {
+            get => _sampling;
+            set
+            {
+                _sampling = value;
+                Recording = _sampling && !_paused;
+            }
+        }
+
+        /// <summary>Freezes measurement without unpatching.</summary>
+        internal static bool Paused
+        {
+            get => _paused;
+            set
+            {
+                _paused = value;
+                Recording = _sampling && !_paused;
+            }
+        }
+
+        /// <summary>
+        /// Seconds between stats rollups; assigned from settings at load.
+        /// </summary>
+        internal static float StatsIntervalSeconds = 0.5f;
+
+        /// <summary>
+        /// How many recent cycles the rollup aggregates. The full ring is
+        /// ~33s of frames at 60fps; a shorter window keeps the numbers
+        /// responsive to what is happening right now.
+        /// </summary>
+        internal static int RollupWindowCycles = 600;
+
+        private static readonly object RowsLock = new object();
+        private static readonly HashSet<string> Pinned = new HashSet<string>(StringComparer.Ordinal);
+        private static List<ProbeRow> _rows = new List<ProbeRow>();
+        private static int _resetGeneration;
+        private static float _sinceRollup;
+        private static int _rollupRunning;
+        private static ProbeSortMode _sortMode = ProbeSortMode.Average;
+
+        internal static ProbeSortMode SortMode
+        {
+            get => _sortMode;
+            set => _sortMode = value;
+        }
+
+        internal static void TogglePinned(string key)
+        {
+            lock (RowsLock)
+            {
+                if (!Pinned.Remove(key))
+                {
+                    Pinned.Add(key);
+                }
+            }
+        }
+
+        internal static bool IsPinned(string key)
+        {
+            lock (RowsLock)
+            {
+                return Pinned.Contains(key);
+            }
+        }
+
+        /// <summary>
+        /// Frame clock, called from the host's LateUpdate (after the frame's
+        /// Update work, so per-frame probes have finished their cycle;
+        /// rendering-side work lands in the next bucket by design).
+        /// </summary>
+        internal static void FrameBoundary(float unscaledDeltaSeconds)
+        {
+            if (!Recording)
+            {
+                return;
+            }
+
+            var frameProbe = ProbeRegistry.GetOrAdd(FrameProbeKey, FrameProbeLabel, ProbeCadence.Frame);
+            frameProbe.AddExternalMilliseconds(unscaledDeltaSeconds * 1000d);
+            ProbeRegistry.CloseCycles(ProbeCadence.Frame);
+
+            _sinceRollup += unscaledDeltaSeconds;
+            if (_sinceRollup >= StatsIntervalSeconds)
+            {
+                _sinceRollup = 0f;
+                ScheduleRollup();
+            }
+        }
+
+        /// <summary>
+        /// Sim-tick clock, called from the TrainController fixed-step
+        /// postfix. Closes only sim-tick probes.
+        /// </summary>
+        internal static void SimTickBoundary()
+        {
+            if (!Recording)
+            {
+                return;
+            }
+
+            ProbeRegistry.CloseCycles(ProbeCadence.SimTick);
+        }
+
+        /// <summary>Latest rolled-up rows (copy; safe to hold across frames).</summary>
+        internal static List<ProbeRow> CopyRows()
+        {
+            lock (RowsLock)
+            {
+                return new List<ProbeRow>(_rows);
+            }
+        }
+
+        internal static void Reset()
+        {
+            Sampling = false;
+            Paused = false;
+            _sinceRollup = 0f;
+            lock (RowsLock)
+            {
+                _resetGeneration++;
+                _rows = new List<ProbeRow>();
+                Pinned.Clear();
+            }
+        }
+
+        private static void ScheduleRollup()
+        {
+            // One rollup in flight at a time; a skipped interval just means
+            // slightly staler rows.
+            if (Interlocked.CompareExchange(ref _rollupRunning, 1, 0) != 0)
+            {
+                return;
+            }
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    RollupOnce();
+                }
+                catch (Exception ex)
+                {
+                    ProfilerLog.Exception("FUSE.Profiler stats rollup failed", ex);
+                }
+                finally
+                {
+                    Interlocked.Exchange(ref _rollupRunning, 0);
+                }
+            });
+        }
+
+        private static void RollupOnce()
+        {
+            int generationAtStart;
+            lock (RowsLock)
+            {
+                generationAtStart = _resetGeneration;
+            }
+
+            var probes = ProbeRegistry.SnapshotProbes();
+            var window = RollupWindowCycles;
+
+            double frameTotalMs = 0d;
+            if (ProbeRegistry.TryGet(FrameProbeKey, out var frameProbe))
+            {
+                frameTotalMs = frameProbe.Aggregate(window).TotalMs;
+            }
+
+            var rows = new List<ProbeRow>(probes.Length);
+            for (var i = 0; i < probes.Length; i++)
+            {
+                var probe = probes[i];
+                var agg = probe.Aggregate(window);
+                if (agg.Samples == 0)
+                {
+                    continue;
+                }
+
+                var percent = probe.Cadence == ProbeCadence.Frame && frameTotalMs > 0d
+                    ? agg.TotalMs / frameTotalMs * 100d
+                    : -1d;
+                rows.Add(new ProbeRow(
+                    probe.Key,
+                    probe.Label,
+                    probe.GroupKey,
+                    probe.Cadence,
+                    agg.AverageMs,
+                    agg.MaxMs,
+                    agg.TotalMs,
+                    agg.Calls,
+                    agg.MaxCallsPerCycle,
+                    percent));
+            }
+
+            HashSet<string> pinnedCopy;
+            lock (RowsLock)
+            {
+                pinnedCopy = new HashSet<string>(Pinned, StringComparer.Ordinal);
+            }
+
+            ProbeRow.SortForDisplay(rows, _sortMode, pinnedCopy);
+
+            lock (RowsLock)
+            {
+                // A Reset (cleanup/close) that landed mid-rollup wins: don't
+                // resurrect rows built from the torn-down registry.
+                if (_resetGeneration == generationAtStart)
+                {
+                    _rows = rows;
+                }
+            }
+        }
+    }
+}

--- a/FUSE.Profiler/Entries/RailroaderEntries.cs
+++ b/FUSE.Profiler/Entries/RailroaderEntries.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using FUSE.Profiler.Instrumentation;
+
+namespace FUSE.Profiler.Entries
+{
+    /// <summary>
+    /// The built-in Railroader profiling categories. Every target is a
+    /// name-resolved spec so a game update that renames something degrades to
+    /// a visible "target failed" row instead of a load failure; the
+    /// FUSE.Tests resolution canaries assert the whole table against the
+    /// installed game so drift is caught at build time.
+    /// </summary>
+    internal static class RailroaderEntries
+    {
+        internal static IEnumerable<ProfilerEntry> CreateBuiltIns()
+        {
+            // Note: the whole-step time (TrainController.FixedUpdate) is
+            // measured by the sim-tick clock driver itself, so it is not a
+            // target here — instrumenting the boundary method would race the
+            // cycle close on patch-priority ties.
+            yield return new ProfilerEntry(
+                "physics.sim",
+                "Train physics step",
+                ProfilerCategory.Physics,
+                () => new[]
+                {
+                    new TargetSpec("Model.Physics.IntegrationSet:Tick"),
+                    new TargetSpec("Model.Physics.CarAirSystem:FixedUpdateAir"),
+                },
+                "The fixed-step train simulation: integration sets and per-car air. Buckets are per physics step, not per frame.");
+
+            yield return new ProfilerEntry(
+                "culling.managers",
+                "Culling managers",
+                ProfilerCategory.Culling,
+                () => new[]
+                {
+                    new TargetSpec("Helpers.Culling.CullingManager:Update"),
+                    new TargetSpec("Helpers.Culling.CullingManager:FixedUpdate"),
+                    new TargetSpec("Helpers.Culling.CullingManager:CullingGroupStateChanged"),
+                },
+                "The shared sphere-culling managers (hoses, bridges, CTC, signals, scenery, flares).");
+
+            yield return new ProfilerEntry(
+                "culling.decals",
+                "Decal culling",
+                ProfilerCategory.Culling,
+                () => new[]
+                {
+                    new TargetSpec("Effects.Decals.DecalCullingManager:Update"),
+                    new TargetSpec("Effects.Decals.DecalCullingManager:FixedUpdate"),
+                    new TargetSpec("Effects.Decals.DecalCullingManager:UpdateDecalVisibilityJob"),
+                    new TargetSpec("Effects.Decals.DecalCullingManager:UpdateScreenSizeThreshold"),
+                },
+                "Car-lettering decal visibility: the per-frame Burst job schedule and threshold updates.");
+
+            yield return new ProfilerEntry(
+                "scenery.streaming",
+                "Scenery streaming",
+                ProfilerCategory.Scenery,
+                () => new[]
+                {
+                    new TargetSpec("Helpers.SceneryAssetManager:LoadScenery", label: "SceneryAssetManager.LoadScenery (sync part)"),
+                    new TargetSpec("Helpers.SceneryAssetInstance:SetLoaded", label: "SceneryAssetInstance.SetLoaded (sync part)"),
+                    new TargetSpec("Helpers.SceneryAssetInstance:CullingSphereStateChanged"),
+                    new TargetSpec("Helpers.SceneryAssetInstance:SetupComponents"),
+                },
+                "Scenery load/unload flips and component setup. The async load bodies count only their synchronous slice.");
+
+            yield return new ProfilerEntry(
+                "scenery.world",
+                "World streaming",
+                ProfilerCategory.Scenery,
+                () => new[]
+                {
+                    new TargetSpec("WorldStreamer2.Streamer:Update"),
+                },
+                "Terrain/world tile streaming.");
+
+            yield return new ProfilerEntry(
+                "track.rebuild",
+                "Track rebuilds",
+                ProfilerCategory.Track,
+                () => new[]
+                {
+                    new TargetSpec("Track.TrackObjectManager:Rebuild"),
+                    new TargetSpec("Track.TrackObjectManager:RebuildCoroutine", coroutine: true),
+                    new TargetSpec("Track.TrackRebuilder:Update"),
+                    new TargetSpec("Track.TrackRebuilder:WorkBuildQueue"),
+                    new TargetSpec("Track.TrackRebuilder:WorkDestroyQueue"),
+                    new TargetSpec("Track.Graph:RebuildCollections"),
+                },
+                "Track descriptor rebuilds and the incremental mesh build/destroy queues.");
+
+            yield return new ProfilerEntry(
+                "ops.controller",
+                "Ops controller",
+                ProfilerCategory.Operations,
+                () => new[]
+                {
+                    new TargetSpec("Model.Ops.OpsController:PeriodicUpdate", coroutine: true),
+                    new TargetSpec("Model.Ops.OpsController:RebuildPopulations"),
+                    new TargetSpec("Model.Ops.OpsController:CheckWaybills"),
+                    new TargetSpec("Model.Ops.OpsController:CheckLoads"),
+                    new TargetSpec("Model.Ops.OpsController:RebuildCollections"),
+                },
+                "Industry population/waybill sweeps.");
+
+            yield return new ProfilerEntry(
+                "ops.passengers",
+                "Passenger stops",
+                ProfilerCategory.Operations,
+                () => new[]
+                {
+                    new TargetSpec("Model.Ops.PassengerStop:Loop", coroutine: true),
+                    new TargetSpec("Model.Ops.PassengerStop:WorkCar", coroutine: true),
+                    new TargetSpec("Model.Ops.PassengerStop:UnloadCar"),
+                    new TargetSpec("Model.Ops.PassengerStop:LoadCar"),
+                    new TargetSpec("Model.Ops.PassengerStop:GrowWaiting"),
+                },
+                "Passenger stop work loops (the family behind stop ping-pong storms).");
+
+            yield return new ProfilerEntry(
+                "ops.autoengineer",
+                "Auto engineer",
+                ProfilerCategory.Operations,
+                () => new[]
+                {
+                    new TargetSpec("Model.AI.AutoEngineerPlanner:Loop", coroutine: true),
+                    new TargetSpec("Model.AI.AutoEngineerPlanner:RouteLoop", coroutine: true),
+                    new TargetSpec("Model.AI.AutoEngineerPlanner:UpdateTargets"),
+                    new TargetSpec("Model.AI.AutoEngineerPlanner:ApplyMovement"),
+                },
+                "AI crew planning and movement application.");
+
+            yield return new ProfilerEntry(
+                "ui.panels",
+                "UI panel rebuilds",
+                ProfilerCategory.UiEvents,
+                () => new[]
+                {
+                    new TargetSpec("UI.Builder.UIPanel:Rebuild"),
+                    new TargetSpec("UI.Builder.UIPanel:InvokeOnRebuild"),
+                },
+                "Full panel rebuilds — event-triggered UI churn shows up here.");
+
+            yield return new ProfilerEntry(
+                "keyvalue.dispatch",
+                "KeyValue writes",
+                ProfilerCategory.KeyValue,
+                () => new[]
+                {
+                    new TargetSpec("KeyValue.Runtime.KeyValueObject:Set"),
+                },
+                "Networked property writes including their synchronous observer callbacks.");
+        }
+    }
+}

--- a/FUSE.Profiler/Entries/RuntimeEntryFactory.cs
+++ b/FUSE.Profiler/Entries/RuntimeEntryFactory.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using FUSE.Profiler.Infrastructure;
+using FUSE.Profiler.Instrumentation;
+using HarmonyLib;
+using UnityModManagerNet;
+
+namespace FUSE.Profiler.Entries
+{
+    /// <summary>
+    /// Creates entries at runtime from user input (search panel) and from the
+    /// live Harmony state (the Mods rollup). Workers only discover and
+    /// resolve targets; every Harmony.Patch is enqueued for the main-thread
+    /// pump. Re-invoking a factory for the same id re-activates the existing
+    /// entry instead of duplicating it.
+    /// </summary>
+    internal static class RuntimeEntryFactory
+    {
+        /// <summary>
+        /// Profile a single "Namespace.Type:Method" (optionally a coroutine).
+        /// </summary>
+        internal static ProfilerEntry CreateMethodEntry(string methodSpec, bool coroutine)
+        {
+            var id = "custom.method." + methodSpec + (coroutine ? "#coroutine" : "");
+            var existing = EntryCatalog.FindById(id);
+            if (existing != null)
+            {
+                EntryCatalog.SetActive(existing, true);
+                return existing;
+            }
+
+            var spec = new TargetSpec(methodSpec, coroutine);
+            var entry = new ProfilerEntry(
+                id,
+                methodSpec + (coroutine ? " (coroutine)" : ""),
+                ProfilerCategory.Custom,
+                () => new[] { spec });
+            EntryCatalog.Register(entry);
+            EntryCatalog.SetActive(entry, true);
+            return entry;
+        }
+
+        /// <summary>Profile every instrumentable method a type declares.</summary>
+        internal static ProfilerEntry CreateTypeEntry(string typeName)
+        {
+            return CreateSweepEntry(
+                "custom.type." + typeName,
+                typeName + " (all methods)",
+                groupKey: null,
+                entry =>
+                {
+                    var type = AccessTools.TypeByName(typeName);
+                    if (type == null)
+                    {
+                        lock (entry.FailedTargets)
+                        {
+                            entry.FailedTargets.Add(typeName + ": type not found");
+                        }
+
+                        return Array.Empty<MethodBase>();
+                    }
+
+                    return MethodResolver.ProfilableDeclaredMethods(type).Cast<MethodBase>().ToArray();
+                });
+        }
+
+        /// <summary>
+        /// Profile every instrumentable method in a mod's main assembly —
+        /// the tool for "this mod is slow in its own MonoBehaviours".
+        /// </summary>
+        internal static ProfilerEntry CreateModAssemblyEntry(UnityModManager.ModEntry mod)
+        {
+            var modName = mod.Info?.DisplayName ?? mod.Info?.Id ?? "<mod>";
+            return CreateSweepEntry(
+                "custom.assembly." + modName,
+                modName + " (whole assembly)",
+                modName,
+                entry =>
+                {
+                    var assembly = mod.Assembly;
+                    if (assembly == null)
+                    {
+                        lock (entry.FailedTargets)
+                        {
+                            entry.FailedTargets.Add(modName + ": mod has no loaded assembly");
+                        }
+
+                        return Array.Empty<MethodBase>();
+                    }
+
+                    Type[] types;
+                    try
+                    {
+                        types = assembly.GetTypes();
+                    }
+                    catch (ReflectionTypeLoadException rtle)
+                    {
+                        types = rtle.Types.Where(t => t != null).ToArray();
+                    }
+
+                    return types
+                        .SelectMany(MethodResolver.ProfilableDeclaredMethods)
+                        .Cast<MethodBase>()
+                        .ToArray();
+                });
+        }
+
+        /// <summary>
+        /// The Mods rollup: one entry instrumenting every foreign Harmony
+        /// prefix/postfix/finalizer in the session, with probes grouped by
+        /// owning mod so the UI can aggregate per mod. Tiny patch methods the
+        /// Mono JIT inlined into their targets cannot be intercepted and are
+        /// undercounted — the whole-assembly sweep covers those.
+        /// </summary>
+        internal static ProfilerEntry CreateForeignPatchesEntry()
+        {
+            var id = "mods.harmony-patches";
+            var existing = EntryCatalog.FindById(id);
+            if (existing != null)
+            {
+                EntryCatalog.SetActive(existing, true);
+                return existing;
+            }
+
+            var entry = new ProfilerEntry(
+                id,
+                "All mods' Harmony patches",
+                ProfilerCategory.Mods,
+                Array.Empty<TargetSpec>,
+                "Every other mod's prefix/postfix/finalizer, attributed to its mod. " +
+                "JIT-inlined patch bodies and transpiler-inserted code are not isolated.");
+            EntryCatalog.Register(entry);
+            entry.Active = true;
+            entry.PatchInFlight = true;
+            var generation = MethodInstrumenter.Generation;
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    foreach (var patch in ModAttribution.EnumerateForeignPatches())
+                    {
+                        var targetName = patch.TargetMethod != null
+                            ? MethodInstrumenter.DescribeMethod(patch.TargetMethod)
+                            : "<unknown>";
+                        var label = patch.ModName + " • " + patch.Kind + " of " + targetName;
+                        var key = entry.Id + "|" + MethodInstrumenter.MethodKey(patch.PatchMethod) + "|" + patch.Kind + "|" + targetName;
+                        MethodInstrumenter.EnqueueInstrumentation(entry, patch.PatchMethod, key, label, patch.ModName, generation);
+                    }
+
+                    MethodInstrumenter.EnqueueCompletion(entry, generation);
+                }
+                catch (Exception ex)
+                {
+                    ProfilerLog.Exception("FUSE.Profiler failed enumerating foreign Harmony patches", ex);
+                    entry.PatchInFlight = false;
+                }
+            });
+
+            return entry;
+        }
+
+        private static ProfilerEntry CreateSweepEntry(
+            string id,
+            string label,
+            string groupKey,
+            Func<ProfilerEntry, MethodBase[]> discover)
+        {
+            var existing = EntryCatalog.FindById(id);
+            if (existing != null)
+            {
+                EntryCatalog.SetActive(existing, true);
+                return existing;
+            }
+
+            var entry = new ProfilerEntry(id, label, ProfilerCategory.Custom, Array.Empty<TargetSpec>);
+            EntryCatalog.Register(entry);
+            entry.Active = true;
+            entry.PatchInFlight = true;
+            var generation = MethodInstrumenter.Generation;
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    var methods = discover(entry);
+                    foreach (var method in methods)
+                    {
+                        var name = MethodInstrumenter.MethodKey(method);
+                        MethodInstrumenter.EnqueueInstrumentation(
+                            entry,
+                            method,
+                            entry.Id + "|" + name,
+                            MethodInstrumenter.DescribeMethod(method),
+                            groupKey,
+                            generation);
+                    }
+
+                    MethodInstrumenter.EnqueueCompletion(entry, generation);
+                }
+                catch (Exception ex)
+                {
+                    ProfilerLog.Exception($"FUSE.Profiler failed discovering targets for '{id}'", ex);
+                    entry.PatchInFlight = false;
+                }
+            });
+
+            return entry;
+        }
+    }
+}

--- a/FUSE.Profiler/FUSE.Profiler.csproj
+++ b/FUSE.Profiler/FUSE.Profiler.csproj
@@ -1,0 +1,106 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Paths.user is imported by Directory.Build.props so that $(GameDir) is
+       available to the property defaults below (same convention as FUSE.csproj). -->
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <AssemblyName>FUSE.Profiler</AssemblyName>
+    <RootNamespace>FUSE.Profiler</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <Platforms>AnyCPU</Platforms>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GameDir Condition="'$(GameDir)' == ''">C:\Steam\steamapps\common\Railroader</GameDir>
+    <UnityManagedDir Condition="'$(UnityManagedDir)' == ''">$(GameDir)\Railroader_Data\Managed</UnityManagedDir>
+    <UnityModManagerDir Condition="'$(UnityModManagerDir)' == ''">$(UnityManagedDir)\UnityModManager</UnityModManagerDir>
+    <ModDeployDir Condition="'$(ModDeployDir)' == ''">$(GameDir)\Mods\FUSE.Profiler</ModDeployDir>
+    <EnableModDeploy Condition="'$(EnableModDeploy)' == ''">false</EnableModDeploy>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="FUSE.Tests" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <UnityModManagerAssemblyPath Condition="'$(UnityModManagerAssemblyPath)' == '' and Exists('$(UnityModManagerDir)\UnityModManagerNet.dll')">$(UnityModManagerDir)\UnityModManagerNet.dll</UnityModManagerAssemblyPath>
+    <UnityModManagerAssemblyPath Condition="'$(UnityModManagerAssemblyPath)' == '' and Exists('$(UnityModManagerDir)\UnityModManager.dll')">$(UnityModManagerDir)\UnityModManager.dll</UnityModManagerAssemblyPath>
+    <UnityModManagerReferenceName Condition="'$(UnityModManagerReferenceName)' == '' and Exists('$(UnityModManagerDir)\UnityModManagerNet.dll')">UnityModManagerNet</UnityModManagerReferenceName>
+    <UnityModManagerReferenceName Condition="'$(UnityModManagerReferenceName)' == '' and Exists('$(UnityModManagerDir)\UnityModManager.dll')">UnityModManager</UnityModManagerReferenceName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="0Harmony" Condition="Exists('$(UnityModManagerDir)\0Harmony.dll')">
+      <HintPath>$(UnityModManagerDir)\0Harmony.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="0Harmony" Condition="!Exists('$(UnityModManagerDir)\0Harmony.dll') and Exists('$(UnityManagedDir)\0Harmony.dll')">
+      <HintPath>$(UnityManagedDir)\0Harmony.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="$(UnityModManagerReferenceName)" Condition="Exists('$(UnityModManagerAssemblyPath)')">
+      <HintPath>$(UnityModManagerAssemblyPath)</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp" Condition="Exists('$(UnityManagedDir)\Assembly-CSharp.dll')">
+      <HintPath>$(UnityManagedDir)\Assembly-CSharp.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Core" Condition="Exists('$(UnityManagedDir)\Core.dll')">
+      <HintPath>$(UnityManagedDir)\Core.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="KeyValue.Runtime" Condition="Exists('$(UnityManagedDir)\KeyValue.Runtime.dll')">
+      <HintPath>$(UnityManagedDir)\KeyValue.Runtime.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule" Condition="Exists('$(UnityManagedDir)\UnityEngine.CoreModule.dll')">
+      <HintPath>$(UnityManagedDir)\UnityEngine.CoreModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule" Condition="Exists('$(UnityManagedDir)\UnityEngine.IMGUIModule.dll')">
+      <HintPath>$(UnityManagedDir)\UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.InputLegacyModule" Condition="Exists('$(UnityManagedDir)\UnityEngine.InputLegacyModule.dll')">
+      <HintPath>$(UnityManagedDir)\UnityEngine.InputLegacyModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule" Condition="Exists('$(UnityManagedDir)\UnityEngine.TextRenderingModule.dll')">
+      <HintPath>$(UnityManagedDir)\UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UIModule" Condition="Exists('$(UnityManagedDir)\UnityEngine.UIModule.dll')">
+      <HintPath>$(UnityManagedDir)\UnityEngine.UIModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UI" Condition="Exists('$(UnityManagedDir)\UnityEngine.UI.dll')">
+      <HintPath>$(UnityManagedDir)\UnityEngine.UI.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Info.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <Target Name="ValidateUnityReferences" BeforeTargets="ResolveReferences">
+    <Error Condition="!Exists('$(UnityModManagerAssemblyPath)')" Text="UnityModManagerNet.dll or UnityModManager.dll was not found. Set UnityModManagerDir or GameDir to your installed Railroader + UMM location." />
+    <Error Condition="!Exists('$(UnityModManagerDir)\0Harmony.dll') and !Exists('$(UnityManagedDir)\0Harmony.dll')" Text="0Harmony.dll was not found. Set UnityModManagerDir or GameDir to your installed Railroader + UMM location." />
+    <Error Condition="!Exists('$(UnityManagedDir)\Assembly-CSharp.dll')" Text="Assembly-CSharp.dll was not found in the Railroader Managed folder." />
+    <Error Condition="!Exists('$(UnityManagedDir)\UnityEngine.CoreModule.dll')" Text="UnityEngine.CoreModule.dll was not found in the Railroader Managed folder." />
+    <Error Condition="!Exists('$(UnityManagedDir)\UnityEngine.IMGUIModule.dll')" Text="UnityEngine.IMGUIModule.dll was not found in the Railroader Managed folder." />
+    <Error Condition="!Exists('$(UnityManagedDir)\UnityEngine.InputLegacyModule.dll')" Text="UnityEngine.InputLegacyModule.dll was not found in the Railroader Managed folder." />
+  </Target>
+
+  <Target Name="DeployToUnityModManagerFolder" AfterTargets="Build" Condition="'$(EnableModDeploy)' == 'true'">
+    <MakeDir Directories="$(ModDeployDir)" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="Info.json" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="false" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="false" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
+  </Target>
+</Project>

--- a/FUSE.Profiler/Info.json
+++ b/FUSE.Profiler/Info.json
@@ -1,0 +1,11 @@
+{
+  "Id": "FUSE.Profiler",
+  "DisplayName": "FUSE Profiler",
+  "Author": "FUSE Development Group",
+  "Version": "0.1.0",
+  "ManagerVersion": "0.27.10",
+  "AssemblyName": "FUSE.Profiler.dll",
+  "EntryMethod": "FUSE.Profiler.ProfilerMod.Load",
+  "HomePage": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup",
+  "Repository": ""
+}

--- a/FUSE.Profiler/Infrastructure/ProfilerLog.cs
+++ b/FUSE.Profiler/Infrastructure/ProfilerLog.cs
@@ -1,0 +1,77 @@
+using System;
+
+namespace FUSE.Profiler.Infrastructure
+{
+    /// <summary>
+    /// Thin logging seam: routes through the UnityModManager mod logger when
+    /// bound (so lines land in the UMM log with the mod prefix), and falls
+    /// back to the Unity player log otherwise (including in unit tests,
+    /// where UnityEngine.Debug is unavailable and the write is swallowed).
+    /// </summary>
+    internal static class ProfilerLog
+    {
+        private static Action<string> _info;
+        private static Action<string> _warning;
+        private static Action<string> _error;
+
+        internal static void Bind(Action<string> info, Action<string> warning, Action<string> error)
+        {
+            _info = info;
+            _warning = warning;
+            _error = error;
+        }
+
+        internal static void Info(string message)
+        {
+            Write(_info, message, isError: false);
+        }
+
+        internal static void Warning(string message)
+        {
+            Write(_warning, message, isError: false);
+        }
+
+        internal static void Error(string message)
+        {
+            Write(_error, message, isError: true);
+        }
+
+        internal static void Exception(string context, Exception ex)
+        {
+            Write(_error, context + ": " + ex, isError: true);
+        }
+
+        /// <summary>
+        /// The most recent sink failure, kept observable because the logger
+        /// has nowhere left to report its own errors (and under the
+        /// unit-test runner the UnityEngine fallback is unavailable by
+        /// design). A logger must never take its caller down.
+        /// </summary>
+        internal static Exception LastLoggingFailure;
+
+        private static void Write(Action<string> sink, string message, bool isError)
+        {
+            try
+            {
+                if (sink != null)
+                {
+                    sink(message);
+                    return;
+                }
+
+                if (isError)
+                {
+                    UnityEngine.Debug.LogError("[FUSE.Profiler] " + message);
+                }
+                else
+                {
+                    UnityEngine.Debug.Log("[FUSE.Profiler] " + message);
+                }
+            }
+            catch (Exception ex)
+            {
+                LastLoggingFailure = ex;
+            }
+        }
+    }
+}

--- a/FUSE.Profiler/Infrastructure/ProfilerSettings.cs
+++ b/FUSE.Profiler/Infrastructure/ProfilerSettings.cs
@@ -1,0 +1,20 @@
+using UnityModManagerNet;
+
+namespace FUSE.Profiler.Infrastructure
+{
+    /// <summary>
+    /// UMM-persisted settings (XML in the mod folder via ModSettings).
+    /// Public mutable fields by XmlSerializer requirement.
+    /// </summary>
+    public sealed class ProfilerSettings : UnityModManager.ModSettings
+    {
+        public int UpdatesPerSecond = 2;
+        public float CleanupDelaySeconds = 30f;
+        public string ToggleKeyName = "F11";
+
+        public override void Save(UnityModManager.ModEntry modEntry)
+        {
+            Save(this, modEntry);
+        }
+    }
+}

--- a/FUSE.Profiler/Instrumentation/EntryCatalog.cs
+++ b/FUSE.Profiler/Instrumentation/EntryCatalog.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Profiler.Engine;
+using FUSE.Profiler.Entries;
+using FUSE.Profiler.Infrastructure;
+
+namespace FUSE.Profiler.Instrumentation
+{
+    /// <summary>
+    /// The registry of selectable profiling entries, grouped by category tab.
+    /// Multiple entries may be active at once (activating one does not
+    /// deactivate the others); instrumentation is applied lazily on first
+    /// activation and torn down globally by the cleanup pass.
+    /// </summary>
+    internal static class EntryCatalog
+    {
+        private static readonly object Gate = new object();
+        private static readonly List<ProfilerEntry> Entries = new List<ProfilerEntry>();
+        private static bool _builtInsRegistered;
+
+        internal static IReadOnlyList<ProfilerEntry> All
+        {
+            get
+            {
+                lock (Gate)
+                {
+                    return Entries.ToArray();
+                }
+            }
+        }
+
+        internal static void EnsureBuiltInsRegistered()
+        {
+            lock (Gate)
+            {
+                if (_builtInsRegistered)
+                {
+                    return;
+                }
+
+                foreach (var entry in RailroaderEntries.CreateBuiltIns())
+                {
+                    Entries.Add(entry);
+                }
+
+                _builtInsRegistered = true;
+            }
+
+            ProfilerLog.Info($"FUSE.Profiler registered {Entries.Count} built-in profiling entr(y/ies).");
+        }
+
+        internal static ProfilerEntry FindById(string id)
+        {
+            lock (Gate)
+            {
+                for (var i = 0; i < Entries.Count; i++)
+                {
+                    if (string.Equals(Entries[i].Id, id, StringComparison.Ordinal))
+                    {
+                        return Entries[i];
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        internal static ProfilerEntry Register(ProfilerEntry entry)
+        {
+            lock (Gate)
+            {
+                for (var i = 0; i < Entries.Count; i++)
+                {
+                    if (string.Equals(Entries[i].Id, entry.Id, StringComparison.Ordinal))
+                    {
+                        return Entries[i];
+                    }
+                }
+
+                Entries.Add(entry);
+            }
+
+            return entry;
+        }
+
+        internal static List<ProfilerEntry> ForCategory(ProfilerCategory category)
+        {
+            var result = new List<ProfilerEntry>();
+            lock (Gate)
+            {
+                for (var i = 0; i < Entries.Count; i++)
+                {
+                    if (Entries[i].Category == category)
+                    {
+                        result.Add(Entries[i]);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        internal static void SetActive(ProfilerEntry entry, bool active)
+        {
+            if (!active)
+            {
+                entry.Active = false;
+                return;
+            }
+
+            // Activate immediately so probes record as soon as the patches
+            // land; instrumentation itself completes on a worker.
+            entry.Active = true;
+            MethodInstrumenter.EnsureInstrumented(entry);
+        }
+
+        /// <summary>
+        /// Deactivate everything and forget patch state. Called by cleanup
+        /// after <see cref="MethodInstrumenter.RemoveAll"/> so entries can be
+        /// re-instrumented next time the profiler opens. Dynamic (non-built-in)
+        /// entries created by the search panel are removed entirely.
+        /// </summary>
+        internal static void ResetAfterCleanup()
+        {
+            lock (Gate)
+            {
+                for (var i = Entries.Count - 1; i >= 0; i--)
+                {
+                    var entry = Entries[i];
+                    entry.Active = false;
+                    entry.Patched = false;
+                    entry.InstrumentedCount = 0;
+                    lock (entry.FailedTargets)
+                    {
+                        entry.FailedTargets.Clear();
+                    }
+
+                    if (entry.Category == ProfilerCategory.Custom || entry.Category == ProfilerCategory.Mods)
+                    {
+                        Entries.RemoveAt(i);
+                    }
+                }
+
+                _builtInsRegistered = Entries.Count > 0;
+            }
+        }
+    }
+}

--- a/FUSE.Profiler/Instrumentation/MethodInstrumenter.cs
+++ b/FUSE.Profiler/Instrumentation/MethodInstrumenter.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FUSE.Profiler.Engine;
+using FUSE.Profiler.Infrastructure;
+using HarmonyLib;
+
+namespace FUSE.Profiler.Instrumentation
+{
+    /// <summary>
+    /// Applies and removes the measurement wrappers.
+    ///
+    /// Threading model: workers do the slow parts (spec resolution, type and
+    /// assembly scans) and enqueue per-method patch actions; the actual
+    /// Harmony.Patch calls run ONLY on the main thread, drained from
+    /// <see cref="DrainPatchQueue"/> under a per-frame time budget. That
+    /// keeps IL recompilation off worker threads while the main thread may
+    /// be executing the very method being patched, and it makes teardown
+    /// race-free by construction: <see cref="RemoveAll"/> (main thread)
+    /// bumps the generation, empties the queue, and unpatches — a stale
+    /// worker can only enqueue actions that no-op their generation check.
+    ///
+    /// A method is Harmony-patched at most once; multiple entries share the
+    /// wrapper through a per-method binding list (a method can legitimately
+    /// belong to a built-in entry, a custom sweep, and the foreign-patch
+    /// rollup at the same time).
+    /// </summary>
+    internal static class MethodInstrumenter
+    {
+        internal const string HarmonyId = "FUSE.Profiler.instrumentation";
+
+        private static readonly Harmony Harmony = new Harmony(HarmonyId);
+
+        private sealed class BindingPair
+        {
+            internal ProbeRing Ring;
+            internal ProfilerEntry Entry;
+        }
+
+        private static readonly ConcurrentDictionary<MethodBase, BindingPair[]> Bindings =
+            new ConcurrentDictionary<MethodBase, BindingPair[]>();
+
+        private static readonly ConcurrentQueue<Action> PatchQueue = new ConcurrentQueue<Action>();
+
+        private static readonly HarmonyMethod WrapperPrefix =
+            new HarmonyMethod(typeof(MethodInstrumenter), nameof(ProbePrefix)) { priority = Priority.First };
+
+        private static readonly HarmonyMethod WrapperPostfix =
+            new HarmonyMethod(typeof(MethodInstrumenter), nameof(ProbePostfix)) { priority = Priority.Last };
+
+        private static int _generation;
+
+        /// <summary>
+        /// The managed id of the Unity main thread; set by the host at load.
+        /// Wrappers ignore calls on other threads (rings are main-thread
+        /// only), and the patch queue asserts it drains here.
+        /// </summary>
+        internal static int MainThreadId = -1;
+
+        internal static int Generation => Volatile.Read(ref _generation);
+
+        internal static int InstrumentedMethodCount => Bindings.Count;
+
+        internal static int PendingPatchCount => PatchQueue.Count;
+
+        /// <summary>
+        /// Resolve an entry's target specs on a worker, then enqueue the
+        /// per-method patching for the main thread. Safe to call repeatedly.
+        /// </summary>
+        internal static void EnsureInstrumented(ProfilerEntry entry)
+        {
+            if (entry.Patched || entry.PatchInFlight)
+            {
+                return;
+            }
+
+            entry.PatchInFlight = true;
+            var generation = Generation;
+            Task.Run(() =>
+            {
+                try
+                {
+                    var resolved = new List<(MethodBase Method, string Label)>();
+                    foreach (var spec in entry.TargetProvider())
+                    {
+                        var method = MethodResolver.Resolve(spec, out var error);
+                        if (method == null)
+                        {
+                            lock (entry.FailedTargets)
+                            {
+                                entry.FailedTargets.Add(error);
+                            }
+
+                            continue;
+                        }
+
+                        resolved.Add((method, spec.Label ?? DescribeMethod(method)));
+                    }
+
+                    foreach (var target in resolved)
+                    {
+                        EnqueueInstrumentation(
+                            entry,
+                            target.Method,
+                            entry.Id + "|" + MethodKey(target.Method),
+                            target.Label,
+                            groupKey: null,
+                            generation);
+                    }
+
+                    EnqueueCompletion(entry, generation);
+                }
+                catch (Exception ex)
+                {
+                    ProfilerLog.Exception($"FUSE.Profiler failed resolving entry '{entry.Id}'", ex);
+                    entry.PatchInFlight = false;
+                }
+            });
+        }
+
+        /// <summary>
+        /// Queue one already-resolved method for instrumentation under an
+        /// entry. Runs (and generation-checks) on the main thread.
+        /// </summary>
+        internal static void EnqueueInstrumentation(
+            ProfilerEntry entry,
+            MethodBase method,
+            string probeKey,
+            string probeLabel,
+            string groupKey,
+            int generation)
+        {
+            PatchQueue.Enqueue(() =>
+            {
+                if (Generation != generation)
+                {
+                    return;
+                }
+
+                PatchOne(entry, method, probeKey, probeLabel, groupKey);
+            });
+        }
+
+        /// <summary>
+        /// Queue the "entry finished instrumenting" marker behind its patch
+        /// actions, so UI state flips only after the last one ran.
+        /// </summary>
+        internal static void EnqueueCompletion(ProfilerEntry entry, int generation)
+        {
+            PatchQueue.Enqueue(() =>
+            {
+                entry.PatchInFlight = false;
+                if (Generation != generation)
+                {
+                    return;
+                }
+
+                entry.Patched = true;
+                int failed;
+                lock (entry.FailedTargets)
+                {
+                    failed = entry.FailedTargets.Count;
+                }
+
+                ProfilerLog.Info(
+                    $"FUSE.Profiler instrumented entry '{entry.Id}': {entry.InstrumentedCount} method(s)" +
+                    (failed > 0 ? $", {failed} target(s) failed" : "") + ".");
+            });
+        }
+
+        /// <summary>
+        /// Main-thread pump: apply queued patch actions until the budget is
+        /// spent. Called by the host every frame; a large assembly sweep
+        /// spreads over multiple frames instead of freezing one.
+        /// </summary>
+        internal static void DrainPatchQueue(double budgetMilliseconds)
+        {
+            if (PatchQueue.IsEmpty)
+            {
+                return;
+            }
+
+            var watch = Stopwatch.StartNew();
+            while (watch.Elapsed.TotalMilliseconds < budgetMilliseconds && PatchQueue.TryDequeue(out var action))
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    ProfilerLog.Exception("FUSE.Profiler patch action failed", ex);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Main-thread teardown: invalidate every queued and in-flight
+        /// worker's generation, drop pending actions, remove every wrapper,
+        /// and clear the binding table.
+        /// </summary>
+        internal static void RemoveAll()
+        {
+            Interlocked.Increment(ref _generation);
+            while (PatchQueue.TryDequeue(out _))
+            {
+            }
+
+            try
+            {
+                Harmony.UnpatchAll(HarmonyId);
+            }
+            catch (Exception ex)
+            {
+                ProfilerLog.Exception("FUSE.Profiler unpatch-all failed", ex);
+            }
+
+            Bindings.Clear();
+        }
+
+        /// <summary>Readable "Type:Name(ParamType, …)" form for labels/keys.</summary>
+        internal static string DescribeMethod(MethodBase method)
+        {
+            var type = method.DeclaringType;
+            var sb = new StringBuilder();
+            sb.Append(type != null ? type.FullName : "<global>").Append(':').Append(method.Name);
+            var parameters = method.GetParameters();
+            sb.Append('(');
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(", ");
+                }
+
+                sb.Append(parameters[i].ParameterType.Name);
+            }
+
+            sb.Append(')');
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Probe-key form of a method identity. Signature-qualified so
+        /// overloads get distinct rings (a shared ring across overloads
+        /// nests Enter/Exit and mixes their numbers).
+        /// </summary>
+        internal static string MethodKey(MethodBase method)
+        {
+            return DescribeMethod(method);
+        }
+
+        private static void PatchOne(ProfilerEntry entry, MethodBase method, string probeKey, string probeLabel, string groupKey)
+        {
+            var existing = Bindings.TryGetValue(method, out var pairs) ? pairs : null;
+            if (existing != null)
+            {
+                for (var i = 0; i < existing.Length; i++)
+                {
+                    if (ReferenceEquals(existing[i].Entry, entry))
+                    {
+                        return;
+                    }
+                }
+            }
+
+            var ring = ProbeRegistry.GetOrAdd(probeKey, probeLabel, entry.Cadence, groupKey);
+            var pair = new BindingPair { Ring = ring, Entry = entry };
+
+            if (existing == null)
+            {
+                // First entry on this method: bind, then patch. Queue and
+                // teardown both run on the main thread, so no patch can land
+                // after RemoveAll within the same generation.
+                Bindings[method] = new[] { pair };
+                try
+                {
+                    Harmony.Patch(method, prefix: WrapperPrefix, postfix: WrapperPostfix);
+                }
+                catch (Exception ex)
+                {
+                    Bindings.TryRemove(method, out _);
+                    lock (entry.FailedTargets)
+                    {
+                        entry.FailedTargets.Add(DescribeMethod(method) + " — " + ex.Message);
+                    }
+
+                    return;
+                }
+            }
+            else
+            {
+                var grown = new BindingPair[existing.Length + 1];
+                Array.Copy(existing, grown, existing.Length);
+                grown[existing.Length] = pair;
+                Bindings[method] = grown;
+            }
+
+            entry.InstrumentedCount++;
+        }
+
+        private static void ProbePrefix(MethodBase __originalMethod)
+        {
+            if (!ProfilerSession.Recording ||
+                Environment.CurrentManagedThreadId != MainThreadId)
+            {
+                return;
+            }
+
+            if (Bindings.TryGetValue(__originalMethod, out var pairs))
+            {
+                for (var i = 0; i < pairs.Length; i++)
+                {
+                    if (pairs[i].Entry.Active)
+                    {
+                        pairs[i].Ring.Enter();
+                    }
+                }
+            }
+        }
+
+        private static void ProbePostfix(MethodBase __originalMethod)
+        {
+            if (Environment.CurrentManagedThreadId != MainThreadId)
+            {
+                return;
+            }
+
+            // No Recording/Active gate on exit: the depth counter makes a
+            // spurious Exit a no-op, while skipping a real one (because a
+            // flag flipped mid-call) would wedge the interval until the next
+            // cycle close.
+            if (Bindings.TryGetValue(__originalMethod, out var pairs))
+            {
+                for (var i = 0; i < pairs.Length; i++)
+                {
+                    pairs[i].Ring.Exit();
+                }
+            }
+        }
+    }
+}

--- a/FUSE.Profiler/Instrumentation/MethodResolver.cs
+++ b/FUSE.Profiler/Instrumentation/MethodResolver.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+
+namespace FUSE.Profiler.Instrumentation
+{
+    /// <summary>
+    /// Turns target specs and search-panel input into patchable MethodBase
+    /// instances, and decides which methods are safe to instrument at all.
+    /// </summary>
+    internal static class MethodResolver
+    {
+        private static readonly Assembly OwnAssembly = typeof(MethodResolver).Assembly;
+
+        /// <summary>
+        /// Resolve a spec of the form "Namespace.Type:Method". For coroutine
+        /// specs the declared method is only the iterator factory; the
+        /// measurable body is the compiler-generated MoveNext.
+        /// </summary>
+        internal static MethodBase Resolve(TargetSpec spec, out string error)
+        {
+            error = null;
+            MethodInfo declared;
+            try
+            {
+                declared = AccessTools.Method(spec.MethodSpec);
+            }
+            catch (Exception ex)
+            {
+                error = spec.MethodSpec + ": " + ex.Message;
+                return null;
+            }
+
+            if (declared == null)
+            {
+                error = spec.MethodSpec + ": method not found";
+                return null;
+            }
+
+            if (!spec.Coroutine)
+            {
+                return Profilable(declared, spec.MethodSpec, ref error);
+            }
+
+            MethodInfo moveNext;
+            try
+            {
+                moveNext = AccessTools.EnumeratorMoveNext(declared);
+            }
+            catch (Exception ex)
+            {
+                error = spec.MethodSpec + " (coroutine): " + ex.Message;
+                return null;
+            }
+
+            if (moveNext == null)
+            {
+                error = spec.MethodSpec + ": no iterator MoveNext found (not a coroutine?)";
+                return null;
+            }
+
+            return Profilable(moveNext, spec.MethodSpec + " (coroutine)", ref error);
+        }
+
+        /// <summary>
+        /// Every instrumentable method a type declares (used by type- and
+        /// assembly-wide profiling).
+        /// </summary>
+        internal static IEnumerable<MethodInfo> ProfilableDeclaredMethods(Type type)
+        {
+            MethodInfo[] declared;
+            try
+            {
+                declared = type.GetMethods(
+                    BindingFlags.Instance | BindingFlags.Static |
+                    BindingFlags.Public | BindingFlags.NonPublic |
+                    BindingFlags.DeclaredOnly);
+            }
+            catch
+            {
+                yield break;
+            }
+
+            for (var i = 0; i < declared.Length; i++)
+            {
+                if (IsProfilable(declared[i]))
+                {
+                    yield return declared[i];
+                }
+            }
+        }
+
+        /// <summary>
+        /// Conservative safety filter: only concrete methods with real IL
+        /// bodies, closed over all type parameters, and outside the profiler
+        /// itself (self-instrumentation would recurse through the wrappers).
+        /// </summary>
+        internal static bool IsProfilable(MethodBase method)
+        {
+            if (method == null || method.IsAbstract)
+            {
+                return false;
+            }
+
+            if (method.ContainsGenericParameters)
+            {
+                return false;
+            }
+
+            var declaringType = method.DeclaringType;
+            if (declaringType == null || declaringType.ContainsGenericParameters)
+            {
+                return false;
+            }
+
+            if (declaringType.Assembly == OwnAssembly)
+            {
+                return false;
+            }
+
+            // Delegate plumbing and MarshalByRef proxies patch badly.
+            if (typeof(Delegate).IsAssignableFrom(declaringType))
+            {
+                return false;
+            }
+
+            try
+            {
+                if (method.GetMethodBody() == null)
+                {
+                    return false;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Assemblies that make sense as profiling targets. Excludes the
+        /// runtime/engine/patching infrastructure whose methods are either
+        /// uninstrumentable or would measure the measurement. Matching is
+        /// exact-name or dot-terminated prefix so legitimately named mods
+        /// (e.g. "Monorail", "SystemsOverhaul") are not caught by bare
+        /// prefixes.
+        /// </summary>
+        internal static bool IsProfilableAssemblyName(string simpleName)
+        {
+            if (string.IsNullOrEmpty(simpleName))
+            {
+                return false;
+            }
+
+            if (simpleName == OwnAssembly.GetName().Name)
+            {
+                return false;
+            }
+
+            return !MatchesInfrastructure(simpleName, "System") &&
+                   !MatchesInfrastructure(simpleName, "mscorlib") &&
+                   !MatchesInfrastructure(simpleName, "netstandard") &&
+                   !MatchesInfrastructure(simpleName, "Unity") &&
+                   !MatchesInfrastructure(simpleName, "UnityEngine") &&
+                   !MatchesInfrastructure(simpleName, "Mono") &&
+                   !MatchesInfrastructure(simpleName, "MonoMod") &&
+                   !MatchesInfrastructure(simpleName, "0Harmony") &&
+                   !MatchesInfrastructure(simpleName, "dnlib");
+        }
+
+        private static bool MatchesInfrastructure(string simpleName, string blocked)
+        {
+            return string.Equals(simpleName, blocked, StringComparison.Ordinal) ||
+                   (simpleName.Length > blocked.Length &&
+                    simpleName[blocked.Length] == '.' &&
+                    simpleName.StartsWith(blocked, StringComparison.Ordinal));
+        }
+
+        private static MethodBase Profilable(MethodInfo method, string describedAs, ref string error)
+        {
+            if (!IsProfilable(method))
+            {
+                error = describedAs + ": not instrumentable (abstract/generic/no body)";
+                return null;
+            }
+
+            return method;
+        }
+    }
+}

--- a/FUSE.Profiler/Instrumentation/ModAttribution.cs
+++ b/FUSE.Profiler/Instrumentation/ModAttribution.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using FUSE.Profiler.Infrastructure;
+using HarmonyLib;
+using UnityModManagerNet;
+
+namespace FUSE.Profiler.Instrumentation
+{
+    /// <summary>
+    /// Maps code back to the mod that shipped it, and enumerates other mods'
+    /// Harmony patches so their cost can be measured and rolled up per mod —
+    /// the attribution answer "which mod is the stutter" is this file's job.
+    /// </summary>
+    internal static class ModAttribution
+    {
+        /// <summary>Harmony ids owned by the profiler itself — never measured.</summary>
+        private static readonly HashSet<string> OwnHarmonyIds = new HashSet<string>(StringComparer.Ordinal)
+        {
+            MethodInstrumenter.HarmonyId,
+            "FUSE.Profiler.static",
+        };
+
+        private static Dictionary<Assembly, string> _assemblyToMod;
+
+        internal readonly struct ForeignPatch
+        {
+            internal ForeignPatch(MethodBase patchMethod, MethodBase targetMethod, string kind, string ownerId, string modName)
+            {
+                PatchMethod = patchMethod;
+                TargetMethod = targetMethod;
+                Kind = kind;
+                OwnerId = ownerId;
+                ModName = modName;
+            }
+
+            internal MethodBase PatchMethod { get; }
+            internal MethodBase TargetMethod { get; }
+            internal string Kind { get; }
+            internal string OwnerId { get; }
+            internal string ModName { get; }
+        }
+
+        /// <summary>
+        /// Best-effort mod name for an assembly: the UnityModManager entry
+        /// that loaded it, falling back to the assembly's simple name.
+        /// </summary>
+        internal static string ModNameFor(Assembly assembly)
+        {
+            if (assembly == null)
+            {
+                return "<unknown>";
+            }
+
+            var map = _assemblyToMod;
+            if (map == null)
+            {
+                map = BuildAssemblyMap();
+                _assemblyToMod = map;
+            }
+
+            return map.TryGetValue(assembly, out var name) ? name : assembly.GetName().Name;
+        }
+
+        /// <summary>Drop the cached map (mods can toggle mid-session).</summary>
+        internal static void InvalidateMap()
+        {
+            _assemblyToMod = null;
+        }
+
+        /// <summary>
+        /// Every prefix/postfix/finalizer currently installed by someone other
+        /// than the profiler. Transpilers are excluded: a transpiler has no
+        /// runtime body of its own to time (measuring transpiler-inserted IL
+        /// is a later feature).
+        /// </summary>
+        internal static List<ForeignPatch> EnumerateForeignPatches()
+        {
+            var result = new List<ForeignPatch>();
+            IEnumerable<MethodBase> patchedMethods;
+            try
+            {
+                patchedMethods = Harmony.GetAllPatchedMethods();
+            }
+            catch (Exception ex)
+            {
+                ProfilerLog.Exception("FUSE.Profiler could not enumerate patched methods", ex);
+                return result;
+            }
+
+            foreach (var target in patchedMethods)
+            {
+                Patches info;
+                try
+                {
+                    info = Harmony.GetPatchInfo(target);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (info == null)
+                {
+                    continue;
+                }
+
+                Collect(result, target, info.Prefixes, "prefix");
+                Collect(result, target, info.Postfixes, "postfix");
+                Collect(result, target, info.Finalizers, "finalizer");
+            }
+
+            return result;
+        }
+
+        private static void Collect(List<ForeignPatch> into, MethodBase target, IReadOnlyCollection<Patch> patches, string kind)
+        {
+            if (patches == null)
+            {
+                return;
+            }
+
+            foreach (var patch in patches)
+            {
+                if (patch == null || OwnHarmonyIds.Contains(patch.owner))
+                {
+                    continue;
+                }
+
+                var patchMethod = patch.PatchMethod;
+                if (patchMethod == null || !MethodResolver.IsProfilable(patchMethod))
+                {
+                    continue;
+                }
+
+                var modName = ModNameFor(patchMethod.DeclaringType?.Assembly);
+                into.Add(new ForeignPatch(patchMethod, target, kind, patch.owner, modName));
+            }
+        }
+
+        private static Dictionary<Assembly, string> BuildAssemblyMap()
+        {
+            var map = new Dictionary<Assembly, string>();
+            try
+            {
+                var entries = UnityModManager.modEntries;
+                if (entries != null)
+                {
+                    for (var i = 0; i < entries.Count; i++)
+                    {
+                        var entry = entries[i];
+                        if (entry?.Assembly == null)
+                        {
+                            continue;
+                        }
+
+                        var name = entry.Info?.DisplayName;
+                        if (string.IsNullOrEmpty(name))
+                        {
+                            name = entry.Info?.Id ?? entry.Assembly.GetName().Name;
+                        }
+
+                        map[entry.Assembly] = name;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                ProfilerLog.Exception("FUSE.Profiler could not build the assembly→mod map", ex);
+            }
+
+            return map;
+        }
+    }
+}

--- a/FUSE.Profiler/Instrumentation/ProfilerEntry.cs
+++ b/FUSE.Profiler/Instrumentation/ProfilerEntry.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Profiler.Engine;
+
+namespace FUSE.Profiler.Instrumentation
+{
+    /// <summary>The tab a profiler entry belongs to.</summary>
+    internal enum ProfilerCategory
+    {
+        Physics,
+        Culling,
+        Scenery,
+        Track,
+        Operations,
+        UiEvents,
+        KeyValue,
+        Mods,
+        Custom,
+    }
+
+    /// <summary>
+    /// How one target method is specified before resolution. Specs use the
+    /// Harmony string form "Namespace.Type:Method"; coroutine targets resolve
+    /// to the compiler-generated iterator MoveNext so the measured time is
+    /// where the coroutine body actually runs.
+    /// </summary>
+    internal readonly struct TargetSpec
+    {
+        internal TargetSpec(string methodSpec, bool coroutine = false, string label = null)
+        {
+            MethodSpec = methodSpec;
+            Coroutine = coroutine;
+            Label = label;
+        }
+
+        internal string MethodSpec { get; }
+        internal bool Coroutine { get; }
+        internal string Label { get; }
+    }
+
+    /// <summary>
+    /// A selectable profiling unit: a named set of target methods that gets
+    /// instrumented on first activation and gated by <see cref="Active"/>
+    /// afterwards. Entries are plain instances — activation state is checked
+    /// through the per-method binding at call time, so no generated types or
+    /// static fields are needed.
+    /// </summary>
+    internal sealed class ProfilerEntry
+    {
+        internal ProfilerEntry(string id, string label, ProfilerCategory category, Func<IEnumerable<TargetSpec>> targetProvider, string tooltip = null)
+        {
+            Id = id;
+            Label = label;
+            Category = category;
+            TargetProvider = targetProvider;
+            Tooltip = tooltip;
+        }
+
+        internal string Id { get; }
+        internal string Label { get; }
+        internal string Tooltip { get; }
+        internal ProfilerCategory Category { get; }
+        internal Func<IEnumerable<TargetSpec>> TargetProvider { get; }
+
+        internal ProbeCadence Cadence =>
+            Category == ProfilerCategory.Physics ? ProbeCadence.SimTick : ProbeCadence.Frame;
+
+        /// <summary>
+        /// Whether this entry's probes record. Volatile-adjacent: written by
+        /// the UI thread, read inside instrumented calls — a stale read for a
+        /// frame is harmless.
+        /// </summary>
+        internal bool Active;
+
+        /// <summary>Set once instrumentation has been applied (or attempted).</summary>
+        internal bool Patched;
+
+        /// <summary>True while a background patching task runs for this entry.</summary>
+        internal bool PatchInFlight;
+
+        internal int InstrumentedCount;
+
+        /// <summary>Targets that failed to resolve or patch, for the UI.</summary>
+        internal readonly List<string> FailedTargets = new List<string>();
+    }
+}

--- a/FUSE.Profiler/Instrumentation/ProfilerRuntime.cs
+++ b/FUSE.Profiler/Instrumentation/ProfilerRuntime.cs
@@ -1,0 +1,174 @@
+using System;
+using FUSE.Profiler.Engine;
+using FUSE.Profiler.Infrastructure;
+using HarmonyLib;
+
+namespace FUSE.Profiler.Instrumentation
+{
+    /// <summary>
+    /// Open/close/cleanup orchestration. Opening the window arms sampling and
+    /// the sim-tick clock; closing stops sampling immediately and schedules a
+    /// full teardown (unpatch everything, drop buffers) after a grace delay
+    /// so quick reopen doesn't pay the patch cost again. A closed, cleaned-up
+    /// profiler leaves zero patches installed.
+    /// </summary>
+    internal static class ProfilerRuntime
+    {
+        private static float _cleanupCountdown = -1f;
+
+        internal static bool WindowVisible { get; private set; }
+
+        internal static float CleanupDelaySeconds = 30f;
+
+        internal static void ToggleWindow()
+        {
+            if (WindowVisible)
+            {
+                CloseWindow();
+            }
+            else
+            {
+                OpenWindow();
+            }
+        }
+
+        internal static void OpenWindow()
+        {
+            _cleanupCountdown = -1f;
+            EntryCatalog.EnsureBuiltInsRegistered();
+            SimTickDriver.Install();
+            ProfilerSession.Sampling = true;
+            WindowVisible = true;
+            ProfilerLog.Info("FUSE.Profiler window opened; sampling armed.");
+        }
+
+        internal static void CloseWindow()
+        {
+            WindowVisible = false;
+            ProfilerSession.Sampling = false;
+            if (CleanupDelaySeconds <= 0f)
+            {
+                // Zero delay means "immediately", not "never" — the countdown
+                // tick treats non-positive as idle.
+                CleanupNow();
+                return;
+            }
+
+            _cleanupCountdown = CleanupDelaySeconds;
+            ProfilerLog.Info(
+                $"FUSE.Profiler window closed; instrumentation teardown in {CleanupDelaySeconds:F0}s unless reopened.");
+        }
+
+        /// <summary>Host Update drives the delayed-teardown countdown.</summary>
+        internal static void TickCleanup(float deltaSeconds)
+        {
+            if (_cleanupCountdown <= 0f)
+            {
+                return;
+            }
+
+            _cleanupCountdown -= deltaSeconds;
+            if (_cleanupCountdown <= 0f)
+            {
+                _cleanupCountdown = -1f;
+                CleanupNow();
+            }
+        }
+
+        /// <summary>Immediate full teardown (also used on mod disable).</summary>
+        internal static void CleanupNow()
+        {
+            WindowVisible = false;
+            ProfilerSession.Sampling = false;
+            MethodInstrumenter.RemoveAll();
+            SimTickDriver.Remove();
+            ProbeRegistry.Clear();
+            EntryCatalog.ResetAfterCleanup();
+            ModAttribution.InvalidateMap();
+            ProfilerSession.Reset();
+            ProfilerLog.Info("FUSE.Profiler instrumentation removed and buffers cleared.");
+        }
+    }
+
+    /// <summary>
+    /// The sim-tick clock source: a prefix/postfix pair on the train
+    /// controller's fixed step, installed only while the profiler is in use.
+    /// The pair also measures the whole step into its own probe, and the
+    /// postfix closes the sim-tick cycle AFTER recording that measurement —
+    /// so boundary-vs-measurement ordering on the same method is
+    /// deterministic by construction instead of by patch-priority ties.
+    /// </summary>
+    internal static class SimTickDriver
+    {
+        internal const string HarmonyId = "FUSE.Profiler.static";
+        internal const string StepProbeKey = "physics.step";
+
+        private static readonly Harmony Harmony = new Harmony(HarmonyId);
+        private static bool _installed;
+        private static ProbeRing _stepProbe;
+
+        internal static void Install()
+        {
+            if (_installed)
+            {
+                return;
+            }
+
+            try
+            {
+                var fixedUpdate = AccessTools.Method(typeof(TrainController), "FixedUpdate");
+                if (fixedUpdate == null)
+                {
+                    ProfilerLog.Warning(
+                        "FUSE.Profiler could not find TrainController.FixedUpdate; sim-tick probes will not sample.");
+                    return;
+                }
+
+                _stepProbe = ProbeRegistry.GetOrAdd(StepProbeKey, "Whole physics step", ProbeCadence.SimTick);
+                Harmony.Patch(
+                    fixedUpdate,
+                    prefix: new HarmonyMethod(typeof(SimTickDriver), nameof(StepPrefix)) { priority = Priority.First },
+                    postfix: new HarmonyMethod(typeof(SimTickDriver), nameof(StepPostfix)) { priority = Priority.Last });
+                _installed = true;
+            }
+            catch (Exception ex)
+            {
+                ProfilerLog.Exception("FUSE.Profiler failed installing the sim-tick clock", ex);
+            }
+        }
+
+        internal static void Remove()
+        {
+            if (!_installed)
+            {
+                return;
+            }
+
+            try
+            {
+                Harmony.UnpatchAll(HarmonyId);
+            }
+            catch (Exception ex)
+            {
+                ProfilerLog.Exception("FUSE.Profiler failed removing the sim-tick clock", ex);
+            }
+
+            _installed = false;
+            _stepProbe = null;
+        }
+
+        private static void StepPrefix()
+        {
+            if (ProfilerSession.Recording)
+            {
+                _stepProbe?.Enter();
+            }
+        }
+
+        private static void StepPostfix()
+        {
+            _stepProbe?.Exit();
+            ProfilerSession.SimTickBoundary();
+        }
+    }
+}

--- a/FUSE.Profiler/Interface/ImguiKit.cs
+++ b/FUSE.Profiler/Interface/ImguiKit.cs
@@ -1,0 +1,166 @@
+using UnityEngine;
+
+namespace FUSE.Profiler.Interface
+{
+    /// <summary>
+    /// Small IMGUI helpers: cached solid textures, styles, and a GL-based
+    /// polyline for the graph panel. Everything is lazily created inside
+    /// OnGUI (Unity requires GUI state to be touched only there).
+    /// </summary>
+    internal static class ImguiKit
+    {
+        private static Texture2D _solidDark;
+        private static Texture2D _solidPanel;
+        private static Texture2D _solidAccent;
+        private static Material _lineMaterial;
+        private static GUIStyle _header;
+        private static GUIStyle _cell;
+        private static GUIStyle _cellRight;
+        private static GUIStyle _rowButton;
+        private static bool _stylesReady;
+
+        internal static readonly Color GraphColor = new Color(0.35f, 0.85f, 1f, 1f);
+        internal static readonly Color GraphMaxColor = new Color(1f, 0.55f, 0.25f, 0.9f);
+
+        internal static GUIStyle Header { get { EnsureStyles(); return _header; } }
+        internal static GUIStyle Cell { get { EnsureStyles(); return _cell; } }
+        internal static GUIStyle CellRight { get { EnsureStyles(); return _cellRight; } }
+        internal static GUIStyle RowButton { get { EnsureStyles(); return _rowButton; } }
+
+        internal static Texture2D SolidDark => _solidDark != null ? _solidDark : (_solidDark = MakeSolid(new Color(0.08f, 0.08f, 0.1f, 0.96f)));
+        internal static Texture2D SolidPanel => _solidPanel != null ? _solidPanel : (_solidPanel = MakeSolid(new Color(0.16f, 0.16f, 0.2f, 1f)));
+        internal static Texture2D SolidAccent => _solidAccent != null ? _solidAccent : (_solidAccent = MakeSolid(new Color(0.25f, 0.45f, 0.65f, 1f)));
+
+        internal static void FillRect(Rect rect, Texture2D texture)
+        {
+            GUI.DrawTexture(rect, texture, ScaleMode.StretchToFill);
+        }
+
+        /// <summary>
+        /// Draw a polyline through <paramref name="values"/> inside
+        /// <paramref name="area"/> (GUI-space rect), scaled so
+        /// <paramref name="maxValue"/> touches the top. Repaint-only; GL in
+        /// screen space, so callers must not put it inside a scroll view.
+        /// </summary>
+        internal static void DrawPolyline(Rect area, double[] values, int count, double maxValue, Color color)
+        {
+            if (Event.current.type != EventType.Repaint || count < 2 || maxValue <= 0d)
+            {
+                return;
+            }
+
+            if (!EnsureLineMaterial())
+            {
+                return;
+            }
+
+            var topLeft = GUIUtility.GUIToScreenPoint(new Vector2(area.x, area.y));
+
+            _lineMaterial.SetPass(0);
+            GL.PushMatrix();
+            GL.LoadPixelMatrix(0f, Screen.width, Screen.height, 0f);
+            GL.Begin(GL.LINE_STRIP);
+            GL.Color(color);
+            var stepX = area.width / (count - 1);
+            for (var i = 0; i < count; i++)
+            {
+                var normalized = (float)(values[i] / maxValue);
+                if (normalized > 1f)
+                {
+                    normalized = 1f;
+                }
+
+                var x = topLeft.x + stepX * i;
+                var y = topLeft.y + area.height * (1f - normalized);
+                GL.Vertex3(x, y, 0f);
+            }
+
+            GL.End();
+            GL.PopMatrix();
+        }
+
+        internal static void DrawHorizontalRule(Rect area, float normalizedHeight, Color color)
+        {
+            if (Event.current.type != EventType.Repaint || !EnsureLineMaterial())
+            {
+                return;
+            }
+
+            var topLeft = GUIUtility.GUIToScreenPoint(new Vector2(area.x, area.y));
+            var y = topLeft.y + area.height * (1f - normalizedHeight);
+
+            _lineMaterial.SetPass(0);
+            GL.PushMatrix();
+            GL.LoadPixelMatrix(0f, Screen.width, Screen.height, 0f);
+            GL.Begin(GL.LINES);
+            GL.Color(color);
+            GL.Vertex3(topLeft.x, y, 0f);
+            GL.Vertex3(topLeft.x + area.width, y, 0f);
+            GL.End();
+            GL.PopMatrix();
+        }
+
+        private static bool EnsureLineMaterial()
+        {
+            if (_lineMaterial != null)
+            {
+                return true;
+            }
+
+            var shader = Shader.Find("Hidden/Internal-Colored");
+            if (shader == null)
+            {
+                return false;
+            }
+
+            _lineMaterial = new Material(shader)
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            _lineMaterial.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+            _lineMaterial.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+            _lineMaterial.SetInt("_Cull", (int)UnityEngine.Rendering.CullMode.Off);
+            _lineMaterial.SetInt("_ZWrite", 0);
+            return true;
+        }
+
+        private static void EnsureStyles()
+        {
+            if (_stylesReady)
+            {
+                return;
+            }
+
+            _header = new GUIStyle(GUI.skin.label)
+            {
+                fontStyle = FontStyle.Bold,
+            };
+            _cell = new GUIStyle(GUI.skin.label)
+            {
+                alignment = TextAnchor.MiddleLeft,
+                clipping = TextClipping.Clip,
+            };
+            _cellRight = new GUIStyle(GUI.skin.label)
+            {
+                alignment = TextAnchor.MiddleRight,
+            };
+            _rowButton = new GUIStyle(GUI.skin.label)
+            {
+                alignment = TextAnchor.MiddleLeft,
+                clipping = TextClipping.Clip,
+            };
+            _stylesReady = true;
+        }
+
+        private static Texture2D MakeSolid(Color color)
+        {
+            var texture = new Texture2D(1, 1, TextureFormat.RGBA32, mipChain: false)
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            texture.SetPixel(0, 0, color);
+            texture.Apply();
+            return texture;
+        }
+    }
+}

--- a/FUSE.Profiler/Interface/ProfilerConsole.cs
+++ b/FUSE.Profiler/Interface/ProfilerConsole.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Reflection;
+using FUSE.Profiler.Infrastructure;
+using FUSE.Profiler.Instrumentation;
+using GalaSoft.MvvmLight.Messaging;
+using Game.Events;
+using UI.Console;
+using UnityEngine;
+
+namespace FUSE.Profiler.Interface
+{
+    [ConsoleCommand("/profiler", "Toggle the FUSE Profiler window.")]
+    public sealed class ProfilerToggleCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            // The game console keeps registered commands for the map's
+            // lifetime and offers no unregister — so if the mod was disabled
+            // after registration, refuse instead of arming sampling with no
+            // host to drive clocks or cleanup.
+            if (!ProfilerHost.IsRunning)
+            {
+                return "FUSE Profiler is disabled (enable it in Unity Mod Manager).";
+            }
+
+            ProfilerRuntime.ToggleWindow();
+            return ProfilerRuntime.WindowVisible ? "Profiler opened." : "Profiler closed.";
+        }
+    }
+
+    /// <summary>
+    /// Registers the console command with the game's handler. The handler is
+    /// scene-bound (absent in the main menu and during early load), and its
+    /// Register method is a non-public generic — so registration is
+    /// reflection-driven and retried on every map load.
+    /// </summary>
+    internal sealed class ProfilerConsole
+    {
+        private static ProfilerConsole _instance;
+        private bool _registered;
+
+        internal static void Initialize()
+        {
+            if (_instance != null)
+            {
+                return;
+            }
+
+            _instance = new ProfilerConsole();
+            Messenger.Default.Register<MapDidLoadEvent>(_instance, _instance.OnMapDidLoad);
+            _instance.TryRegister();
+        }
+
+        internal static void Shutdown()
+        {
+            if (_instance == null)
+            {
+                return;
+            }
+
+            Messenger.Default.Unregister(_instance);
+            _instance = null;
+        }
+
+        private void OnMapDidLoad(MapDidLoadEvent message)
+        {
+            // A fresh map brings a fresh ConsoleCommandHandler instance.
+            _registered = false;
+            TryRegister();
+        }
+
+        private void TryRegister()
+        {
+            if (_registered)
+            {
+                return;
+            }
+
+            try
+            {
+                var handler = UnityEngine.Object.FindObjectOfType<ConsoleCommandHandler>();
+                if (handler == null)
+                {
+                    return;
+                }
+
+                var register = typeof(ConsoleCommandHandler).GetMethod(
+                    "Register",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                if (register == null)
+                {
+                    ProfilerLog.Warning("FUSE.Profiler could not find ConsoleCommandHandler.Register; /profiler unavailable.");
+                    return;
+                }
+
+                var command = new ProfilerToggleCommand();
+                register.MakeGenericMethod(command.GetType()).Invoke(handler, new object[] { command });
+                _registered = true;
+                ProfilerLog.Info("FUSE.Profiler registered the /profiler console command.");
+            }
+            catch (Exception ex)
+            {
+                ProfilerLog.Exception("FUSE.Profiler console registration failed", ex);
+            }
+        }
+    }
+}

--- a/FUSE.Profiler/Interface/ProfilerHost.cs
+++ b/FUSE.Profiler/Interface/ProfilerHost.cs
@@ -1,0 +1,158 @@
+using System;
+using FUSE.Profiler.Engine;
+using FUSE.Profiler.Infrastructure;
+using FUSE.Profiler.Instrumentation;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace FUSE.Profiler.Interface
+{
+    /// <summary>
+    /// The always-on scene host: a hidden DontDestroyOnLoad GameObject whose
+    /// MonoBehaviour drives the frame clock, the hotkey, the main-thread
+    /// patch pump, the cleanup countdown, and the window's OnGUI. Created
+    /// unconditionally at mod load so nothing the UI does can starve the
+    /// runtime. Also owns an invisible uGUI raycast blocker matched to the
+    /// window rect so profiler clicks don't fall through into the game
+    /// world.
+    /// </summary>
+    internal static class ProfilerHost
+    {
+        /// <summary>
+        /// Per-frame budget for applying queued Harmony patches. Large
+        /// sweeps intentionally trade a few choppy frames for progress.
+        /// </summary>
+        private const double PatchBudgetMsPerFrame = 25.0;
+
+        private static GameObject _host;
+
+        internal static KeyCode ToggleKey = KeyCode.F11;
+
+        internal static bool IsRunning => _host != null;
+
+        internal static void EnsureStarted()
+        {
+            if (_host != null)
+            {
+                return;
+            }
+
+            try
+            {
+                MethodInstrumenter.MainThreadId = Environment.CurrentManagedThreadId;
+                _host = new GameObject("FUSE.Profiler.Host");
+                UnityEngine.Object.DontDestroyOnLoad(_host);
+                _host.hideFlags = HideFlags.HideAndDontSave;
+                _host.AddComponent<ProfilerHostRunner>();
+                ProfilerLog.Info("FUSE.Profiler host initialized.");
+            }
+            catch (Exception ex)
+            {
+                ProfilerLog.Exception("FUSE.Profiler host creation failed", ex);
+            }
+        }
+
+        internal static void Shutdown()
+        {
+            if (_host == null)
+            {
+                return;
+            }
+
+            UnityEngine.Object.Destroy(_host);
+            _host = null;
+        }
+
+        private sealed class ProfilerHostRunner : MonoBehaviour
+        {
+            private Canvas _blockerCanvas;
+            private RectTransform _blockerRect;
+
+            private void Update()
+            {
+                if (ToggleKey != KeyCode.None && Input.GetKeyDown(ToggleKey))
+                {
+                    ProfilerRuntime.ToggleWindow();
+                }
+
+                MethodInstrumenter.DrainPatchQueue(PatchBudgetMsPerFrame);
+                ProfilerRuntime.TickCleanup(Time.unscaledDeltaTime);
+                UpdateClickBlocker();
+            }
+
+            // Frame cycles close in LateUpdate: all Update-phase and coroutine
+            // work of this frame is inside the closing bucket; render-side
+            // work lands in the next one. Consistent bucketing beats perfect
+            // frame alignment.
+            private void LateUpdate()
+            {
+                ProfilerSession.FrameBoundary(Time.unscaledDeltaTime);
+            }
+
+            private void OnGUI()
+            {
+                if (ProfilerRuntime.WindowVisible)
+                {
+                    ProfilerWindow.Draw();
+                }
+            }
+
+            private void OnDestroy()
+            {
+                if (_blockerCanvas != null)
+                {
+                    Destroy(_blockerCanvas.gameObject);
+                    _blockerCanvas = null;
+                    _blockerRect = null;
+                }
+            }
+
+            /// <summary>
+            /// Keep an invisible, raycast-blocking uGUI image congruent with
+            /// the IMGUI window. IMGUI draws above uGUI but does not
+            /// participate in EventSystem raycasts, so without this a click
+            /// on a profiler row also hits whatever game control or world
+            /// object sits underneath.
+            /// </summary>
+            private void UpdateClickBlocker()
+            {
+                var visible = ProfilerRuntime.WindowVisible;
+                if (_blockerCanvas == null)
+                {
+                    if (!visible)
+                    {
+                        return;
+                    }
+
+                    var canvasObject = new GameObject("FUSE.Profiler.ClickBlocker");
+                    canvasObject.transform.SetParent(_host != null ? _host.transform : null, worldPositionStays: false);
+                    _blockerCanvas = canvasObject.AddComponent<Canvas>();
+                    _blockerCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+                    _blockerCanvas.sortingOrder = short.MaxValue;
+                    canvasObject.AddComponent<GraphicRaycaster>();
+
+                    var imageObject = new GameObject("Blocker");
+                    imageObject.transform.SetParent(canvasObject.transform, worldPositionStays: false);
+                    var image = imageObject.AddComponent<Image>();
+                    image.color = new Color(0f, 0f, 0f, 0f);
+                    image.raycastTarget = true;
+                    _blockerRect = image.rectTransform;
+                    _blockerRect.anchorMin = new Vector2(0f, 1f);
+                    _blockerRect.anchorMax = new Vector2(0f, 1f);
+                    _blockerRect.pivot = new Vector2(0f, 1f);
+                }
+
+                _blockerCanvas.enabled = visible;
+                if (visible && _blockerRect != null)
+                {
+                    // IMGUI rects are top-left-origin screen points; the
+                    // anchored rect mirrors that with a top-left anchor and a
+                    // negative Y offset.
+                    var rect = ProfilerWindow.CurrentWindowRect;
+                    _blockerRect.anchoredPosition = new Vector2(rect.x, -rect.y);
+                    _blockerRect.sizeDelta = new Vector2(rect.width, rect.height);
+                }
+            }
+        }
+    }
+}

--- a/FUSE.Profiler/Interface/ProfilerWindow.cs
+++ b/FUSE.Profiler/Interface/ProfilerWindow.cs
@@ -1,0 +1,530 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Profiler.Engine;
+using FUSE.Profiler.Entries;
+using FUSE.Profiler.Instrumentation;
+using UnityEngine;
+using UnityModManagerNet;
+
+namespace FUSE.Profiler.Interface
+{
+    /// <summary>
+    /// The profiler window: category tabs on the left, the sorted results
+    /// table in the middle, a per-selection graph at the bottom, and the
+    /// search/custom tools on the Custom tab.
+    ///
+    /// IMGUI discipline: everything the layout depends on (rows, entry
+    /// states, mod lists) is snapshotted ONCE per frame on the Layout event
+    /// and rendered from that snapshot — background patching tasks mutate
+    /// entry state at arbitrary times, and a control-count change between
+    /// the Layout and Repaint halves of one frame throws GUILayout's
+    /// "Getting control N's position" ArgumentException.
+    /// </summary>
+    internal static class ProfilerWindow
+    {
+        private const int WindowId = 0x46555345; // 'FUSE'
+        private const float TabColumnWidth = 210f;
+        private const float GraphHeight = 150f;
+        private const float RowHeight = 22f;
+
+        private sealed class EntryView
+        {
+            internal ProfilerEntry Entry;
+            internal string Display;
+            internal bool Active;
+            internal string FailedNote;
+        }
+
+        private sealed class ModView
+        {
+            internal UnityModManager.ModEntry Mod;
+            internal string Display;
+        }
+
+        private static Rect _windowRect = new Rect(80f, 80f, 1040f, 680f);
+        private static bool _resizing;
+        private static ProfilerCategory _selectedCategory = ProfilerCategory.Culling;
+        private static Vector2 _rowScroll;
+        private static Vector2 _entryScroll;
+        private static string _selectedRowKey;
+        private static string _searchInput = "";
+        private static string _searchNotice = "";
+        private static readonly double[] GraphBuffer = new double[400];
+
+        // Per-frame snapshot (rebuilt on Layout, rendered on every event).
+        private static List<ProbeRow> _rows = new List<ProbeRow>();
+        private static List<ProbeRow> _visibleRows = new List<ProbeRow>();
+        private static List<EntryView> _entryViews = new List<EntryView>();
+        private static List<ModView> _modViews = new List<ModView>();
+        private static List<string> _modRollupLines = new List<string>();
+        private static float _rowsRefreshedAt = -10f;
+
+        internal static Rect CurrentWindowRect => _windowRect;
+
+        internal static void Draw()
+        {
+            if (Event.current.type == EventType.Layout)
+            {
+                RefreshFrameState();
+            }
+
+            _windowRect = GUI.Window(WindowId, _windowRect, DrawWindow, GUIContent.none);
+        }
+
+        private static void RefreshFrameState()
+        {
+            // Rows at most a few times a second; the cheap view models every
+            // frame (they must track toggles immediately).
+            if (Time.unscaledTime - _rowsRefreshedAt > 0.25f)
+            {
+                _rows = ProfilerSession.CopyRows();
+                _rowsRefreshedAt = Time.unscaledTime;
+            }
+
+            _visibleRows = FilterRowsForCategory(_selectedCategory);
+
+            _entryViews.Clear();
+            var entryCategory = _selectedCategory;
+            foreach (var entry in EntryCatalog.ForCategory(entryCategory))
+            {
+                int failed;
+                lock (entry.FailedTargets)
+                {
+                    failed = entry.FailedTargets.Count;
+                }
+
+                var suffix = entry.PatchInFlight
+                    ? " (patching…)"
+                    : entry.Patched
+                        ? $" ({entry.InstrumentedCount})"
+                        : "";
+                _entryViews.Add(new EntryView
+                {
+                    Entry = entry,
+                    Display = entry.Label + suffix,
+                    Active = entry.Active,
+                    FailedNote = failed > 0 ? $"  {failed} target(s) failed — see log" : null,
+                });
+            }
+
+            if (_selectedCategory == ProfilerCategory.Custom)
+            {
+                _modViews.Clear();
+                var mods = UnityModManager.modEntries;
+                if (mods != null)
+                {
+                    for (var i = 0; i < mods.Count; i++)
+                    {
+                        var mod = mods[i];
+                        if (mod?.Assembly == null || mod.Info == null)
+                        {
+                            continue;
+                        }
+
+                        if (!MethodResolver.IsProfilableAssemblyName(mod.Assembly.GetName().Name))
+                        {
+                            continue;
+                        }
+
+                        _modViews.Add(new ModView { Mod = mod, Display = mod.Info.DisplayName ?? mod.Info.Id });
+                    }
+                }
+            }
+
+            if (_selectedCategory == ProfilerCategory.Mods)
+            {
+                _modRollupLines = BuildModRollupLines();
+            }
+        }
+
+        private static void DrawWindow(int id)
+        {
+            var area = new Rect(0f, 0f, _windowRect.width, _windowRect.height);
+            ImguiKit.FillRect(area, ImguiKit.SolidDark);
+
+            DrawTitleRow();
+
+            var contentTop = 30f;
+            var graphTop = _windowRect.height - GraphHeight - 8f;
+            var tabsRect = new Rect(6f, contentTop, TabColumnWidth, graphTop - contentTop - 4f);
+            var rowsRect = new Rect(TabColumnWidth + 12f, contentTop, _windowRect.width - TabColumnWidth - 18f, graphTop - contentTop - 4f);
+            var graphRect = new Rect(6f, graphTop, _windowRect.width - 12f, GraphHeight);
+
+            DrawTabColumn(tabsRect);
+            DrawRowsPanel(rowsRect);
+            DrawGraphPanel(graphRect);
+            HandleResize();
+
+            // Title strip drags the window; keep the strip clear of buttons.
+            GUI.DragWindow(new Rect(0f, 0f, _windowRect.width - 220f, 26f));
+        }
+
+        private static void DrawTitleRow()
+        {
+            GUI.Label(new Rect(10f, 4f, 300f, 22f), "FUSE Profiler", ImguiKit.Header);
+
+            var x = _windowRect.width - 214f;
+            var paused = ProfilerSession.Paused;
+            if (GUI.Button(new Rect(x, 4f, 70f, 22f), paused ? "Resume" : "Pause"))
+            {
+                ProfilerSession.Paused = !paused;
+            }
+
+            if (GUI.Button(new Rect(x + 74f, 4f, 76f, 22f), "Sort: " + ProfilerSession.SortMode))
+            {
+                var next = (int)ProfilerSession.SortMode + 1;
+                if (next > (int)ProbeSortMode.Name)
+                {
+                    next = 0;
+                }
+
+                ProfilerSession.SortMode = (ProbeSortMode)next;
+            }
+
+            if (GUI.Button(new Rect(x + 154f, 4f, 54f, 22f), "Close"))
+            {
+                ProfilerRuntime.CloseWindow();
+            }
+        }
+
+        private static void DrawTabColumn(Rect rect)
+        {
+            ImguiKit.FillRect(rect, ImguiKit.SolidPanel);
+            GUILayout.BeginArea(new Rect(rect.x + 4f, rect.y + 4f, rect.width - 8f, rect.height - 8f));
+
+            foreach (ProfilerCategory category in Enum.GetValues(typeof(ProfilerCategory)))
+            {
+                var isSelected = category == _selectedCategory;
+                if (GUILayout.Toggle(isSelected, CategoryLabel(category), GUI.skin.button) && !isSelected)
+                {
+                    _selectedCategory = category;
+                    _selectedRowKey = null;
+                }
+            }
+
+            GUILayout.Space(8f);
+            _entryScroll = GUILayout.BeginScrollView(_entryScroll);
+            switch (_selectedCategory)
+            {
+                case ProfilerCategory.Custom:
+                    DrawCustomTools();
+                    break;
+                case ProfilerCategory.Mods:
+                    DrawModsTools();
+                    break;
+                default:
+                    DrawEntryToggles();
+                    break;
+            }
+
+            GUILayout.EndScrollView();
+            GUILayout.EndArea();
+        }
+
+        private static void DrawEntryToggles()
+        {
+            for (var i = 0; i < _entryViews.Count; i++)
+            {
+                var view = _entryViews[i];
+                var next = GUILayout.Toggle(view.Active, view.Display);
+                if (next != view.Active)
+                {
+                    view.Active = next;
+                    EntryCatalog.SetActive(view.Entry, next);
+                }
+
+                if (view.FailedNote != null)
+                {
+                    GUILayout.Label(view.FailedNote, ImguiKit.Cell);
+                }
+            }
+        }
+
+        private static void DrawCustomTools()
+        {
+            GUILayout.Label("Method spec:", ImguiKit.Cell);
+            _searchInput = GUILayout.TextField(_searchInput ?? "");
+            GUILayout.BeginHorizontal();
+            if (GUILayout.Button("Method"))
+            {
+                RunSearch(coroutine: false, asType: false);
+            }
+
+            if (GUILayout.Button("Coroutine"))
+            {
+                RunSearch(coroutine: true, asType: false);
+            }
+
+            if (GUILayout.Button("Type"))
+            {
+                RunSearch(coroutine: false, asType: true);
+            }
+
+            GUILayout.EndHorizontal();
+            GUILayout.Label("Namespace.Type:Method or Namespace.Type", ImguiKit.Cell);
+            if (!string.IsNullOrEmpty(_searchNotice))
+            {
+                GUILayout.Label(_searchNotice, ImguiKit.Cell);
+            }
+
+            GUILayout.Space(6f);
+            DrawEntryToggles();
+
+            GUILayout.Space(6f);
+            GUILayout.Label("Profile a mod's assembly:", ImguiKit.Cell);
+            for (var i = 0; i < _modViews.Count; i++)
+            {
+                if (GUILayout.Button(_modViews[i].Display))
+                {
+                    RuntimeEntryFactory.CreateModAssemblyEntry(_modViews[i].Mod);
+                    _searchNotice = "Instrumenting " + _modViews[i].Display + "…";
+                }
+            }
+        }
+
+        private static void DrawModsTools()
+        {
+            GUILayout.Label("Attribute Harmony patch cost to mods:", ImguiKit.Cell);
+            if (GUILayout.Button("Instrument all mods' patches"))
+            {
+                RuntimeEntryFactory.CreateForeignPatchesEntry();
+            }
+
+            GUILayout.Space(4f);
+            DrawEntryToggles();
+
+            GUILayout.Space(8f);
+            GUILayout.Label("Per-mod totals (avg ms per frame):", ImguiKit.Cell);
+            for (var i = 0; i < _modRollupLines.Count; i++)
+            {
+                GUILayout.Label(_modRollupLines[i], ImguiKit.Cell);
+            }
+        }
+
+        private static void RunSearch(bool coroutine, bool asType)
+        {
+            var input = (_searchInput ?? "").Trim();
+            if (input.Length == 0)
+            {
+                _searchNotice = "Enter a spec first.";
+                return;
+            }
+
+            if (asType)
+            {
+                RuntimeEntryFactory.CreateTypeEntry(input);
+                _searchNotice = "Instrumenting type " + input + "…";
+                return;
+            }
+
+            if (!input.Contains(":"))
+            {
+                _searchNotice = "Method specs need the form Namespace.Type:Method.";
+                return;
+            }
+
+            RuntimeEntryFactory.CreateMethodEntry(input, coroutine);
+            _searchNotice = "Instrumenting " + input + "…";
+        }
+
+        private static void DrawRowsPanel(Rect rect)
+        {
+            ImguiKit.FillRect(rect, ImguiKit.SolidPanel);
+
+            var header = new Rect(rect.x + 6f, rect.y + 2f, rect.width - 12f, 20f);
+            var labelWidth = header.width - 90f - 90f - 70f - 70f - 30f;
+            GUI.Label(new Rect(header.x + 30f, header.y, labelWidth, 20f), "Name", ImguiKit.Header);
+            GUI.Label(new Rect(header.x + 30f + labelWidth, header.y, 90f, 20f), "Avg ms", ImguiKit.Header);
+            GUI.Label(new Rect(header.x + 30f + labelWidth + 90f, header.y, 90f, 20f), "Max ms", ImguiKit.Header);
+            GUI.Label(new Rect(header.x + 30f + labelWidth + 180f, header.y, 70f, 20f), "Calls", ImguiKit.Header);
+            GUI.Label(new Rect(header.x + 30f + labelWidth + 250f, header.y, 70f, 20f), "%", ImguiKit.Header);
+
+            var visible = _visibleRows;
+            var viewRect = new Rect(0f, 0f, rect.width - 24f, visible.Count * RowHeight);
+            var scrollArea = new Rect(rect.x + 2f, rect.y + 24f, rect.width - 4f, rect.height - 28f);
+            _rowScroll = GUI.BeginScrollView(scrollArea, _rowScroll, viewRect);
+
+            // Manual virtualization: only draw rows inside the view window.
+            // Fixed-position GUI.* controls, so a mid-frame count change
+            // cannot desync IMGUI layout state.
+            var firstVisible = Mathf.Max(0, (int)(_rowScroll.y / RowHeight) - 1);
+            var lastVisible = Mathf.Min(visible.Count - 1, (int)((_rowScroll.y + scrollArea.height) / RowHeight) + 1);
+            for (var i = firstVisible; i <= lastVisible; i++)
+            {
+                DrawRow(visible[i], i, viewRect.width, labelWidth);
+            }
+
+            GUI.EndScrollView();
+        }
+
+        private static void DrawRow(ProbeRow row, int index, float width, float labelWidth)
+        {
+            var y = index * RowHeight;
+            var rowRect = new Rect(0f, y, width, RowHeight);
+            if (row.Key == _selectedRowKey)
+            {
+                ImguiKit.FillRect(rowRect, ImguiKit.SolidAccent);
+            }
+            else if (index % 2 == 0)
+            {
+                ImguiKit.FillRect(rowRect, ImguiKit.SolidDark);
+            }
+
+            var pinned = ProfilerSession.IsPinned(row.Key);
+            if (GUI.Button(new Rect(2f, y, 24f, RowHeight), pinned ? "★" : "☆", ImguiKit.Cell))
+            {
+                ProfilerSession.TogglePinned(row.Key);
+            }
+
+            if (GUI.Button(new Rect(30f, y, labelWidth, RowHeight), row.Label, ImguiKit.RowButton))
+            {
+                _selectedRowKey = row.Key;
+            }
+
+            GUI.Label(new Rect(30f + labelWidth, y, 84f, RowHeight), row.AverageMs.ToString("0.000"), ImguiKit.CellRight);
+            GUI.Label(new Rect(30f + labelWidth + 90f, y, 84f, RowHeight), row.MaxMs.ToString("0.000"), ImguiKit.CellRight);
+            GUI.Label(new Rect(30f + labelWidth + 180f, y, 64f, RowHeight), row.Calls.ToString(), ImguiKit.CellRight);
+            GUI.Label(
+                new Rect(30f + labelWidth + 250f, y, 64f, RowHeight),
+                row.PercentOfFrame >= 0d ? row.PercentOfFrame.ToString("0.0") : "—",
+                ImguiKit.CellRight);
+        }
+
+        private static void DrawGraphPanel(Rect rect)
+        {
+            ImguiKit.FillRect(rect, ImguiKit.SolidPanel);
+            var inner = new Rect(rect.x + 6f, rect.y + 22f, rect.width - 12f, rect.height - 28f);
+
+            if (_selectedRowKey == null || !ProbeRegistry.TryGet(_selectedRowKey, out var probe))
+            {
+                GUI.Label(new Rect(rect.x + 8f, rect.y + 2f, rect.width - 16f, 20f), "Select a row to graph its per-cycle time.", ImguiKit.Cell);
+                return;
+            }
+
+            var count = probe.CopyRecentInto(GraphBuffer, GraphBuffer.Length);
+            double max = 0d;
+            for (var i = 0; i < count; i++)
+            {
+                if (GraphBuffer[i] > max)
+                {
+                    max = GraphBuffer[i];
+                }
+            }
+
+            GUI.Label(
+                new Rect(rect.x + 8f, rect.y + 2f, rect.width - 16f, 20f),
+                $"{probe.Label} — last {count} cycles, peak {max:0.000} ms",
+                ImguiKit.Cell);
+
+            if (count >= 2 && max > 0d)
+            {
+                ImguiKit.DrawHorizontalRule(inner, 1f, ImguiKit.GraphMaxColor);
+                ImguiKit.DrawPolyline(inner, GraphBuffer, count, max, ImguiKit.GraphColor);
+            }
+        }
+
+        private static void HandleResize()
+        {
+            var handle = new Rect(_windowRect.width - 18f, _windowRect.height - 18f, 18f, 18f);
+            GUI.Label(handle, "◢");
+            var e = Event.current;
+
+            // rawType sees the MouseUp even when it happens outside the
+            // window/control, so a released drag can never stick.
+            if (_resizing && e.rawType == EventType.MouseUp)
+            {
+                _resizing = false;
+                GUIUtility.hotControl = 0;
+                e.Use();
+                return;
+            }
+
+            if (e.type == EventType.MouseDown && handle.Contains(e.mousePosition))
+            {
+                _resizing = true;
+                GUIUtility.hotControl = GUIUtility.GetControlID(FocusType.Passive);
+                e.Use();
+            }
+            else if (_resizing && e.type == EventType.MouseDrag)
+            {
+                _windowRect.width = Mathf.Max(720f, _windowRect.width + e.delta.x);
+                _windowRect.height = Mathf.Max(420f, _windowRect.height + e.delta.y);
+                e.Use();
+            }
+        }
+
+        private static List<ProbeRow> FilterRowsForCategory(ProfilerCategory category)
+        {
+            var entries = EntryCatalog.ForCategory(category);
+            var result = new List<ProbeRow>();
+            for (var i = 0; i < _rows.Count; i++)
+            {
+                var row = _rows[i];
+                if (row.Key == ProfilerSession.FrameProbeKey)
+                {
+                    result.Add(row);
+                    continue;
+                }
+
+                if (category == ProfilerCategory.Physics && row.Key == SimTickDriver.StepProbeKey)
+                {
+                    result.Add(row);
+                    continue;
+                }
+
+                for (var j = 0; j < entries.Count; j++)
+                {
+                    if (row.Key.StartsWith(entries[j].Id + "|", StringComparison.Ordinal))
+                    {
+                        result.Add(row);
+                        break;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static List<string> BuildModRollupLines()
+        {
+            var totals = new Dictionary<string, double>(StringComparer.Ordinal);
+            for (var i = 0; i < _rows.Count; i++)
+            {
+                var row = _rows[i];
+                if (row.GroupKey == null)
+                {
+                    continue;
+                }
+
+                totals.TryGetValue(row.GroupKey, out var sum);
+                totals[row.GroupKey] = sum + row.AverageMs;
+            }
+
+            var lines = new List<string>();
+            if (totals.Count == 0)
+            {
+                lines.Add("(no grouped probes yet)");
+                return lines;
+            }
+
+            var ordered = new List<KeyValuePair<string, double>>(totals);
+            ordered.Sort((a, b) => b.Value.CompareTo(a.Value));
+            for (var i = 0; i < ordered.Count; i++)
+            {
+                lines.Add($"{ordered[i].Key}: {ordered[i].Value:0.000} ms");
+            }
+
+            return lines;
+        }
+
+        private static string CategoryLabel(ProfilerCategory category)
+        {
+            switch (category)
+            {
+                case ProfilerCategory.UiEvents: return "UI / Events";
+                case ProfilerCategory.KeyValue: return "Key-Value";
+                default: return category.ToString();
+            }
+        }
+    }
+}

--- a/FUSE.Profiler/ProfilerMod.cs
+++ b/FUSE.Profiler/ProfilerMod.cs
@@ -1,0 +1,102 @@
+using System;
+using FUSE.Profiler.Engine;
+using FUSE.Profiler.Infrastructure;
+using FUSE.Profiler.Instrumentation;
+using FUSE.Profiler.Interface;
+using UnityEngine;
+using UnityModManagerNet;
+
+namespace FUSE.Profiler
+{
+    /// <summary>UnityModManager entry point.</summary>
+    public static class ProfilerMod
+    {
+        internal static ProfilerSettings Settings { get; private set; } = new ProfilerSettings();
+
+        public static bool Load(UnityModManager.ModEntry modEntry)
+        {
+            try
+            {
+                Settings = UnityModManager.ModSettings.Load<ProfilerSettings>(modEntry) ?? new ProfilerSettings();
+                ProfilerLog.Bind(
+                    message => modEntry.Logger.Log(message),
+                    message => modEntry.Logger.Warning(message),
+                    message => modEntry.Logger.Error(message));
+
+                ApplySettings();
+
+                modEntry.OnToggle = OnToggle;
+                modEntry.OnGUI = OnSettingsGui;
+                modEntry.OnSaveGUI = entry => Settings.Save(entry);
+
+                ProfilerHost.EnsureStarted();
+                ProfilerConsole.Initialize();
+                ProfilerLog.Info($"FUSE.Profiler loaded. Toggle with {ProfilerHost.ToggleKey} or /profiler.");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                modEntry.Logger.Error("FUSE.Profiler failed to load: " + ex);
+                return false;
+            }
+        }
+
+        private static bool OnToggle(UnityModManager.ModEntry modEntry, bool enabled)
+        {
+            if (enabled)
+            {
+                ProfilerHost.EnsureStarted();
+                ProfilerConsole.Initialize();
+            }
+            else
+            {
+                ProfilerRuntime.CleanupNow();
+                ProfilerConsole.Shutdown();
+                ProfilerHost.Shutdown();
+            }
+
+            return true;
+        }
+
+        private static void OnSettingsGui(UnityModManager.ModEntry modEntry)
+        {
+            GUILayout.BeginVertical();
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Stats refreshes per second: " + Settings.UpdatesPerSecond, GUILayout.Width(220f));
+            Settings.UpdatesPerSecond = Mathf.RoundToInt(
+                GUILayout.HorizontalSlider(Settings.UpdatesPerSecond, 1f, 10f, GUILayout.Width(200f)));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Toggle key:", GUILayout.Width(220f));
+            Settings.ToggleKeyName = GUILayout.TextField(Settings.ToggleKeyName ?? "F11", GUILayout.Width(120f));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Teardown delay after close (s): " + Settings.CleanupDelaySeconds.ToString("0"), GUILayout.Width(220f));
+            Settings.CleanupDelaySeconds = GUILayout.HorizontalSlider(Settings.CleanupDelaySeconds, 0f, 120f, GUILayout.Width(200f));
+            GUILayout.EndHorizontal();
+            GUILayout.EndVertical();
+
+            ApplySettings();
+        }
+
+        private static void ApplySettings()
+        {
+            var updates = Settings.UpdatesPerSecond < 1 ? 1 : Settings.UpdatesPerSecond;
+            ProfilerSession.StatsIntervalSeconds = 1f / updates;
+            ProfilerRuntime.CleanupDelaySeconds = Settings.CleanupDelaySeconds;
+            ProfilerHost.ToggleKey = ParseKey(Settings.ToggleKeyName, KeyCode.F11);
+        }
+
+        private static KeyCode ParseKey(string name, KeyCode fallback)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return fallback;
+            }
+
+            return Enum.TryParse<KeyCode>(name.Trim(), ignoreCase: true, out var key) ? key : fallback;
+        }
+    }
+}

--- a/FUSE.Profiler/README.md
+++ b/FUSE.Profiler/README.md
@@ -1,0 +1,50 @@
+# FUSE Profiler
+
+An in-game performance profiler for Railroader. Opens with **F11** (or the
+`/profiler` console command) and shows, live, where frame time is going:
+per-system tabs for the game's hot paths (culling, scenery streaming, track
+rebuilds, ops/AI, UI and event dispatch, train physics), a search box to
+profile any method or any mod's whole assembly on the fly, and a per-mod
+rollup that attributes the cost of every Harmony patch in the session to the
+mod that installed it.
+
+Measurement is Harmony-based and only active while the profiler window is
+open; patches are removed and buffers freed shortly after it closes, so an
+installed-but-closed profiler costs nothing.
+
+## Design credit
+
+The architecture — category entries over Harmony-instrumented method sets,
+per-frame/per-tick ring-buffer sampling with off-thread stat rollups, and
+Harmony-patch cost attribution — follows the excellent design of
+[Dubs Performance Analyzer](https://github.com/Dubwise56/Dubs-Performance-Analyzer)
+for RimWorld, by Dubwise and simplyWiri. This is an independent
+reimplementation for Railroader: no code is shared with that project.
+
+## Usage notes
+
+- The profiler measures **inclusive wall-clock time** per method, bucketed per
+  frame (or per physics step for the Physics tab). Percentages are relative to
+  the measured whole-frame time.
+- Profiling adds overhead to the methods being measured. Compare numbers
+  against each other, not against an unprofiled session.
+- The **Mods** tab shows other mods' Harmony patch cost attributed by patch
+  owner. A mod with expensive patches shows up immediately; a mod that is slow
+  in its own MonoBehaviours instead shows up via **assembly profiling** from
+  the search panel.
+
+## Known limitations
+
+- Probes measure **main-thread** calls only; instrumented methods invoked on
+  worker threads (async continuations, thread pools) are ignored rather than
+  corrupting the buffers.
+- Tiny Harmony patch methods the Mono JIT has inlined into their targets
+  cannot be intercepted — the Mods tab undercounts those. Whole-assembly
+  profiling of the suspect mod covers the gap.
+- Transpiler-inserted code is not isolated (the transpiled method's total is
+  attributed to the game method, not the transpiling mod).
+- Async method bodies count only their synchronous slice; coroutine targets
+  are measured at their real bodies via the iterator's MoveNext.
+- The window blocks clicks over UI beneath it via an invisible raycast
+  blocker, but game systems that poll input directly may still react to
+  clicks made over the profiler.

--- a/FUSE.Tests/FUSE.Tests.csproj
+++ b/FUSE.Tests/FUSE.Tests.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FUSE\FUSE.csproj" />
+    <ProjectReference Include="..\FUSE.Profiler\FUSE.Profiler.csproj" />
     <!-- FUSE.Editor reference is for pure-logic test coverage of types
          like FuseEditorWindowRegistry. Unity-coupled types in the editor
          (FuseEditorScreen, FuseNodeMarker) stay in the in-game harness;

--- a/FUSE.Tests/Profiler/ProbeRingTests.cs
+++ b/FUSE.Tests/Profiler/ProbeRingTests.cs
@@ -1,0 +1,137 @@
+using FUSE.Profiler.Engine;
+using Xunit;
+
+namespace FUSE.Tests.Profiler
+{
+    public class ProbeRingTests
+    {
+        [Fact]
+        public void CloseCycle_records_hits_and_advances_the_ring()
+        {
+            var ring = new ProbeRing("k", "label", ProbeCadence.Frame, null);
+            ring.Enter();
+            ring.Exit();
+            ring.Enter();
+            ring.Exit();
+            ring.CloseCycle();
+            ring.CloseCycle(); // empty cycle
+
+            var agg = ring.Aggregate(10);
+            Assert.Equal(2, agg.Samples);
+            Assert.Equal(2, agg.Calls);
+            Assert.Equal(2, agg.MaxCallsPerCycle);
+        }
+
+        [Fact]
+        public void Reentrant_Enter_does_not_double_count_time_but_counts_calls()
+        {
+            var ring = new ProbeRing("k", "label", ProbeCadence.Frame, null);
+            ring.Enter();
+            ring.Enter(); // nested call: depth 2, one shared interval
+            ring.Exit();
+            ring.Exit();
+            ring.CloseCycle();
+
+            var agg = ring.Aggregate(1);
+            Assert.Equal(2, agg.Calls);
+            Assert.Equal(1, agg.Samples);
+        }
+
+        [Fact]
+        public void Nested_Exit_keeps_timing_until_the_outermost_Exit()
+        {
+            var ring = new ProbeRing("k", "label", ProbeCadence.Frame, null);
+            ring.Enter();
+            ring.Enter();
+            ring.Exit(); // inner return: depth 1 — the watch must keep running
+            var tail = System.Diagnostics.Stopwatch.StartNew();
+            while (tail.Elapsed.TotalMilliseconds < 6)
+            {
+                // The outer method's tail work.
+            }
+
+            ring.Exit();
+            ring.CloseCycle();
+
+            var agg = ring.Aggregate(1);
+            Assert.True(agg.TotalMs >= 5.0, $"outer tail time was dropped: {agg.TotalMs:0.000}ms");
+        }
+
+        [Fact]
+        public void Unbalanced_Exit_is_harmless_and_CloseCycle_heals_a_stuck_depth()
+        {
+            var ring = new ProbeRing("k", "label", ProbeCadence.Frame, null);
+            ring.Exit(); // spurious exit at depth 0: no-op
+            ring.Enter(); // a throwing method: Exit never came
+            ring.CloseCycle(); // resets both watch and depth
+
+            ring.Enter();
+            ring.Exit();
+            ring.CloseCycle();
+
+            var agg = ring.Aggregate(1);
+            Assert.Equal(1, agg.Calls);
+            Assert.Equal(1, agg.Samples);
+        }
+
+        [Fact]
+        public void External_milliseconds_feed_the_cycle_total()
+        {
+            var ring = new ProbeRing("k", "label", ProbeCadence.Frame, null);
+            ring.AddExternalMilliseconds(16.5);
+            ring.CloseCycle();
+
+            var agg = ring.Aggregate(1);
+            Assert.Equal(1, agg.Calls);
+            Assert.Equal(16.5, agg.TotalMs, 3);
+            Assert.Equal(16.5, agg.MaxMs, 3);
+        }
+
+        [Fact]
+        public void Aggregate_window_is_bounded_by_recorded_cycles()
+        {
+            var ring = new ProbeRing("k", "label", ProbeCadence.Frame, null);
+            for (var i = 0; i < 5; i++)
+            {
+                ring.AddExternalMilliseconds(1.0);
+                ring.CloseCycle();
+            }
+
+            Assert.Equal(3, ring.Aggregate(3).Samples);
+            Assert.Equal(5, ring.Aggregate(50).Samples);
+            Assert.Equal(5.0, ring.Aggregate(50).TotalMs, 3);
+        }
+
+        [Fact]
+        public void Ring_wraps_without_losing_the_newest_samples()
+        {
+            var ring = new ProbeRing("k", "label", ProbeCadence.Frame, null);
+            for (var i = 0; i < ProbeRing.SlotCount + 10; i++)
+            {
+                ring.AddExternalMilliseconds(i);
+                ring.CloseCycle();
+            }
+
+            var buffer = new double[3];
+            var copied = ring.CopyRecentInto(buffer, 3);
+            Assert.Equal(3, copied);
+            // Newest-last ordering; the newest cycle recorded SlotCount+9.
+            Assert.Equal(ProbeRing.SlotCount + 9, buffer[2], 3);
+            Assert.Equal(ProbeRing.SlotCount + 8, buffer[1], 3);
+            Assert.Equal(ProbeRing.SlotCount + 7, buffer[0], 3);
+        }
+
+        [Fact]
+        public void Empty_cycles_do_not_contribute_time()
+        {
+            var ring = new ProbeRing("k", "label", ProbeCadence.Frame, null);
+            ring.CloseCycle();
+            ring.CloseCycle();
+
+            var agg = ring.Aggregate(10);
+            Assert.Equal(2, agg.Samples);
+            Assert.Equal(0, agg.Calls);
+            Assert.Equal(0d, agg.TotalMs, 6);
+        }
+    }
+}

--- a/FUSE.Tests/Profiler/ProbeRowSortTests.cs
+++ b/FUSE.Tests/Profiler/ProbeRowSortTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Profiler.Engine;
+using Xunit;
+
+namespace FUSE.Tests.Profiler
+{
+    public class ProbeRowSortTests
+    {
+        private static ProbeRow Row(string key, double avg, double max, long calls)
+        {
+            return new ProbeRow(key, key, null, ProbeCadence.Frame, avg, max, avg * 10, calls, 1, 0d);
+        }
+
+        [Fact]
+        public void Sorts_descending_by_the_selected_metric()
+        {
+            var rows = new List<ProbeRow> { Row("a", 1, 9, 5), Row("b", 3, 1, 1), Row("c", 2, 5, 9) };
+
+            ProbeRow.SortForDisplay(rows, ProbeSortMode.Average, null);
+            Assert.Equal(new[] { "b", "c", "a" }, rows.ConvertAll(r => r.Key));
+
+            ProbeRow.SortForDisplay(rows, ProbeSortMode.Max, null);
+            Assert.Equal(new[] { "a", "c", "b" }, rows.ConvertAll(r => r.Key));
+
+            ProbeRow.SortForDisplay(rows, ProbeSortMode.Calls, null);
+            Assert.Equal(new[] { "c", "a", "b" }, rows.ConvertAll(r => r.Key));
+        }
+
+        [Fact]
+        public void Pinned_rows_float_to_the_top_regardless_of_metric()
+        {
+            var rows = new List<ProbeRow> { Row("big", 100, 100, 100), Row("small", 1, 1, 1) };
+            var pinned = new HashSet<string>(StringComparer.Ordinal) { "small" };
+
+            ProbeRow.SortForDisplay(rows, ProbeSortMode.Average, pinned);
+            Assert.Equal("small", rows[0].Key);
+        }
+
+        [Fact]
+        public void Name_sort_is_case_insensitive_ascending()
+        {
+            var rows = new List<ProbeRow> { Row("beta", 1, 1, 1), Row("Alpha", 2, 2, 2) };
+            ProbeRow.SortForDisplay(rows, ProbeSortMode.Name, null);
+            Assert.Equal("Alpha", rows[0].Key);
+        }
+    }
+}

--- a/FUSE.Tests/Profiler/RailroaderTargetResolutionTests.cs
+++ b/FUSE.Tests/Profiler/RailroaderTargetResolutionTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Profiler.Entries;
+using FUSE.Profiler.Instrumentation;
+using Xunit;
+
+namespace FUSE.Tests.Profiler
+{
+    /// <summary>
+    /// Canary net for the built-in category tables: every target spec must
+    /// resolve against the installed game assemblies. A game update that
+    /// renames or removes one of these methods fails here at build time
+    /// instead of silently showing a dead row in the field.
+    /// </summary>
+    public class RailroaderTargetResolutionTests
+    {
+        public static IEnumerable<object[]> AllBuiltInSpecs()
+        {
+            foreach (var entry in RailroaderEntries.CreateBuiltIns())
+            {
+                foreach (var spec in entry.TargetProvider())
+                {
+                    yield return new object[] { entry.Id, spec.MethodSpec, spec.Coroutine };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(AllBuiltInSpecs))]
+        public void Every_builtin_target_resolves_against_the_game(string entryId, string methodSpec, bool coroutine)
+        {
+            var method = MethodResolver.Resolve(new TargetSpec(methodSpec, coroutine), out var error);
+            Assert.True(method != null, $"{entryId}: {error}");
+        }
+
+        [Fact]
+        public void BuiltIn_entry_ids_are_unique()
+        {
+            var ids = RailroaderEntries.CreateBuiltIns().Select(e => e.Id).ToList();
+            Assert.Equal(ids.Count, ids.Distinct().Count());
+        }
+
+        [Fact]
+        public void Physics_entries_use_the_sim_tick_clock_and_others_do_not()
+        {
+            foreach (var entry in RailroaderEntries.CreateBuiltIns())
+            {
+                if (entry.Category == ProfilerCategory.Physics)
+                {
+                    Assert.Equal(FUSE.Profiler.Engine.ProbeCadence.SimTick, entry.Cadence);
+                }
+                else
+                {
+                    Assert.Equal(FUSE.Profiler.Engine.ProbeCadence.Frame, entry.Cadence);
+                }
+            }
+        }
+    }
+}

--- a/FUSE.slnx
+++ b/FUSE.slnx
@@ -11,6 +11,7 @@
   <Project Path="FUSE.TestCli/FUSE.TestCli.csproj" />
   <Project Path="FUSE.LiveHarness/FUSE.LiveHarness.csproj" />
   <Project Path="FUSE.LiveHarness.Tests/FUSE.LiveHarness.Tests.csproj" />
+  <Project Path="FUSE.Profiler/FUSE.Profiler.csproj" />
   <Project Path="FUSE.Tests/FUSE.Tests.csproj" />
   <Project Path="FUSE/FUSE.csproj" />
 </Solution>


### PR DESCRIPTION
## What

A new standalone UMM mod, **FUSE.Profiler**, living in the FUSE repo/solution: an in-game profiler for hunting exactly the class of performance problems we have been chasing from field logs. Toggle with **F11** or `/profiler`.

- **Built-in category tabs** with concrete, canary-tested targets: Physics (per-step buckets incl. a whole-step probe), Culling (incl. `DecalCullingManager.UpdateDecalVisibilityJob`), Scenery/World streaming, Track rebuilds, Ops/AI (real coroutine-body timing via iterator `MoveNext` for `PassengerStop.Loop`, `OpsController.PeriodicUpdate`, AutoEngineer), UI panel rebuilds, KeyValue writes.
- **Mod attribution** — one click instruments every other mod''s Harmony prefix/postfix/finalizer and rolls the cost up **per mod**; one click profiles a mod''s **whole assembly** for cost living in its own MonoBehaviours. This is the "is it FUSE, MapEnhancer, or a Legos pack" answer machine.
- **Search panel** — profile any `Namespace.Type:Method`, coroutine, or whole type at runtime.
- **Zero cost when closed** — instrumentation applies on demand and is fully removed (unpatch + buffers freed) shortly after the window closes.

## Provenance

The architecture follows the excellent design of Dubs Performance Analyzer (RimWorld, by Dubwise and simplyWiri), which ships **without a license** — so this is a **clean-room reimplementation**: original code written from a functional analysis, with the design credited in the README and genuine divergences (instance-based entry gating instead of emitted types, main-thread-queued prefix/postfix instrumentation instead of IL transplanting, GL polyline graphs). No code is shared with the original.

## Engineering notes

- Workers only *resolve* targets; every `Harmony.Patch` runs on the **main thread** from a 25ms/frame budgeted queue. Teardown (generation bump → queue clear → `UnpatchAll`) is race-free by construction.
- Probes are depth-counted (recursion keeps the outer interval), exception-bounded (cycle close heals a stuck depth), pause-safe (a single `Recording` gate), and main-thread-only by explicit thread check.
- The IMGUI window snapshots all layout-feeding state on the Layout event (no `GUILayout` control-count mismatches from background patching), and an invisible uGUI raycast blocker prevents click-through into the game world.
- An adversarial multi-agent review ran over the implementation; all 26 confirmed findings are addressed in this commit. Known limitations are documented in the README (JIT-inlined foreign patches undercount, transpiler-inserted code not isolated, async bodies count their sync slice).

## Tests

- `RailroaderTargetResolutionTests` — every built-in target spec must resolve against the installed game assemblies (drift canary).
- Ring-buffer semantics (reentrancy tail-time, wraparound, healing) and display sorting.
- Suite: **1,568 passed / 0 failed**; slopwatch clean.