### PR TITLE
Fix passenger-stop neighbor reconciliation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,7 @@ jobs:
 
           Copy-Item "FUSE\bin\Release\net48\FUSE.dll" $modFolder
           Copy-Item "FUSE\bin\Release\net48\Info.json" $modFolder
+          Copy-Item "LICENSE" $modFolder
           Copy-Item -Recurse "schemas" $modFolder
           Copy-Item "tools\assets\fuse_converter_icon.png" (Join-Path $modFolder 'assets\fuse_icon.png')
 

--- a/FUSE.Tests/API/FusePassengerStopNeighborResolverTests.cs
+++ b/FUSE.Tests/API/FusePassengerStopNeighborResolverTests.cs
@@ -1,0 +1,69 @@
+using FUSE.Runtime.API;
+using Xunit;
+
+namespace FUSE.Tests.API
+{
+    public class FusePassengerStopNeighborResolverTests
+    {
+        [Fact]
+        public void Resolve_TwoModdedStops_UsesCompletedLiveRegistry()
+        {
+            var whittier = new Stop("whittier", "WHT");
+            var bryson = new Stop("bryson", "BRY");
+            var liveStops = new[] { whittier, bryson };
+
+            var whittierNeighbors = Resolve(new[] { "whittier", "bryson" }, whittier, liveStops);
+            var brysonNeighbors = Resolve(new[] { "whittier", "bryson" }, bryson, liveStops);
+
+            Assert.Equal(new[] { bryson }, whittierNeighbors);
+            Assert.Equal(new[] { whittier }, brysonNeighbors);
+        }
+
+        [Fact]
+        public void Resolve_MatchesIdentifierAndTimetableCode_IgnoringCaseAndWhitespace()
+        {
+            var source = new Stop("ela", "ELA");
+            var whittier = new Stop("whittier", "WHT");
+            var bryson = new Stop("bryson", "BRY");
+
+            var neighbors = Resolve(
+                new[] { " WHITTIER ", "bRy" },
+                source,
+                new[] { source, whittier, bryson });
+
+            Assert.Equal(new[] { whittier, bryson }, neighbors);
+        }
+
+        [Fact]
+        public void Resolve_MissingOrBlankNeighborIds_ReturnsNoNeighbors()
+        {
+            var source = new Stop("whittier", "WHT");
+            var bryson = new Stop("bryson", "BRY");
+
+            Assert.Empty(Resolve(null, source, new[] { source, bryson }));
+            Assert.Empty(Resolve(new[] { " ", null }, source, new[] { source, bryson }));
+        }
+
+        private static Stop[] Resolve(string[] neighborIds, Stop source, Stop[] candidates)
+        {
+            return FusePassengerStopNeighborResolver.Resolve(
+                neighborIds,
+                source,
+                candidates,
+                stop => stop.Identifier,
+                stop => stop.TimetableCode);
+        }
+
+        private sealed class Stop
+        {
+            internal Stop(string identifier, string timetableCode)
+            {
+                Identifier = identifier;
+                TimetableCode = timetableCode;
+            }
+
+            internal string Identifier { get; }
+            internal string TimetableCode { get; }
+        }
+    }
+}

--- a/FUSE/Runtime/API/FusePassengerStopComponent.cs
+++ b/FUSE/Runtime/API/FusePassengerStopComponent.cs
@@ -192,19 +192,24 @@ namespace FUSE.Runtime.API
 
             var boundSpans = ResolveBoundSpans().ToArray();
             stopObject.name = string.IsNullOrWhiteSpace(name) ? stopIdentifier : name;
-            passengerStop.neighbors = ResolveNeighbors().ToArray();
+            passengerStop.neighbors = Array.Empty<PassengerStop>();
             ConfigureTimetable(passengerStop);
 
             stopObject.SetActive(true);
             PassengerStopSpansField?.SetValue(passengerStop, boundSpans);
             PassengerStopMarkersField?.SetValue(passengerStop, RebuildPassengerStopMarkers(passengerStop.transform, boundSpans));
             var cacheCount = RefreshPassengerStopCache();
+            // Each refresh replaces a PassengerStop instance. Re-resolve every
+            // FUSE stop only after the live cache contains the replacement so
+            // earlier modded stops cannot retain missing or destroyed neighbors.
+            var reconciledStops = ReconcileAllFusePassengerStopNeighbors();
             var reboundAgents = StationAPI.RebindStationAgentsForPassengerStop(passengerStop);
             FusePassengerStopValidation.MarkDirty();
             FuseLog.Info(
                 $"FUSE passenger stop refreshed id='{stopIdentifier}' " +
                 $"component='{Identifier}' spanCount={boundSpans.Length} " +
                 $"loadId='{PassengerLoad.id ?? string.Empty}' cacheCount={cacheCount} " +
+                $"reconciledNeighborStops={reconciledStops} " +
                 $"reboundStationAgents={reboundAgents}.");
         }
 
