### PR TITLE
Include license in CI package artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
           # Read the computed version from the environment rather than ${{ }}
           # template expansion. Mirrors the TAG_NAME hardening in release.yml.
           MOD_VERSION: ${{ steps.build_id.outputs.version }}
-        run: dotnet build FUSE/FUSE.csproj -c Release "-p:ModVersion=$env:MOD_VERSION"
+        run: dotnet build FUSE/FUSE.csproj -c Release --no-restore "-p:ModVersion=$env:MOD_VERSION"
 
       - name: Package mod zip
         shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,8 @@ jobs:
           Copy-Item -Recurse "schemas" $modFolder
           Copy-Item "tools\assets\fuse_converter_icon.png" (Join-Path $modFolder 'assets\fuse_icon.png')
 
+          Copy-Item 'LICENSE' $modFolder
+
           Compress-Archive -Path $modFolder -DestinationPath $archivePath -CompressionLevel Optimal
 
       # Prove the freshly-packaged zip is actually loadable by Unity Mod Manager


### PR DESCRIPTION
## Summary

- copy the repository `LICENSE` into the CI mod staging folder before compression
- reuse the job's existing restore for the final version-stamped Release rebuild
- keep CI artifacts aligned with the release workflow and package validator

## Root cause

The CI packaging step copied the DLL, manifest, schemas, and icon but omitted `LICENSE`. The following package-validation step correctly rejected that archive because the project ships under AGPL-3.0. This failure also occurred on the current `main` branch and was unrelated to PR #191.

After adding the license, the self-hosted runner twice failed an unnecessary second NuGet restore with `RestoreTask returned false but did not log an error`, despite the earlier Debug and Release builds and all 1,763 tests passing. The final rebuild changes only the version stamp, so it now reuses the already-restored assets.

## Validation

- `git diff --check`
- initial Release build and stamped `--no-restore` rebuild succeeded with 0 errors against the repository's archived public test references
- reproduced the CI ZIP locally and confirmed `FUSE/LICENSE` is present
- `scripts/Validate-ModPackage.cs` passed for the reproduced archive
