### PR TITLE
ci: run the wiki sync so docs/ actually reaches the wiki

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -18,8 +18,9 @@ on:
   # editing pages in the UI by mistake.
   workflow_dispatch:
 
-permissions:
-  contents: write
+# Least privilege: no job gets a token scope unless it asks. The write scope is
+# granted on the sync job alone, below.
+permissions: {}
 
 # The wiki is a single git repo with no merge strategy here — the script force-
 # rewrites the page set. Overlapping runs would race on the push.
@@ -33,6 +34,17 @@ jobs:
     # only, no Railroader or Unity assemblies. Verified the script runs clean
     # under PowerShell 7 on a non-Windows host.
     runs-on: ubuntu-latest
+
+    # A normal sync is clone + rewrite ~14 files + push, well under a minute.
+    # The cap is here so a hung git network call cannot hold the sync-wiki
+    # concurrency slot until the 360-minute default expires.
+    timeout-minutes: 10
+
+    permissions:
+      # Sync-Wiki.ps1 pushes to <repo>.wiki.git with GITHUB_TOKEN. Nothing here
+      # writes to the code repo itself — the checkout above sets
+      # persist-credentials: false.
+      contents: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -79,11 +79,34 @@ jobs:
           # remote echoed back by git can never surface here verbatim.
           $detail = $output.Replace($env:WIKI_TOKEN, '***').Trim()
 
+          # git reports a missing repository identically whether the wiki merely
+          # has no pages or the wiki feature is switched off for the repo. Ask
+          # the API which it is: telling someone to open a Wiki tab that does not
+          # exist is worse than saying nothing. Only on the failure path, so a
+          # healthy run stays a single probe.
+          $wikiEnabled = $null
+          try {
+            $repoInfo = Invoke-RestMethod -Uri "https://api.github.com/repos/$($env:REPO)" -Headers @{
+              Authorization  = "Bearer $($env:WIKI_TOKEN)"
+              Accept         = 'application/vnd.github+json'
+              'User-Agent'   = 'fuse-sync-wiki'
+            }
+            $wikiEnabled = [bool]$repoInfo.has_wiki
+          }
+          catch {
+            # Metadata is a nicety, not a requirement — fall through to the git
+            # output. $wikiEnabled stays $null, which matches neither branch.
+            Write-Host "note: could not query repository metadata ($($_.Exception.Message)); classifying from git output alone."
+          }
+
           # Deliberately narrow. "Could not read from remote repository" is NOT
           # matched here: git emits it for permission and auth failures too, so
           # keying on it would reintroduce the misdiagnosis this check exists to
           # avoid. Only git's genuine repo-missing wording counts.
