### PR TITLE
Show hosted legacy plugins in FUSE Mods page

### DIFF
--- a/FUSE.Tests/Interface/MenuWindow/ModsPanelBuilderTests.cs
+++ b/FUSE.Tests/Interface/MenuWindow/ModsPanelBuilderTests.cs
@@ -1,0 +1,111 @@
+using System.IO;
+using FUSE.Interface.MenuWindow;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Interface.MenuWindow
+{
+    public sealed class ModsPanelBuilderTests
+    {
+        [Fact]
+        public void MergeHostedLegacyPackageSnapshots_adds_code_only_hosted_package()
+        {
+            var folder = Path.Combine("C:\\Railroader\\Mods", "NotEnoughRosters");
+            var hosted = new FuseLegacyAssemblyManifest
+            {
+                Id = "Joo.NotEnoughRosters",
+                Name = "NotEnoughRosters",
+                Version = "1.1.0",
+                FolderPath = folder,
+                Assemblies = new[] { "NotEnoughRosters" }
+            };
+
+            var result = ModsPanelBuilder.MergeHostedLegacyPackageSnapshots(
+                dataPackageSnapshots: null,
+                hostedLegacyManifests: new[] { hosted });
+
+            var snapshot = Assert.Single(result);
+            Assert.Equal("Joo.NotEnoughRosters", snapshot.Id);
+            Assert.Equal("NotEnoughRosters", snapshot.DisplayName);
+            Assert.Equal("1.1.0", snapshot.Version);
+            Assert.Equal(folder, snapshot.FolderPath);
+            Assert.Equal("NotEnoughRosters", snapshot.FolderName);
+            Assert.True(snapshot.IsLegacyHosted);
+        }
+
+        [Fact]
+        public void MergeHostedLegacyPackageSnapshots_preserves_data_snapshot_on_folder_collision()
+        {
+            var folder = Path.Combine("C:\\Railroader\\Mods", "SignalsEverywhere");
+            var dataSnapshot = new FusePackageManifestSnapshot
+            {
+                Id = "Joo.SignalsEverywhere.FUSE",
+                DisplayName = "Signals Everywhere",
+                FolderPath = folder + Path.DirectorySeparatorChar,
+                IsLegacyConverted = true
+            };
+            var hosted = new FuseLegacyAssemblyManifest
+            {
+                Id = "Joo.SignalsEverywhere",
+                Name = "SignalsEverywhere",
+                FolderPath = folder
+            };
+
+            var result = ModsPanelBuilder.MergeHostedLegacyPackageSnapshots(
+                new[] { dataSnapshot },
+                new[] { hosted });
+
+            Assert.Same(dataSnapshot, Assert.Single(result));
+        }
+
+        [Fact]
+        public void MergeHostedLegacyPackageSnapshots_deduplicates_hosted_instances_by_folder()
+        {
+            var folder = Path.Combine("C:\\Railroader\\Mods", "NotEnoughRosters");
+            var first = new FuseLegacyAssemblyManifest
+            {
+                Id = "Joo.NotEnoughRosters",
+                Name = "NotEnoughRosters",
+                FolderPath = folder
+            };
+            var second = new FuseLegacyAssemblyManifest
+            {
+                Id = "Joo.NotEnoughRosters.SecondPlugin",
+                Name = "NotEnoughRosters Helper",
+                FolderPath = folder + Path.DirectorySeparatorChar
+            };
+
+            var result = ModsPanelBuilder.MergeHostedLegacyPackageSnapshots(
+                dataPackageSnapshots: null,
+                hostedLegacyManifests: new[] { first, second });
+
+            Assert.Equal("Joo.NotEnoughRosters", Assert.Single(result).Id);
+        }
+
+        [Fact]
+        public void MergeHostedLegacyPackageSnapshots_deduplicates_hosted_instances_by_id_after_folder()
+        {
+            var hosted = new[]
+            {
+                new FuseLegacyAssemblyManifest
+                {
+                    Id = "Joo.NotEnoughRosters",
+                    Name = "NotEnoughRosters",
+                    FolderPath = Path.Combine("C:\\Railroader\\Mods", "NotEnoughRosters")
+                },
+                new FuseLegacyAssemblyManifest
+                {
+                    Id = "joo.notenoughrosters",
+                    Name = "Duplicate NotEnoughRosters",
+                    FolderPath = Path.Combine("D:\\Railroader\\Mods", "NotEnoughRosters")
+                }
+            };
+
+            var result = ModsPanelBuilder.MergeHostedLegacyPackageSnapshots(
+                dataPackageSnapshots: null,
+                hostedLegacyManifests: hosted);
+
+            Assert.Equal("NotEnoughRosters", Assert.Single(result).DisplayName);
+        }
+    }
+}

--- a/FUSE/Interface/MenuWindow/ModsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/ModsPanelBuilder.cs
@@ -19,7 +19,9 @@ namespace FUSE.Interface.MenuWindow
     {
         public static void Build(UIPanelBuilder builder, UIState<string> selectedItem)
         {
-            var manifests = FuseDataPackageDiscovery.GetPackageManifestSnapshots();
+            var manifests = MergeHostedLegacyPackageSnapshots(
+                FuseDataPackageDiscovery.GetPackageManifestSnapshots(),
+                FuseLegacyAssemblyHost.EnumerateAllHostedPlugins().Select(info => info.Manifest));
 
             List<UIPanelBuilder.ListItem<FusePackageManifestSnapshot>> list = manifests
                 .OrderBy(m => m.DisplayName)
@@ -42,6 +44,74 @@ namespace FUSE.Interface.MenuWindow
                     builder.VScrollView(b => BuildModDetail(b, manifest));
                 }
             });
