### PR TITLE
feat(maps): load custom replacement worlds without embedded editor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,11 @@ jobs:
       # Pass a non-default ModVersion so the InjectModVersionIntoInfoJson
       # target runs (it is gated on '$(ModVersion)' != '0.0.0'). This catches
       # regressions in the post-build PowerShell that stamps Info.json.
-      # Build FUSE.Editor.csproj since it ProjectReferences FUSE.csproj —
-      # MSBuild builds FUSE.dll first, FUSE.Editor.dll second.
       - name: Build (Debug)
-        run: dotnet build FUSE.Editor/FUSE.Editor.csproj -c Debug -p:ModVersion=0.0.1-ci
+        run: dotnet build FUSE/FUSE.csproj -c Debug -p:ModVersion=0.0.1-ci
 
       - name: Build (Release)
-        run: dotnet build FUSE.Editor/FUSE.Editor.csproj -c Release -p:ModVersion=0.0.1-ci
+        run: dotnet build FUSE/FUSE.csproj -c Release -p:ModVersion=0.0.1-ci
 
       - name: Verify Info.json stamped with version
         shell: powershell
@@ -280,7 +278,7 @@ jobs:
           # Read the computed version from the environment rather than ${{ }}
           # template expansion. Mirrors the TAG_NAME hardening in release.yml.
           MOD_VERSION: ${{ steps.build_id.outputs.version }}
-        run: dotnet build FUSE.Editor/FUSE.Editor.csproj -c Release "-p:ModVersion=$env:MOD_VERSION"
+        run: dotnet build FUSE/FUSE.csproj -c Release "-p:ModVersion=$env:MOD_VERSION"
 
       - name: Package mod zip
         shell: powershell
@@ -301,14 +299,6 @@ jobs:
 
           Copy-Item "FUSE\bin\Release\net48\FUSE.dll" $modFolder
           Copy-Item "FUSE\bin\Release\net48\Info.json" $modFolder
-          # FUSE.Editor.dll ships side-by-side with FUSE.dll; FUSE loads it
-          # lazily from this folder via Assembly.LoadFrom after UMM boots.
-          Copy-Item "FUSE.Editor\bin\Release\net48\FUSE.Editor.dll" $modFolder
-          # FUSE.Converter.dll is referenced by the editor's Convert
-          # button. Project-reference flows it to FUSE.Editor's output
-          # naturally; the deploy step explicitly copies it so the
-          # zipped mod folder is self-contained.
-          Copy-Item "FUSE.Editor\bin\Release\net48\FUSE.Converter.dll" $modFolder
           Copy-Item -Recurse "schemas" $modFolder
           Copy-Item "tools\assets\fuse_converter_icon.png" (Join-Path $modFolder 'assets\fuse_icon.png')
 

--- a/.github/workflows/release-externaleditor.yml
+++ b/.github/workflows/release-externaleditor.yml
@@ -4,7 +4,7 @@ name: Release External Editor
 # net10, game-free). Triggered by externaleditor-v<semver> tags so the external
 # editor ships on its own cadence, decoupled from the mod's mod-v<semver>
 # release (release.yml). The prefix is externaleditor- (not editor-) to keep it
-# distinct from the in-game editor, which ships inside the mod.
+# distinct from the retired in-game editor.
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,9 +79,7 @@ jobs:
 
       - name: Build FUSE mod (Release)
         shell: powershell
-        # Build FUSE.Editor.csproj: it ProjectReferences FUSE.csproj, so
-        # MSBuild builds FUSE.dll first and FUSE.Editor.dll second.
-        run: dotnet build FUSE.Editor/FUSE.Editor.csproj -c Release -p:ModVersion=${{ steps.version.outputs.version }}
+        run: dotnet build FUSE/FUSE.csproj -c Release -p:ModVersion=${{ steps.version.outputs.version }}
 
       - name: Package UMM mod zip
         id: package
@@ -105,14 +103,6 @@ jobs:
           # rewrite is what ships.
           Copy-Item "FUSE\bin\Release\net48\FUSE.dll" $modFolder
           Copy-Item "FUSE\bin\Release\net48\Info.json" $modFolder
-          # FUSE.Editor.dll ships side-by-side with FUSE.dll; FUSE loads it
-          # lazily from this folder via Assembly.LoadFrom after UMM boots.
-          Copy-Item "FUSE.Editor\bin\Release\net48\FUSE.Editor.dll" $modFolder
-          # FUSE.Converter.dll is referenced by the editor's Convert
-          # button. Project-reference flows it to FUSE.Editor's output
-          # naturally; the release step explicitly copies it so the
-          # release zip is self-contained.
-          Copy-Item "FUSE.Editor\bin\Release\net48\FUSE.Converter.dll" $modFolder
 
           # Schemas are referenced by FUSE.csproj and copied into bin. We re-copy
           # from source to avoid picking up any stale files left over in bin

--- a/FUSE.Core/Model/FuseMapDeclaration.cs
+++ b/FUSE.Core/Model/FuseMapDeclaration.cs
@@ -1,0 +1,20 @@
+namespace Fuse.Core.Model
+{
+    /// <summary>
+    /// Declares that the package provides a selectable map. The map's identity
+    /// is the package id — one map per package. <see cref="MapFolder"/> is a
+    /// package-relative folder shaped exactly like the game's
+    /// StreamingAssets/Maps/&lt;name&gt; directories: a Map.json (origin
+    /// lat/lon, tileDimension, tile list) plus tile_XXX_YYY.data heightmap
+    /// tiles. When the map is the active session map, FUSE redirects
+    /// MapStore.Load to this folder, so the pack's Map.json wholesale replaces
+    /// the stock origin and tile set for that session.
+    /// </summary>
+    public sealed class FuseMapDeclaration
+    {
+        public string DisplayName { get; set; }
+        public string Description { get; set; }
+        public string MapFolder { get; set; }
+        public bool SuppressBaseWorld { get; set; } = true;
+    }
+}

--- a/FUSE.Core/Model/FuseModDefinition.cs
+++ b/FUSE.Core/Model/FuseModDefinition.cs
@@ -18,6 +18,7 @@ namespace Fuse.Core.Model
         public string Description { get; set; }
         public string[] Tags { get; set; } = Array.Empty<string>();
         public string CoordinateSpace { get; set; } = "world";
+        public FuseMapDeclaration Map { get; set; }
         public FuseMixintoDefinition Mixinto { get; set; }
         public FuseTrackDefinition Tracks { get; set; } = new FuseTrackDefinition();
         public FuseOperationsDefinition Operations { get; set; } = new FuseOperationsDefinition();

--- a/FUSE.Core/Validation/FuseDefinitionValidator.cs
+++ b/FUSE.Core/Validation/FuseDefinitionValidator.cs
@@ -27,6 +27,7 @@ namespace Fuse.Core.Validation
             FuseMigration.Normalize(value);
             Required(result, "id", value.Id);
             Required(result, "name", value.Name);
+            ValidateMap(result, value.Map);
             ValidateMixinto(result, value.Mixinto);
 
             if (value.SchemaVersion != FuseMigration.CurrentVersion)
@@ -52,6 +53,34 @@ namespace Fuse.Core.Validation
             ValidateProgression(result, value.Progression);
             ValidateSettings(result, value.Settings);
             return result;
+        }
+
+        private static void ValidateMap(ValidationResult result, FuseMapDeclaration map)
+        {
+            if (map == null)
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(map.DisplayName))
+            {
+                result.AddWarning("map.displayName", "Map displayName is blank; the package name will be shown instead.", "fuse.map.displayName.blank");
+            }
+
+            if (string.IsNullOrWhiteSpace(map.MapFolder))
+            {
+                result.AddError("map.mapFolder", "Map packages must set mapFolder to the package-relative folder containing Map.json and its tiles.", "fuse.map.folder.required");
+                return;
+            }
+
+            var folder = map.MapFolder.Trim();
+            var isRooted = folder.StartsWith("/", StringComparison.Ordinal) ||
+                           folder.StartsWith("\\", StringComparison.Ordinal) ||
+                           folder.IndexOf(':') >= 0;
+            if (isRooted || folder.Contains(".."))
+            {
+                result.AddError("map.mapFolder", "Map mapFolder must be a package-relative path that stays inside the package folder.", "fuse.map.folder.outsidePackage", map.MapFolder);
+            }
         }
 
         private static void ValidateMixinto(ValidationResult result, FuseMixintoDefinition mixinto)

--- a/FUSE.Core/Validation/Help/fuse-validation-help.json
+++ b/FUSE.Core/Validation/Help/fuse-validation-help.json
@@ -41,6 +41,24 @@
     "fix": "Make the top level of the file a JSON object, with at least id and name set.",
     "example": "{\"id\":\"my-mod\",\"name\":\"My Mod\"}"
   },
+  "fuse.map.displayName.blank": {
+    "title": "Map displayName is blank",
+    "why": "The map declaration has no displayName, so wherever the map is offered for selection (console listings, menus) FUSE falls back to the package name. That usually reads worse than a purpose-written map title.",
+    "fix": "Set map.displayName to the player-facing name of the map.",
+    "example": "{\"map\": {\"displayName\": \"PRR Middle Division\", \"mapFolder\": \"Map\"}}"
+  },
+  "fuse.map.folder.outsidePackage": {
+    "title": "Map mapFolder escapes the package",
+    "why": "mapFolder is rooted or uses .. segments, so it resolves outside the package folder. FUSE refuses those paths: a distributed pack must be self-contained, and path escapes would read from unpredictable locations on other machines.",
+    "fix": "Move the map data inside the package and reference it with a plain relative path such as \"Map\" or \"Data/Map\".",
+    "example": "{\"map\": {\"displayName\": \"PRR Middle Division\", \"mapFolder\": \"Map\"}}"
+  },
+  "fuse.map.folder.required": {
+    "title": "Map mapFolder is missing",
+    "why": "A map declaration without mapFolder cannot point FUSE at the folder holding Map.json and the tile_XXX_YYY.data heightmap tiles, so the map can never be registered or launched.",
+    "fix": "Set map.mapFolder to the package-relative folder that contains Map.json and the map's tiles.",
+    "example": "{\"map\": {\"displayName\": \"PRR Middle Division\", \"mapFolder\": \"Map\"}}"
+  },
   "fuse.mapMask.circle.radius": {
     "title": "Circle mask needs a positive radius",
     "why": "A map mask with type circle has no radius, or its radius is zero or negative, so the circle would cover no area. This is an error and must be fixed before the mask is usable.",
@@ -167,17 +185,17 @@
     "fix": "Set density to 0 or a positive number, or omit the field to use the default.",
     "example": "{ \"operations\": { \"loads\": { \"coal\": { \"name\": \"Coal\", \"units\": \"pounds\", \"density\": 47.5 } } } }"
   },