@@ -293,19 +298,42 @@ namespace FUSE.Runtime.API
             return markers;
         }
 
-        private IEnumerable<PassengerStop> ResolveNeighbors()
+        private static int ReconcileAllFusePassengerStopNeighbors()
         {
-            if (NeighborIds == null || NeighborIds.Length == 0)
+            var liveStops = PassengerStop.FindAll()
+                .Where(stop => stop != null)
+                .ToArray();
+            if (liveStops.Length == 0)
             {
-                return Enumerable.Empty<PassengerStop>();
+                return 0;
             }
 
-            var neighborCodes = new HashSet<string>(NeighborIds.Where(id => !string.IsNullOrWhiteSpace(id)), StringComparer.OrdinalIgnoreCase);
-            return PassengerStop.FindAll().Where(stop =>
-                stop != null &&
-                stop != this &&
-                ((!string.IsNullOrWhiteSpace(stop.identifier) && neighborCodes.Contains(stop.identifier)) ||
-                 (!string.IsNullOrWhiteSpace(stop.timetableCode) && neighborCodes.Contains(stop.timetableCode))));
+            var reconciledStops = 0;
+            foreach (var component in UnityEngine.Object.FindObjectsOfType<FusePassengerStopComponent>(true))
+            {
+                if (component == null)
+                {
+                    continue;
+                }
+
+                var stopIdentifier = component.GetStopIdentifier();
+                var sourceStop = liveStops.FirstOrDefault(stop =>
+                    string.Equals(stop.identifier, stopIdentifier, StringComparison.OrdinalIgnoreCase));
+                if (sourceStop == null)
+                {
+                    continue;
+                }
+
+                sourceStop.neighbors = FusePassengerStopNeighborResolver.Resolve(
+                    component.NeighborIds,
+                    sourceStop,
+                    liveStops,
+                    stop => stop.identifier,
+                    stop => stop.timetableCode);
+                reconciledStops++;
+            }
+
+            return reconciledStops;
         }
 
         private void ConfigureTimetable(PassengerStop passengerStop)

--- a/FUSE/Runtime/API/FusePassengerStopNeighborResolver.cs
+++ b/FUSE/Runtime/API/FusePassengerStopNeighborResolver.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FUSE.Runtime.API
+{
+    internal static class FusePassengerStopNeighborResolver
+    {
+        internal static T[] Resolve<T>(
+            IEnumerable<string> neighborIds,
+            T source,
+            IEnumerable<T> candidates,
+            Func<T, string> identifierSelector,
+            Func<T, string> timetableCodeSelector)
+            where T : class
+        {
+            if (neighborIds == null || candidates == null)
+            {
+                return Array.Empty<T>();
+            }
+
+            if (identifierSelector == null)
+            {
+                throw new ArgumentNullException(nameof(identifierSelector));
+            }
+
+            if (timetableCodeSelector == null)
+            {
+                throw new ArgumentNullException(nameof(timetableCodeSelector));
+            }
+
+            var requestedIds = new HashSet<string>(
+                neighborIds
+                    .Where(id => !string.IsNullOrWhiteSpace(id))
+                    .Select(id => id.Trim()),
+                StringComparer.OrdinalIgnoreCase);
+            if (requestedIds.Count == 0)
+            {
+                return Array.Empty<T>();
+            }
+
+            return candidates
+                .Where(candidate =>
+                    candidate != null &&
+                    !ReferenceEquals(candidate, source) &&
+                    (Matches(requestedIds, identifierSelector(candidate)) ||
+                     Matches(requestedIds, timetableCodeSelector(candidate))))
+                .ToArray();
+        }
+
+        private static bool Matches(HashSet<string> requestedIds, string candidateId)
+        {
+            return !string.IsNullOrWhiteSpace(candidateId) &&
+                   requestedIds.Contains(candidateId.Trim());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- defer passenger-stop neighbor assignment until the refreshed stop is present in Railroader's live cache
- reconcile every FUSE passenger stop after each refresh so earlier stops do not retain missing or destroyed neighbors
- match identifiers and timetable codes case-insensitively with focused pure resolver tests

## Validation
- `dotnet test FUSE.Tests/FUSE.Tests.csproj -c Release`: 1,760 passed
- `dotnet slopwatch analyze -d .`: 0 errors, 1 pre-existing timing-test warning

This PR is submitted for review only. It has not been merged.