### PR TITLE
ci(release): publish plain 0.x tags as full releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,12 @@ jobs:
           $version = $Matches.version
           "version=$version" >> $env:GITHUB_OUTPUT
 
-          # Treat anything in the 0.x series or with a pre-release suffix as a
-          # GitHub pre-release. FUSE is still in beta so 0.10.0 ships as a
-          # pre-release until a 1.0.0 GA tag.
-          if ($version -match '^0\.' -or $version -match '-') {
+          # Only an explicit pre-release suffix (-rc.1, -beta.2, ...) marks a
+          # GitHub pre-release. Plain 0.x tags publish as full releases so the
+          # repo front page shows a "Latest" card with the version number —
+          # when every release is a pre-release, GitHub hides the card and
+          # shows only the bare tag count.
+          if ($version -match '-') {
             "is_prerelease=true" >> $env:GITHUB_OUTPUT
           }
           else {


### PR DESCRIPTION
Fixes the "releases just show a tag count" problem: all 16 releases to date carry prerelease=true (the 0.x-is-beta rule), and GitHub only renders the front-page "Latest release" card - the thing that displays the version number - for full releases.

Change: plain mod-vX.Y.Z tags now publish as full releases; only an explicit pre-release suffix (mod-v1.0.0-rc.1 style) sets prerelease. No packaging changes - the release already ships the UMM-validated mod zip, LiveBridge zip, converter/installer executables, and the folder-converter pyz.

Existing releases are untouched; the next tag becomes the repo''s visible Latest.