-  "fuse.operations.loads.units": {
-    "title": "Invalid load units",
-    "why": "The load's units value is not one of the three recognized unit kinds. The validator only accepts Pounds, Gallons, or Quantity (case-insensitive), and anything else is an error that fails validation.",
-    "fix": "Set units to \"pounds\", \"gallons\", or \"quantity\".",
-    "example": "{ \"operations\": { \"loads\": { \"diesel\": { \"name\": \"Diesel Fuel\", \"units\": \"gallons\" } } } }"
-  },
   "fuse.operations.loads.unitWeightInPounds": {
     "title": "Negative load unit weight",
     "why": "The load's unitWeightInPounds is set to a value below 0, which the validator rejects — it must be greater than or equal to 0. The definition fails validation until corrected.",
     "fix": "Set unitWeightInPounds to 0 or a positive number of pounds per unit, or omit the field.",
     "example": "{ \"operations\": { \"loads\": { \"crates\": { \"name\": \"Crates\", \"units\": \"quantity\", \"unitWeightInPounds\": 1200 } } } }"
+  },
+  "fuse.operations.loads.units": {
+    "title": "Invalid load units",
+    "why": "The load's units value is not one of the three recognized unit kinds. The validator only accepts Pounds, Gallons, or Quantity (case-insensitive), and anything else is an error that fails validation.",
+    "fix": "Set units to \"pounds\", \"gallons\", or \"quantity\".",
+    "example": "{ \"operations\": { \"loads\": { \"diesel\": { \"name\": \"Diesel Fuel\", \"units\": \"gallons\" } } } }"
   },
   "fuse.operations.teamTrack.profile": {
     "title": "Team track missing team profiles",

--- a/FUSE.Editor/FUSE.Editor.csproj
+++ b/FUSE.Editor/FUSE.Editor.csproj
@@ -19,11 +19,11 @@
     <UnityModManagerDir Condition="'$(UnityModManagerDir)' == ''">$(UnityManagedDir)\UnityModManager</UnityModManagerDir>
     <ModDeployDir Condition="'$(ModDeployDir)' == ''">$(GameDir)\Mods\FUSE</ModDeployDir>
     <EnableModDeploy Condition="'$(EnableModDeploy)' == ''">false</EnableModDeploy>
+    <EnableInGameEditorDeploy Condition="'$(EnableInGameEditorDeploy)' == ''">false</EnableInGameEditorDeploy>
   </PropertyGroup>
 
-  <!-- FUSE.Editor ships inside the FUSE mod folder; it has no Info.json of its
-       own. FUSE.csproj is the UMM entry point and loads FUSE.Editor.dll lazily
-       from the same folder via Assembly.LoadFrom once the mod has booted. -->
+  <!-- The retired in-game editor remains buildable for source history and its
+       pure-logic tests, but FUSE no longer initializes or ships this assembly. -->
   <ItemGroup>
     <ProjectReference Include="..\FUSE\FUSE.csproj" />
     <!-- FUSE.Converter is the legacy-to-FUSE conversion engine the
@@ -146,10 +146,8 @@
     <Error Condition="!Exists('$(UnityManagedDir)\UnityEngine.CoreModule.dll')" Text="UnityEngine.CoreModule.dll was not found in the Railroader Managed folder." />
   </Target>
 
-  <!-- FUSE.Editor.dll deploys into the same Mods/FUSE/ folder as FUSE.dll.
-       FUSE.csproj's deploy target already creates that directory; build order
-       (FUSE.Editor depends on FUSE) means FUSE has already deployed by the
-       time this target fires. -->
+  <!-- Legacy developer-only deployment. It requires a second explicit opt-in
+       so a normal FUSE deployment cannot restore the retired editor files. -->
   <!-- Icons folder: loose PNGs the runtime loads via File.ReadAllBytes +
        Texture2D.LoadImage. Each <FuseEditorIconKind>.png is optional —
        FuseEditorIcons falls back to a Unicode glyph when a file is
@@ -167,7 +165,7 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="DeployFuseEditorToUnityModManagerFolder" AfterTargets="Build" Condition="'$(EnableModDeploy)' == 'true'">
+  <Target Name="DeployFuseEditorToUnityModManagerFolder" AfterTargets="Build" Condition="'$(EnableModDeploy)' == 'true' and '$(EnableInGameEditorDeploy)' == 'true'">
     <MakeDir Directories="$(ModDeployDir)" />
     <MakeDir Directories="$(ModDeployDir)\Icons" />
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="true" />

--- a/FUSE.Tests/Loading/FuseMapPackageRegistryTests.cs
+++ b/FUSE.Tests/Loading/FuseMapPackageRegistryTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.IO;
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public class FuseMapPackageRegistryTests : IDisposable
+    {
+        private readonly string _root;
+
+        public FuseMapPackageRegistryTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "fuse-map-registry-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_root, true);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                // Best-effort temp cleanup; a leftover temp folder is harmless.
+                System.Console.WriteLine($"FuseMapPackageRegistryTests temp cleanup failed: {ex.Message}");
+            }
+        }
+
+        private string CreatePackageFolder(string name, bool withMapFolder = true, bool withMapJson = true)
+        {
+            var packageFolder = Path.Combine(_root, name);
+            Directory.CreateDirectory(packageFolder);
+            if (withMapFolder)
+            {
+                var mapFolder = Path.Combine(packageFolder, "Map");
+                Directory.CreateDirectory(mapFolder);
+                if (withMapJson)
+                {
+                    File.WriteAllText(
+                        Path.Combine(mapFolder, "Map.json"),
+                        "{\"origin\":{\"latitude\":40.43,\"longitude\":-77.72},\"tileDimension\":500,\"tiles\":[]}");
+                }
+            }
+
+            return packageFolder;
+        }
+
+        public class TryResolveMapFolder : FuseMapPackageRegistryTests
+        {
+            [Fact]
+            public void ValidRelativeFolder_Resolves()
+            {
+                var packageFolder = CreatePackageFolder("pack");
+
+                var ok = FuseMapPackageRegistry.TryResolveMapFolder(packageFolder, "Map", out var resolved, out var error);
+
+                Assert.True(ok, error);
+                Assert.Equal(Path.Combine(Path.GetFullPath(packageFolder), "Map"), resolved);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("   ")]
+            public void BlankFolder_IsRejected(string mapFolder)
+            {
+                var packageFolder = CreatePackageFolder("pack");
+
+                Assert.False(FuseMapPackageRegistry.TryResolveMapFolder(packageFolder, mapFolder, out _, out var error));
+                Assert.Contains("blank", error);
+            }
+
+            [Fact]
+            public void RootedFolder_IsRejected()
+            {
+                var packageFolder = CreatePackageFolder("pack");
+                var rooted = Path.Combine(packageFolder, "Map");
+
+                Assert.False(FuseMapPackageRegistry.TryResolveMapFolder(packageFolder, rooted, out _, out var error));
+                Assert.Contains("rooted", error);
+            }
+
+            [Fact]
+            public void TraversalOutsidePackage_IsRejected()
+            {
+                CreatePackageFolder("other");
+                var packageFolder = CreatePackageFolder("pack");
+
+                Assert.False(FuseMapPackageRegistry.TryResolveMapFolder(packageFolder, "..\\other\\Map", out _, out var error));
+                Assert.Contains("outside", error);
+            }
+
+            [Fact]
+            public void SiblingFolderWithSamePrefix_IsRejected()
+            {
+                var packageFolder = CreatePackageFolder("pack");
+                CreatePackageFolder("pack2");
+
+                Assert.False(FuseMapPackageRegistry.TryResolveMapFolder(packageFolder, "..\\pack2\\Map", out _, out var error));
+                Assert.Contains("outside", error);
+            }
+
+            [Fact]
+            public void MissingFolder_IsRejected()
+            {
+                var packageFolder = CreatePackageFolder("pack", withMapFolder: false);
+
+                Assert.False(FuseMapPackageRegistry.TryResolveMapFolder(packageFolder, "Map", out _, out var error));
+                Assert.Contains("does not exist", error);
+            }
+
+            [Fact]
+            public void UnknownPackageFolder_IsRejected()
+            {
+                Assert.False(FuseMapPackageRegistry.TryResolveMapFolder(null, "Map", out _, out var error));
+                Assert.Contains("package folder", error);
+            }
+        }
+
+        public class BuildEntry : FuseMapPackageRegistryTests
+        {
+            [Fact]
+            public void ValidDeclaration_ProducesValidEntry()
+            {
+                var packageFolder = CreatePackageFolder("pack");
+                var declaration = new FuseMapDeclaration { DisplayName = "PRR Middle Division", MapFolder = "Map" };
+
+                var entry = FuseMapPackageRegistry.BuildEntry("prr", "PRR Pack", packageFolder, declaration);
+
+                Assert.True(entry.IsValid, entry.FaultReason);
+                Assert.Equal("prr", entry.MapId);
+                Assert.Equal("PRR Middle Division", entry.DisplayName);
+                Assert.True(File.Exists(Path.Combine(entry.MapFolder, "Map.json")));
+                Assert.True(entry.SuppressBaseWorld);
+            }
+
+            [Fact]
+            public void DeclarationCanKeepBaseWorldForIntentionalOverlay()
+            {
+                var packageFolder = CreatePackageFolder("overlay");
+                var declaration = new FuseMapDeclaration
+                {
+                    MapFolder = "Map",
+                    SuppressBaseWorld = false
+                };
+
+                var entry = FuseMapPackageRegistry.BuildEntry(
+                    "overlay",
+                    "Overlay",
+                    packageFolder,
+                    declaration);
+
+                Assert.False(entry.SuppressBaseWorld);
+                Assert.False(FuseBaseWorldIsolation.ShouldSuppress(entry));
+            }
+
+            [Fact]
+            public void DisplayNameFallsBackToPackageNameThenId()
+            {
+                var packageFolder = CreatePackageFolder("pack");
+
+                var fromName = FuseMapPackageRegistry.BuildEntry("prr", "PRR Pack", packageFolder, new FuseMapDeclaration { MapFolder = "Map" });
+                var fromId = FuseMapPackageRegistry.BuildEntry("prr", null, packageFolder, new FuseMapDeclaration { MapFolder = "Map" });
+
+                Assert.Equal("PRR Pack", fromName.DisplayName);
+                Assert.Equal("prr", fromId.DisplayName);
+            }
+
+            [Fact]
+            public void MissingMapJson_ProducesFaultedEntry()
+            {
+                var packageFolder = CreatePackageFolder("pack", withMapFolder: true, withMapJson: false);
+
+                var entry = FuseMapPackageRegistry.BuildEntry("prr", "PRR Pack", packageFolder, new FuseMapDeclaration { MapFolder = "Map" });
+
+                Assert.False(entry.IsValid);
+                Assert.Contains("Map.json", entry.FaultReason);
+                Assert.Equal(string.Empty, entry.MapFolder);
+            }
+
+            [Fact]
+            public void BlankMapFolder_ProducesFaultedEntry()
+            {
+                var packageFolder = CreatePackageFolder("pack");
+
+                var entry = FuseMapPackageRegistry.BuildEntry("prr", "PRR Pack", packageFolder, new FuseMapDeclaration());
+
+                Assert.False(entry.IsValid);
+                Assert.Contains("blank", entry.FaultReason);
+            }
+        }
+
+        public class Registration : FuseMapPackageRegistryTests
+        {
+            private FuseLoadedMod LoadedMapPackage(string id, string packageFolder)
+            {
+                return new FuseLoadedMod(packageFolder, Path.Combine(packageFolder, "fuse-mod.json"), new FuseModDefinition
+                {
+                    Id = id,
+                    Name = id,
+                    Map = new FuseMapDeclaration { DisplayName = id, MapFolder = "Map" }
+                });
+            }
+
+            [Fact]
+            public void RegisterTryGetUnregister_RoundTrips()
+            {
+                var id = "map-" + Guid.NewGuid().ToString("N");
+                var packageFolder = CreatePackageFolder("pack");
+
+                FuseMapPackageRegistry.RegisterFromDefinition(LoadedMapPackage(id, packageFolder));
+                try
+                {
+                    Assert.True(FuseMapPackageRegistry.TryGetMap(id, out var map));
+                    Assert.True(map.IsValid, map.FaultReason);
+                    Assert.Contains(FuseMapPackageRegistry.GetRegisteredMaps(), m => m.MapId == id);
+                }
+                finally
+                {
+                    FuseMapPackageRegistry.Unregister(id);
+                }
+
+                Assert.False(FuseMapPackageRegistry.TryGetMap(id, out _));
+            }
+
+            [Fact]
+            public void ReplacementWithoutMapDeclaration_RemovesRegistration()
+            {
+                var id = "map-" + Guid.NewGuid().ToString("N");
+                var packageFolder = CreatePackageFolder("pack");
+
+                FuseMapPackageRegistry.RegisterFromDefinition(LoadedMapPackage(id, packageFolder));
+                try
+                {
+                    var withoutMap = new FuseLoadedMod(packageFolder, null, new FuseModDefinition { Id = id, Name = id });
+                    FuseMapPackageRegistry.RegisterFromDefinition(withoutMap);
+
+                    Assert.False(FuseMapPackageRegistry.TryGetMap(id, out _));
+                }
+                finally
+                {
+                    FuseMapPackageRegistry.Unregister(id);
+                }
+            }
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseMapSessionTests.cs
+++ b/FUSE.Tests/Loading/FuseMapSessionTests.cs
@@ -1,0 +1,82 @@
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public class FuseMapSessionTests
+    {
+        private static FuseModDefinition MapPackage(string id) => new FuseModDefinition
+        {
+            Id = id,
+            Name = id,
+            Map = new FuseMapDeclaration { DisplayName = id, MapFolder = "Map" }
+        };
+
+        private static FuseModDefinition NormalPackage(string id) => new FuseModDefinition
+        {
+            Id = id,
+            Name = id
+        };
+
+        [Fact]
+        public void ShouldApply_NullDefinition_IsTrue()
+        {
+            Assert.True(FuseMapSession.ShouldApply(null, "some-map"));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("some-map")]
+        public void ShouldApply_PackageWithoutMap_IsTrueRegardlessOfActiveMap(string activeMapId)
+        {
+            Assert.True(FuseMapSession.ShouldApply(NormalPackage("pkg"), activeMapId));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void ShouldApply_MapPackageWithNoActiveMap_IsFalse(string activeMapId)
+        {
+            Assert.False(FuseMapSession.ShouldApply(MapPackage("prr-middle-division"), activeMapId));
+        }
+
+        [Fact]
+        public void ShouldApply_MapPackageMatchingActiveMap_IsTrue()
+        {
+            Assert.True(FuseMapSession.ShouldApply(MapPackage("prr-middle-division"), "prr-middle-division"));
+        }
+
+        [Fact]
+        public void ShouldApply_MatchIsCaseInsensitiveAndTrimmed()
+        {
+            Assert.True(FuseMapSession.ShouldApply(MapPackage("PRR-Middle-Division"), "  prr-middle-division  "));
+        }
+
+        [Fact]
+        public void ShouldApply_MapPackageForDifferentMap_IsFalse()
+        {
+            Assert.False(FuseMapSession.ShouldApply(MapPackage("prr-middle-division"), "other-map"));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("other-map")]
+        public void InactiveSkipReason_StartsWithOptionalSkipPrefix(string activeMapId)
+        {
+            var reason = FuseMapSession.InactiveSkipReason(activeMapId);
+
+            Assert.StartsWith(FuseMapSession.InactiveSkipReasonPrefix, reason);
+            Assert.True(FusePackageFaultRegistry.IsOptionalSkipReason(reason));
+        }
+
+        [Fact]
+        public void IsOptionalSkipReason_StillAcceptsMixintoReason_AndRejectsOthers()
+        {
+            Assert.True(FusePackageFaultRegistry.IsOptionalSkipReason("mixinto dependency missing: someMod"));
+            Assert.False(FusePackageFaultRegistry.IsOptionalSkipReason("runtime apply exception"));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseNewGameMapMenuPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseNewGameMapMenuPatchTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using FUSE.Patches;
+using HarmonyLib;
+using UI.Menu;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseNewGameMapMenuPatchTests
+    {
+        [Fact]
+        public void BuildPanelTranspiler_InsertsMapFieldAndRelabelsProgression()
+        {
+            var target = AccessTools.Method(
+                typeof(NewGameMenu),
+                "BuildPanelContent");
+            var patchType = typeof(FuseNewGameMapMenuPatch);
+            var transpiler = patchType.GetMethod(
+                "BuildPanelContentTranspiler",
+                BindingFlags.Static | BindingFlags.NonPublic);
+            var addWorldField = patchType.GetMethod(
+                "AddWorldField",
+                BindingFlags.Static | BindingFlags.NonPublic);
+            var original = PatchProcessor
+                .GetOriginalInstructions(target)
+                .ToList();
+
+            var patched = (List<CodeInstruction>)transpiler.Invoke(
+                null,
+                new object[] { original });
+
+            Assert.Contains(
+                patched,
+                instruction => instruction.Calls(addWorldField));
+            Assert.Contains(
+                patched,
+                instruction =>
+                    instruction.opcode == OpCodes.Ldstr &&
+                    (string)instruction.operand == "Starting Progression");
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseNewGameMapOptionTests.cs
+++ b/FUSE.Tests/Patches/FuseNewGameMapOptionTests.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Loading;
+using FUSE.Patches;
+using Game.State;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseNewGameMapOptionTests
+    {
+        [Fact]
+        public void Build_UsesNativeStockOptionThenValidCustomMaps()
+        {
+            var maps = new List<FuseRegisteredMap>
+            {
+                new FuseRegisteredMap("z-map", "Zulu", "", "C:\\maps\\z", ""),
+                new FuseRegisteredMap("bad-map", "Broken", "", "", "Map.json missing"),
+                new FuseRegisteredMap("a-map", "Alpha", "", "C:\\maps\\a", ""),
+            };
+
+            var options = FuseNewGameMapOption.Build(maps);
+
+            Assert.Collection(
+                options,
+                option =>
+                {
+                    Assert.True(option.IsStock);
+                    Assert.Equal("Railroader Base Map", option.DisplayName);
+                },
+                option => Assert.Equal("a-map", option.MapId),
+                option => Assert.Equal("z-map", option.MapId));
+        }
+
+        [Fact]
+        public void Build_DeduplicatesMapIdsIgnoringCase()
+        {
+            var maps = new[]
+            {
+                new FuseRegisteredMap("prr", "PRR", "", "C:\\maps\\prr", ""),
+                new FuseRegisteredMap("PRR", "PRR duplicate", "", "C:\\maps\\prr2", ""),
+            };
+
+            var options = FuseNewGameMapOption.Build(maps);
+
+            Assert.Equal(2, options.Count);
+        }
+
+        [Fact]
+        public void SelectionMarker_RoundTripsNormalizedMapId()
+        {
+            var marker = FuseNewGameMapOption.CreateSelectionMarker("  prr-middle  ");
+
+            Assert.True(FuseNewGameMapOption.TryParseSelectionMarker(marker, out var mapId));
+            Assert.Equal("prr-middle", mapId);
+        }
+
+        [Fact]
+        public void MarkAndClearSelection_PreserveNewGameIdentityAndMode()
+        {
+            var original = new NewGameSetup(
+                "Test Railroad",
+                "TEST",
+                GameMode.Company,
+                "ewh",
+                "ewh-steam");
+
+            var marked = FuseNewGameMapOption.MarkSelection(original, "prr-middle");
+            var cleared = FuseNewGameMapOption.ClearSelectionMarker(marked);
+
+            Assert.Equal(original.RailroadName, cleared.RailroadName);
+            Assert.Equal(original.ReportingMark, cleared.ReportingMark);
+            Assert.Equal(original.Mode, cleared.Mode);
+            Assert.Equal(original.ProgressionId, cleared.ProgressionId);
+            Assert.Equal(original.SetupId, cleared.SetupId);
+        }
+
+        [Fact]
+        public void MarkSelection_StoresMapOutsideProgressionFields()
+        {
+            var original = new NewGameSetup(
+                "Test Railroad",
+                "TEST",
+                GameMode.Company,
+                "custom-progression",
+                "custom-setup");
+
+            var marked = FuseNewGameMapOption.MarkSelection(
+                original,
+                "prr-middle");
+
+            Assert.Equal(
+                original.ProgressionId,
+                marked.ProgressionId);
+            Assert.True(
+                FuseNewGameMapOption.TryParseSelectionMarker(
+                    marked.SetupId,
+                    out var mapId,
+                    out var originalSetupId));
+            Assert.Equal("prr-middle", mapId);
+            Assert.Equal("custom-setup", originalSetupId);
+        }
+
+        [Fact]
+        public void ProgressionOptions_UseMapProgressionsOrNoProgressionFallback()
+        {
+            var withProgressions = new FuseRegisteredMap(
+                "prr",
+                "PRR",
+                "",
+                "C:\\maps\\prr",
+                "",
+                progressionIds: new[] { "late-era", "early-era" });
+            var withoutProgressions = new FuseRegisteredMap(
+                "rutland",
+                "Rutland",
+                "",
+                "C:\\maps\\rutland",
+                "");
+
+            var progressionOptions =
+                FuseNewGameProgressionOption.Build(withProgressions);
+            var fallbackOptions =
+                FuseNewGameProgressionOption.Build(withoutProgressions);
+
+            Assert.Equal(
+                new[] { "early-era", "late-era" },
+                progressionOptions.Select(option => option.ProgressionId));
+            Assert.Single(fallbackOptions);
+            Assert.Null(fallbackOptions[0].ProgressionId);
+            Assert.Equal(
+                FuseNewGameProgressionOption.NoProgressionName,
+                fallbackOptions[0].DisplayName);
+        }
+    }
+}

--- a/FUSE.Tests/Serialization/FuseMapDeclarationSerializationTests.cs
+++ b/FUSE.Tests/Serialization/FuseMapDeclarationSerializationTests.cs
@@ -1,0 +1,66 @@
+using FUSE.Authoring.Data;
+using FUSE.Authoring.Serialization;
+using Xunit;
+
+namespace FUSE.Tests.Serialization
+{
+    public class FuseMapDeclarationSerializationTests
+    {
+        [Fact]
+        public void MapDeclaration_RoundTripsThroughJson()
+        {
+            var definition = new FuseModDefinition
+            {
+                Id = "prr-middle-division",
+                Name = "PRR Middle Division",
+                Map = new FuseMapDeclaration
+                {
+                    DisplayName = "PRR Middle Division + EBT",
+                    Description = "Altoona to Harrisburg with the East Broad Top.",
+                    MapFolder = "Map",
+                    SuppressBaseWorld = false
+                }
+            };
+
+            var roundTripped = FuseSerializer.FromJson(FuseSerializer.ToJson(definition));
+
+            Assert.NotNull(roundTripped.Map);
+            Assert.Equal("PRR Middle Division + EBT", roundTripped.Map.DisplayName);
+            Assert.Equal("Altoona to Harrisburg with the East Broad Top.", roundTripped.Map.Description);
+            Assert.Equal("Map", roundTripped.Map.MapFolder);
+            Assert.False(roundTripped.Map.SuppressBaseWorld);
+        }
+
+        [Fact]
+        public void MapDeclaration_UsesCamelCaseJsonNames()
+        {
+            var json = FuseSerializer.ToJson(new FuseModDefinition
+            {
+                Id = "prr",
+                Name = "PRR",
+                Map = new FuseMapDeclaration { DisplayName = "PRR", MapFolder = "Map" }
+            });
+
+            Assert.Contains("\"map\"", json);
+            Assert.Contains("\"displayName\"", json);
+            Assert.Contains("\"mapFolder\"", json);
+            Assert.Contains("\"suppressBaseWorld\"", json);
+        }
+
+        [Fact]
+        public void MapDeclaration_SuppressesBaseWorldByDefault()
+        {
+            var declaration = new FuseMapDeclaration();
+
+            Assert.True(declaration.SuppressBaseWorld);
+        }
+
+        [Fact]
+        public void DefinitionWithoutMap_OmitsMapProperty()
+        {
+            var json = FuseSerializer.ToJson(new FuseModDefinition { Id = "plain", Name = "Plain" });
+
+            Assert.DoesNotContain("\"map\"", json);
+        }
+    }
+}

--- a/FUSE.Tests/Validation/FuseDefinitionValidatorMapTests.cs
+++ b/FUSE.Tests/Validation/FuseDefinitionValidatorMapTests.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using FUSE.Authoring.Data;
+using FUSE.Authoring.Validation;
+using Xunit;
+
+namespace FUSE.Tests.Validation
+{
+    public class FuseDefinitionValidatorMapTests
+    {
+        private static FuseModDefinition Definition(FuseMapDeclaration map) => new FuseModDefinition
+        {
+            Id = "pkg",
+            Name = "Package",
+            SchemaVersion = "1.0",
+            Map = map
+        };
+
+        private static FuseDefinitionValidator NewValidator() => new FuseDefinitionValidator();
+
+        [Fact]
+        public void NoMapDeclaration_ProducesNoMapDiagnostics()
+        {
+            var result = NewValidator().Validate(Definition(null));
+
+            Assert.DoesNotContain(result.Errors, e => e.Field.StartsWith("map"));
+            Assert.DoesNotContain(result.Warnings, w => w.Field.StartsWith("map"));
+        }
+
+        [Fact]
+        public void ValidMapDeclaration_ProducesNoMapDiagnostics()
+        {
+            var result = NewValidator().Validate(Definition(new FuseMapDeclaration
+            {
+                DisplayName = "PRR Middle Division",
+                MapFolder = "Map"
+            }));
+
+            Assert.DoesNotContain(result.Errors, e => e.Field.StartsWith("map"));
+            Assert.DoesNotContain(result.Warnings, w => w.Field.StartsWith("map"));
+        }
+
+        [Fact]
+        public void BlankMapFolder_IsAnError()
+        {
+            var result = NewValidator().Validate(Definition(new FuseMapDeclaration
+            {
+                DisplayName = "PRR Middle Division"
+            }));
+
+            Assert.Contains(result.Errors, e => e.Field == "map.mapFolder" && e.Code == "fuse.map.folder.required");
+        }
+
+        [Theory]
+        [InlineData("C:\\Maps\\PRR")]
+        [InlineData("/maps/prr")]
+        [InlineData("\\maps\\prr")]
+        [InlineData("..\\outside")]
+        [InlineData("Map/../../outside")]
+        public void RootedOrEscapingMapFolder_IsAnError(string mapFolder)
+        {
+            var result = NewValidator().Validate(Definition(new FuseMapDeclaration
+            {
+                DisplayName = "PRR Middle Division",
+                MapFolder = mapFolder
+            }));
+
+            Assert.Contains(result.Errors, e => e.Field == "map.mapFolder" && e.Code == "fuse.map.folder.outsidePackage");
+        }
+
+        [Fact]
+        public void BlankDisplayName_IsAWarningOnly()
+        {
+            var result = NewValidator().Validate(Definition(new FuseMapDeclaration
+            {
+                MapFolder = "Map"
+            }));
+
+            Assert.Contains(result.Warnings, w => w.Field == "map.displayName" && w.Code == "fuse.map.displayName.blank");
+            Assert.DoesNotContain(result.Errors, e => e.Field.StartsWith("map"));
+        }
+    }
+}

--- a/FUSE/Authoring/Data/FuseModDefinition.cs
+++ b/FUSE/Authoring/Data/FuseModDefinition.cs
@@ -18,6 +18,7 @@ namespace FUSE.Authoring.Data
         public string Description { get; set; }
         public string[] Tags { get; set; } = Array.Empty<string>();
         public string CoordinateSpace { get; set; } = "world";
+        public FuseMapDeclaration Map { get; set; }
         public FuseMixintoDefinition Mixinto { get; set; }
         public FuseTrackDefinition Tracks { get; set; } = new FuseTrackDefinition();
         public FuseOperationsDefinition Operations { get; set; } = new FuseOperationsDefinition();

--- a/FUSE/Authoring/Data/Maps/FuseMapDeclaration.cs
+++ b/FUSE/Authoring/Data/Maps/FuseMapDeclaration.cs
@@ -1,0 +1,27 @@
+namespace FUSE.Authoring.Data
+{
+    /// <summary>
+    /// Declares that the package provides a selectable map. The map's identity
+    /// is the package id — one map per package. <see cref="MapFolder"/> is a
+    /// package-relative folder shaped exactly like the game's
+    /// StreamingAssets/Maps/&lt;name&gt; directories: a Map.json (origin
+    /// lat/lon, tileDimension, tile list) plus tile_XXX_YYY.data heightmap
+    /// tiles. When the map is the active session map, FUSE redirects
+    /// MapStore.Load to this folder, so the pack's Map.json wholesale replaces
+    /// the stock origin and tile set for that session.
+    /// </summary>
+    public sealed class FuseMapDeclaration
+    {
+        public string DisplayName { get; set; }
+        public string Description { get; set; }
+        public string MapFolder { get; set; }
+
+        /// <summary>
+        /// Whether the stock Bushnell/Whittier world content is removed from
+        /// the session before this map package is applied. Map declarations
+        /// are complete worlds by default; set this to false only for a terrain
+        /// replacement that intentionally keeps the stock graph and scenery.
+        /// </summary>
+        public bool SuppressBaseWorld { get; set; } = true;
+    }
+}

--- a/FUSE/Authoring/Validation/FuseDefinitionValidator.cs
+++ b/FUSE/Authoring/Validation/FuseDefinitionValidator.cs
@@ -24,6 +24,7 @@ namespace FUSE.Authoring.Validation
             FuseMigration.Normalize(value);
             Required(result, "id", value.Id);
             Required(result, "name", value.Name);
+            ValidateMap(result, value.Map);
             ValidateMixinto(result, value.Mixinto);
 
             if (value.SchemaVersion != FuseMigration.CurrentVersion)
@@ -49,6 +50,34 @@ namespace FUSE.Authoring.Validation
             ValidateProgression(result, value.Progression);
             ValidateSettings(result, value.Settings);
             return result;
+        }
+
+        private static void ValidateMap(ValidationResult result, FuseMapDeclaration map)
+        {
+            if (map == null)
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(map.DisplayName))
+            {
+                result.AddWarning("map.displayName", "Map displayName is blank; the package name will be shown instead.", "fuse.map.displayName.blank");
+            }
+
+            if (string.IsNullOrWhiteSpace(map.MapFolder))
+            {
+                result.AddError("map.mapFolder", "Map packages must set mapFolder to the package-relative folder containing Map.json and its tiles.", "fuse.map.folder.required");
+                return;
+            }
+
+            var folder = map.MapFolder.Trim();
+            var isRooted = folder.StartsWith("/", StringComparison.Ordinal) ||
+                           folder.StartsWith("\\", StringComparison.Ordinal) ||
+                           folder.IndexOf(':') >= 0;
+            if (isRooted || folder.Contains(".."))
+            {
+                result.AddError("map.mapFolder", "Map mapFolder must be a package-relative path that stays inside the package folder.", "fuse.map.folder.outsidePackage", map.MapFolder);
+            }
         }
 
         private static void ValidateMixinto(ValidationResult result, FuseMixintoDefinition mixinto)

--- a/FUSE/FusePlugin.cs
+++ b/FUSE/FusePlugin.cs
@@ -27,6 +27,10 @@ namespace FUSE
     {
         private const string HarmonyId = "FUSE";
         private const string ConverterVersion = "0.2.0";
+
+        // The retired in-game editor is intentionally disconnected from FUSE
+        // startup. Custom map discovery and launching do not depend on it.
+        internal static bool InGameEditorEnabled => false;
 #if DEBUG
         private const string BuildConfiguration = "Debug";
 #else
@@ -79,8 +83,11 @@ namespace FUSE
                 // re-attempts registration on the first map load.
                 FuseConsoleRegistrar.TryRegisterAll();
 
-                FuseEditorAssemblyLoader.TryInitialize(modEntry.Path);
-                FuseEditorBridge.NotifyFuseLoaded();
+                if (InGameEditorEnabled)
+                {
+                    FuseEditorAssemblyLoader.TryInitialize(modEntry.Path);
+                    FuseEditorBridge.NotifyFuseLoaded();
+                }
                 FuseOrphanedCarWindow.Ensure();
                 FuseMenuWindow.Ensure();
                 FuseTrackDebugOverlay.Ensure();
@@ -252,9 +259,13 @@ namespace FUSE
             FuseUnusedAssetReclaimer.Reset();
             FuseConstrainedTextureMemoryPolicy.Restore();
 
-            if (_isLoaded)
+            if (_isLoaded && InGameEditorEnabled)
             {
                 FuseEditorBridge.NotifyFuseUnloaded();
+            }
+
+            if (_isLoaded)
+            {
                 FuseEvents.RaiseFuseUnloaded();
                 FuseLog.Info("FUSE unloaded.");
             }

--- a/FUSE/Interface/Console/FuseConsoleCommands.cs
+++ b/FUSE/Interface/Console/FuseConsoleCommands.cs
@@ -29,6 +29,8 @@ namespace FUSE.Interface.Console
             {
                 new FuseReportCommand(),
                 new FuseLoadedCommand(),
+                new FuseMapsCommand(),
+                new FuseMapLaunchCommand(),
                 new FuseAssetsCommand(),
                 new FuseGraphCommand(),
                 new FuseProgressionsCommand(),
@@ -730,6 +732,63 @@ namespace FUSE.Interface.Console
             }
 
             return sb.ToString();
+        }
+    }
+
+    [ConsoleCommand("/fuse.maps", "List maps registered by FUSE map packages and the active session map.")]
+    public sealed class FuseMapsCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            var maps = FuseMapPackageRegistry.GetRegisteredMaps();
+            var sb = new StringBuilder();
+            var active = FuseMapSession.ActiveMapId;
+            sb.AppendLine($"FUSE registered maps: {maps.Count} (active session map: {(string.IsNullOrEmpty(active) ? "stock map" : active)})");
+            foreach (var map in maps)
+            {
+                var status = map.IsValid ? "ok" : $"faulted: {map.FaultReason}";
+                sb.AppendLine($"  {map.MapId}  '{map.DisplayName}'  [{status}]");
+            }
+
+            if (maps.Count == 0)
+            {
+                sb.AppendLine("  (no loaded package declares a map)");
+            }
+
+            return sb.ToString();
+        }
+    }
+
+    [ConsoleCommand("/fuse.map.launch", "Launch a new sandbox session on a registered FUSE map: /fuse.map.launch <mapId> [railroadName] [reportingMark]. Main menu only.")]
+    public sealed class FuseMapLaunchCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            var mapId = components != null && components.Length > 0 ? components[0] : null;
+            if (string.IsNullOrWhiteSpace(mapId))
+            {
+                return "Usage: /fuse.map.launch <mapId> [railroadName] [reportingMark]";
+            }
+
+            if (FuseConsoleCommands.IsInSession())
+            {
+                return "fuse.map.launch refused: a session is already running. Return to the main menu first.";
+            }
+
+            var railroadName = components.Length > 1 ? components[1] : null;
+            var reportingMark = components.Length > 2 ? components[2] : null;
+
+            try
+            {
+                return FuseMapLauncher.TryLaunchMap(mapId, railroadName, reportingMark, out var error)
+                    ? $"FUSE map launch dispatched for '{mapId}'."
+                    : $"FUSE map launch failed: {error}";
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception($"FUSE map launch threw for '{mapId}'", ex);
+                return $"FUSE map launch threw: {ex.GetBaseException().Message}";
+            }
         }
     }
 