-          if ($detail -match 'not found|does not exist') {
+          if ($wikiEnabled -eq $false) {
+            Write-Host "::error::Wikis are disabled for $($env:REPO), so there is no wiki to sync to and no Wiki tab to create a page in. Enable it under Settings -> General -> Features -> Wikis, create any page, then re-run this workflow."
+          }
+          elseif ($detail -match 'not found|does not exist') {
             Write-Host "::error::The wiki for $($env:REPO) has no pages yet, so GitHub has not created its repository. Open the repo's Wiki tab, create any page, save it, then re-run this workflow — everything after that is automatic."
           }
           else {

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -57,18 +57,40 @@ jobs:
       # GitHub does not create the <repo>.wiki.git repository until the wiki has
       # at least one page, so on a wiki that has never been opened the clone
       # fails with a bare "Repository not found". Check first and say what to do.
+      #
+      # Probe with the same tokenized remote the sync uses, so this keeps working
+      # if the repo goes private, and distinguish a genuinely missing wiki from a
+      # transient network or auth failure — reporting "create a page" for those
+      # would send someone to create a page that already exists.
       - name: Verify the wiki has been initialized
         shell: pwsh
         env:
+          WIKI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
-          $url = "https://github.com/$($env:REPO).wiki.git"
-          git ls-remote $url *> $null
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "::error::The wiki repo for $($env:REPO) does not exist yet. GitHub only creates it once the wiki has one page: open the repo's Wiki tab, create any page, save it, then re-run this workflow. Everything after that is automatic."
-            exit 1
+          $url = "https://x-access-token:$($env:WIKI_TOKEN)@github.com/$($env:REPO).wiki.git"
+          $output = (git ls-remote $url 2>&1 | Out-String)
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Wiki repo present."
+            return
           }
-          Write-Host "Wiki repo present."
+
+          # Actions masks GITHUB_TOKEN in logs; scrub anyway so a tokenized
+          # remote echoed back by git can never surface here verbatim.
+          $detail = $output.Replace($env:WIKI_TOKEN, '***').Trim()
+
+          # Deliberately narrow. "Could not read from remote repository" is NOT
+          # matched here: git emits it for permission and auth failures too, so
+          # keying on it would reintroduce the misdiagnosis this check exists to
+          # avoid. Only git's genuine repo-missing wording counts.
+          if ($detail -match 'not found|does not exist') {
+            Write-Host "::error::The wiki for $($env:REPO) has no pages yet, so GitHub has not created its repository. Open the repo's Wiki tab, create any page, save it, then re-run this workflow — everything after that is automatic."
+          }
+          else {
+            Write-Host "::error::Could not reach the wiki remote for $($env:REPO) (git exit $LASTEXITCODE). This is not the same as an uninitialized wiki; check the detail below and re-run."
+            Write-Host $detail
+          }
+          exit 1
 
       - name: Configure git identity
         shell: pwsh

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,83 @@
+name: Sync Wiki
+
+# Mirrors the user-facing subset of docs/ into the GitHub Wiki by running
+# scripts/Sync-Wiki.ps1. The script has existed since the documentation
+# restructure but nothing invoked it, so docs/ changes never reached the wiki.
+#
+# The repo is the source of truth. Pages edited in the wiki UI are overwritten
+# on the next run — the generated footer on each page says so.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "scripts/Sync-Wiki.ps1"
+      - ".github/workflows/sync-wiki.yml"
+  # Manual runs, for backfilling after the wiki is first created or after
+  # editing pages in the UI by mistake.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# The wiki is a single git repo with no merge strategy here — the script force-
+# rewrites the page set. Overlapping runs would race on the push.
+concurrency:
+  group: sync-wiki
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    # ubuntu-latest, not the self-hosted runner: this needs git and PowerShell
+    # only, no Railroader or Unity assemblies. Verified the script runs clean
+    # under PowerShell 7 on a non-Windows host.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing pushes back to this repo; the wiki push uses its own
+          # tokenized remote below.
+          persist-credentials: false
+
+      # GitHub does not create the <repo>.wiki.git repository until the wiki has
+      # at least one page, so on a wiki that has never been opened the clone
+      # fails with a bare "Repository not found". Check first and say what to do.
+      - name: Verify the wiki has been initialized
+        shell: pwsh
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          $url = "https://github.com/$($env:REPO).wiki.git"
+          git ls-remote $url *> $null
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::The wiki repo for $($env:REPO) does not exist yet. GitHub only creates it once the wiki has one page: open the repo's Wiki tab, create any page, save it, then re-run this workflow. Everything after that is automatic."
+            exit 1
+          }
+          Write-Host "Wiki repo present."
+
+      - name: Configure git identity
+        shell: pwsh
+        run: |
+          # Sync-Wiki.ps1 commits inside the wiki checkout. A runner has no
+          # global identity, so git commit would fail without this. Set it
+          # globally rather than in the script, which is also run by hand on
+          # machines that already have an identity.
+          git config --global user.name  "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync docs to wiki
+        shell: pwsh
+        env:
+          # Passed through the environment rather than template-expanded into
+          # the script body. GITHUB_TOKEN is masked in logs, and the tokenized
+          # remote only ever lives in the ephemeral wiki checkout.
+          WIKI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Explicit $(...) subexpressions around the variables so the trailing
+          # ".wiki.git" cannot be read as part of the variable path.
+          $url = "https://x-access-token:$($env:WIKI_TOKEN)@github.com/$($env:REPO).wiki.git"
+          ./scripts/Sync-Wiki.ps1 -WikiUrl $url -WorkDir "$($env:RUNNER_TEMP)/fuse-wiki-sync"


### PR DESCRIPTION
The wiki is empty because **nothing ever ran the sync**. `scripts/Sync-Wiki.ps1` has been in the repo since the documentation restructure, but no workflow invokes it — its own header says *"Run this after merging a docs change to main"*, and that never happened.

## What this adds

A workflow that runs the existing script on pushes to `main` touching `docs/**` or the script itself, plus `workflow_dispatch` for backfilling. No changes to the script's behavior.

`ubuntu-latest` rather than the self-hosted runner — this needs git and PowerShell only, no Railroader or Unity assemblies.

## Two gaps the script doesn't cover itself

- **No git identity on a runner.** The script commits inside the wiki checkout; without a configured identity `git commit` fails. Set in the workflow rather than the script, since the script is also run by hand on machines that already have an identity.
- **The wiki repo may not exist.** GitHub doesn't create `<repo>.wiki.git` until the wiki has at least one page, and the clone otherwise fails with a bare `Repository not found`. A preflight step turns that into an actionable message.

## ⚠️ One manual step before this can work

**The wiki has never been initialized** — `FuseDevelopmentGroup.wiki.git` currently returns `Repository not found`. GitHub only creates it once a page exists.

Open the repo's **Wiki** tab, create any page (contents don't matter — the sync overwrites everything), save, then run this workflow manually. After that it's automatic. Until then this workflow will fail with the message above rather than something cryptic.

## Verification

Ran `Sync-Wiki.ps1` end-to-end against a stand-in wiki repo under PowerShell 7:

- 12 pages generated plus `Home` and `_Sidebar`
- Sibling doc links rewritten to wiki page names, anchors preserved — `](Settings#multiplayer)`, `](Getting-Started#uninstalling)`
- Links escaping `docs/` rewritten to blob URLs — `../LICENSE`, `../schemas/FUSE_JSON_SCHEMA.md`
- No unrewritten `.md` links remaining
- Commit and push to the wiki remote succeeded

Contributor docs (`ARCHITECTURE`, `RELEASING`, `EDITOR_*`, `CHANGELOG`) are deliberately not mirrored — that's the script's existing policy, unchanged here.