+        }
+
+        internal static IReadOnlyList<FusePackageManifestSnapshot> MergeHostedLegacyPackageSnapshots(
+            IEnumerable<FusePackageManifestSnapshot> dataPackageSnapshots,
+            IEnumerable<FuseLegacyAssemblyManifest> hostedLegacyManifests)
+        {
+            var manifests = (dataPackageSnapshots ?? Enumerable.Empty<FusePackageManifestSnapshot>())
+                .Where(manifest => manifest != null)
+                .ToList();
+            var knownFolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var knownIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var manifest in manifests)
+            {
+                AddPackageIdentity(knownFolders, knownIds, manifest.FolderPath, manifest.Id);
+            }
+
+            foreach (var hosted in hostedLegacyManifests ?? Enumerable.Empty<FuseLegacyAssemblyManifest>())
+            {
+                if (hosted == null)
+                {
+                    continue;
+                }
+
+                var normalizedFolder = NormalizePath(hosted.FolderPath);
+                var folderName = normalizedFolder.Length == 0 ? string.Empty : Path.GetFileName(normalizedFolder);
+                var id = string.IsNullOrWhiteSpace(hosted.Id) ? folderName : hosted.Id.Trim();
+                if ((normalizedFolder.Length > 0 && knownFolders.Contains(normalizedFolder)) ||
+                    (id.Length > 0 && knownIds.Contains(id)) ||
+                    (normalizedFolder.Length == 0 && id.Length == 0))
+                {
+                    continue;
+                }
+
+                var folderPath = hosted.FolderPath ?? string.Empty;
+                manifests.Add(new FusePackageManifestSnapshot
+                {
+                    Order = manifests.Count + 1,
+                    Id = id,
+                    DisplayName = string.IsNullOrWhiteSpace(hosted.Name) ? id : hosted.Name.Trim(),
+                    Version = hosted.Version ?? string.Empty,
+                    FolderName = folderName,
+                    FolderPath = folderPath,
+                    IsLegacyHosted = true
+                });
+                AddPackageIdentity(knownFolders, knownIds, folderPath, id);
+            }
+
+            return manifests;
+        }
+
+        private static void AddPackageIdentity(
+            ISet<string> knownFolders,
+            ISet<string> knownIds,
+            string folderPath,
+            string id)
+        {
+            var normalizedFolder = NormalizePath(folderPath);
+            if (normalizedFolder.Length > 0)
+            {
+                knownFolders.Add(normalizedFolder);
+            }
+
+            var normalizedId = (id ?? string.Empty).Trim();
+            if (normalizedId.Length > 0)
+            {
+                knownIds.Add(normalizedId);
+            }
         }
 
         private static void BuildModDetail(UIPanelBuilder builder, FusePackageManifestSnapshot manifest)
@@ -280,7 +350,20 @@ namespace FUSE.Interface.MenuWindow
 
         private static string NormalizePath(string value)
         {
-            return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                return Path.GetFullPath(value.Trim())
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+            catch
+            {
+                return value.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
         }
 
         private static string BuildSelectedPackageReport(FusePackageManifestSnapshot manifest, IReadOnlyList<FuseLoadedMod> definitions)
@@ -339,7 +422,7 @@ namespace FUSE.Interface.MenuWindow
                 return manifest.Faults.Length + " fault(s)";
             }
 
-            return manifest.IsLegacyConverted ? "ready | legacy" : "ready";
+            return manifest.IsLegacyConverted || manifest.IsLegacyHosted ? "ready | legacy" : "ready";
         }
 
         private static string PackageStatusTextMarkup(FusePackageManifestSnapshot manifest)
@@ -359,7 +442,7 @@ namespace FUSE.Interface.MenuWindow
                 return "<color=\"red\">Error: " + manifest.Faults.Length + " fault(s)";
             }
 
-            return manifest.IsLegacyConverted
+            return manifest.IsLegacyConverted || manifest.IsLegacyHosted
                 ? "<color=\"green\">Ready</color> - Legacy"
                 : "<color=\"green\"Ready";
         }

--- a/FUSE/Loading/FuseDataPackageDiscovery.cs
+++ b/FUSE/Loading/FuseDataPackageDiscovery.cs
@@ -1041,6 +1041,7 @@ namespace FUSE.Loading
         public bool Disabled { get; set; }
         public string DisabledReason { get; set; } = string.Empty;
         public bool IsLegacyConverted { get; set; }
+        public bool IsLegacyHosted { get; set; }
         public string[] Faults { get; set; } = Array.Empty<string>();
     }
 }


### PR DESCRIPTION
## Summary

- include assembly-only hosted legacy packages in the FUSE Mods page
- keep existing data-package snapshots authoritative and deduplicate hosted entries by folder and package ID
- mark projected entries as legacy-hosted so their existing mod-tab handlers are reachable
- add focused coverage for code-only packages and both deduplication paths

## Root cause

The Mods page was populated only from data-package discovery. A code-only legacy package can be hosted successfully by `FuseLegacyAssemblyHost` without producing a convertible data-package snapshot, which made plugins such as NotEnoughRosters absent from the list and left their existing settings tab unreachable.

## Validation

- `python tools/cs_lint.py`
- `git diff --check`
- `dotnet slopwatch analyze -d .` (one unrelated pre-existing `SW004` warning in `TerrainGenerationServiceTests.cs`)
- focused `ModsPanelBuilderTests` execution was attempted, but the local Railroader install is missing `UnityModManagerNet.dll` / `UnityModManager.dll`, so dependency validation stopped before compilation; CI has the required game references

Addresses #196