--- a/FUSE/Interface/MenuWindow/RuntimeActionsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/RuntimeActionsToolPage.cs
@@ -1,5 +1,6 @@
 using FUSE.Authoring.Migrations;
 using FUSE.Infrastructure;
+using FUSE.Interface.Console;
 using FUSE.Loading;
 using FUSE.Runtime.API;
 using FUSE.Runtime.Cache;
@@ -53,6 +54,10 @@ namespace FUSE.Interface.MenuWindow
 
             builder.Spacer(8f);
 
+            AddMapsSection(builder);
+
+            builder.Spacer(8f);
+
             builder.AddSection("Diagnostics Export");
             builder.AddLabel("Attach these to bug reports: the snapshot is a quick paste, the bundle is the full machine-readable state.");
             builder.HStack(row =>
@@ -69,6 +74,47 @@ namespace FUSE.Interface.MenuWindow
             builder.Spacer(8f);
 
             AddWrappedField(builder, "Last Action", _lastAction, 44f);
+        }
+
+        private static void AddMapsSection(UIPanelBuilder builder)
+        {
+            var maps = FuseMapPackageRegistry.GetRegisteredMaps();
+            if (maps.Count == 0)
+            {
+                return;
+            }
+
+            builder.AddSection("Maps");
+            var activeMapId = FuseMapSession.ActiveMapId;
+            builder.AddLabel(string.IsNullOrEmpty(activeMapId)
+                ? "Launch a new sandbox session on a FUSE map. Only available from the main menu."
+                : $"Active session map: {activeMapId}. Return to the main menu to launch a different map.");
+
+            foreach (var map in maps)
+            {
+                var captured = map;
+                builder.HStack(row =>
+                {
+                    if (captured.IsValid)
+                    {
+                        row.AddButtonCompact($"Launch {captured.DisplayName}", () => RunAction(builder, "launch map", () =>
+                        {
+                            if (FuseConsoleCommands.IsInSession())
+                            {
+                                return "Map launch refused: a session is already running. Return to the main menu first.";
+                            }
+
+                            return FuseMapLauncher.TryLaunchMap(captured.MapId, null, null, out var error)
+                                ? $"Launching map '{captured.DisplayName}'…"
+                                : $"Map launch failed: {error}";
+                        }));
+                    }
+                    else
+                    {
+                        row.AddLabel($"{captured.DisplayName}: {captured.FaultReason}");
+                    }
+                }, 6f).Height(32f);
+            }
         }
 
         private static void RunAction(UIPanelBuilder builder, string actionName, Func<string> action)

