### PR TITLE
Fix base-game whistle models shadowed by mod aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,7 @@ jobs:
 
           Copy-Item "FUSE\bin\Release\net48\FUSE.dll" $modFolder
           Copy-Item "FUSE\bin\Release\net48\Info.json" $modFolder
+          Copy-Item "LICENSE" $modFolder
           Copy-Item -Recurse "schemas" $modFolder
           Copy-Item "tools\assets\fuse_converter_icon.png" (Join-Path $modFolder 'assets\fuse_icon.png')
 

--- a/FUSE.Tests/Loading/FuseLegacyAssetPackAliasTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyAssetPackAliasTests.cs
@@ -48,5 +48,39 @@ namespace FUSE.Tests.Loading
         {
             Assert.Equal(expected, FuseAssetPackRegistry.NormalizeLegacyAssetPackIdentifier(input));
         }
+
+        [Fact]
+        public void DoesNotApplyModAlias_WhenBaseGameStoreOwnsExactIdentifier()
+        {
+            // AFARWhistlePack ships a mod pack whose folder/catalog alias is
+            // "audio.whistles01". Railroader already owns that exact identifier,
+            // and its base-game pack contains the 3ChimeA model used by the
+            // Virginian 3 Chime (MD) whistle. The legacy alias must not redirect
+            // that request to AFARWhistlePack/audio.whistles01.
+            Assert.False(FuseAssetPackRegistry.ShouldApplyLegacyAssetPackAlias(
+                "audio.whistles01",
+                "AFARWhistlePack/audio.whistles01",
+                hasExactRegisteredStore: true));
+        }
+
+        [Fact]
+        public void AppliesModAlias_WhenNoStoreOwnsIncomingIdentifier()
+        {
+            Assert.True(FuseAssetPackRegistry.ShouldApplyLegacyAssetPackAlias(
+                "audio.whistles01",
+                "AFARWhistlePack/audio.whistles01",
+                hasExactRegisteredStore: false));
+        }
+
+        [Fact]
+        public void AppliesLegacySchemeAlias_WhenOnlyNormalizedIdentifierExists()
+        {
+            // The incoming scheme-prefixed string is not an exact host-store
+            // identifier, so it still needs the legacy rewrite.
+            Assert.True(FuseAssetPackRegistry.ShouldApplyLegacyAssetPackAlias(
+                "zsc://Owner/Pack",
+                "Owner/Pack",
+                hasExactRegisteredStore: false));
+        }
     }
 }

--- a/FUSE/Loading/FuseAssetPackRegistry.LegacyAlias.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.LegacyAlias.cs
@@ -16,8 +16,17 @@ namespace FUSE.Loading
 {
     internal static partial class FuseAssetPackRegistry
     {
+        private static int ExactIdentifierLookupFailureLogged;
 
         internal static bool TryResolveLegacyAssetPackIdentifier(string identifier, out string resolvedIdentifier)
+        {
+            return TryResolveLegacyAssetPackIdentifier(null, identifier, out resolvedIdentifier);
+        }
+
+        internal static bool TryResolveLegacyAssetPackIdentifier(
+            PrefabStore prefabStore,
+            string identifier,
+            out string resolvedIdentifier)
         {
             resolvedIdentifier = null;
             var normalized = NormalizeLegacyAssetPackIdentifier(identifier);
@@ -28,8 +37,65 @@ namespace FUSE.Loading
 
             var aliases = GetLegacyAssetPackAliases();
             return aliases.TryGetValue(normalized, out resolvedIdentifier) &&
+                   ShouldApplyLegacyAssetPackAlias(
+                       identifier,
+                       resolvedIdentifier,
+                       HasExactRegisteredAssetPackIdentifier(prefabStore, identifier));
+        }
+
+        internal static bool ShouldApplyLegacyAssetPackAlias(
+            string identifier,
+            string resolvedIdentifier,
+            bool hasExactRegisteredStore)
+        {
+            return !hasExactRegisteredStore &&
                    !string.IsNullOrWhiteSpace(resolvedIdentifier) &&
                    !string.Equals(resolvedIdentifier, identifier, StringComparison.Ordinal);
+        }
+
+        private static bool HasExactRegisteredAssetPackIdentifier(
+            PrefabStore prefabStore,
+            string identifier)
+        {
+            if (prefabStore == null ||
+                string.IsNullOrWhiteSpace(identifier) ||
+                PrefabStoreStoresField == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                if (!(PrefabStoreStoresField.GetValue(prefabStore) is System.Collections.IEnumerable stores))
+                {
+                    return false;
+                }
+
+                foreach (var item in stores)
+                {
+                    if (item is AssetPackRuntimeStore store &&
+                        string.Equals(store.Identifier, identifier, StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Alias resolution is best-effort. If the host changes the
+                // backing store shape, retain the prior behavior instead of
+                // breaking every AssetPackForIdentifier call.
+                if (System.Threading.Interlocked.Exchange(
+                        ref ExactIdentifierLookupFailureLogged,
+                        1) == 0)
+                {
+                    FuseLog.Warning(
+                        "FUSE could not inspect PrefabStore identifiers before applying a legacy " +
+                        $"asset-pack alias; falling back to legacy alias behavior: {ex.GetBaseException().Message}");
+                }
+            }
+
+            return false;
         }
 
         internal static string ResolveLegacyAssetPackIdentifier(string identifier)

--- a/FUSE/Patches/FusePrefabStoreLegacyAssetPackIdentifierPatch.cs
+++ b/FUSE/Patches/FusePrefabStoreLegacyAssetPackIdentifierPatch.cs
@@ -16,14 +16,20 @@ namespace FUSE.Patches
     [HarmonyPatch(typeof(PrefabStore), "AssetPackForIdentifier")]
     internal static class FusePrefabStoreLegacyAssetPackIdentifierPatch
     {
-        private static void Prefix(ref string assetPackIdentifier, out string __state)
+        private static void Prefix(
+            PrefabStore __instance,
+            ref string assetPackIdentifier,
+            out string __state)
         {
             // Capture the input so the Postfix can produce a single line
             // covering "<incoming> -> <resolved> -> store at <basepath>"
             // — three independent moving parts that together describe
             // the lookup outcome for one call.
             __state = assetPackIdentifier;
-            if (FuseAssetPackRegistry.TryResolveLegacyAssetPackIdentifier(assetPackIdentifier, out var resolved))
+            if (FuseAssetPackRegistry.TryResolveLegacyAssetPackIdentifier(
+                    __instance,
+                    assetPackIdentifier,
+                    out var resolved))
             {
                 assetPackIdentifier = resolved;
             }


### PR DESCRIPTION
## Summary
- preserve exact registered asset-pack identifiers before applying legacy aliases
- prevent mod aliases such as AFARWhistlePack/audio.whistles01 from shadowing Railroader's base audio.whistles01 pack
- retain legacy scheme-prefixed alias behavior when no exact store exists
- add regression coverage for the Virginian 3 Chime (MD) / 3ChimeA failure

## Validation
- dotnet test FUSE.Tests/FUSE.Tests.csproj --configuration Debug (1,760 passed)
- dotnet slopwatch analyze -d . (0 errors; 1 unrelated pre-existing warning)