### PR TITLE
docs(nexus): link the Nexus page to the GitHub repository

### DIFF
--- a/docs/NEXUS_DESCRIPTION.bbcode
+++ b/docs/NEXUS_DESCRIPTION.bbcode
@@ -21,7 +21,7 @@ FUSE itself adds no content. It is the layer that loads content packages.
 
 [size=4][b]Your existing mods keep working[/b][/size]
 
-Packages built for [b]Railloader[/b], [b]Strange Customs[/b], [b]ConfusingSupplements[/b], [b]For Your Convenience[/b], and [b]Alina's Map Mod[/b] load through FUSE's compatibility layer. Package authors can also convert them to the FUSE format with the converter tool on GitHub.
+Packages built for [b]Railloader[/b], [b]Strange Customs[/b], [b]ConfusingSupplements[/b], [b]For Your Convenience[/b], and [b]Alina's Map Mod[/b] load through FUSE's compatibility layer. Package authors can also convert them to the FUSE format with the [url=https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases]converter tool on GitHub[/url].
 
 [line]
 
@@ -108,4 +108,12 @@ Post a bug report with:
 
 [size=4][b]Source and license[/b][/size]
 
-FUSE is free software, released under the [b]GNU Affero General Public License v3.0[/b]. Source code, the converter, the bulk installer, and the complete toolchain bundle are all on GitHub.
+FUSE is free software, released under the [b]GNU Affero General Public License v3.0[/b].
+
+Source code, the converter, the bulk installer, and the complete toolchain bundle all live on GitHub:
+
+[list]
+[*][url=https://github.com/F-U-S-E-E/FuseDevelopmentGroup]Repository[/url] — source, documentation, and the issue tracker
+[*][url=https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases]Releases[/url] — the tools, and [b]FUSE-Complete[/b] with everything in one download
+[*][url=https://github.com/F-U-S-E-E/FuseDevelopmentGroup/issues/new/choose]Report a bug[/url] — please include the logs listed above
+[/list]


### PR DESCRIPTION
The Nexus description said the source and tools *"are all on GitHub"* with no URL. That was deliberate at the time — the repo was private, so a link would have 404'd for anyone arriving from Nexus. It's public now, so this links it properly.

## Changes

The **Source and license** section now points at:

- [Repository](https://github.com/F-U-S-E-E/FuseDevelopmentGroup) — source, docs, issue tracker
- [Releases](https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases) — the tools, and `FUSE-Complete` with everything in one download
- [Report a bug](https://github.com/F-U-S-E-E/FuseDevelopmentGroup/issues/new/choose) — lands on the issue form, which requires the logs the page already asks for

The existing "converter tool on GitHub" mention in the legacy-mods section is now a real link too.

## Verification

- All three GitHub URLs return **200 anonymously** — checked without credentials, since Nexus visitors aren't logged into the repo
- BBCode tags balanced: `b` 38/38, `i` 7/7, `list` 8/8, `size` 11/11, `url` 5/5

This file is the copy-paste source for the Nexus mod page; the page itself still needs updating by hand.