--- a/FUSE/Loading/FuseBaseWorldIsolation.cs
+++ b/FUSE/Loading/FuseBaseWorldIsolation.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GalaSoft.MvvmLight.Messaging;
+using Game.Events;
+using FUSE.Infrastructure;
+using FUSE.Runtime.API;
+using UnityEngine;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// Turns the stock Bushnell/Whittier scene into a runtime host for a
+    /// complete FUSE map. Railroader still needs the scene's manager objects,
+    /// but its authored track, operations, labels, scenery, signs, setups,
+    /// progression, and CTC content must not leak into the replacement world.
+    /// </summary>
+    internal static class FuseBaseWorldIsolation
+    {
+        private static readonly HashSet<string> PreservedWorldChildren =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "Track",
+                "Prefab Instancer",
+                "Light Probe Group",
+                "Environment Effects",
+                "SceneryEditorSentinel",
+            };
+
+        private static readonly string[] ContentRoots =
+        {
+            "Ops",
+            "MapFeatures",
+            "Progressions",
+            "Setups",
+            "CTC",
+            "CTC Auxiliary",
+        };
+
+        private static string _isolatedMapId = string.Empty;
+
+        internal static bool ShouldSuppress(FuseRegisteredMap map)
+        {
+            return map != null && map.IsValid && map.SuppressBaseWorld;
+        }
+
+        internal static bool ApplyForActiveMap(string reason)
+        {
+            var mapId = FuseMapSession.ActiveMapId;
+            if (string.IsNullOrWhiteSpace(mapId) ||
+                !FuseMapPackageRegistry.TryGetMap(mapId, out var map) ||
+                !ShouldSuppress(map))
+            {
+                return false;
+            }
+
+            if (string.Equals(_isolatedMapId, map.MapId, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var deactivatedRoots = DeactivateStockSceneContent();
+            var removedTracks = RemoveStockTrackGraph();
+            NotifyIndustriesChanged();
+            _isolatedMapId = map.MapId;
+
+            FuseLog.Info(
+                $"FUSE isolated base world for map='{map.MapId}' reason='{reason ?? "unspecified"}' " +
+                $"deactivatedContentRoots={deactivatedRoots} removedSpans={removedTracks.Spans} " +
+                $"removedSegments={removedTracks.Segments} removedNodes={removedTracks.Nodes}.");
+            return true;
+        }
+
+        internal static void Reset()
+        {
+            _isolatedMapId = string.Empty;
+        }
+
+        private static int DeactivateStockSceneContent()
+        {
+            var deactivated = 0;
+            var world = GameObject.Find("World");
+            if (world != null)
+            {
+                deactivated += DeactivateChildren(world.transform, PreservedWorldChildren);
+            }
+
+            foreach (var rootName in ContentRoots)
+            {
+                var root = GameObject.Find(rootName);
+                if (root != null)
+                {
+                    deactivated += DeactivateChildren(
+                        root.transform,
+                        new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+                }
+            }
+
+            return deactivated;
+        }
+
+        private static int DeactivateChildren(
+            Transform root,
+            HashSet<string> preservedNames)
+        {
+            if (root == null)
+            {
+                return 0;
+            }
+
+            var children = new List<GameObject>();
+            for (var index = 0; index < root.childCount; index++)
+            {
+                var child = root.GetChild(index);
+                if (child != null && child.gameObject != null)
+                {
+                    children.Add(child.gameObject);
+                }
+            }
+
+            var deactivated = 0;
+            foreach (var child in children)
+            {
+                if (child == null ||
+                    preservedNames.Contains(child.name) ||
+                    !child.activeSelf)
+                {
+                    continue;
+                }
+
+                child.SetActive(false);
+                deactivated++;
+            }
+
+            return deactivated;
+        }
+
+        private static RemovedTrackCounts RemoveStockTrackGraph()
+        {
+            var counts = new RemovedTrackCounts();
+            TrackAPI.BeginBatch();
+            try
+            {
+                foreach (var spanId in TrackAPI.GetAllSpans()
+                             .Where(span => span != null && !string.IsNullOrWhiteSpace(span.id))
+                             .Select(span => span.id)
+                             .Distinct(StringComparer.OrdinalIgnoreCase)
+                             .ToArray())
+                {
+                    if (TryRemove("span", spanId, TrackAPI.RemoveSpan))
+                    {
+                        counts.Spans++;
+                    }
+                }
+
+                foreach (var segmentId in TrackAPI.GetAllSegments()
+                             .Where(segment => segment != null && !string.IsNullOrWhiteSpace(segment.id))
+                             .Select(segment => segment.id)
+                             .Distinct(StringComparer.OrdinalIgnoreCase)
+                             .ToArray())
+                {
+                    if (TryRemove("segment", segmentId, TrackAPI.RemoveSegment))
+                    {
+                        counts.Segments++;
+                    }
+                }
+
+                foreach (var nodeId in TrackAPI.GetAllNodes()
+                             .Where(node => node != null && !string.IsNullOrWhiteSpace(node.id))
+                             .Select(node => node.id)
+                             .Distinct(StringComparer.OrdinalIgnoreCase)
+                             .ToArray())
+                {
+                    if (TryRemove("node", nodeId, TrackAPI.RemoveNode))
+                    {
+                        counts.Nodes++;
+                    }
+                }
+            }
+            finally
+            {
+                // The normal map-load apply/cleanup pipeline owns the single
+                // graph rebuild after the replacement package has been added.
+                TrackAPI.EndBatch(false);
+            }
+
+            return counts;
+        }
+
+        private static bool TryRemove(string kind, string id, Action<string> remove)
+        {
+            try
+            {
+                remove(id);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE base-world isolation could not remove stock track {kind} " +
+                    $"id='{id}': {ex.Message}");
+                return false;
+            }
+        }
+
+        private static void NotifyIndustriesChanged()
+        {
+            try
+            {
+                Messenger.Default.Send(default(IndustriesDidChange));
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE base-world isolation could not refresh operations collections: " +
+                    ex.Message);
+            }
+        }
+
+        private sealed class RemovedTrackCounts
+        {
+            internal int Spans { get; set; }
+            internal int Segments { get; set; }
+            internal int Nodes { get; set; }
+        }
+    }
+}

--- a/FUSE/Loading/FuseMapLauncher.cs
+++ b/FUSE/Loading/FuseMapLauncher.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Game.State;
+using HarmonyLib;
+using Network;
+using FUSE.Infrastructure;
+using UI.Menu;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// Launches a new sandbox session on a registered FUSE map. Same launch
+    /// shape as the FUSE editor session (and the game's own singleplayer
+    /// start): the stock map scene hosts the session while
+    /// <see cref="FuseMapSession"/> + the MapStore redirect swap the terrain
+    /// source, and the apply pipeline swaps the world content. Only usable
+    /// from the main menu, where MenuManager exists.
+    /// </summary>
+    public static class FuseMapLauncher
+    {
+        private static readonly FieldInfo MenuManagerGameManagerField =
+            AccessTools.Field(typeof(MenuManager), "gameManager");
+
+        public const string DefaultReportingMark = "FUSE";
+
+        public static bool TryLaunchMap(string mapId, string railroadName, string reportingMark, out string error)
+        {
+            error = null;
+
+            if (!FuseMapPackageRegistry.TryGetMap(mapId, out var map))
+            {
+                error = $"No registered map '{mapId}'. Use /fuse.maps to list registered maps.";
+                return false;
+            }
+
+            if (!map.IsValid)
+            {
+                error = $"Map '{map.MapId}' cannot launch: {map.FaultReason}";
+                return false;
+            }
+
+            var menuManager = UnityEngine.Object.FindObjectOfType<MenuManager>();
+            if (menuManager == null)
+            {
+                error = "Maps can only be launched from the main menu (MenuManager not found).";
+                return false;
+            }
+
+            if (MenuManagerGameManagerField == null ||
+                !(MenuManagerGameManagerField.GetValue(menuManager) is GlobalGameManager gameManager))
+            {
+                error = "Could not resolve GlobalGameManager from MenuManager.";
+                return false;
+            }
+
+            // Same composition MenuManager uses for singleplayer: the stock
+            // map scene as the active scene plus the environment scene.
+            var sceneList = new List<SceneDescriptor>
+            {
+                SceneDescriptor.BushnellWhittier,
+                SceneDescriptor.EnvironmentEnviro,
+            };
+            var sceneSetup = new GlobalGameManager.SceneLoadSetup(sceneList, SceneDescriptor.BushnellWhittier);
+
+            var newGame = new NewGameSetup(
+                railroadName: string.IsNullOrWhiteSpace(railroadName) ? map.DisplayName : railroadName.Trim(),
+                reportingMark: string.IsNullOrWhiteSpace(reportingMark) ? DefaultReportingMark : reportingMark.Trim(),
+                mode: GameMode.Sandbox,
+                progressionId: null,
+                setupId: null);
+            var gameSetup = new GameSetup(saveName: null, setup: newGame);
+
+            FuseMapSession.Activate(map.MapId);
+            try
+            {
+                gameManager.Launch(sceneSetup, gameSetup, default(StartSingleplayerSetup));
+            }
+            catch (Exception)
+            {
+                FuseMapSession.Deactivate("map launch dispatch failed");
+                throw;
+            }
+
+            FuseLog.Info($"FUSE map session launch dispatched map='{map.MapId}' displayName='{map.DisplayName}'.");
+            return true;
+        }
+    }
+}

--- a/FUSE/Loading/FuseMapPackageRegistry.cs
+++ b/FUSE/Loading/FuseMapPackageRegistry.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FUSE.Authoring.Data;
+using FUSE.Infrastructure;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// A selectable map registered by a map package. The map id is the owning
+    /// package id. Entries whose map folder failed to resolve are kept with a
+    /// <see cref="FaultReason"/> so diagnostics can show why a declared map is
+    /// not launchable.
+    /// </summary>
+    public sealed class FuseRegisteredMap
+    {
+        internal FuseRegisteredMap(
+            string mapId,
+            string displayName,
+            string description,
+            string mapFolder,
+            string faultReason,
+            bool suppressBaseWorld = true,
+            IEnumerable<string> progressionIds = null)
+        {
+            MapId = mapId ?? string.Empty;
+            DisplayName = displayName ?? string.Empty;
+            Description = description ?? string.Empty;
+            MapFolder = mapFolder ?? string.Empty;
+            FaultReason = faultReason ?? string.Empty;
+            SuppressBaseWorld = suppressBaseWorld;
+            ProgressionIds = (progressionIds ?? Enumerable.Empty<string>())
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        public string MapId { get; }
+        public string DisplayName { get; }
+        public string Description { get; }
+
+        /// <summary>Resolved absolute folder containing Map.json and tiles; empty when faulted.</summary>
+        public string MapFolder { get; }
+
+        public string FaultReason { get; }
+        public bool IsValid => string.IsNullOrEmpty(FaultReason);
+        public bool SuppressBaseWorld { get; }
+        public IReadOnlyList<string> ProgressionIds { get; }
+    }
+
+    /// <summary>
+    /// Registry of maps declared by loaded packages. Populated when definitions
+    /// are registered with the loader (independent of runtime apply, so maps
+    /// are listable from the main menu before any session exists) and cleared
+    /// when their package unloads.
+    /// </summary>
+    public static class FuseMapPackageRegistry
+    {
+        private const string MapJsonFileName = "Map.json";
+
+        private static readonly object Sync = new object();
+        private static readonly Dictionary<string, FuseRegisteredMap> Maps =
+            new Dictionary<string, FuseRegisteredMap>(StringComparer.OrdinalIgnoreCase);
+
+        internal static void RegisterFromDefinition(FuseLoadedMod loaded)
+        {
+            var definition = loaded?.Definition;
+            if (definition == null || string.IsNullOrWhiteSpace(definition.Id))
+            {
+                return;
+            }
+
+            if (definition.Map == null)
+            {
+                // A replaced definition may have dropped its map declaration.
+                Unregister(definition.Id);
+                return;
+            }
+
+            var progressionIds = definition.Progression?.Progressions?.Keys;
+            var entry = BuildEntry(
+                definition.Id,
+                definition.Name,
+                loaded.FolderPath,
+                definition.Map,
+                progressionIds);
+            lock (Sync)
+            {
+                Maps[entry.MapId] = entry;
+            }
+
+            if (entry.IsValid)
+            {
+                FuseLog.Info($"FUSE registered map package='{entry.MapId}' displayName='{entry.DisplayName}' mapFolder='{entry.MapFolder}'.");
+            }
+            else
+            {
+                FuseLog.Warning($"FUSE registered map package='{entry.MapId}' as faulted: {entry.FaultReason}");
+            }
+        }
+
+        internal static void Unregister(string packageId)
+        {
+            if (string.IsNullOrWhiteSpace(packageId))
+            {
+                return;
+            }
+
+            lock (Sync)
+            {
+                Maps.Remove(packageId);
+            }
+        }
+
+        internal static void Clear()
+        {
+            lock (Sync)
+            {
+                Maps.Clear();
+            }
+        }
+
+        public static IReadOnlyList<FuseRegisteredMap> GetRegisteredMaps()
+        {
+            lock (Sync)
+            {
+                return Maps.Values
+                    .OrderBy(map => map.MapId, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+            }
+        }
+
+        public static bool TryGetMap(string mapId, out FuseRegisteredMap map)
+        {
+            map = null;
+            if (string.IsNullOrWhiteSpace(mapId))
+            {
+                return false;
+            }
+
+            lock (Sync)
+            {
+                return Maps.TryGetValue(mapId.Trim(), out map);
+            }
+        }
+
+        internal static FuseRegisteredMap BuildEntry(
+            string packageId,
+            string packageName,
+            string packageFolder,
+            FuseMapDeclaration declaration,
+            IEnumerable<string> progressionIds = null)
+        {
+            var displayName = FirstNonBlank(declaration?.DisplayName, packageName, packageId);
+            var description = declaration?.Description ?? string.Empty;
+            var suppressBaseWorld = declaration?.SuppressBaseWorld ?? true;
+
+            if (string.IsNullOrWhiteSpace(declaration?.MapFolder))
+            {
+                return new FuseRegisteredMap(
+                    packageId,
+                    displayName,
+                    description,
+                    string.Empty,
+                    "mapFolder is blank.",
+                    suppressBaseWorld,
+                    progressionIds);
+            }
+
+            if (!TryResolveMapFolder(packageFolder, declaration.MapFolder, out var resolved, out var error))
+            {
+                return new FuseRegisteredMap(
+                    packageId,
+                    displayName,
+                    description,
+                    string.Empty,
+                    error,
+                    suppressBaseWorld,
+                    progressionIds);
+            }
+
+            var mapJsonPath = Path.Combine(resolved, MapJsonFileName);
+            if (!File.Exists(mapJsonPath))
+            {
+                return new FuseRegisteredMap(
+                    packageId, displayName, description, string.Empty,
+                    $"{MapJsonFileName} not found in resolved map folder '{resolved}'.",
+                    suppressBaseWorld,
+                    progressionIds);
+            }
+
+            return new FuseRegisteredMap(
+                packageId,
+                displayName,
+                description,
+                resolved,
+                null,
+                suppressBaseWorld,
+                progressionIds);
+        }
+
+        internal static bool TryResolveMapFolder(string packageFolder, string mapFolder, out string resolved, out string error)
+        {
+            resolved = string.Empty;
+            error = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(mapFolder))
+            {
+                error = "mapFolder is blank.";
+                return false;
+            }
+
+            if (Path.IsPathRooted(mapFolder))
+            {
+                error = $"mapFolder '{mapFolder}' must be package-relative, not rooted.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(packageFolder))
+            {
+                error = "package folder is unknown, so mapFolder cannot be resolved.";
+                return false;
+            }
+
+            string packageRoot;
+            string combined;
+            try
+            {
+                packageRoot = Path.GetFullPath(packageFolder);
+                combined = Path.GetFullPath(Path.Combine(packageRoot, mapFolder));
+            }
+            catch (Exception ex) when (ex is ArgumentException || ex is NotSupportedException || ex is PathTooLongException)
+            {
+                error = $"mapFolder '{mapFolder}' could not be resolved: {ex.Message}";
+                return false;
+            }
+
+            var rootWithSeparator = packageRoot.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+                ? packageRoot
+                : packageRoot + Path.DirectorySeparatorChar;
+            if (!combined.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase))
+            {
+                error = $"mapFolder '{mapFolder}' resolves outside the package folder.";
+                return false;
+            }
+
+            if (!Directory.Exists(combined))
+            {
+                error = $"mapFolder '{mapFolder}' does not exist (resolved to '{combined}').";
+                return false;
+            }
+
+            resolved = combined;
+            return true;
+        }
+
+        private static string FirstNonBlank(params string[] values)
+        {
+            for (var index = 0; index < values.Length; index++)
+            {
+                if (!string.IsNullOrWhiteSpace(values[index]))
+                {
+                    return values[index].Trim();
+                }
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/FUSE/Loading/FuseMapSession.cs
+++ b/FUSE/Loading/FuseMapSession.cs
@@ -1,0 +1,90 @@
+using System;
+using FUSE.Authoring.Data;
+using FUSE.Infrastructure;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// Which registered map (if any) the current or pending game session runs
+    /// on. Set by the map launcher right before the session launches and
+    /// cleared when the main menu comes back up. While a map is active:
+    /// MapStore.Load is redirected to the pack's map folder, and packages
+    /// declaring a different map are skipped by the apply pipeline. With no
+    /// active map, the stock map loads untouched and every map package stays
+    /// dormant.
+    /// </summary>
+    public static class FuseMapSession
+    {
+        internal const string InactiveSkipReasonPrefix = "map package inactive";
+
+        private static readonly object Sync = new object();
+        private static string _activeMapId = string.Empty;
+
+        /// <summary>Empty when the session is (or will be) on the stock map.</summary>
+        public static string ActiveMapId
+        {
+            get
+            {
+                lock (Sync)
+                {
+                    return _activeMapId;
+                }
+            }
+        }
+
+        public static bool HasActiveMap => !string.IsNullOrEmpty(ActiveMapId);
+
+        internal static void Activate(string mapId)
+        {
+            var normalized = (mapId ?? string.Empty).Trim();
+            lock (Sync)
+            {
+                _activeMapId = normalized;
+            }
+
+            FuseLog.Info($"FUSE map session activated map='{normalized}'.");
+        }
+
+        internal static void Deactivate(string reason)
+        {
+            string previous;
+            lock (Sync)
+            {
+                previous = _activeMapId;
+                _activeMapId = string.Empty;
+            }
+
+            if (!string.IsNullOrEmpty(previous))
+            {
+                FuseLog.Info($"FUSE map session deactivated map='{previous}' reason='{reason ?? "unspecified"}'.");
+            }
+        }
+
+        internal static bool ShouldApplyDefinition(FuseModDefinition definition)
+        {
+            return ShouldApply(definition, ActiveMapId);
+        }
+
+        /// <summary>
+        /// A package with no map declaration always applies. A map package
+        /// applies only while its map is the active session map.
+        /// </summary>
+        internal static bool ShouldApply(FuseModDefinition definition, string activeMapId)
+        {
+            if (definition?.Map == null)
+            {
+                return true;
+            }
+
+            return !string.IsNullOrWhiteSpace(activeMapId) &&
+                   string.Equals(definition.Id, activeMapId.Trim(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static string InactiveSkipReason(string activeMapId)
+        {
+            return string.IsNullOrWhiteSpace(activeMapId)
+                ? $"{InactiveSkipReasonPrefix} (no map selected; stock map session)"
+                : $"{InactiveSkipReasonPrefix} (active map='{activeMapId}')";
+        }
+    }
+}

--- a/FUSE/Loading/FuseModLoader.cs
+++ b/FUSE/Loading/FuseModLoader.cs
@@ -113,8 +113,16 @@ namespace FUSE.Loading
         public static int ApplyLoadedDefinitions(string reason)
         {
             var ids = GetLoadedDefinitionIdsInOrder();
-            ApplyGlobalLoadCatalog(ids, reason);
-            PreEnableInitialTrackGroups(ids);
+            // Map packages participate in the shared load catalog and initial
+            // track groups only while their map is the active session map;
+            // otherwise their content must leave the stock map untouched.
+            var applicableIds = ids
+                .Where(id => !LoadedMods.TryGetValue(id, out var mod) ||
+                             mod?.Definition == null ||
+                             FuseMapSession.ShouldApplyDefinition(mod.Definition))
+                .ToArray();
+            ApplyGlobalLoadCatalog(applicableIds, reason);
+            PreEnableInitialTrackGroups(applicableIds);
 
             var candidates = new List<FuseStagedApplyCandidate>();
             var outcomes = new List<PackageApplyOutcome>();
@@ -139,6 +147,18 @@ namespace FUSE.Loading
                         continue;
                     }
 
+                    if (!FuseMapSession.ShouldApplyDefinition(loaded.Definition))
+                    {
+                        var mapSkipReason = FuseMapSession.InactiveSkipReason(FuseMapSession.ActiveMapId);
+                        ReleaseInactiveMapPackageClaims(id);
+                        FusePackageFaultRegistry.MarkSkipped(id, mapSkipReason);
+                        outcomes.Add(PackageApplyOutcome.ForSkipped(id, mapSkipReason));
+                        FuseLog.Info(
+                            $"FUSE skipped map package='{id}' operation='runtime apply' " +
+                            $"id='{id}' reason='{mapSkipReason}'.");
+                        continue;
+                    }
+
                     candidates.Add(new FuseStagedApplyCandidate(loaded, AppliedDefinitionIds.Contains(id)));
                 }
                 catch (Exception ex)
@@ -159,6 +179,35 @@ namespace FUSE.Loading
         public static int ReapplyLoadedDefinitions(string reason)
         {
             return ApplyLoadedDefinitions(reason);
+        }
+
+        /// <summary>
+        /// A map package that was applied in an earlier session but is inactive
+        /// for this one still holds registry claims from that apply. Release
+        /// them (same set the definition-replacement path releases) so the
+        /// claims don't shadow other packages while the map sits dormant.
+        /// </summary>
+        private static void ReleaseInactiveMapPackageClaims(string id)
+        {
+            if (!AppliedDefinitionIds.Contains(id))
+            {
+                return;
+            }
+
+            try
+            {
+                FuseAudioAPI.ReleasePackage(id);
+                FuseWorldSuppressor.ReleasePackage(id);
+                var released = FuseRegistry.ReleaseAllForPackage(id);
+                AppliedDefinitionIds.Remove(id);
+                FuseLog.Info(
+                    $"FUSE released claims for inactive map package='{id}' operation='runtime apply' " +
+                    $"id='{id}' releasedClaims={released}.");
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception($"FUSE failed to release claims for inactive map package '{id}'", ex);
+            }
         }
 
         private static void RegisterLoadedDefinition(FuseModDefinition definition, string folderPath, string definitionPath)
@@ -186,6 +235,15 @@ namespace FUSE.Loading
             if (firstLoad && !LoadedOrder.Contains(definition.Id, StringComparer.OrdinalIgnoreCase))
             {
                 LoadedOrder.Add(definition.Id);
+            }
+
+            try
+            {
+                FuseMapPackageRegistry.RegisterFromDefinition(LoadedMods[definition.Id]);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception($"FUSE failed to register map declaration for '{definition.Id}'", ex);
             }
 
             FuseLog.Info($"FUSE loaded definition package='{definition.Id}' operation='load definition' id='{definition.Id}' definitionPath='{definitionPath ?? string.Empty}' folderPath='{folderPath ?? string.Empty}'.");
@@ -461,6 +519,8 @@ namespace FUSE.Loading
                     FuseLog.Exception($"FUSE failed to unregister map tile sources for unloaded mod '{modId}'", ex);
                 }
 
+                FuseMapPackageRegistry.Unregister(modId);
+
                 try
                 {
                     FuseEvents.RaiseModUnloaded(modId);
@@ -511,6 +571,7 @@ namespace FUSE.Loading
             {
                 FuseWorldSuppressor.RestoreAll("unload all");
             }
+            FuseMapPackageRegistry.Clear();
             // Per-mod claims were released in UnloadMod; reset registry to drop
             // any orphaned shared claims and the conflict history.
             FuseRegistry.Reset();
@@ -540,6 +601,11 @@ namespace FUSE.Loading
             foreach (var loaded in GetLoadedModsInOrder())
             {
                 var definition = loaded?.Definition;
+                if (!FuseMapSession.ShouldApplyDefinition(definition))
+                {
+                    continue;
+                }
+
                 var industryIds = definition?.Operations?.Removals?.Industries;
                 if (industryIds == null || industryIds.Length == 0)
                 {

--- a/FUSE/Loading/FusePackageFaultRegistry.cs
+++ b/FUSE/Loading/FusePackageFaultRegistry.cs
@@ -168,7 +168,8 @@ namespace FUSE.Loading
         public static bool IsOptionalSkipReason(string reason)
         {
             return !string.IsNullOrWhiteSpace(reason) &&
-                   reason.StartsWith("mixinto dependency missing", StringComparison.OrdinalIgnoreCase);
+                   (reason.StartsWith("mixinto dependency missing", StringComparison.OrdinalIgnoreCase) ||
+                    reason.StartsWith(FuseMapSession.InactiveSkipReasonPrefix, StringComparison.OrdinalIgnoreCase));
         }
 
         public static void LogFinalReport(string reason, int residentDefinitionCount)

--- a/FUSE/Patches/FuseEditorMainMenuPatch.cs
+++ b/FUSE/Patches/FuseEditorMainMenuPatch.cs
@@ -29,23 +29,14 @@ namespace FUSE.Patches
     /// Skipped when no lifecycle provider is registered so users without
     /// FUSE.Editor.dll deployed don't see a dead button.
     ///
-    /// Currently gated off via <see cref="EditorButtonEnabled"/> while the
-    /// editor is still under development — the button is not injected even
-    /// when a lifecycle provider is present. Flip the flag to true to
-    /// restore it once the editor is ready to ship.
+    /// Gated off with the in-game editor bootstrap. Custom maps remain
+    /// available through <see cref="FuseNewGameMapMenuPatch"/>.
     /// </summary>
     [HarmonyPatch(typeof(MainMenu), "Awake")]
     internal static class FuseEditorMainMenuPatch
     {
         private const string InjectedButtonName = "FuseEditorMainMenuButton";
         private const string InjectedButtonLabel = "FUSE Editor";
-
-        // Temporary gate: the FUSE Editor surface isn't ready for general
-        // use yet, so its main-menu entry point stays hidden. Kept as a
-        // static readonly (not a const) so the gated-off injection path
-        // below doesn't trip an unreachable-code warning. Flip to true to
-        // surface the button once the editor is shippable.
-        private static readonly bool EditorButtonEnabled = false;
 
         private static readonly FieldInfo MenuManagerGameManagerField =
             AccessTools.Field(typeof(MenuManager), "gameManager");
@@ -73,7 +64,7 @@ namespace FUSE.Patches
             // stays hidden for the time being. The stale pending-flag
             // clear above still runs, so a leftover flag can't spuriously
             // open the editor on the next sandbox session.
-            if (!EditorButtonEnabled)
+            if (!FusePlugin.InGameEditorEnabled)
             {
                 return;
             }

--- a/FUSE/Patches/FuseMapSessionPatches.cs
+++ b/FUSE/Patches/FuseMapSessionPatches.cs
@@ -1,0 +1,66 @@
+using System;
+using HarmonyLib;
+using Map.Runtime;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using UI.Menu;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Session plumbing for FUSE map packages. While <see cref="FuseMapSession"/>
+    /// has an active map, <c>MapStore.Load</c> is redirected from
+    /// StreamingAssets/Maps/&lt;dir&gt; to the pack's map folder, so the pack's
+    /// Map.json supplies the origin and the complete tile set — a wholesale
+    /// replacement of the stock terrain rather than an overlay. Returning to the
+    /// main menu always deactivates the session, so a subsequent stock-map
+    /// launch is untouched.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FuseMapSessionPatches
+    {
+        [HarmonyPatch(typeof(MapStore), "Load", typeof(string))]
+        [HarmonyPrefix]
+        private static void MapStoreLoadPrefix(ref string basePath)
+        {
+            try
+            {
+                var activeMapId = FuseMapSession.ActiveMapId;
+                if (string.IsNullOrEmpty(activeMapId))
+                {
+                    return;
+                }
+
+                if (!FuseMapPackageRegistry.TryGetMap(activeMapId, out var map) || !map.IsValid)
+                {
+                    var fault = map == null ? "map is not registered" : map.FaultReason;
+                    FuseLog.Warning(
+                        $"FUSE map session '{activeMapId}' cannot load: {fault}. Falling back to the stock map for this session.");
+                    FuseMapSession.Deactivate("registered map missing or faulted at MapStore.Load");
+                    return;
+                }
+
+                FuseLog.Info($"FUSE redirected MapStore.Load from '{basePath}' to '{map.MapFolder}' for map '{map.MapId}'.");
+                basePath = map.MapFolder;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE map session redirect failed in MapStore.Load; loading the stock map.", ex);
+            }
+        }
+
+        [HarmonyPatch(typeof(MainMenu), "Awake")]
+        [HarmonyPostfix]
+        private static void MainMenuAwakePostfix()
+        {
+            try
+            {
+                FuseMapSession.Deactivate("main menu");
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE failed to deactivate the map session at the main menu.", ex);
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseNewGameMapMenuPatch.cs
+++ b/FUSE/Patches/FuseNewGameMapMenuPatch.cs
@@ -1,0 +1,461 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using Game.State;
+using HarmonyLib;
+using Network;
+using UI.Builder;
+using UI.Common;
+using UI.Menu;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Adds a world/map dropdown to New Game while preserving Railroader's
+    /// existing map control as a separate starting-progression dropdown. The
+    /// world selection travels with the new-game setup as a temporary marker
+    /// and is consumed immediately before launch, keeping Back/cancel flows
+    /// from leaving a stale active map.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FuseNewGameMapMenuPatch
+    {
+        private sealed class MenuSelection
+        {
+            internal string MapId = string.Empty;
+        }
+
+        private static readonly ConditionalWeakTable<NewGameMenu, MenuSelection> Selections =
+            new ConditionalWeakTable<NewGameMenu, MenuSelection>();
+
+        private static readonly FieldInfo ProgressionIdField =
+            AccessTools.Field(typeof(NewGameMenu), "_progressionId");
+
+        private static readonly FieldInfo SetupIdField =
+            AccessTools.Field(typeof(NewGameMenu), "_setupId");
+
+        private static readonly MethodInfo SelectProgressionIdMethod =
+            AccessTools.Method(
+                typeof(NewGameMenu),
+                "SelectProgressionId",
+                new[] { typeof(string) });
+
+        [HarmonyPatch(typeof(NewGameMenu), "BuildPanelContent")]
+        [HarmonyTranspiler]
+        private static List<CodeInstruction> BuildPanelContentTranspiler(
+            IEnumerable<CodeInstruction> instructions)
+        {
+            var result = instructions.ToList();
+            var addFieldMethod = AccessTools.Method(
+                typeof(UIPanelBuilder),
+                "AddField",
+                new[] { typeof(string), typeof(RectTransform) });
+            var addWorldFieldMethod = AccessTools.Method(
+                typeof(FuseNewGameMapMenuPatch),
+                nameof(AddWorldField));
+
+            var modeLabelIndex = result.FindIndex(instruction =>
+                instruction.opcode == OpCodes.Ldstr &&
+                string.Equals(
+                    instruction.operand as string,
+                    "Mode",
+                    StringComparison.Ordinal));
+            var insertionIndex = FindInsertionAfterField(
+                result,
+                modeLabelIndex,
+                addFieldMethod);
+
+            if (insertionIndex < 0 || addWorldFieldMethod == null)
+            {
+                FuseLog.Warning(
+                    "FUSE could not place the New Game world selector; " +
+                    "Railroader's NewGameMenu layout no longer matched the expected shape.");
+                return result;
+            }
+
+            result.InsertRange(
+                insertionIndex,
+                new[]
+                {
+                    new CodeInstruction(OpCodes.Ldarg_0),
+                    new CodeInstruction(OpCodes.Ldarg_1),
+                    new CodeInstruction(OpCodes.Call, addWorldFieldMethod),
+                });
+
+            for (var index = insertionIndex + 3; index < result.Count; index++)
+            {
+                if (result[index].opcode == OpCodes.Ldstr &&
+                    string.Equals(
+                        result[index].operand as string,
+                        "Map",
+                        StringComparison.Ordinal))
+                {
+                    result[index].operand = "Starting Progression";
+                    break;
+                }
+            }
+
+            return result;
+        }
+
+        [HarmonyPatch(typeof(NewGameMenu), "BuildMapSelect")]
+        [HarmonyPrefix]
+        private static bool BuildMapSelectPrefix(
+            NewGameMenu __instance,
+            UIPanelBuilder builder,
+            ref RectTransform __result)
+        {
+            if (__instance == null ||
+                ProgressionIdField == null ||
+                SetupIdField == null ||
+                SelectProgressionIdMethod == null)
+            {
+                return true;
+            }
+
+            try
+            {
+                var selection = Selections.GetValue(
+                    __instance,
+                    CreateMenuSelection);
+                if (string.IsNullOrWhiteSpace(selection.MapId))
+                {
+                    return true;
+                }
+
+                if (!FuseMapPackageRegistry.TryGetMap(
+                        selection.MapId,
+                        out var map) ||
+                    !map.IsValid)
+                {
+                    selection.MapId = string.Empty;
+                    SelectStockMap(__instance);
+                    return true;
+                }
+
+                var options = FuseNewGameProgressionOption.Build(map);
+                var currentProgressionId =
+                    ProgressionIdField.GetValue(__instance) as string;
+                var selectedIndex = FindProgressionIndex(
+                    options,
+                    currentProgressionId);
+                if (selectedIndex < 0)
+                {
+                    selectedIndex = 0;
+                    SelectProgression(
+                        __instance,
+                        options[selectedIndex].ProgressionId);
+                }
+
+                __result = builder.AddDropdown(
+                    options.Select(option => option.DisplayName).ToList(),
+                    selectedIndex,
+                    index =>
+                    {
+                        if (index >= 0 && index < options.Count)
+                        {
+                            SelectProgression(
+                                __instance,
+                                options[index].ProgressionId);
+                        }
+                    });
+                return false;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception(
+                    "FUSE failed to build the selected custom map's progression dropdown; " +
+                    "using Railroader's stock options.",
+                    ex);
+                return true;
+            }
+        }
+
+        [HarmonyPatch(typeof(NewGameMenu), "StartButtonClicked")]
+        [HarmonyPrefix]
+        private static void StartButtonClickedPrefix(
+            NewGameMenu __instance,
+            out Action<string, NewGameSetup> __state)
+        {
+            var continuation = __instance?.OnContinue;
+            __state = continuation;
+            if (continuation == null ||
+                !Selections.TryGetValue(__instance, out var selection) ||
+                string.IsNullOrEmpty(selection.MapId))
+            {
+                return;
+            }
+
+            var mapId = selection.MapId;
+            __instance.OnContinue = (saveName, setup) =>
+                continuation(
+                    saveName,
+                    FuseNewGameMapOption.MarkSelection(setup, mapId));
+        }
+
+        [HarmonyPatch(typeof(NewGameMenu), "StartButtonClicked")]
+        [HarmonyPostfix]
+        private static void StartButtonClickedPostfix(
+            NewGameMenu __instance,
+            Action<string, NewGameSetup> __state)
+        {
+            if (__instance != null)
+            {
+                __instance.OnContinue = __state;
+            }
+        }
+
+        [HarmonyPatch(
+            typeof(MenuManager),
+            "Launch",
+            new[]
+            {
+                typeof(GameSetup?),
+                typeof(INetworkSetup),
+                typeof(GlobalGameManager.SceneLoadSetup),
+            })]
+        [HarmonyPrefix]
+        private static bool LaunchPrefix(ref GameSetup? gameSetup)
+        {
+            try
+            {
+                if (!TryPrepareMapLaunch(ref gameSetup, out var error))
+                {
+                    FuseLog.Warning(
+                        "FUSE custom map launch blocked: " + error);
+                    Toast.Present(
+                        "FUSE map launch failed: " + error);
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                FuseMapSession.Deactivate(
+                    "native map dropdown launch preparation threw");
+                FuseLog.Exception(
+                    "FUSE failed to prepare the selected custom map; launch was blocked.",
+                    ex);
+                Toast.Present(
+                    "FUSE map launch failed; see FUSE.log.");
+                return false;
+            }
+        }
+
+        internal static bool TryPrepareMapLaunch(
+            ref GameSetup? gameSetup,
+            out string error)
+        {
+            error = string.Empty;
+            if (!gameSetup.HasValue ||
+                !gameSetup.Value.NewGameSetup.HasValue ||
+                !FuseNewGameMapOption.TryParseSelectionMarker(
+                    gameSetup.Value.NewGameSetup.Value.SetupId,
+                    out var mapId))
+            {
+                FuseMapSession.Deactivate(
+                    "stock map selected in New Game");
+                return true;
+            }
+
+            if (!FuseMapPackageRegistry.TryGetMap(mapId, out var map))
+            {
+                FuseMapSession.Deactivate(
+                    "selected New Game map is no longer registered");
+                error =
+                    $"Map package '{mapId}' is not installed or enabled.";
+                return false;
+            }
+
+            if (!map.IsValid)
+            {
+                FuseMapSession.Deactivate(
+                    "selected New Game map is faulted");
+                error =
+                    $"Map package '{mapId}' cannot load: {map.FaultReason}";
+                return false;
+            }
+
+            var updatedGameSetup = gameSetup.Value;
+            updatedGameSetup.NewGameSetup =
+                FuseNewGameMapOption.ClearSelectionMarker(
+                    updatedGameSetup.NewGameSetup.Value);
+            gameSetup = updatedGameSetup;
+            FuseMapSession.Activate(map.MapId);
+            return true;
+        }
+
+        private static int FindInsertionAfterField(
+            List<CodeInstruction> instructions,
+            int startIndex,
+            MethodInfo addFieldMethod)
+        {
+            if (startIndex < 0 || addFieldMethod == null)
+            {
+                return -1;
+            }
+
+            for (var index = startIndex + 1;
+                 index < instructions.Count;
+                 index++)
+            {
+                if (!instructions[index].Calls(addFieldMethod))
+                {
+                    continue;
+                }
+
+                var insertionIndex = index + 1;
+                if (insertionIndex < instructions.Count &&
+                    instructions[insertionIndex].opcode == OpCodes.Pop)
+                {
+                    insertionIndex++;
+                }
+
+                return insertionIndex;
+            }
+
+            return -1;
+        }
+
+        private static int FindSelectedIndex(
+            IReadOnlyList<FuseNewGameMapOption> options,
+            string selectedMapId)
+        {
+            if (string.IsNullOrEmpty(selectedMapId))
+            {
+                return 0;
+            }
+
+            for (var index = 1; index < options.Count; index++)
+            {
+                if (string.Equals(
+                        options[index].MapId,
+                        selectedMapId,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return index;
+                }
+            }
+
+            return -1;
+        }
+
+        private static int FindProgressionIndex(
+            IReadOnlyList<FuseNewGameProgressionOption> options,
+            string progressionId)
+        {
+            for (var index = 0; index < options.Count; index++)
+            {
+                if (string.Equals(
+                        options[index].ProgressionId,
+                        progressionId,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return index;
+                }
+            }
+
+            return -1;
+        }
+
+        private static MenuSelection CreateMenuSelection(NewGameMenu _)
+        {
+            return new MenuSelection();
+        }
+
+        private static void AddWorldField(
+            NewGameMenu menu,
+            UIPanelBuilder builder)
+        {
+            try
+            {
+                FuseDataPackageDiscovery.LoadPackagesFromDisk(false);
+                var options = FuseNewGameMapOption.Build(
+                    FuseMapPackageRegistry.GetRegisteredMaps());
+                var selection = Selections.GetValue(
+                    menu,
+                    CreateMenuSelection);
+                var selectedIndex = FindSelectedIndex(
+                    options,
+                    selection.MapId);
+                if (selectedIndex < 0)
+                {
+                    selection.MapId = string.Empty;
+                    selectedIndex = 0;
+                }
+
+                builder.AddField(
+                    "Map",
+                    builder.AddDropdown(
+                        options
+                            .Select(option => option.DisplayName)
+                            .ToList(),
+                        selectedIndex,
+                        index =>
+                        {
+                            if (index < 0 || index >= options.Count)
+                            {
+                                return;
+                            }
+
+                            selection.MapId = options[index].MapId;
+                            SelectDefaultProgression(
+                                menu,
+                                selection.MapId);
+                            builder.Rebuild();
+                        }));
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception(
+                    "FUSE failed to add the New Game world selector.",
+                    ex);
+            }
+        }
+
+        private static void SelectDefaultProgression(
+            NewGameMenu menu,
+            string mapId)
+        {
+            if (string.IsNullOrWhiteSpace(mapId))
+            {
+                SelectStockMap(menu);
+                return;
+            }
+
+            if (!FuseMapPackageRegistry.TryGetMap(
+                    mapId,
+                    out var map) ||
+                !map.IsValid)
+            {
+                SelectProgression(menu, null);
+                return;
+            }
+
+            var option = FuseNewGameProgressionOption.Build(map)[0];
+            SelectProgression(menu, option.ProgressionId);
+        }
+
+        private static void SelectProgression(
+            NewGameMenu menu,
+            string progressionId)
+        {
+            ProgressionIdField.SetValue(menu, progressionId);
+            SetupIdField.SetValue(menu, null);
+        }
+
+        private static void SelectStockMap(NewGameMenu menu)
+        {
+            SelectProgressionIdMethod.Invoke(
+                menu,
+                new object[] { FuseNewGameMapOption.StockProgressionId });
+        }
+    }
+}

--- a/FUSE/Patches/FuseNewGameMapOption.cs
+++ b/FUSE/Patches/FuseNewGameMapOption.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Loading;
+using Game.State;
+
+namespace FUSE.Patches
+{
+    internal sealed class FuseNewGameMapOption
+    {
+        internal const string StockMapName = "Railroader Base Map";
+        internal const string StockProgressionName = "East Whittier Start";
+        internal const string StockProgressionId = "ewh";
+        internal const string SelectionMarkerPrefix = "fuse-map:";
+        private const string OriginalSetupSeparator = "|setup:";
+
+        private FuseNewGameMapOption(string mapId, string displayName)
+        {
+            MapId = mapId ?? string.Empty;
+            DisplayName = displayName ?? string.Empty;
+        }
+
+        internal string MapId { get; }
+        internal string DisplayName { get; }
+        internal bool IsStock => string.IsNullOrEmpty(MapId);
+
+        internal static IReadOnlyList<FuseNewGameMapOption> Build(IEnumerable<FuseRegisteredMap> maps)
+        {
+            var options = new List<FuseNewGameMapOption>
+            {
+                new FuseNewGameMapOption(string.Empty, StockMapName),
+            };
+
+            var seenMapIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var map in (maps ?? Enumerable.Empty<FuseRegisteredMap>())
+                         .Where(candidate => candidate != null &&
+                                             candidate.IsValid &&
+                                             !string.IsNullOrWhiteSpace(candidate.MapId))
+                         .OrderBy(candidate => candidate.DisplayName, StringComparer.OrdinalIgnoreCase)
+                         .ThenBy(candidate => candidate.MapId, StringComparer.OrdinalIgnoreCase))
+            {
+                if (!seenMapIds.Add(map.MapId))
+                {
+                    continue;
+                }
+
+                options.Add(new FuseNewGameMapOption(map.MapId, map.DisplayName));
+            }
+
+            return options;
+        }
+
+        internal static string CreateSelectionMarker(
+            string mapId,
+            string originalSetupId = null)
+        {
+            var normalized = (mapId ?? string.Empty).Trim();
+            return string.IsNullOrEmpty(normalized)
+                ? string.Empty
+                : SelectionMarkerPrefix + normalized +
+                  OriginalSetupSeparator + (originalSetupId ?? string.Empty);
+        }
+
+        internal static bool TryParseSelectionMarker(
+            string setupId,
+            out string mapId)
+        {
+            return TryParseSelectionMarker(setupId, out mapId, out _);
+        }
+
+        internal static bool TryParseSelectionMarker(
+            string setupId,
+            out string mapId,
+            out string originalSetupId)
+        {
+            mapId = string.Empty;
+            originalSetupId = null;
+            if (string.IsNullOrWhiteSpace(setupId) ||
+                !setupId.StartsWith(SelectionMarkerPrefix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var payload = setupId.Substring(SelectionMarkerPrefix.Length);
+            var separatorIndex = payload.IndexOf(
+                OriginalSetupSeparator,
+                StringComparison.Ordinal);
+            if (separatorIndex >= 0)
+            {
+                mapId = payload.Substring(0, separatorIndex).Trim();
+                originalSetupId = payload.Substring(
+                    separatorIndex + OriginalSetupSeparator.Length);
+                if (string.IsNullOrEmpty(originalSetupId))
+                {
+                    originalSetupId = null;
+                }
+            }
+            else
+            {
+                mapId = payload.Trim();
+            }
+
+            return !string.IsNullOrEmpty(mapId);
+        }
+
+        internal static NewGameSetup MarkSelection(NewGameSetup setup, string mapId)
+        {
+            return new NewGameSetup(
+                setup.RailroadName,
+                setup.ReportingMark,
+                setup.Mode,
+                setup.ProgressionId,
+                CreateSelectionMarker(mapId, setup.SetupId));
+        }
+
+        internal static NewGameSetup ClearSelectionMarker(NewGameSetup setup)
+        {
+            var originalSetupId = setup.SetupId;
+            if (TryParseSelectionMarker(
+                    setup.SetupId,
+                    out _,
+                    out var parsedSetupId))
+            {
+                originalSetupId = parsedSetupId;
+            }
+
+            return new NewGameSetup(
+                setup.RailroadName,
+                setup.ReportingMark,
+                setup.Mode,
+                setup.ProgressionId,
+                originalSetupId);
+        }
+    }
+
+    internal sealed class FuseNewGameProgressionOption
+    {
+        internal const string NoProgressionName = "None (map default)";
+
+        private FuseNewGameProgressionOption(
+            string displayName,
+            string progressionId)
+        {
+            DisplayName = displayName ?? string.Empty;
+            ProgressionId = progressionId;
+        }
+
+        internal string DisplayName { get; }
+        internal string ProgressionId { get; }
+
+        internal static IReadOnlyList<FuseNewGameProgressionOption> Build(
+            FuseRegisteredMap map)
+        {
+            var progressionIds = map?.ProgressionIds ?? Array.Empty<string>();
+            if (progressionIds.Count == 0)
+            {
+                return new[]
+                {
+                    new FuseNewGameProgressionOption(NoProgressionName, null),
+                };
+            }
+
+            return progressionIds
+                .Select(id => new FuseNewGameProgressionOption(id, id))
+                .ToArray();
+        }
+    }
+}

--- a/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
+++ b/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
@@ -110,6 +110,11 @@ namespace FUSE.Runtime.Lifecycle
             {
                 terrainScope = FuseTerrainRefreshScope.Begin();
                 FuseLegacyAssemblyHost.LoadAllAvailableAssemblies("map load fallback");
+                if (canMutateWorld)
+                {
+                    FuseLoadingScreen.SetStep("Preparing map", "Removing the stock world");
+                    FuseBaseWorldIsolation.ApplyForActiveMap("map load before cache rebuild");
+                }
                 var cacheStopwatch = Stopwatch.StartNew();
                 FuseCacheRegistry.RebuildAll();
                 FusePerformanceMetrics.RecordTiming("cache rebuild before map load apply", cacheStopwatch.ElapsedMilliseconds);
@@ -370,6 +375,7 @@ namespace FUSE.Runtime.Lifecycle
                 FuseWorldSuppressor.RestoreAll("map unload");
                 FuseEarlyLoader.RestoreOnMapUnload();
                 FuseModLoader.UnloadAll(resetDiscovery: true, restoreTrackSnapshots: false);
+                FuseBaseWorldIsolation.Reset();
                 FuseMapTileRegistry.ClearAll();
                 TrackAPI.ClearBaseGraphSnapshot();
                 ProgressionAPI.ClearRememberedReferenceIds();

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ FUSE supports these package categories:
 
 - Route/data packages with `*.fuse.json` files
 - Map tile overlays
+- Custom map packages selectable from a dedicated New Game map dropdown, with Railroader's existing control retained separately for starting progression
 - Asset packs, including direct nested asset pack discovery under converted mod folders
 - Track graph nodes, segments, spans, areas, groups, removals, and turntables
 - World scenery, scene clones, map labels, speed signs, map masks, splineys, telegraph poles, telegraph pole movements, and spawn points
@@ -28,7 +29,8 @@ The FUSE JSON schema lives at `schemas/fuse-mod.schema.json`. The hand-written s
 
 ## Not Supported
 
-- Full public in-game editor workflow
+- The retired in-game editor (use an external editor; FUSE still discovers and
+  loads custom map packages at runtime)
 - Multiplayer is compatibility-mode only. FUSE does not sync package contents over the network; instead every host/client applies its own local package stack, matching the legacy Railloader expectation that everyone has the same mods installed. Non-host clients log a warning the first time they apply runtime world changes. Servers that want strict client blocking can set `Settings.BlockNonHostMultiplayerClientWorldApply` to `true`.
 - Arbitrary legacy script mods that are not data, asset, audio, or supported runtime component packages
 - Rolling stock and locomotive/car mods, except audio definitions that FUSE can import

--- a/docs/EDITOR_ARCHITECTURE.md
+++ b/docs/EDITOR_ARCHITECTURE.md
@@ -1,8 +1,11 @@
 # FUSE Editor — Architecture
 
-The FUSE editor is being built as its own top-level mode, inspired by Arma 3's
-EDEN editor. This doc captures the target architecture and the path between
-where we are today (a visual mockup) and the final shape.
+> **Status: retired.** FUSE no longer initializes or ships this in-game editor.
+> The source remains as a historical design reference. Custom map loading and
+> the standalone editor are separate systems and remain supported.
+
+The FUSE editor was designed as its own top-level mode, inspired by Arma 3's
+EDEN editor. This doc captures that historical target architecture.
 
 ## North Star
 
@@ -75,9 +78,8 @@ EDEN parallels:
 - Owns the Harmony patches that touch game UI (the main-menu button).
 - Holds the bridge interfaces (`IFuseEditorLifecycle`, `IFuseSelectionProvider`,
   `IFuseEditorProvider`) and the `FuseEditorBridge` static dispatcher.
-- Loads `FUSE.Editor.dll` lazily via `FuseEditorAssemblyLoader` once UMM
-  has booted. After that one reflection point, every cross-assembly call
-  is typed via the bridge.
+- Retains the disabled `FuseEditorAssemblyLoader` and bridge contracts for
+  source history; the runtime feature gate prevents bootstrap.
 
 `FUSE.Editor.dll`
 
@@ -90,7 +92,7 @@ EDEN parallels:
   logic. These are paused-out today (no entry path); they'll be re-summoned
   once the screen has selection plumbing.
 
-Bridge methods used by the current flow:
+Bridge methods used by the former flow:
 
 | Direction         | Method                                | Use                                             |
 | ----------------- | ------------------------------------- | ----------------------------------------------- |

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,7 +2,8 @@
 
 ## Deferred Systems
 
-- The public in-game editor workflow is not a beta blocker yet.
+- The in-game editor is retired and no longer initialized or shipped with the
+  runtime mod. External editors can continue to produce custom map packages.
 - Rolling stock and locomotive/car mods are out of beta scope unless they are audio-only horn, whistle, or bell packs.
 
 ## Game Limitations

--- a/docs/PACKAGE_AUTHOR_GUIDE.md
+++ b/docs/PACKAGE_AUTHOR_GUIDE.md
@@ -75,6 +75,13 @@ Custom components can use `fields` for reflection-bound values. The custom compo
 
 Use `world.scenery` for asset-pack objects. Use `world.sceneClones` for base-game scene objects. Use `world.mapMasks` for terrain flattening, tree cutting, height masks, and mask modifiers. Use `world.splineys` for roads, rivers, trestles, and related spline builders.
 
+Packages with a `map` declaration are treated as complete replacement worlds:
+`map.suppressBaseWorld` defaults to `true`. FUSE keeps Railroader's required
+scene managers but removes the stock track graph and suppresses the stock
+operations, scenery, map labels, signs, setups, progression, and CTC content
+before applying the selected package. Set `suppressBaseWorld` to `false` only
+for a map that intentionally overlays custom terrain on Bushnell/Whittier.
+
 Asset pack objects should keep their real asset identifiers. Do not alias to unrelated assets if the correct pack exists.
 
 ## Diagnostics

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,8 +13,8 @@ Runs [`.github/workflows/release.yml`](../.github/workflows/release.yml) on the
 **self-hosted** Railroader runner (it needs the game's Unity/UMM reference
 assemblies). Produces and attaches:
 
-- `FUSE-v<ver>.zip` — the UMM mod (FUSE.dll, FUSE.Editor.dll, FUSE.Converter.dll,
-  stamped `Info.json`, schemas, icon)
+- `FUSE-v<ver>.zip` — the UMM runtime mod (FUSE.dll, stamped `Info.json`,
+  schemas, icon)
 - `FUSE.LiveBridge-v<ver>.zip` — optional in-game hot-reload bridge
 - `FUSE-Converter.exe`, `FUSE-Installer.exe`, `FUSEConvertFolder.pyz` — tools
 
@@ -30,7 +30,7 @@ This lane does **not** ship the standalone editor — that has its own lane.
 Tag: `externaleditor-v0.2.0`, `externaleditor-v1.0.0-rc.1`, ...
 
 The prefix is `externaleditor-` (not `editor-`) to distinguish the standalone
-desktop editor from the in-game editor, which ships inside the mod.
+desktop editor from the retired in-game editor, which is no longer shipped.
 
 Runs [`.github/workflows/release-externaleditor.yml`](../.github/workflows/release-externaleditor.yml)
 on a **GitHub-hosted** `ubuntu-latest` runner — the standalone editor is

--- a/schemas/FUSE_JSON_SCHEMA.md
+++ b/schemas/FUSE_JSON_SCHEMA.md
@@ -17,6 +17,12 @@ Top-level object groups:
 - `operations`: loads, industries, loaders, turntables, and passenger stations.
 - `world`: scenery, spawn points, splineys, telegraph poles, map labels, map masks, map tile overlays, scene clones, and optional removals for base scene objects.
 - `progression`: progression trees and map features.
+
+Map declarations are complete replacement worlds by default. `map.suppressBaseWorld`
+defaults to `true`, which removes the stock Bushnell/Whittier graph and suppresses
+its operations, scenery, labels, signs, setup, progression, and CTC content before
+the selected package applies. Set it to `false` only when the package deliberately
+uses custom terrain as an overlay on the stock world.
 - `settings`: package-declared UI settings with user, profile, or server scope. Runtime values are stored under LocalLow/FUSE, not written into package folders.
 - `editor`: optional editor-only state that FUSE can ignore at runtime.
 - `extensions`: optional namespaced third-party data.

--- a/schemas/fuse-mod.schema.json
+++ b/schemas/fuse-mod.schema.json
@@ -64,6 +64,10 @@
             ],
             "default": "world"
         },
+        "map": {
+            "$ref": "#/$defs/map",
+            "description": "Declares that this package provides a selectable map. The map id is the package id. Map-package content applies only when its map is the active session map."
+        },
         "mixinto": {
             "$ref": "#/$defs/mixinto",
             "description": "Optional legacy conditional mixinto metadata. FUSE applies this fragment only when its requirements are satisfied, matching RailLoader/Strange Customs conditional mixins."
@@ -135,6 +139,32 @@
             "type": "object",
             "propertyNames": {
                 "$ref": "#/$defs/id"
+            }
+        },
+        "map": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "mapFolder"
+            ],
+            "properties": {
+                "displayName": {
+                    "type": "string",
+                    "description": "Name shown wherever the map is offered for selection. Falls back to the package name when blank."
+                },
+                "description": {
+                    "type": "string"
+                },
+                "mapFolder": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Package-relative folder shaped like StreamingAssets/Maps/<name>: Map.json (origin, tileDimension, tiles) plus tile_XXX_YYY.data heightmap tiles. Must stay inside the package folder."
+                },
+                "suppressBaseWorld": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "When true, the stock Bushnell/Whittier track graph, operations, scenery, labels, signs, setups, progression, and CTC content are suppressed before this complete map package applies. Set false only for an intentional terrain overlay on the stock world."
+                }
             }
         },
         "mixinto": {

--- a/scripts/Validate-ModPackage.cs
+++ b/scripts/Validate-ModPackage.cs
@@ -15,8 +15,8 @@
 //
 // Checks:
 //   - Archive layout: exactly one top-level folder named <mod-id> containing the
-//     runtime DLL set (FUSE.dll, FUSE.Editor.dll, FUSE.Converter.dll), Info.json,
-//     a non-empty schemas/ tree and assets/fuse_icon.png. No stray files, no *.pdb.
+//     runtime DLL (FUSE.dll), Info.json, a non-empty schemas/ tree and
+//     assets/fuse_icon.png. No stray files, no *.pdb.
 //   - Info.json: required fields present and non-empty; Version is the version
 //     CORE (MAJOR.MINOR.PATCH, the only shape UMM's System.Version parser accepts)
 //     and matches the expected core; AssemblyName matches the entry DLL;
@@ -56,13 +56,9 @@ string expectedVersion = args[1];
 string modId = args.Length > 2 && !string.IsNullOrWhiteSpace(args[2]) ? args[2] : "FUSE";
 string? refDirArg = args.Length > 3 && !string.IsNullOrWhiteSpace(args[3]) ? args[3] : null;
 
-// The entry DLL (carries EntryMethod) plus the companion assemblies FUSE ships
-// alongside it. FUSE.dll loads FUSE.Editor.dll lazily via Assembly.LoadFrom after
-// UMM boots; FUSE.Editor.dll references FUSE.Converter.dll for its Convert button.
-// All three must be present for the mod to be functional, so a release missing any
-// of them is a packaging regression worth failing on.
+// The entry DLL carries the UMM EntryMethod. The retired in-game editor and its
+// converter dependency are intentionally not part of the runtime mod package.
 string entryDll = $"{modId}.dll";
-string[] companionDlls = { "FUSE.Editor.dll", "FUSE.Converter.dll" };
 
 // UMM does not accept SemVer pre-release tags in Info.json (it parses Version as
 // System.Version, which only allows numeric segments), so the build stamps Info.json
@@ -144,8 +140,6 @@ try
 
     Require(infoExists, "Info.json missing from mod folder.");
     Require(entryDllExists, $"{entryDll} missing from mod folder.");
-    foreach (var dll in companionDlls)
-        Require(File.Exists(Path.Combine(modFolder.FullName, dll)), $"{dll} missing from mod folder.");
 
     // schemas/ ships the JSON schemas FUSE validates mods against at runtime; an
     // empty or absent tree means the zip is broken.
@@ -170,7 +164,6 @@ try
         "Info.json",
         entryDll,
     };
-    foreach (var dll in companionDlls) allowedFlat.Add(dll);
 
     bool IsAllowed(string rel) =>
         allowedFlat.Contains(rel) ||

--- a/scripts/generate-test-map-pack.py
+++ b/scripts/generate-test-map-pack.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Generate the FUSE test map pack: a small flat-terrain map used to verify
+FUSE map-package loading end to end (registry -> launch -> MapStore redirect).
+
+Tile format (reverse-engineered from Map.Runtime.TileData.Save):
+  - each tile_XXX_YYY.data is a 513x513 RGBA PNG
+  - height is a 16-bit value split across R (high byte) and G (low byte),
+    encoded as (heightMeters - 500) * 65.535, clamped to [0, 65535]
+    (the game's terrain band is 500..1500 m)
+  - B is unused (0); A packs vegetation/water mask bits (0 = defaults)
+
+Map.json mirrors StreamingAssets/Maps/BushnellWhittier/Map.json:
+  {"origin": {"latitude": ..., "longitude": ...}, "tileDimension": 500,
+   "tiles": [{"x": ..., "y": ...}, ...]}
+
+Usage:
+  python scripts/generate-test-map-pack.py [output-folder]
+
+Default output folder is the pack folder inside the Railroader Mods
+directory: C:/Steam/steamapps/common/Railroader/Mods/FuseTestMap
+"""
+
+import json
+import math
+import os
+import sys
+
+from PIL import Image
+
+RESOLUTION = 513
+TILE_DIMENSION = 500
+BASE_HEIGHT_M = 550.0
+HILL_HEIGHT_M = 40.0
+
+# PRR Middle Division project center (Tuscarora Valley) so the test pack also
+# exercises an origin far away from the stock map's Bushnell, NC origin.
+ORIGIN_LAT = 40.43
+ORIGIN_LON = -77.72
+
+# Tile grid: generous coverage around the world origin so the stock spawn
+# point (somewhere in the Whittier area of game-coordinate space) sits over
+# real terrain instead of a hole.
+TILE_RANGE_X = range(-2, 15)
+TILE_RANGE_Y = range(-2, 15)
+
+PACK_ID = "fuse-test-map"
+DEFAULT_OUTPUT = r"C:\Steam\steamapps\common\Railroader\Mods\FuseTestMap"
+
+
+def height_at(world_x: float, world_z: float) -> float:
+    """Flat plain with one broad sinusoidal hill so terrain is visibly ours."""
+    hill = (
+        math.sin(world_x / 700.0 * math.pi)
+        * math.sin(world_z / 700.0 * math.pi)
+    )
+    return BASE_HEIGHT_M + HILL_HEIGHT_M * max(0.0, hill)
+
+
+def encode_height(height_m: float) -> int:
+    value = int((height_m - 500.0) * 65.535)
+    return max(0, min(65535, value))
+
+
+def build_tile(tile_x: int, tile_y: int) -> Image.Image:
+    image = Image.new("RGBA", (RESOLUTION, RESOLUTION))
+    pixels = image.load()
+    step = TILE_DIMENSION / (RESOLUTION - 1)
+    for row in range(RESOLUTION):
+        world_z = (tile_y * TILE_DIMENSION) + row * step
+        for col in range(RESOLUTION):
+            world_x = (tile_x * TILE_DIMENSION) + col * step
+            encoded = encode_height(height_at(world_x, world_z))
+            pixels[col, row] = ((encoded >> 8) & 0xFF, encoded & 0xFF, 0, 0)
+    return image
+
+
+def tile_coord(value: int) -> str:
+    """Match C# value.ToString("000"): minimum three digits, sign extra."""
+    return f"-{abs(value):03d}" if value < 0 else f"{value:03d}"
+
+
+def main() -> None:
+    output = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_OUTPUT
+    map_folder = os.path.join(output, "Map")
+    os.makedirs(map_folder, exist_ok=True)
+
+    tiles = []
+    for tile_x in TILE_RANGE_X:
+        for tile_y in TILE_RANGE_Y:
+            tiles.append({"x": tile_x, "y": tile_y})
+            tile_path = os.path.join(
+                map_folder, f"tile_{tile_coord(tile_x)}_{tile_coord(tile_y)}.data"
+            )
+            build_tile(tile_x, tile_y).save(tile_path, format="PNG")
+
+    map_json = {
+        "origin": {"latitude": ORIGIN_LAT, "longitude": ORIGIN_LON},
+        "tileDimension": TILE_DIMENSION,
+        "tiles": tiles,
+    }
+    with open(os.path.join(map_folder, "Map.json"), "w", encoding="utf-8") as f:
+        json.dump(map_json, f)
+
+    definition = {
+        "schemaVersion": "1.0",
+        "id": PACK_ID,
+        "name": "FUSE Test Map",
+        "author": "FUSE",
+        "description": (
+            "Flat test terrain used to verify FUSE map-package loading. "
+            "Launch from the FUSE console (/fuse.map.launch fuse-test-map) "
+            "or the FUSE menu Tools page."
+        ),
+        "map": {
+            "displayName": "FUSE Test Map (Flat Plain)",
+            "description": "A flat 550 m plain with one broad hill.",
+            "mapFolder": "Map",
+        },
+    }
+    definition_path = os.path.join(output, f"{PACK_ID}.fuse.json")
+    with open(definition_path, "w", encoding="utf-8") as f:
+        json.dump(definition, f, indent=2)
+
+    # FUSE package discovery only treats a Mods folder as a data package when
+    # Info.json declares FuseDataFile(s) (or a FUSE requirement plus a root
+    # definition). Without this, the pack is silently ignored.
+    info = {
+        "Id": PACK_ID,
+        "DisplayName": "FUSE Test Map",
+        "Author": "FUSE",
+        "Version": "0.1.0",
+        "ManagerVersion": "0.27.10",
+        "GameVersion": "2025.1",
+        "Requirements": ["FUSE"],
+        "LoadAfter": ["FUSE"],
+        "FuseDataFiles": [f"{PACK_ID}.fuse.json"],
+    }
+    with open(os.path.join(output, "Info.json"), "w", encoding="utf-8") as f:
+        json.dump(info, f, indent=2)
+
+    print(f"Wrote {len(tiles)} tiles, Info.json, and {definition_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add package-declared replacement maps to the native New Game flow
- isolate stock world content when a complete custom map is selected
- retire embedded FUSE editor startup/deployment while retaining map loading and external-editor workflows
- rebase the work on current main so the latest performance changes, diagnostics, and third-party guards are present

## Verification
- focused custom-map tests: 49 passed
- full FUSE.Tests: 1,757 passed
- Release FUSE runtime build and deployment: succeeded
- Slopwatch: no new findings (one warning in an untouched pre-existing external-editor timeout test)