### PR TITLE
fix(compat): harden legacy map loading and runtime isolation

### DIFF
--- a/FUSE.Converter/Conversion/LegacyIndustryComponentConverter.cs
+++ b/FUSE.Converter/Conversion/LegacyIndustryComponentConverter.cs
@@ -156,12 +156,50 @@ namespace FUSE.Converter.Conversion
         public static bool ShouldConvertComponentAsPartial(JObject item)
         {
             if (item == null) return false;
-            // Explicit type → never partial.
-            if (item["type"] != null || item["Type"] != null) return false;
+            var explicitType = item.Value<string>("type") ?? item.Value<string>("Type");
+            if (!string.IsNullOrWhiteSpace(explicitType))
+            {
+                var normalizedType = NormalizeComponentType(explicitType);
+                var isLegacyRuntimeType = !string.Equals(
+                    explicitType.Trim(),
+                    normalizedType,
+                    StringComparison.OrdinalIgnoreCase);
+                return isLegacyRuntimeType
+                    && HasComponentPatchPayload(item)
+                    && RequiresTrackSpan(normalizedType)
+                    && normalizedType != "passengerStop"
+                    && !HasLoadComponentBindingShape(item);
+            }
             // No standalone shape → partial.
             if (!HasStandaloneComponentShape(item)) return true;
             // Legacy load-op fields without span/load binding → partial.
             return HasLegacyLoadOperationShape(item) && !HasLoadComponentBindingShape(item);
+        }
+
+        private static bool HasComponentPatchPayload(JObject item)
+        {
+            return item != null && item.Properties().Any(property =>
+                !string.Equals(property.Name, "type", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(property.Name, "name", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static bool RequiresTrackSpan(string normalizedType)
+        {
+            switch (normalizedType)
+            {
+                case "loader":
+                case "unloader":
+                case "repairTrack":
+                case "teamTrack":
+                case "interchange":
+                case "interchangedLoader":
+                case "interchangedUnloader":
+                case "progression":
+                case "passengerStop":
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         /// <summary>

--- a/FUSE.Converter/Conversion/LegacyKindDetector.cs
+++ b/FUSE.Converter/Conversion/LegacyKindDetector.cs
@@ -39,7 +39,7 @@ namespace FUSE.Converter.Conversion
 
         private static readonly HashSet<string> LegacyDataKeys = new HashSet<string>(StringComparer.Ordinal)
         {
-            "tracks", "areas", "industries", "loads", "turntables",
+            "tracks", "nodes", "segments", "spans", "areas", "industries", "loads", "turntables",
             "scenery", "splineys", "mandelas", "texts", "simpleGraphs",
             "progression", "progressions", "mapFeatures",
         };

--- a/FUSE.Converter/Conversion/LegacySourceConverter.cs
+++ b/FUSE.Converter/Conversion/LegacySourceConverter.cs
@@ -70,7 +70,16 @@ namespace FUSE.Converter.Conversion
         private static void ApplyTracks(JObject source, JObject rail, string sourceName, List<FuseConversionReportEntry> report)
         {
             var tracks = source["tracks"] as JObject;
-            if (tracks == null) return;
+            var legacyNodes = MergeLegacyDictionaries(
+                source["nodes"] as JObject,
+                tracks == null ? null : tracks["nodes"] as JObject);
+            var legacySegments = MergeLegacyDictionaries(
+                source["segments"] as JObject,
+                tracks == null ? null : tracks["segments"] as JObject);
+            var legacySpans = MergeLegacyDictionaries(
+                source["spans"] as JObject,
+                tracks == null ? null : tracks["spans"] as JObject);
+            if (!legacyNodes.HasValues && !legacySegments.HasValues && !legacySpans.HasValues) return;
 
             var railTracks = rail["tracks"] as JObject ?? new JObject();
             var nodes = (railTracks["nodes"] as JObject) ?? new JObject();
@@ -81,7 +90,7 @@ namespace FUSE.Converter.Conversion
             var segmentRemovals = (removals["segments"] as JArray) ?? new JArray();
             var spanRemovals = (removals["spans"] as JArray) ?? new JArray();
 
-            if (tracks["nodes"] is JObject legacyNodes)
+            if (legacyNodes.HasValues)
             {
                 foreach (var prop in legacyNodes.Properties())
                 {
@@ -98,7 +107,7 @@ namespace FUSE.Converter.Conversion
                 }
             }
 
-            if (tracks["segments"] is JObject legacySegments)
+            if (legacySegments.HasValues)
             {
                 foreach (var prop in legacySegments.Properties())
                 {
@@ -132,7 +141,7 @@ namespace FUSE.Converter.Conversion
                 }
             }
 
-            if (tracks["spans"] is JObject legacySpans)
+            if (legacySpans.HasValues)
             {
                 foreach (var prop in legacySpans.Properties())
                 {
@@ -148,6 +157,23 @@ namespace FUSE.Converter.Conversion
                     }
                 }
             }
+        }
+
+        private static JObject MergeLegacyDictionaries(params JObject[] sources)
+        {
+            var merged = new JObject();
+            if (sources == null) return merged;
+
+            foreach (var source in sources)
+            {
+                if (source == null) continue;
+                foreach (var property in source.Properties())
+                {
+                    merged[property.Name] = property.Value.DeepClone();
+                }
+            }
+
+            return merged;
         }
 
         private static void ApplyLoads(JObject source, JObject rail, string sourceName, List<FuseConversionReportEntry> report)

--- a/FUSE.Tests/API/FusePassengerStopNeighborResolverTests.cs
+++ b/FUSE.Tests/API/FusePassengerStopNeighborResolverTests.cs
@@ -44,6 +44,40 @@ namespace FUSE.Tests.API
             Assert.Empty(Resolve(new[] { " ", null }, source, new[] { source, bryson }));
         }
 
+        [Fact]
+        public void ResolveIncoming_FindsStopThatReferencesSourceTimetableCode()
+        {
+            var oliveHill = new Stop("olivehill-station", "OH");
+            var airport = new Stop("mca-station", "MCA", "OH");
+            var iodla = new Stop("iodla-jct-station", "IJ", "MCA");
+
+            var incoming = FusePassengerStopNeighborResolver.ResolveIncoming(
+                oliveHill,
+                new[] { oliveHill, airport, iodla },
+                stop => stop.NeighborIds,
+                stop => stop.Identifier,
+                stop => stop.TimetableCode);
+
+            Assert.Equal(new[] { airport }, incoming);
+        }
+
+        [Fact]
+        public void ResolveIncoming_IgnoresSelfBlankAndUnrelatedReferences()
+        {
+            var source = new Stop("olivehill-station", "OH", "OH");
+            var blank = new Stop("blank", "BLK", " ", null);
+            var unrelated = new Stop("mca-station", "MCA", "IJ");
+
+            var incoming = FusePassengerStopNeighborResolver.ResolveIncoming(
+                source,
+                new[] { source, blank, unrelated },
+                stop => stop.NeighborIds,
+                stop => stop.Identifier,
+                stop => stop.TimetableCode);
+
+            Assert.Empty(incoming);
+        }
+
         private static Stop[] Resolve(string[] neighborIds, Stop source, Stop[] candidates)
         {
             return FusePassengerStopNeighborResolver.Resolve(
@@ -56,14 +90,16 @@ namespace FUSE.Tests.API
 
         private sealed class Stop
         {
-            internal Stop(string identifier, string timetableCode)
+            internal Stop(string identifier, string timetableCode, params string[] neighborIds)
             {
                 Identifier = identifier;
                 TimetableCode = timetableCode;
+                NeighborIds = neighborIds;
             }
 
             internal string Identifier { get; }
             internal string TimetableCode { get; }
+            internal string[] NeighborIds { get; }
         }
     }
 }

--- a/FUSE.Tests/API/ProgressionSectionInitializationTests.cs
+++ b/FUSE.Tests/API/ProgressionSectionInitializationTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Runtime.Serialization;
+using FUSE.Runtime.API;
+using Game.Progression;
+using Xunit;
+
+namespace FUSE.Tests.API
+{
+    public class ProgressionSectionInitializationTests
+    {
+        [Fact]
+        public void EnsureSectionCollectionsInitialized_DefaultsNullCollections()
+        {
+            var section = (Section)FormatterServices.GetUninitializedObject(typeof(Section));
+
+            ProgressionAPI.EnsureSectionCollectionsInitialized(section);
+
+            Assert.Empty(section.deliveryPhases);
+            Assert.Empty(section.prerequisiteSections);
+            Assert.Empty(section.enableFeaturesOnUnlock);
+            Assert.Empty(section.enableFeaturesOnAvailable);
+            Assert.Empty(section.disableFeaturesOnUnlock);
+        }
+
+        [Fact]
+        public void EnsureSectionCollectionsInitialized_PreservesExistingCollections()
+        {
+            var section = (Section)FormatterServices.GetUninitializedObject(typeof(Section));
+            var phases = new[] { new Section.DeliveryPhase() };
+            var prerequisites = new Section[1];
+            var enableOnUnlock = new MapFeature[1];
+            var enableOnAvailable = new MapFeature[1];
+            var disableOnUnlock = new MapFeature[1];
+            section.deliveryPhases = phases;
+            section.prerequisiteSections = prerequisites;
+            section.enableFeaturesOnUnlock = enableOnUnlock;
+            section.enableFeaturesOnAvailable = enableOnAvailable;
+            section.disableFeaturesOnUnlock = disableOnUnlock;
+
+            ProgressionAPI.EnsureSectionCollectionsInitialized(section);
+
+            Assert.Same(phases, section.deliveryPhases);
+            Assert.Same(prerequisites, section.prerequisiteSections);
+            Assert.Same(enableOnUnlock, section.enableFeaturesOnUnlock);
+            Assert.Same(enableOnAvailable, section.enableFeaturesOnAvailable);
+            Assert.Same(disableOnUnlock, section.disableFeaturesOnUnlock);
+        }
+    }
+}

--- a/FUSE.Tests/Converter/LegacyIndustryComponentConverterTests.cs
+++ b/FUSE.Tests/Converter/LegacyIndustryComponentConverterTests.cs
@@ -65,6 +65,15 @@ namespace FUSE.Tests.Converter
         public void ShouldConvertComponentAsPartial_returns_false_when_type_set()
         {
             Assert.False(LegacyIndustryComponentConverter.ShouldConvertComponentAsPartial(JObject.Parse("{ \"type\": \"loader\" }")));
+            Assert.False(LegacyIndustryComponentConverter.ShouldConvertComponentAsPartial(
+                JObject.Parse("{ \"type\": \"loader\", \"trackSpans\": [\"P1\"] }")));
+        }
+
+        [Fact]
+        public void ShouldConvertComponentAsPartial_returns_true_for_typed_base_component_patch_without_spans()
+        {
+            Assert.True(LegacyIndustryComponentConverter.ShouldConvertComponentAsPartial(
+                JObject.Parse("{ \"type\": \"Model.Ops.IndustryLoader\", \"loadId\": \"logs\", \"maxStorage\": 128 }")));
         }
 
         [Fact]
@@ -298,6 +307,21 @@ namespace FUSE.Tests.Converter
             // The rate fields the mod actually wants to change survive.
             Assert.Equal(72, converted.Value<int>("storageChangeRate"));
             Assert.Equal("logs", converted.Value<string>("loadId"));
+        }
+
+        [Fact]
+        public void ConvertComponent_marks_explicitly_typed_spanless_base_loader_patch_as_partial()
+        {
+            var converted = LegacyIndustryComponentConverter.ConvertComponent(
+                "l1",
+                JObject.Parse("{ \"type\": \"Model.Ops.IndustryLoader\", \"name\": \"Connelly Creek L1\", \"loadId\": \"logs\", \"storageChangeRate\": 64, \"maxStorage\": 128 }"),
+                context: null);
+
+            Assert.True(converted.Value<bool>("partial"));
+            Assert.Null(converted["type"]);
+            Assert.Null(converted["trackSpanIds"]);
+            Assert.Equal("Connelly Creek L1", converted.Value<string>("name"));
+            Assert.Equal(128, converted.Value<int>("maxStorage"));
         }
 
         // ------------------------------------------------------------------

--- a/FUSE.Tests/Converter/LegacyKindDetectorTests.cs
+++ b/FUSE.Tests/Converter/LegacyKindDetectorTests.cs
@@ -48,6 +48,16 @@ namespace FUSE.Tests.Converter
         }
 
         [Fact]
+        public void DetectKind_returns_route_for_root_level_legacy_spans()
+        {
+            var folder = Path.Combine(_workspace, "root-spans");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(Path.Combine(folder, "Industry.json"),
+                "{ \"spans\": { \"KG-R1\": {} } }");
+            Assert.Equal("route", LegacyKindDetector.DetectKind(folder, "auto"));
+        }
+
+        [Fact]
         public void DetectKind_returns_asset_for_asset_pack_folder()
         {
             var folder = Path.Combine(_workspace, "asset-pack");

--- a/FUSE.Tests/Converter/LegacySourceConverterTests.cs
+++ b/FUSE.Tests/Converter/LegacySourceConverterTests.cs
@@ -235,6 +235,83 @@ namespace FUSE.Tests.Converter
         }
 
         [Fact]
+        public void ConvertSource_accepts_root_level_legacy_track_dictionaries()
+        {
+            // Flying Spuds and other RailLoader packages place all three
+            // dictionaries at the document root instead of under tracks.
+            var source = JObject.Parse(@"{
+                ""nodes"": {
+                    ""NPOE-7j00"": {
+                        ""position"": { ""x"": 9458.39, ""y"": 546.64, ""z"": 7536.29 },
+                        ""rotation"": { ""x"": 0, ""y"": 152.5, ""z"": 0 }
+                    },
+                    ""NPOE-7j01"": {
+                        ""position"": { ""x"": 9477.55, ""y"": 546.64, ""z"": 7499.48 },
+                        ""rotation"": { ""x"": 0, ""y"": 152.5, ""z"": 0 }
+                    }
+                },
+                ""segments"": {
+                    ""SPOE-7j00"": {
+                        ""style"": ""Standard"",
+                        ""trackClass"": ""Mainline"",
+                        ""startId"": ""NPOE-7j01"",
+                        ""endId"": ""NPOE-7j00""
+                    }
+                },
+                ""spans"": {
+                    ""KG-R1"": {
+                        ""upper"": { ""segmentId"": ""SPOE-7j00"", ""end"": ""Start"", ""distance"": 0 },
+                        ""lower"": { ""segmentId"": ""SPOE-7j00"", ""end"": ""End"", ""distance"": 0 }
+                    }
+                }
+            }");
+
+            var rail = NewSkeleton();
+            LegacySourceConverter.ConvertSource(source, rail, "Industry.json", null, report: null);
+
+            var tracks = (JObject)rail["tracks"];
+            Assert.Equal(2, ((JObject)tracks["nodes"]).Count);
+            Assert.Equal("NPOE-7j01", tracks["segments"]["SPOE-7j00"].Value<string>("startNodeId"));
+            Assert.Equal("NPOE-7j00", tracks["segments"]["SPOE-7j00"].Value<string>("endNodeId"));
+
+            var spans = (JObject)tracks["spans"];
+            var span = (JObject)spans["KG-R1"];
+            Assert.NotNull(span);
+            Assert.Equal("SPOE-7j00", span["upper"].Value<string>("segmentId"));
+            Assert.Equal("A", span["upper"].Value<string>("end"));
+            Assert.Equal("SPOE-7j00", span["lower"].Value<string>("segmentId"));
+            Assert.Equal("B", span["lower"].Value<string>("end"));
+        }
+
+        [Fact]
+        public void ConvertSource_nested_span_overrides_root_level_alias()
+        {
+            var source = JObject.Parse(@"{
+                ""spans"": {
+                    ""shared"": {
+                        ""upper"": { ""segmentId"": ""old"" },
+                        ""lower"": { ""segmentId"": ""old"" }
+                    }
+                },
+                ""tracks"": {
+                    ""spans"": {
+                        ""shared"": {
+                            ""upper"": { ""segmentId"": ""new"" },
+                            ""lower"": { ""segmentId"": ""new"" }
+                        }
+                    }
+                }
+            }");
+
+            var rail = NewSkeleton();
+            LegacySourceConverter.ConvertSource(source, rail, "Industry.json", null, report: null);
+
+            var span = rail["tracks"]["spans"]["shared"];
+            Assert.Equal("new", span["upper"].Value<string>("segmentId"));
+            Assert.Equal("new", span["lower"].Value<string>("segmentId"));
+        }
+
+        [Fact]
         public void ConvertSource_pushes_short_splineys_into_extensions_bucket()
         {
             // Splineys with <2 points get stashed under

--- a/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
@@ -33,6 +33,7 @@ namespace FUSE.Tests.Infrastructure
                 "mapEnhancerCullingGuarded=0 " +
                 "rebillAutoConfigSuppressed=0 " +
                 "brssModMenuDeferred=0 " +
+                "timeSyncMainThread=0 " +
                 "flares=0 switchRailsBackfilled=0 frameSpikes=0",
                 FuseRuntimeGuardCounters.FormatSummary());
         }
@@ -89,17 +90,19 @@ namespace FUSE.Tests.Infrastructure
             Assert.Equal(2, FuseRuntimeGuardCounters.RecordMapEnhancerCullingGuarded());
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordRebillAutoConfigSuppressed());
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordBrssModMenuDeferred());
+            Assert.Equal(1, FuseRuntimeGuardCounters.RecordTimeSyncMainThreadMarshaled());
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordSwitchGeometryRailsBackfilled());
 
             // Third-party containment must surface as guard activity: an
             // active suppression storm reading as "guards idle" would hide
             // the offender from every report surface.
             Assert.False(FuseRuntimeGuardCounters.AllIdle);
-            Assert.Equal(5, FuseRuntimeGuardCounters.GuardTotal);
+            Assert.Equal(6, FuseRuntimeGuardCounters.GuardTotal);
             var summary = FuseRuntimeGuardCounters.FormatSummary();
             Assert.Contains("mapEnhancerCullingGuarded=2", summary);
             Assert.Contains("rebillAutoConfigSuppressed=1", summary);
             Assert.Contains("brssModMenuDeferred=1", summary);
+            Assert.Contains("timeSyncMainThread=1", summary);
             Assert.Contains("switchRailsBackfilled=1", summary);
         }
     }

--- a/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
@@ -32,6 +32,7 @@ namespace FUSE.Tests.Infrastructure
                 "sceneryLoadWatch=0 " +
                 "mapEnhancerCullingGuarded=0 " +
                 "rebillAutoConfigSuppressed=0 " +
+                "brssModMenuDeferred=0 " +
                 "flares=0 switchRailsBackfilled=0 frameSpikes=0",
                 FuseRuntimeGuardCounters.FormatSummary());
         }
@@ -87,16 +88,18 @@ namespace FUSE.Tests.Infrastructure
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordMapEnhancerCullingGuarded());
             Assert.Equal(2, FuseRuntimeGuardCounters.RecordMapEnhancerCullingGuarded());
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordRebillAutoConfigSuppressed());
+            Assert.Equal(1, FuseRuntimeGuardCounters.RecordBrssModMenuDeferred());
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordSwitchGeometryRailsBackfilled());
 
             // Third-party containment must surface as guard activity: an
             // active suppression storm reading as "guards idle" would hide
             // the offender from every report surface.
             Assert.False(FuseRuntimeGuardCounters.AllIdle);
-            Assert.Equal(4, FuseRuntimeGuardCounters.GuardTotal);
+            Assert.Equal(5, FuseRuntimeGuardCounters.GuardTotal);
             var summary = FuseRuntimeGuardCounters.FormatSummary();
             Assert.Contains("mapEnhancerCullingGuarded=2", summary);
             Assert.Contains("rebillAutoConfigSuppressed=1", summary);
+            Assert.Contains("brssModMenuDeferred=1", summary);
             Assert.Contains("switchRailsBackfilled=1", summary);
         }
     }

--- a/FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FUSE.Authoring.Serialization;
 using FUSE.Authoring.Validation;
 using FUSE.Loading;
@@ -278,6 +279,82 @@ namespace FUSE.Tests.Loading
                 var result = new FuseDefinitionValidator().Validate(definition);
 
                 Assert.DoesNotContain(result.Errors, e => e.Code == "fuse.operations.component.trackSpanIds");
+            }
+        }
+
+        public class ReplaceDirectives
+        {
+            [Fact]
+            public void TrackSpanReplace_RoundTripsAsReplacementPatch()
+            {
+                var source = new JObject
+                {
+                    ["industries"] = new JObject
+                    {
+                        ["wh-e-engine"] = new JObject
+                        {
+                            ["components"] = new JObject
+                            {
+                                ["coaling"] = new JObject
+                                {
+                                    ["trackSpans"] = new JObject
+                                    {
+                                        ["$replace"] = new JArray("Pn9z", "WhittierCoal2")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var converted = (JObject)industries["wh-e-engine"]["components"]["coaling"];
+                Assert.Equal(
+                    new[] { "Pn9z", "WhittierCoal2" },
+                    converted["trackSpanPatch"]["replace"].Values<string>());
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                var component = definition.Operations.Industries["wh-e-engine"].Components["coaling"];
+                Assert.Equal(new[] { "Pn9z", "WhittierCoal2" }, component.TrackSpanPatch.Replace);
+            }
+
+            [Fact]
+            public void ComponentDictionaryReplace_RoundTripsAsWholesaleReplacement()
+            {
+                var source = new JObject
+                {
+                    ["industries"] = new JObject
+                    {
+                        ["wh-e-engine"] = new JObject
+                        {
+                            ["components"] = new JObject
+                            {
+                                ["$replace"] = new JObject
+                                {
+                                    ["diesel"] = new JObject
+                                    {
+                                        ["trackSpans"] = new JObject
+                                        {
+                                            ["$replace"] = new JArray("Pq23")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var converted = (JObject)industries["wh-e-engine"];
+                Assert.True(converted.Value<bool>("replaceComponents"));
+                Assert.False(converted.Value<bool>("mergeComponents"));
+                Assert.Equal(new[] { "diesel" }, ((JObject)converted["components"]).Properties().Select(p => p.Name));
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                var industry = definition.Operations.Industries["wh-e-engine"];
+                Assert.True(industry.ReplaceComponents);
+                Assert.False(industry.MergeComponents);
+                Assert.Equal(new[] { "diesel" }, industry.Components.Keys);
             }
         }
 

--- a/FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs
@@ -280,6 +280,54 @@ namespace FUSE.Tests.Loading
 
                 Assert.DoesNotContain(result.Errors, e => e.Code == "fuse.operations.component.trackSpanIds");
             }
+
+            [Fact]
+            public void ExplicitLegacyLoaderTypes_StillPatchBaseComponentsAndPassValidation()
+            {
+                var components = new JObject();
+                foreach (var id in new[] { "l1", "p1", "l2", "p2", "l3", "p34" })
+                {
+                    components[id] = new JObject
+                    {
+                        ["type"] = "Model.Ops.IndustryLoader",
+                        ["name"] = "Connelly Creek " + id,
+                        ["loadId"] = id.StartsWith("p") ? "pulpwood" : "logs",
+                        ["storageChangeRate"] = 64.0,
+                        ["maxStorage"] = 128.0,
+                        ["carTransferRate"] = 256.0
+                    };
+                }
+
+                var source = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["connelly"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["connelly0"] = new JObject
+                                {
+                                    ["components"] = components
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var converted = (JObject)industries["connelly0"]["components"];
+                foreach (var id in new[] { "l1", "p1", "l2", "p2", "l3", "p34" })
+                {
+                    Assert.True(converted[id].Value<bool>("partial"), $"{id} should inherit its base-game track spans");
+                    Assert.Null(converted[id]["type"]);
+                    Assert.Null(converted[id]["trackSpanIds"]);
+                }
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                var result = new FuseDefinitionValidator().Validate(definition);
+                Assert.DoesNotContain(result.Errors, error => error.Code == "fuse.operations.component.trackSpanIds");
+            }
         }
 
         public class ReplaceDirectives
@@ -355,6 +403,249 @@ namespace FUSE.Tests.Loading
                 Assert.True(industry.ReplaceComponents);
                 Assert.False(industry.MergeComponents);
                 Assert.Equal(new[] { "diesel" }, industry.Components.Keys);
+            }
+        }
+
+        public class RootLevelLegacySpans
+        {
+            private static JObject Span(string upperSegment, string upperEnd, string lowerSegment, string lowerEnd)
+            {
+                return new JObject
+                {
+                    ["upper"] = new JObject
+                    {
+                        ["segmentId"] = upperSegment,
+                        ["distance"] = 0,
+                        ["end"] = upperEnd
+                    },
+                    ["lower"] = new JObject
+                    {
+                        ["segmentId"] = lowerSegment,
+                        ["distance"] = 0,
+                        ["end"] = lowerEnd
+                    }
+                };
+            }
+
+            [Fact]
+            public void FlyingSpudsShape_ConvertsRootNodesSegmentsAndSpans()
+            {
+                var source = new JObject
+                {
+                    ["nodes"] = new JObject
+                    {
+                        ["NPOE-7j00"] = new JObject
+                        {
+                            ["position"] = new JObject { ["x"] = 9458.39, ["y"] = 546.64, ["z"] = 7536.29 },
+                            ["rotation"] = new JObject { ["x"] = 0, ["y"] = 152.5, ["z"] = 0 }
+                        },
+                        ["NPOE-7j01"] = new JObject
+                        {
+                            ["position"] = new JObject { ["x"] = 9477.55, ["y"] = 546.64, ["z"] = 7499.48 },
+                            ["rotation"] = new JObject { ["x"] = 0, ["y"] = 152.5, ["z"] = 0 }
+                        }
+                    },
+                    ["segments"] = new JObject
+                    {
+                        ["SPOE-7j00"] = new JObject
+                        {
+                            ["style"] = "Standard",
+                            ["trackClass"] = "Mainline",
+                            ["startId"] = "NPOE-7j01",
+                            ["endId"] = "NPOE-7j00"
+                        }
+                    },
+                    ["spans"] = new JObject
+                    {
+                        ["EPO_EP1"] = Span("SPOE-7j00", "Start", "SPOE-7j00", "End")
+                    }
+                };
+
+                var (root, _) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var tracks = (JObject)root["tracks"];
+                Assert.Equal(2, ((JObject)tracks["nodes"]).Count);
+                Assert.Single((JObject)tracks["segments"]);
+                Assert.Single((JObject)tracks["spans"]);
+                Assert.Equal("NPOE-7j01", (string)tracks["segments"]["SPOE-7j00"]["startNodeId"]);
+                Assert.Equal("NPOE-7j00", (string)tracks["segments"]["SPOE-7j00"]["endNodeId"]);
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                Assert.Equal(2, definition.Tracks.Nodes.Count);
+                Assert.Single(definition.Tracks.Segments);
+                Assert.Single(definition.Tracks.Spans);
+            }
+
+            [Fact]
+            public void CompatibilityExpansion_NormalizesRootTrackDictionariesBeforePatchingRuntimeState()
+            {
+                var source = new JObject
+                {
+                    ["nodes"] = new JObject
+                    {
+                        ["root-node"] = new JObject { ["position"] = new JObject() },
+                        ["shared-node"] = new JObject { ["position"] = new JObject { ["x"] = 1 } }
+                    },
+                    ["segments"] = new JObject
+                    {
+                        ["root-segment"] = new JObject { ["startId"] = "root-node", ["endId"] = "shared-node" }
+                    },
+                    ["spans"] = new JObject
+                    {
+                        ["root-span"] = Span("root-segment", "Start", "root-segment", "End")
+                    },
+                    ["tracks"] = new JObject
+                    {
+                        ["nodes"] = new JObject
+                        {
+                            ["nested-node"] = new JObject { ["position"] = new JObject() },
+                            ["shared-node"] = new JObject { ["position"] = new JObject { ["x"] = 2 } }
+                        }
+                    }
+                };
+
+                FuseLegacyGameGraphCompatibility.NormalizeRootTrackDictionaries(source);
+
+                Assert.Null(source["nodes"]);
+                Assert.Null(source["segments"]);
+                Assert.Null(source["spans"]);
+                var tracks = (JObject)source["tracks"];
+                Assert.Equal(3, ((JObject)tracks["nodes"]).Count);
+                Assert.NotNull(tracks["segments"]["root-segment"]);
+                Assert.NotNull(tracks["spans"]["root-span"]);
+                Assert.Equal(2, tracks["nodes"]["shared-node"]["position"].Value<int>("x"));
+
+                var state = new JObject
+                {
+                    ["tracks"] = new JObject
+                    {
+                        ["nodes"] = new JObject(),
+                        ["segments"] = new JObject(),
+                        ["spans"] = new JObject()
+                    }
+                };
+                FuseLegacyJsonPatch.Apply(state, source, "Potato.json");
+                var expandedSlice = FuseLegacyGameGraphCompatibility.BuildPatchSlice(state, source);
+
+                Assert.Equal(3, ((JObject)expandedSlice["tracks"]["nodes"]).Count);
+                Assert.NotNull(expandedSlice["tracks"]["segments"]["root-segment"]);
+                Assert.NotNull(expandedSlice["tracks"]["spans"]["root-span"]);
+            }
+
+            [Fact]
+            public void AndrewsValleyPowerShape_AcceptsLegacySegmentIDCapitalization()
+            {
+                var source = new JObject
+                {
+                    ["tracks"] = new JObject
+                    {
+                        ["spans"] = new JObject
+                        {
+                            ["KRPcoalLoad1"] = new JObject
+                            {
+                                ["upper"] = new JObject
+                                {
+                                    ["segmentId"] = "S_WNC_KCM_y69t",
+                                    ["distance"] = 0,
+                                    ["end"] = "Start"
+                                },
+                                // Andrews Valley Power uses segmentID here.
+                                ["lower"] = new JObject
+                                {
+                                    ["segmentID"] = "S_WNC_KCM_y69t",
+                                    ["distance"] = 0,
+                                    ["end"] = "End"
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var (root, _) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var span = root["tracks"]["spans"]["KRPcoalLoad1"];
+                Assert.Equal("S_WNC_KCM_y69t", (string)span["upper"]["segmentId"]);
+                Assert.Equal("S_WNC_KCM_y69t", (string)span["lower"]["segmentId"]);
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                var result = new FuseDefinitionValidator().Validate(definition);
+                Assert.DoesNotContain(result.Errors, error =>
+                    error.Code == "fuse.required" && error.Field.Contains("KRPcoalLoad1"));
+            }
+
+            [Fact]
+            public void SutherlandGapShape_ConvertsSpansAndKeepsLoaderBindings()
+            {
+                var source = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["nantahala"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["KG_Mine"] = new JObject
+                                {
+                                    ["name"] = "Sutherland Gap Coal",
+                                    ["components"] = new JObject
+                                    {
+                                        ["KG-coal-loader"] = new JObject
+                                        {
+                                            ["type"] = "Model.Ops.TeleportLoadingIndustry",
+                                            ["name"] = "Sutherland Gap Coal R1/R2",
+                                            ["trackSpans"] = new JArray("KG-R1", "KG-R2"),
+                                            ["inputSpans"] = new JArray("KG-R1", "KG-R2"),
+                                            ["outputSpans"] = new JArray("KG-O1", "KG-O2"),
+                                            ["loadId"] = "coal",
+                                            ["maxStorage"] = 2700000.0
+                                        },
+                                        ["KG-Supplies"] = new JObject
+                                        {
+                                            ["type"] = "Model.Ops.IndustryUnloader",
+                                            ["trackSpans"] = new JArray("KG-S1"),
+                                            ["loadId"] = "mining-supplies",
+                                            ["maxStorage"] = 150000.0
+                                        },
+                                        ["Freight Depot"] = new JObject
+                                        {
+                                            ["type"] = "Model.Ops.IndustryUnloader",
+                                            ["trackSpans"] = new JArray("KG-ER1"),
+                                            ["loadId"] = "camp_supplies",
+                                            ["maxStorage"] = 100000.0
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    // This root-level placement is the exact RailLoader shape
+                    // used by Sutherland Gap Coal's Industry.json.
+                    ["spans"] = new JObject
+                    {
+                        ["KG-O1"] = Span("S_KG_Mine_Output_1", "End", "S_KG_Mine_Output_1.1", "Start"),
+                        ["KG-O2"] = Span("S_KG_Mine_Output_2", "End", "S_KG_Mine_Output_2.1", "Start"),
+                        ["KG-R1"] = Span("S_KG_Mine_Input_0.9", "Start", "S_KG_Mine_Input_1.1", "End"),
+                        ["KG-R2"] = Span("S_KG_Mine_Input_1.9", "Start", "S_KG_Mine_Input_2.1", "End"),
+                        ["KG-S1"] = Span("S_KG_Mine_Supplies", "Start", "S_KG_Mine_Supplies", "End"),
+                        ["KG-ER1"] = Span("S_KG_Mine_Freight_House", "Start", "S_KG_Mine_Freight_House", "End")
+                    }
+                };
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var spans = (JObject)root["tracks"]["spans"];
+                Assert.Equal(6, spans.Count);
+                Assert.Equal("S_KG_Mine_Input_0.9", (string)spans["KG-R1"]["upper"]["segmentId"]);
+                Assert.Equal("A", (string)spans["KG-R1"]["upper"]["end"]);
+                Assert.Equal("B", (string)spans["KG-R1"]["lower"]["end"]);
+
+                var components = (JObject)industries["KG_Mine"]["components"];
+                Assert.Equal(new[] { "KG-R1", "KG-R2" }, components["KG-coal-loader"]["trackSpanIds"].Values<string>());
+                Assert.Equal(new[] { "KG-S1" }, components["KG-Supplies"]["trackSpanIds"].Values<string>());
+                Assert.Equal(new[] { "KG-ER1" }, components["Freight Depot"]["trackSpanIds"].Values<string>());
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                Assert.Equal(6, definition.Tracks.Spans.Count);
+                Assert.Equal(
+                    new[] { "KG-R1", "KG-R2" },
+                    definition.Operations.Industries["KG_Mine"].Components["KG-coal-loader"].TrackSpanIds);
             }
         }
 

--- a/FUSE.Tests/Loading/FuseLegacyMandelaConverterTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyMandelaConverterTests.cs
@@ -39,6 +39,20 @@ namespace FUSE.Tests.Loading
         private static (JObject root, JObject sceneClones, JArray removals, JArray suppressions)
             ConvertMandelas(JObject mandelas)
         {
+            var root = ConvertLegacySource(new JObject
+            {
+                ["mandelas"] = mandelas
+            });
+
+            var world = (JObject)root["world"];
+            var sceneClones = (JObject)world["sceneClones"];
+            var removals = (JArray)world["removals"]["sceneClones"];
+            var suppressions = (JArray)world["suppressBaseScenePaths"];
+            return (root, sceneClones, removals, suppressions);
+        }
+
+        private static JObject ConvertLegacySource(JObject source)
+        {
             var manifest = new FuseLegacyPackageManifest
             {
                 PackageId = "test-pkg",
@@ -47,17 +61,8 @@ namespace FUSE.Tests.Loading
                 Version = "1.0.0"
             };
             var root = FuseLegacyDataConverter.CreateSkeleton(manifest, "mandela-fragment");
-            var source = new JObject
-            {
-                ["mandelas"] = mandelas
-            };
             FuseLegacyDataConverter.ConvertSource(source, root, manifest);
-
-            var world = (JObject)root["world"];
-            var sceneClones = (JObject)world["sceneClones"];
-            var removals = (JArray)world["removals"]["sceneClones"];
-            var suppressions = (JArray)world["suppressBaseScenePaths"];
-            return (root, sceneClones, removals, suppressions);
+            return root;
         }
 
         public class EnabledTrue
@@ -308,6 +313,79 @@ namespace FUSE.Tests.Loading
                 Assert.False(keepEntry.ContainsKey("localPosition"));
                 Assert.False(keepEntry.ContainsKey("localRotation"));
                 Assert.False(keepEntry.ContainsKey("localScale"));
+            }
+        }
+
+        public class GeneratedLoader
+        {
+            [Fact]
+            public void MatchingLoaderTransform_IsFoldedIntoLoader_NotRegisteredAsSceneClone()
+            {
+                const string loaderId = "FranklinCoalTower";
+                const string loaderPath = "World/Loaders/FranklinCoalTower";
+                var root = FuseLegacyMandelaConverterTests.ConvertLegacySource(new JObject
+                {
+                    ["splineys"] = new JObject
+                    {
+                        [loaderId] = new JObject
+                        {
+                            ["Position"] = new JObject { ["x"] = 11190f, ["y"] = 615f, ["z"] = -22610f },
+                            ["Rotation"] = new JObject { ["x"] = 0f, ["y"] = 159f, ["z"] = 0f },
+                            ["Prefab"] = "vanilla://coalTower",
+                            ["Industry"] = "franklinservice",
+                            ["Handler"] = "AlinasMapMod.LoaderBuilder"
+                        }
+                    },
+                    ["mandelas"] = new JObject
+                    {
+                        [loaderPath] = new JObject
+                        {
+                            ["localPosition"] = new JObject { ["x"] = 11190.2021f, ["y"] = 616.399658f, ["z"] = -22610.15f },
+                            ["localRotation"] = new JObject { ["x"] = 0f, ["y"] = 271f, ["z"] = 0f },
+                            ["enabled"] = true
+                        }
+                    }
+                });
+
+                var loader = (JObject)root["operations"]["loaders"][loaderId];
+                var position = (JObject)loader["position"];
+                var rotation = (JObject)loader["rotation"];
+                var sceneClones = (JObject)root["world"]["sceneClones"];
+
+                Assert.Equal(11190.2021f, (float)position["x"], precision: 2);
+                Assert.Equal(616.399658f, (float)position["y"], precision: 3);
+                Assert.Equal(-22610.15f, (float)position["z"], precision: 2);
+                Assert.Equal(271f, (float)rotation["y"]);
+                Assert.False(sceneClones.ContainsKey(loaderPath));
+            }
+
+            [Fact]
+            public void ScaledLoaderPath_RemainsSceneCloneBecauseLoaderDefinitionsCannotRepresentScale()
+            {
+                const string loaderId = "ScaledLoader";
+                const string loaderPath = "World/Loaders/ScaledLoader";
+                var root = FuseLegacyMandelaConverterTests.ConvertLegacySource(new JObject
+                {
+                    ["splineys"] = new JObject
+                    {
+                        [loaderId] = new JObject
+                        {
+                            ["Position"] = new JObject { ["x"] = 1f, ["y"] = 2f, ["z"] = 3f },
+                            ["Prefab"] = "vanilla://coalTower",
+                            ["Handler"] = "AlinasMapMod.LoaderBuilder"
+                        }
+                    },
+                    ["mandelas"] = new JObject
+                    {
+                        [loaderPath] = new JObject
+                        {
+                            ["localScale"] = new JObject { ["x"] = 2f, ["y"] = 2f, ["z"] = 2f },
+                            ["enabled"] = true
+                        }
+                    }
+                });
+
+                Assert.True(((JObject)root["world"]["sceneClones"]).ContainsKey(loaderPath));
             }
         }
     }

--- a/FUSE.Tests/Loading/FuseLegacySplineyConverterTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacySplineyConverterTests.cs
@@ -1,0 +1,69 @@
+using FUSE.Authoring.Serialization;
+using FUSE.Loading;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseLegacySplineyConverterTests
+    {
+        [Fact]
+        public void PointsReplace_RoundTripsAsSplineyGeometry()
+        {
+            var source = new JObject
+            {
+                ["splineys"] = new JObject
+                {
+                    ["World/Roads Sylva/Chipper Curve"] = new JObject
+                    {
+                        ["profile"] = "Railroader Paved Road",
+                        ["style"] = "Road",
+                        ["points"] = new JObject
+                        {
+                            ["$replace"] = new JArray(
+                                Point(25052.1875f, 623.3373f, -911.4685f),
+                                Point(25047.8848f, 623.9138f, -903.40564f))
+                        }
+                    }
+                }
+            };
+            var manifest = new FuseLegacyPackageManifest
+            {
+                PackageId = "test-pkg",
+                DisplayName = "Test Package",
+                Author = "tester",
+                Version = "1.0.0"
+            };
+            var root = FuseLegacyDataConverter.CreateSkeleton(manifest, "spliney-fragment");
+
+            FuseLegacyDataConverter.ConvertSource(source, root, manifest);
+
+            var converted = (JObject)root["world"]["splineys"]["World/Roads Sylva/Chipper Curve"];
+            Assert.Equal(2, ((JArray)converted["points"]).Count);
+            var definition = FuseSerializer.FromJson(root.ToString());
+            Assert.Equal(
+                2,
+                definition.World.Splineys["World/Roads Sylva/Chipper Curve"].Points.Length);
+        }
+
+        private static JObject Point(float x, float y, float z)
+        {
+            return new JObject
+            {
+                ["position"] = new JObject
+                {
+                    ["x"] = x,
+                    ["y"] = y,
+                    ["z"] = z
+                },
+                ["rotation"] = new JObject
+                {
+                    ["x"] = 0f,
+                    ["y"] = 0f,
+                    ["z"] = 0f
+                },
+                ["width"] = 6.7056f
+            };
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseModLoaderTrackMergingTests.cs
+++ b/FUSE.Tests/Loading/FuseModLoaderTrackMergingTests.cs
@@ -1,0 +1,28 @@
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseModLoaderTrackMergingTests
+    {
+        [Theory]
+        [InlineData("ARC.Whittier.FUSE.arc-whittier", "ARC.Whittier.FUSE.arc-whittier", false, true)]
+        [InlineData("ARC.Whittier.FUSE.arc-whittier", "ARC.Whittier.FUSE.arc-whittier", true, false)]
+        [InlineData("ARC.Whittier.FUSE.arc-whittier", "another.package", false, false)]
+        [InlineData("ARC.Whittier.FUSE.arc-whittier", null, false, false)]
+        [InlineData(null, "ARC.Whittier.FUSE.arc-whittier", false, false)]
+        public void MissingMergedSpan_IsReconciledOnlyForItsWinningOwner(
+            string plannedOwner,
+            string registryOwner,
+            bool spanPresent,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseModLoader.ShouldReconcileMergedSpan(
+                    plannedOwner,
+                    registryOwner,
+                    spanPresent));
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseModLoaderTrackMergingTests.cs
+++ b/FUSE.Tests/Loading/FuseModLoaderTrackMergingTests.cs
@@ -1,3 +1,5 @@
+using FUSE.Authoring.Data;
+using FUSE.Authoring.Data.Common;
 using FUSE.Loading;
 using Xunit;
 
@@ -23,6 +25,35 @@ namespace FUSE.Tests.Loading
                     plannedOwner,
                     registryOwner,
                     spanPresent));
+        }
+
+        [Theory]
+        [InlineData("S6jh", "Scv4", "S_AWHI_dtmt", "S_AWHI_dtmt", true)]
+        [InlineData("A", "B", "A", "B", false)]
+        [InlineData("A", "B", "B", "A", false)]
+        [InlineData(null, "B", "A", "B", true)]
+        [InlineData("A", "B", null, "B", false)]
+        public void MergedSpan_RecreatesRuntimeObjectOnlyWhenEndpointTopologyChanges(
+            string runtimeUpper,
+            string runtimeLower,
+            string replacementUpper,
+            string replacementLower,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseModLoader.ShouldRecreateMergedSpanRuntime(
+                    Span(runtimeUpper, runtimeLower),
+                    Span(replacementUpper, replacementLower)));
+        }
+
+        private static FuseSpan Span(string upperSegmentId, string lowerSegmentId)
+        {
+            return new FuseSpan
+            {
+                Upper = new FuseTrackLocation { SegmentId = upperSegmentId },
+                Lower = new FuseTrackLocation { SegmentId = lowerSegmentId }
+            };
         }
     }
 }

--- a/FUSE.Tests/Patches/FuseAssetPackBundleAuditTests.cs
+++ b/FUSE.Tests/Patches/FuseAssetPackBundleAuditTests.cs
@@ -144,6 +144,32 @@ namespace FUSE.Tests.Patches
             Assert.Equal("wh-5-drg-st.wav", entry.Filename);
         }
 
+        [Fact]
+        public void BaseGameAssetPackPath_IsExcludedFromExternalBundleAudit()
+        {
+            var streamingAssets = System.IO.Path.Combine("game", "Railroader_Data", "StreamingAssets");
+            var builtInPack = System.IO.Path.Combine(streamingAssets, "AssetPacks", "scenery-structures01");
+
+            Assert.True(FuseAssetPackBundleAuditPatch.IsBaseGameAssetPackPath(
+                builtInPack,
+                streamingAssets));
+        }
+
+        [Fact]
+        public void ModAssetPackPath_RemainsEligibleForBundleAudit()
+        {
+            var streamingAssets = System.IO.Path.Combine("game", "Railroader_Data", "StreamingAssets");
+            var externalPack = System.IO.Path.Combine("game", "Mods", "AspensAssets", "aspensassets");
+            var prefixCollision = System.IO.Path.Combine(streamingAssets, "AssetPacksExternal", "not-built-in");
+
+            Assert.False(FuseAssetPackBundleAuditPatch.IsBaseGameAssetPackPath(
+                externalPack,
+                streamingAssets));
+            Assert.False(FuseAssetPackBundleAuditPatch.IsBaseGameAssetPackPath(
+                prefixCollision,
+                streamingAssets));
+        }
+
         [Theory]
         [InlineData(null, (int)FuseAssetPackBundleAuditPatch.CatalogAssetTypeClassification.Unknown)]
         [InlineData("", (int)FuseAssetPackBundleAuditPatch.CatalogAssetTypeClassification.Unknown)]

--- a/FUSE.Tests/Patches/FuseBrssModMenuGuardPatchesTests.cs
+++ b/FUSE.Tests/Patches/FuseBrssModMenuGuardPatchesTests.cs
@@ -1,0 +1,23 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseBrssModMenuGuardPatchesTests
+    {
+        [Theory]
+        [InlineData(false, false, false)]
+        [InlineData(false, true, true)]
+        [InlineData(true, false, true)]
+        [InlineData(true, true, true)]
+        public void CreateWindow_RunsUnlessBothWindowAndSelectionAreMissing(
+            bool hasWindow,
+            bool hasSelectedCar,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseBrssModMenuGuardPatches.ShouldRunOriginal(hasWindow, hasSelectedCar));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseTimeSyncMainThreadGuardPatchesTests.cs
+++ b/FUSE.Tests/Patches/FuseTimeSyncMainThreadGuardPatchesTests.cs
@@ -1,0 +1,24 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseTimeSyncMainThreadGuardPatchesTests
+    {
+        [Theory]
+        [InlineData(12, 0, true)]
+        [InlineData(12, 7, true)]
+        [InlineData(7, 7, false)]
+        public void SyncTimes_DefersUntilTheCallbackIsOnTheRecordedMainThread(
+            int currentThreadId,
+            int mainThreadId,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseTimeSyncMainThreadGuardPatches.ShouldDefer(
+                    currentThreadId,
+                    mainThreadId));
+        }
+    }
+}

--- a/FUSE/Infrastructure/FuseRuntimeGuardCounters.cs
+++ b/FUSE/Infrastructure/FuseRuntimeGuardCounters.cs
@@ -5,8 +5,8 @@ namespace FUSE.Infrastructure
     /// broken content (decal culling, car-decal helpers, curve-mesh culling,
     /// scenery decal machinery, scenery asset loads, stale flares, switch
     /// geometry backfills, and the third-party containment guards for Map
-    /// Enhancer culling and Rebill Industry Cars config loads) plus the
-    /// frame-spike diagnostic.
+    /// Enhancer culling, Rebill Industry Cars config loads, and BRSS mod-menu
+    /// startup) plus the frame-spike diagnostic.
     ///
     /// Lives in Infrastructure so both ends of the dependency rule work: the
     /// guard patches (FUSE.Patches) write here, and the load report
@@ -32,6 +32,7 @@ namespace FUSE.Infrastructure
         internal static long SwitchGeometryRailsBackfilled { get; private set; }
         internal static long MapEnhancerCullingGuarded { get; private set; }
         internal static long RebillAutoConfigSuppressed { get; private set; }
+        internal static long BrssModMenuDeferred { get; private set; }
 
         internal static long FrameSpikes { get; private set; }
         internal static float FrameSpikeWorstMs { get; private set; }
@@ -61,7 +62,8 @@ namespace FUSE.Infrastructure
             FlareSuppressed +
             SwitchGeometryRailsBackfilled +
             MapEnhancerCullingGuarded +
-            RebillAutoConfigSuppressed;
+            RebillAutoConfigSuppressed +
+            BrssModMenuDeferred;
 
         internal static bool AllIdle => GuardTotal == 0;
 
@@ -90,6 +92,8 @@ namespace FUSE.Infrastructure
         internal static long RecordMapEnhancerCullingGuarded() => ++MapEnhancerCullingGuarded;
 
         internal static long RecordRebillAutoConfigSuppressed() => ++RebillAutoConfigSuppressed;
+
+        internal static long RecordBrssModMenuDeferred() => ++BrssModMenuDeferred;
 
         internal static long RecordFrameSpike(float frameMs)
         {
@@ -122,6 +126,7 @@ namespace FUSE.Infrastructure
                 $"sceneryLoadWatch={SceneryLoadWatchAttached} " +
                 $"mapEnhancerCullingGuarded={MapEnhancerCullingGuarded} " +
                 $"rebillAutoConfigSuppressed={RebillAutoConfigSuppressed} " +
+                $"brssModMenuDeferred={BrssModMenuDeferred} " +
                 $"flares={FlareSuppressed} switchRailsBackfilled={SwitchGeometryRailsBackfilled} " +
                 spikes;
         }
@@ -142,6 +147,7 @@ namespace FUSE.Infrastructure
             SwitchGeometryRailsBackfilled = 0;
             MapEnhancerCullingGuarded = 0;
             RebillAutoConfigSuppressed = 0;
+            BrssModMenuDeferred = 0;
             FrameSpikes = 0;
             FrameSpikeWorstMs = 0f;
             SceneryLoadWatchAttached = 0;

--- a/FUSE/Infrastructure/FuseRuntimeGuardCounters.cs
+++ b/FUSE/Infrastructure/FuseRuntimeGuardCounters.cs
@@ -5,8 +5,9 @@ namespace FUSE.Infrastructure
     /// broken content (decal culling, car-decal helpers, curve-mesh culling,
     /// scenery decal machinery, scenery asset loads, stale flares, switch
     /// geometry backfills, and the third-party containment guards for Map
-    /// Enhancer culling, Rebill Industry Cars config loads, and BRSS mod-menu
-    /// startup) plus the frame-spike diagnostic.
+    /// Enhancer culling, Rebill Industry Cars config loads, BRSS mod-menu
+    /// startup, and TimeSync main-thread dispatch) plus the frame-spike
+    /// diagnostic.
     ///
     /// Lives in Infrastructure so both ends of the dependency rule work: the
     /// guard patches (FUSE.Patches) write here, and the load report
@@ -33,6 +34,7 @@ namespace FUSE.Infrastructure
         internal static long MapEnhancerCullingGuarded { get; private set; }
         internal static long RebillAutoConfigSuppressed { get; private set; }
         internal static long BrssModMenuDeferred { get; private set; }
+        internal static long TimeSyncMainThreadMarshaled { get; private set; }
 
         internal static long FrameSpikes { get; private set; }
         internal static float FrameSpikeWorstMs { get; private set; }
@@ -63,7 +65,8 @@ namespace FUSE.Infrastructure
             SwitchGeometryRailsBackfilled +
             MapEnhancerCullingGuarded +
             RebillAutoConfigSuppressed +
-            BrssModMenuDeferred;
+            BrssModMenuDeferred +
+            TimeSyncMainThreadMarshaled;
 
         internal static bool AllIdle => GuardTotal == 0;
 
@@ -94,6 +97,8 @@ namespace FUSE.Infrastructure
         internal static long RecordRebillAutoConfigSuppressed() => ++RebillAutoConfigSuppressed;
 
         internal static long RecordBrssModMenuDeferred() => ++BrssModMenuDeferred;
+
+        internal static long RecordTimeSyncMainThreadMarshaled() => ++TimeSyncMainThreadMarshaled;
 
         internal static long RecordFrameSpike(float frameMs)
         {
@@ -127,6 +132,7 @@ namespace FUSE.Infrastructure
                 $"mapEnhancerCullingGuarded={MapEnhancerCullingGuarded} " +
                 $"rebillAutoConfigSuppressed={RebillAutoConfigSuppressed} " +
                 $"brssModMenuDeferred={BrssModMenuDeferred} " +
+                $"timeSyncMainThread={TimeSyncMainThreadMarshaled} " +
                 $"flares={FlareSuppressed} switchRailsBackfilled={SwitchGeometryRailsBackfilled} " +
                 spikes;
         }
@@ -148,6 +154,7 @@ namespace FUSE.Infrastructure
             MapEnhancerCullingGuarded = 0;
             RebillAutoConfigSuppressed = 0;
             BrssModMenuDeferred = 0;
+            TimeSyncMainThreadMarshaled = 0;
             FrameSpikes = 0;
             FrameSpikeWorstMs = 0f;
             SceneryLoadWatchAttached = 0;

--- a/FUSE/Loading/FuseLegacyDataConverter.Components.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.Components.cs
@@ -118,7 +118,7 @@ namespace FUSE.Loading
 
         private static bool ShouldConvertAsPartialComponent(JObject item, string explicitType, JObject trackSpanPatch)
         {
-            if (item == null || !string.IsNullOrWhiteSpace(explicitType))
+            if (item == null)
             {
                 return false;
             }
@@ -128,12 +128,41 @@ namespace FUSE.Loading
                 return true;
             }
 
+            if (!string.IsNullOrWhiteSpace(explicitType))
+            {
+                var normalizedType = FuseIndustryComponentTypes.Normalize(NormalizeComponentType(explicitType));
+                var isLegacyRuntimeType = !string.Equals(
+                    explicitType.Trim(),
+                    normalizedType,
+                    StringComparison.OrdinalIgnoreCase);
+
+                // Legacy game-graph mixins commonly repeat the runtime type while
+                // patching an existing base-game component by industry/component id.
+                // The type is descriptive in that shape; it does not turn the patch
+                // into a new standalone component. If a span-bound component carries
+                // no span binding, preserve it as a partial merge so the runtime keeps
+                // the base component's spans. Spanless passenger stops are the one
+                // supported standalone exception.
+                return isLegacyRuntimeType &&
+                       HasComponentPatchPayload(item) &&
+                       FuseIndustryComponentTypes.UsesTrackSpanIds(normalizedType) &&
+                       !string.Equals(normalizedType, FuseIndustryComponentTypes.PassengerStop, StringComparison.OrdinalIgnoreCase) &&
+                       !HasLoadComponentBindingShape(item);
+            }
+
             if (!HasStandaloneComponentShape(item))
             {
                 return true;
             }
 
             return HasLoadOperationShape(item) && !HasLoadComponentBindingShape(item);
+        }
+
+        private static bool HasComponentPatchPayload(JObject item)
+        {
+            return item != null && item.Properties().Any(property =>
+                !string.Equals(property.Name, "type", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(property.Name, "name", StringComparison.OrdinalIgnoreCase));
         }
 
         private static bool HasStandaloneComponentShape(JObject item)

--- a/FUSE/Loading/FuseLegacyDataConverter.Helpers.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.Helpers.cs
@@ -43,6 +43,37 @@ namespace FUSE.Loading
             }
         }
 
+        /// <summary>
+        /// Combines dictionary aliases in legacy-precedence order. Some older
+        /// RailLoader packages wrote nodes, segments, and spans at the document
+        /// root while newer packages write them under tracks. Later sources win so the
+        /// canonical nested form can intentionally override the legacy alias,
+        /// including overriding an entry with null to request a removal.
+        /// </summary>
+        private static JObject MergeLegacyDictionaries(params JObject[] sources)
+        {
+            var merged = new JObject();
+            if (sources == null)
+            {
+                return merged;
+            }
+
+            foreach (var source in sources)
+            {
+                if (source == null)
+                {
+                    continue;
+                }
+
+                foreach (var property in source.Properties())
+                {
+                    merged[property.Name] = property.Value.DeepClone();
+                }
+            }
+
+            return merged;
+        }
+
         private static JObject Vector(JToken value, bool defaultScale)
         {
             var fallback = defaultScale ? 1f : 0f;

--- a/FUSE/Loading/FuseLegacyDataConverter.World.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.World.cs
@@ -45,12 +45,86 @@ namespace FUSE.Loading
                     continue;
                 }
 
+                // Legacy map packs commonly create an operations loader and then
+                // use a mandela entry such as World/Loaders/<id> to correct the
+                // loader root's final transform. Treating that correction as a
+                // scene clone attaches scene-clone lifecycle state to a functional
+                // loader, causing it to participate in snapshot/rebind passes and
+                // making diagnostics classify it as scenery. Fold transform-only
+                // corrections into the loader definition instead.
+                if (TryMergeGeneratedLoaderMandela(property.Name, item, root))
+                {
+                    continue;
+                }
+
                 var converted = ConvertSceneClone(property.Name, property.Value);
                 if (converted != null)
                 {
                     sceneClones[property.Name] = Clean(converted);
                 }
             }
+        }
+
+        private static bool TryMergeGeneratedLoaderMandela(string id, JObject item, JObject root)
+        {
+            if (item == null || root == null)
+            {
+                return false;
+            }
+
+            // A source means "instantiate a new object", not "adjust the loader
+            // created by this package". Loader definitions also have no scale
+            // field, so keep scaled entries in the scene-clone pipeline rather
+            // than silently dropping authored behavior.
+            if (!string.IsNullOrWhiteSpace(ReadString(item, "source", "instantiateFrom")) ||
+                HasAnyProperty(item, "localScale", "scale"))
+            {
+                return false;
+            }
+
+            var targetPath = ReadString(item, "targetPath") ?? id;
+            const string worldPrefix = "World/Loaders/";
+            const string rootPrefix = "Loaders/";
+            string loaderId;
+            if (targetPath.StartsWith(worldPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                loaderId = targetPath.Substring(worldPrefix.Length);
+            }
+            else if (targetPath.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                loaderId = targetPath.Substring(rootPrefix.Length);
+            }
+            else
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(loaderId) ||
+                loaderId.IndexOf('/') >= 0 ||
+                loaderId.IndexOf('\\') >= 0)
+            {
+                return false;
+            }
+
+            var loaders = root["operations"]?["loaders"] as JObject;
+            var loaderProperty = loaders?.Properties().FirstOrDefault(property =>
+                string.Equals(property.Name, loaderId, StringComparison.OrdinalIgnoreCase));
+            if (!(loaderProperty?.Value is JObject loader))
+            {
+                return false;
+            }
+
+            if (HasAnyProperty(item, "localPosition", "position"))
+            {
+                loader["position"] = Vector(item["localPosition"] ?? item["position"], false);
+            }
+
+            if (HasAnyProperty(item, "localRotation", "rotation"))
+            {
+                loader["rotation"] = Vector(item["localRotation"] ?? item["rotation"], false);
+            }
+
+            return true;
         }
 
         private static bool TryConvertMandelaSuppression(string id, JObject item, JArray suppressions)
@@ -285,7 +359,7 @@ namespace FUSE.Loading
 
             var result = new JObject
             {
-                ["segmentId"] = ReadString(item, "segmentId", "segment", "id") ?? string.Empty,
+                ["segmentId"] = ReadString(item, "segmentId", "segmentID", "SegmentId", "SegmentID", "segment", "id") ?? string.Empty,
                 ["end"] = NormalizeEnd(ReadString(item, "end", "End")) ?? "A"
             };
 

--- a/FUSE/Loading/FuseLegacyDataConverter.World.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.World.cs
@@ -596,6 +596,7 @@ namespace FUSE.Loading
                 }
 
                 var handler = ReadHandler(item);
+                var points = ReadLegacyReplacementArray(item["points"]);
                 if (IsTurntableHandler(handler))
                 {
                     ((JObject)root["operations"]["turntables"])[property.Name] = ConvertTurntable(property.Name, item);
@@ -625,7 +626,7 @@ namespace FUSE.Loading
                 }
                 else if (!string.IsNullOrWhiteSpace(handler) &&
                          !SplineyHandlerMap.ContainsKey(handler) &&
-                         (item["points"] as JArray) == null)
+                         points == null)
                 {
                     // FUSE doesn't recognize this handler natively and the
                     // spliney has no curve geometry of its own; defer to
@@ -636,7 +637,7 @@ namespace FUSE.Loading
                     FuseSplineyPluginHost.Register(property.Name, item);
                     continue;
                 }
-                else if ((item["points"] as JArray)?.Count >= 2)
+                else if (points?.Count >= 2)
                 {
                     ((JObject)root["world"]["splineys"])[property.Name] = ConvertSpliney(item);
                 }
@@ -667,6 +668,23 @@ namespace FUSE.Loading
             return ReadString(item, "handler", "Handler") ?? string.Empty;
         }
 
+        private static JArray ReadLegacyReplacementArray(JToken value)
+        {
+            if (value is JArray array)
+            {
+                return array;
+            }
+
+            if (value is JObject patch &&
+                patch.TryGetValue("$replace", StringComparison.OrdinalIgnoreCase, out var replacement) &&
+                replacement is JArray replacementArray)
+            {
+                return replacementArray;
+            }
+
+            return null;
+        }
+
         private static JObject ConvertSpliney(JObject item)
         {
             var handler = ReadHandler(item);
@@ -677,7 +695,7 @@ namespace FUSE.Loading
             }
 
             var points = new JArray();
-            foreach (var point in (item["points"] as JArray)?.OfType<JObject>() ?? Enumerable.Empty<JObject>())
+            foreach (var point in ReadLegacyReplacementArray(item["points"])?.OfType<JObject>() ?? Enumerable.Empty<JObject>())
             {
                 points.Add(CleanObject(new JObject
                 {

--- a/FUSE/Loading/FuseLegacyDataConverter.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.cs
@@ -750,12 +750,19 @@ namespace FUSE.Loading
         internal static void ConvertSource(JObject source, JObject root, FuseLegacyPackageManifest manifest)
         {
             var tracks = source["tracks"] as JObject;
-            if (tracks != null)
-            {
-                ConvertDictionary(tracks["nodes"], root["tracks"]["nodes"] as JObject, root["tracks"]["removals"]["nodes"] as JArray, ConvertNode);
-                ConvertDictionary(tracks["segments"], root["tracks"]["segments"] as JObject, root["tracks"]["removals"]["segments"] as JArray, ConvertSegment);
-                ConvertDictionary(tracks["spans"], root["tracks"]["spans"] as JObject, root["tracks"]["removals"]["spans"] as JArray, ConvertSpan);
-            }
+            // RailLoader accepts both the original root-level track dictionaries
+            // and the later dictionaries nested under `tracks`. Convert both
+            // shapes so older route packages retain their physical track and
+            // industry span bindings. Canonical nested entries win duplicate ids.
+            var nestedNodes = tracks == null ? null : tracks["nodes"] as JObject;
+            var nestedSegments = tracks == null ? null : tracks["segments"] as JObject;
+            var nestedSpans = tracks == null ? null : tracks["spans"] as JObject;
+            var legacyNodes = MergeLegacyDictionaries(source["nodes"] as JObject, nestedNodes);
+            var legacySegments = MergeLegacyDictionaries(source["segments"] as JObject, nestedSegments);
+            var legacySpans = MergeLegacyDictionaries(source["spans"] as JObject, nestedSpans);
+            ConvertDictionary(legacyNodes, root["tracks"]["nodes"] as JObject, root["tracks"]["removals"]["nodes"] as JArray, ConvertNode);
+            ConvertDictionary(legacySegments, root["tracks"]["segments"] as JObject, root["tracks"]["removals"]["segments"] as JArray, ConvertSegment);
+            ConvertDictionary(legacySpans, root["tracks"]["spans"] as JObject, root["tracks"]["removals"]["spans"] as JArray, ConvertSpan);
 
             ConvertDictionary(source["loads"], root["operations"]["loads"] as JObject, null, ConvertLoad);
 

--- a/FUSE/Loading/FuseLegacyGameGraphCompatibility.cs
+++ b/FUSE/Loading/FuseLegacyGameGraphCompatibility.cs
@@ -76,6 +76,7 @@ namespace FUSE.Loading
             }
 
             var source = FuseLegacyDataConverter.ReadLegacyObject(sourcePath);
+            NormalizeRootTrackDictionaries(source);
             FuseLegacyJsonPatch.Apply(state, source, Path.GetFileName(sourcePath));
             MirrorAreaIndustriesToTopLevel(state, source);
             var slice = BuildPatchSlice(state, source);
@@ -96,6 +97,59 @@ namespace FUSE.Loading
             definition.Progression = expandedDefinition.Progression;
             MarkExpanded(definition, sourcePath, true);
             return true;
+        }
+
+        /// <summary>
+        /// RailLoader's original game-graph schema placed nodes, segments, and
+        /// spans at the document root. The compatibility expander patches each
+        /// legacy file against a canonical runtime snapshot whose track data is
+        /// under <c>tracks</c>. Normalize those aliases before applying the JSON
+        /// patch; otherwise the expander creates disconnected root dictionaries
+        /// and then replaces the already-correct first-pass conversion with a
+        /// slice that contains no track data.
+        /// </summary>
+        internal static void NormalizeRootTrackDictionaries(JObject source)
+        {
+            if (source == null)
+            {
+                return;
+            }
+
+            var tracks = GetPropertyValue(source, "tracks") as JObject;
+            foreach (var section in new[] { "nodes", "segments", "spans" })
+            {
+                var rootProperty = source.Properties().FirstOrDefault(property =>
+                    string.Equals(property.Name, section, StringComparison.OrdinalIgnoreCase));
+                if (!(rootProperty?.Value is JObject rootDictionary))
+                {
+                    continue;
+                }
+
+                if (tracks == null)
+                {
+                    tracks = new JObject();
+                    source["tracks"] = tracks;
+                }
+
+                var merged = new JObject();
+                foreach (var property in rootDictionary.Properties())
+                {
+                    merged[property.Name] = property.Value.DeepClone();
+                }
+
+                if (GetPropertyValue(tracks, section) is JObject nestedDictionary)
+                {
+                    foreach (var property in nestedDictionary.Properties())
+                    {
+                        // The newer canonical shape wins if both aliases name
+                        // the same object, including a null removal directive.
+                        merged[property.Name] = property.Value.DeepClone();
+                    }
+                }
+
+                tracks[section] = merged;
+                rootProperty.Remove();
+            }
         }
 
         private static bool ShouldExpand(FuseLoadedMod loaded)
@@ -520,7 +574,7 @@ namespace FUSE.Loading
             return result;
         }
 
-        private static JObject BuildPatchSlice(JObject state, JObject patch)
+        internal static JObject BuildPatchSlice(JObject state, JObject patch)
         {
             var slice = new JObject();
             CopyTracks(slice, state, patch);

--- a/FUSE/Loading/FuseModLoader.TrackMerging.cs
+++ b/FUSE/Loading/FuseModLoader.TrackMerging.cs
@@ -1456,10 +1456,30 @@ namespace FUSE.Loading
                 return;
             }
 
-            var exists = TrackAPI.GetSpan(entry.Id) != null;
+            var runtimeSpan = TrackAPI.GetSpan(entry.Id);
+            var exists = runtimeSpan != null;
+            var recreateForTopologyChange =
+                exists &&
+                ShouldRecreateMergedSpanRuntime(
+                    TrackAPI.GetDefinition(runtimeSpan),
+                    entry.Value);
             transaction.TryApply("track span", entry.Id, exists, () =>
             {
-                if (exists)
+                if (recreateForTopologyChange)
+                {
+                    // A Unity Destroy requested while the old segment topology
+                    // was removed is deferred until the end of the frame. Updating
+                    // that retiring TrackSpan object makes the replacement appear
+                    // to succeed, then disappear when Unity finishes the pending
+                    // destroy. A fresh graph child is required when the endpoint
+                    // segment set changes (ARC Whittier's Pyc3/Pap9 case).
+                    TrackAPI.RemoveSpan(entry.Id);
+                    TrackAPI.AddSpan(entry.Id, entry.Value);
+                    FuseLog.Info(
+                        $"FUSE recreated track span package='{definition.Id}' operation='apply-merged-spans' " +
+                        $"kind='track span' id='{entry.Id}' message='endpoint topology changed; avoided reusing retiring runtime span instance'.");
+                }
+                else if (exists)
                 {
                     TrackAPI.UpdateSpan(entry.Id, entry.Value);
                 }
@@ -1468,6 +1488,36 @@ namespace FUSE.Loading
                     TrackAPI.AddSpan(entry.Id, entry.Value);
                 }
             });
+        }
+
+        internal static bool ShouldRecreateMergedSpanRuntime(
+            FuseSpan runtimeDefinition,
+            FuseSpan replacementDefinition)
+        {
+            var runtimeUpper = runtimeDefinition?.Upper?.SegmentId;
+            var runtimeLower = runtimeDefinition?.Lower?.SegmentId;
+            var replacementUpper = replacementDefinition?.Upper?.SegmentId;
+            var replacementLower = replacementDefinition?.Lower?.SegmentId;
+
+            if (string.IsNullOrWhiteSpace(replacementUpper) ||
+                string.IsNullOrWhiteSpace(replacementLower))
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(runtimeUpper) ||
+                string.IsNullOrWhiteSpace(runtimeLower))
+            {
+                return true;
+            }
+
+            var sameOrder =
+                string.Equals(runtimeUpper, replacementUpper, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(runtimeLower, replacementLower, StringComparison.OrdinalIgnoreCase);
+            var reversedOrder =
+                string.Equals(runtimeUpper, replacementLower, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(runtimeLower, replacementUpper, StringComparison.OrdinalIgnoreCase);
+            return !sameOrder && !reversedOrder;
         }
     }
 }

--- a/FUSE/Loading/FuseModLoader.TrackMerging.cs
+++ b/FUSE/Loading/FuseModLoader.TrackMerging.cs
@@ -1089,6 +1089,87 @@ namespace FUSE.Loading
             {
                 TrackAPI.RebuildCollectionsOnly();
             }
+
+            ReconcileMissingMergedSpans(plan);
+        }
+
+        /// <summary>
+        /// A structural graph rebuild can retire a base span whose endpoint
+        /// segments were removed, while the final lightweight collection refresh
+        /// can still omit the replacement span created under the same id. This is
+        /// observable with ARC Whittier's Pyc3/Pap9 replacements: their new
+        /// definitions point at new single segments, but the old base spans point
+        /// at the deleted four-segment topology. Reconcile only spans whose final
+        /// plan owner still owns the exclusive registry claim, so this recovery
+        /// cannot override a conflict winner or another package's runtime span.
+        /// </summary>
+        private static void ReconcileMissingMergedSpans(FuseMergedTrackPlan plan)
+        {
+            if (plan?.Spans == null || plan.Spans.Count == 0)
+            {
+                return;
+            }
+
+            var restored = 0;
+            TrackAPI.BeginBatch();
+            try
+            {
+                foreach (var entry in plan.Spans.Values.OrderBy(item => item.Sequence))
+                {
+                    var packageId = entry.Owner?.Loaded?.Definition?.Id;
+                    if (!ShouldReconcileMergedSpan(
+                            packageId,
+                            FuseRegistry.GetExclusiveOwner(FuseClaimKind.Span, entry.Id),
+                            TrackAPI.GetSpan(entry.Id) != null))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        TrackAPI.AddSpan(entry.Id, entry.Value);
+                        entry.Owner.Transaction.PostBind(
+                            "track span",
+                            entry.Id,
+                            "restored after final graph collection refresh");
+                        restored++;
+                    }
+                    catch (Exception ex)
+                    {
+                        entry.Owner.Transaction.Error("track span", entry.Id, ex.Message);
+                        FuseLog.Exception(
+                            $"FUSE final span reconciliation failed package='{packageId ?? string.Empty}' " +
+                            $"kind='track span' id='{entry.Id}'",
+                            ex);
+                    }
+                }
+            }
+            finally
+            {
+                TrackAPI.EndBatch(false);
+            }
+
+            if (restored == 0)
+            {
+                return;
+            }
+
+            FuseLog.Info(
+                $"FUSE restored {restored} merged track span(s) that were missing after the final graph collection refresh.");
+            if (!TrackAPI.IsBatching && TrackAPI.ConsumePendingRebuildRequest())
+            {
+                TrackAPI.RebuildCollectionsOnly();
+            }
+        }
+
+        internal static bool ShouldReconcileMergedSpan(
+            string plannedOwner,
+            string registryOwner,
+            bool spanPresent)
+        {
+            return !spanPresent &&
+                   !string.IsNullOrWhiteSpace(plannedOwner) &&
+                   string.Equals(plannedOwner, registryOwner, StringComparison.OrdinalIgnoreCase);
         }
 
         private static FuseTrackAssemblyBridgeApplySummary ApplyMergedTrackAssemblyPackages(

--- a/FUSE/Patches/FuseAssetPackBundleAuditPatch.cs
+++ b/FUSE/Patches/FuseAssetPackBundleAuditPatch.cs
@@ -12,8 +12,12 @@ using UnityEngine;
 namespace FUSE.Patches
 {
     /// <summary>
-    /// Faults catalog/bundle mismatches the moment they are knowable instead of
-    /// letting them surface as per-retry load exceptions.
+    /// Faults external catalog/bundle mismatches the moment they are knowable
+    /// instead of letting them surface as per-retry load exceptions. Base-game
+    /// packs are excluded because their catalogs contain compatibility aliases
+    /// that can resolve through game-owned stores without a same-named bundle
+    /// entry; treating those aliases as broken makes FUSE report stock content
+    /// such as Allen Dual Shed and Great Northern 5 Chime as mod failures.
     ///
     /// An asset pack's Catalog.json declares assets by name/filename, but nothing
     /// validates that the pack's bundle actually contains them. A declared-but-
@@ -104,7 +108,13 @@ namespace FUSE.Patches
                     return;
                 }
 
-                var declared = ReadDeclaredAssets(store);
+                var basePath = FuseAssetPackPatchHelpers.ResolveBasePath(store);
+                if (IsBaseGameAssetPackPath(basePath, Application.streamingAssetsPath))
+                {
+                    return;
+                }
+
+                var declared = ReadDeclaredAssets(store, basePath);
                 if (declared.Count == 0)
                 {
                     return;
@@ -143,10 +153,11 @@ namespace FUSE.Patches
         // on the malformed catalogs some packs ship, and pulling the parsed
         // struct in would add an AssetPack.Common compile-time reference for two
         // string fields.
-        private static List<CatalogAssetEntry> ReadDeclaredAssets(AssetPackRuntimeStore store)
+        private static List<CatalogAssetEntry> ReadDeclaredAssets(
+            AssetPackRuntimeStore store,
+            string basePath)
         {
             var declared = new List<CatalogAssetEntry>();
-            var basePath = FuseAssetPackPatchHelpers.ResolveBasePath(store);
             if (string.IsNullOrWhiteSpace(basePath))
             {
                 return declared;
@@ -185,6 +196,30 @@ namespace FUSE.Patches
             }
 
             return declared;
+        }
+
+        internal static bool IsBaseGameAssetPackPath(string basePath, string streamingAssetsPath)
+        {
+            if (string.IsNullOrWhiteSpace(basePath) ||
+                string.IsNullOrWhiteSpace(streamingAssetsPath))
+            {
+                return false;
+            }
+
+            try
+            {
+                var candidate = Path.GetFullPath(basePath)
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var assetPackRoot = Path.GetFullPath(Path.Combine(streamingAssetsPath, "AssetPacks"))
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var rootPrefix = assetPackRoot + Path.DirectorySeparatorChar;
+                return string.Equals(candidate, assetPackRoot, StringComparison.OrdinalIgnoreCase) ||
+                       candidate.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         /// <summary>

--- a/FUSE/Patches/FuseBrssModMenuGuardPatches.cs
+++ b/FUSE/Patches/FuseBrssModMenuGuardPatches.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Reflection;
+using FUSE.Infrastructure;
+using HarmonyLib;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Defers Beemans Rolling Stock Scripts' aux-tender window creation until
+    /// BRSS has a selected car. BRSS 4.0.0 handles MapDidLoad by calling
+    /// ModMenu.CreateWindow before snapshot restore necessarily selects a car,
+    /// then unconditionally reads _selectedCar.name while _selectedCar is null.
+    /// FUSE's longer map-load pipeline makes that pre-existing timing race
+    /// reproducible; Railloader's shorter path usually hides it.
+    ///
+    /// Installed by name because BRSS is optional. The prefix only skips the
+    /// unsafe no-window/no-selection call. BRSS's SelectedCarChanged handler
+    /// updates _selectedCar before calling Show(), which calls CreateWindow
+    /// again and follows the original healthy path.
+    /// </summary>
+    internal static class FuseBrssModMenuGuardPatches
+    {
+        private static bool _createWindowPatched;
+        private static FieldInfo _windowField;
+        private static FieldInfo _selectedCarField;
+
+        internal static bool Installed => _createWindowPatched;
+
+        internal static string EnsureInstalled(Harmony harmony)
+        {
+            if (_createWindowPatched)
+            {
+                return "installed";
+            }
+
+            if (harmony == null)
+            {
+                return "unavailable (no harmony)";
+            }
+
+            var modMenuType = AccessTools.TypeByName("BRSS.Windows.ModMenu");
+            if (modMenuType == null)
+            {
+                return "idle (not present)";
+            }
+
+            var createWindow = AccessTools.DeclaredMethod(modMenuType, "CreateWindow", Type.EmptyTypes);
+            var windowField = AccessTools.Field(modMenuType, "_window");
+            var selectedCarField = AccessTools.Field(modMenuType, "_selectedCar");
+            if (createWindow == null || windowField == null || selectedCarField == null)
+            {
+                return "idle (surface changed)";
+            }
+
+            _windowField = windowField;
+            _selectedCarField = selectedCarField;
+            harmony.Patch(
+                createWindow,
+                prefix: new HarmonyMethod(
+                    typeof(FuseBrssModMenuGuardPatches),
+                    nameof(CreateWindowPrefix)));
+            _createWindowPatched = true;
+            return "installed";
+        }
+
+        internal static bool ShouldRunOriginal(bool hasWindow, bool hasSelectedCar)
+        {
+            return hasWindow || hasSelectedCar;
+        }
+
+        private static bool CreateWindowPrefix(object __instance)
+        {
+            try
+            {
+                if (__instance == null)
+                {
+                    return true;
+                }
+
+                var hasWindow = _windowField.GetValue(__instance) != null;
+                var hasSelectedCar = _selectedCarField.GetValue(__instance) != null;
+                if (ShouldRunOriginal(hasWindow, hasSelectedCar))
+                {
+                    return true;
+                }
+
+                var deferred = FuseRuntimeGuardCounters.RecordBrssModMenuDeferred();
+                if (FuseGuardLog.ShouldLog(deferred))
+                {
+                    FuseLog.Warning(
+                        $"FUSE deferred BRSS aux-tender mod-menu window creation #{deferred}: " +
+                        "MapDidLoad arrived before BRSS had a selected car, and BRSS 4.0.0 would " +
+                        "dereference _selectedCar.name in this state. BRSS will create the window " +
+                        "after a compatible car is selected.");
+                }
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception(
+                    "FUSE BRSS mod-menu guard failed; letting BRSS CreateWindow run unchanged",
+                    ex);
+                return true;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FusePrefabStoreDefinitionCheckPerformancePatch.cs
+++ b/FUSE/Patches/FusePrefabStoreDefinitionCheckPerformancePatch.cs
@@ -15,6 +15,13 @@ namespace FUSE.Patches
     /// active, so malformed assets still fail at their actual point of use.
     /// </summary>
     [HarmonyPatch(typeof(PrefabStore), "CheckDefinitions")]
+    // AssetLoader 1.0.1 performs all UMM mod-folder asset-store discovery in
+    // its own CheckDefinitions prefix. If this skip prefix runs first,
+    // Harmony suppresses AssetLoader's state-mutating prefix along with the
+    // original method: UMM reports the rolling-stock mods active, but their
+    // Definitions.json files never enter PrefabStore. Run after AssetLoader so
+    // its discovery completes before FUSE skips only the stock diagnostic pass.
+    [HarmonyAfter("AssetLoader")]
     internal static class FusePrefabStoreDefinitionCheckPerformancePatch
     {
         private static bool _logged;

--- a/FUSE/Patches/FuseThirdPartyGuardInstaller.cs
+++ b/FUSE/Patches/FuseThirdPartyGuardInstaller.cs
@@ -8,7 +8,8 @@ namespace FUSE.Patches
     /// Single idempotent entry point for the guards FUSE keeps around
     /// third-party mods it has no compile-time reference to (currently the
     /// Map Enhancer culling guard, the Rebill Industry Cars config-load
-    /// guard, and the BRSS mod-menu startup guard). Each guard resolves its
+    /// guard, the BRSS mod-menu startup guard, and the TimeSync main-thread
+    /// guard). Each guard resolves its
     /// target by name and idles silently
     /// when the mod — or the exact member surface the guard understands —
     /// is absent.
@@ -85,9 +86,21 @@ namespace FUSE.Patches
                 brssStatus = "failed";
             }
 
+            string timeSyncStatus;
+            try
+            {
+                timeSyncStatus = FuseTimeSyncMainThreadGuardPatches.EnsureInstalled(_harmony);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE TimeSync main-thread guard failed to install", ex);
+                timeSyncStatus = "failed";
+            }
+
             var summary =
                 $"FUSE third-party guards: mapEnhancerCulling='{mapEnhancerStatus}' " +
-                $"rebillIndustryCars='{rebillStatus}' brssModMenu='{brssStatus}'.";
+                $"rebillIndustryCars='{rebillStatus}' brssModMenu='{brssStatus}' " +
+                $"timeSyncMainThread='{timeSyncStatus}'.";
             if (!string.Equals(summary, _lastSummary, StringComparison.Ordinal))
             {
                 _lastSummary = summary;

--- a/FUSE/Patches/FuseThirdPartyGuardInstaller.cs
+++ b/FUSE/Patches/FuseThirdPartyGuardInstaller.cs
@@ -7,8 +7,9 @@ namespace FUSE.Patches
     /// <summary>
     /// Single idempotent entry point for the guards FUSE keeps around
     /// third-party mods it has no compile-time reference to (currently the
-    /// Map Enhancer culling guard and the Rebill Industry Cars config-load
-    /// guard). Each guard resolves its target by name and idles silently
+    /// Map Enhancer culling guard, the Rebill Industry Cars config-load
+    /// guard, and the BRSS mod-menu startup guard). Each guard resolves its
+    /// target by name and idles silently
     /// when the mod — or the exact member surface the guard understands —
     /// is absent.
     ///
@@ -73,9 +74,20 @@ namespace FUSE.Patches
                 rebillStatus = "failed";
             }
 
+            string brssStatus;
+            try
+            {
+                brssStatus = FuseBrssModMenuGuardPatches.EnsureInstalled(_harmony);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE BRSS mod-menu guard failed to install", ex);
+                brssStatus = "failed";
+            }
+
             var summary =
                 $"FUSE third-party guards: mapEnhancerCulling='{mapEnhancerStatus}' " +
-                $"rebillIndustryCars='{rebillStatus}'.";
+                $"rebillIndustryCars='{rebillStatus}' brssModMenu='{brssStatus}'.";
             if (!string.Equals(summary, _lastSummary, StringComparison.Ordinal))
             {
                 _lastSummary = summary;

--- a/FUSE/Patches/FuseTimeSyncMainThreadGuardPatches.cs
+++ b/FUSE/Patches/FuseTimeSyncMainThreadGuardPatches.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Threading;
+using FUSE.Infrastructure;
+using HarmonyLib;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Moves TimeSync Mod's periodic synchronization onto Unity's main thread.
+    /// TimeSync 1.0.26128.1713 uses <see cref="System.Threading.Timer"/> and calls
+    /// StateManager.ApplyLocal directly from its worker callback. That call logs
+    /// to the in-game console, which creates TextMeshPro objects and native Mesh
+    /// instances; Unity crashes when that work runs off the main thread.
+    ///
+    /// The Harmony prefix is intentionally tiny on the timer thread: it queues
+    /// the original receiver and argument, then suppresses that invocation. The
+    /// always-on FUSE runtime pump replays the method on the next frame. Harmony
+    /// re-enters this prefix there, recognizes the recorded main thread, and lets
+    /// the original method execute unchanged.
+    /// </summary>
+    internal static class FuseTimeSyncMainThreadGuardPatches
+    {
+        private static readonly ConcurrentQueue<PendingSync> Pending =
+            new ConcurrentQueue<PendingSync>();
+
+        private static bool _syncTimesPatched;
+        private static MethodInfo _syncTimesMethod;
+        private static int _mainThreadId;
+
+        internal static bool Installed => _syncTimesPatched;
+
+        internal static string EnsureInstalled(Harmony harmony)
+        {
+            if (_syncTimesPatched)
+            {
+                return "installed";
+            }
+
+            if (harmony == null)
+            {
+                return "unavailable (no harmony)";
+            }
+
+            var timeSyncType = AccessTools.TypeByName("TimeSyncMod.TimeSyncMod");
+            if (timeSyncType == null)
+            {
+                return "idle (not present)";
+            }
+
+            var syncTimes = AccessTools.DeclaredMethod(
+                timeSyncType,
+                "SyncTimes",
+                new[] { typeof(object) });
+            if (syncTimes == null)
+            {
+                return "idle (surface changed)";
+            }
+
+            _syncTimesMethod = syncTimes;
+            harmony.Patch(
+                syncTimes,
+                prefix: new HarmonyMethod(
+                    typeof(FuseTimeSyncMainThreadGuardPatches),
+                    nameof(SyncTimesPrefix)));
+            _syncTimesPatched = true;
+            return "installed";
+        }
+
+        internal static bool ShouldDefer(int currentThreadId, int mainThreadId)
+        {
+            return mainThreadId == 0 || currentThreadId != mainThreadId;
+        }
+
+        private static bool SyncTimesPrefix(object __instance, object __0)
+        {
+            if (!ShouldDefer(
+                    Environment.CurrentManagedThreadId,
+                    Volatile.Read(ref _mainThreadId)))
+            {
+                return true;
+            }
+
+            Pending.Enqueue(new PendingSync(__instance, __0));
+            return false;
+        }
+
+        /// <summary>
+        /// Replays queued timer callbacks. Called once per frame by
+        /// <c>FuseRuntimePump</c>, so this method also records the authoritative
+        /// Unity main-thread id before invoking any queued work.
+        /// </summary>
+        internal static void DrainPending()
+        {
+            Volatile.Write(ref _mainThreadId, Environment.CurrentManagedThreadId);
+
+            while (Pending.TryDequeue(out var pending))
+            {
+                try
+                {
+                    _syncTimesMethod?.Invoke(
+                        pending.Instance,
+                        new[] { pending.StateInfo });
+
+                    var marshaled = FuseRuntimeGuardCounters.RecordTimeSyncMainThreadMarshaled();
+                    if (FuseGuardLog.ShouldLog(marshaled))
+                    {
+                        FuseLog.Warning(
+                            $"FUSE moved TimeSync Mod timer callback #{marshaled} onto Unity's main thread " +
+                            "to prevent its background-thread console/UI crash.");
+                    }
+                }
+                catch (TargetInvocationException ex)
+                {
+                    FuseLog.Exception(
+                        "FUSE TimeSync main-thread callback failed",
+                        ex.InnerException ?? ex);
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception("FUSE TimeSync main-thread callback failed", ex);
+                }
+            }
+        }
+
+        private sealed class PendingSync
+        {
+            internal PendingSync(object instance, object stateInfo)
+            {
+                Instance = instance;
+                StateInfo = stateInfo;
+            }
+
+            internal object Instance { get; }
+
+            internal object StateInfo { get; }
+        }
+    }
+}

--- a/FUSE/Runtime/API/FusePassengerStopComponent.cs
+++ b/FUSE/Runtime/API/FusePassengerStopComponent.cs
@@ -309,13 +309,11 @@ namespace FUSE.Runtime.API
             }
 
             var reconciledStops = 0;
-            foreach (var component in UnityEngine.Object.FindObjectsOfType<FusePassengerStopComponent>(true))
+            var fuseComponents = UnityEngine.Object.FindObjectsOfType<FusePassengerStopComponent>(true)
+                .Where(component => component != null)
+                .ToArray();
+            foreach (var component in fuseComponents)
             {
-                if (component == null)
-                {
-                    continue;
-                }
-
                 var stopIdentifier = component.GetStopIdentifier();
                 var sourceStop = liveStops.FirstOrDefault(stop =>
                     string.Equals(stop.identifier, stopIdentifier, StringComparison.OrdinalIgnoreCase));
@@ -324,16 +322,51 @@ namespace FUSE.Runtime.API
                     continue;
                 }
 
-                sourceStop.neighbors = FusePassengerStopNeighborResolver.Resolve(
+                var neighbors = FusePassengerStopNeighborResolver.Resolve(
                     component.NeighborIds,
                     sourceStop,
                     liveStops,
                     stop => stop.identifier,
                     stop => stop.timetableCode);
+
+                // Legacy station packs occasionally author only one half of an
+                // undirected passenger-stop link. Do not rewrite an explicit
+                // route, but keep a stop with no outgoing links from becoming
+                // isolated when another FUSE stop clearly names it as a
+                // neighbor (by identifier or timetable code).
+                if (neighbors.Length == 0)
+                {
+                    neighbors = FusePassengerStopNeighborResolver.ResolveIncoming(
+                            component,
+                            fuseComponents,
+                            candidate => candidate.NeighborIds,
+                            candidate => candidate.GetStopIdentifier(),
+                            candidate => candidate.TimetableCode)
+                        .Select(candidate => FindLiveStop(candidate, liveStops))
+                        .Where(stop => stop != null && !ReferenceEquals(stop, sourceStop))
+                        .Distinct()
+                        .ToArray();
+                }
+
+                sourceStop.neighbors = neighbors;
                 reconciledStops++;
             }
 
             return reconciledStops;
+        }
+
+        private static PassengerStop FindLiveStop(
+            FusePassengerStopComponent component,
+            IEnumerable<PassengerStop> liveStops)
+        {
+            var identifier = component?.GetStopIdentifier();
+            var timetableCode = component?.TimetableCode;
+            return (liveStops ?? Enumerable.Empty<PassengerStop>()).FirstOrDefault(stop =>
+                stop != null &&
+                ((!string.IsNullOrWhiteSpace(identifier) &&
+                  string.Equals(stop.identifier, identifier, StringComparison.OrdinalIgnoreCase)) ||
+                 (!string.IsNullOrWhiteSpace(timetableCode) &&
+                  string.Equals(stop.timetableCode, timetableCode, StringComparison.OrdinalIgnoreCase))));
         }
 
         private void ConfigureTimetable(PassengerStop passengerStop)

--- a/FUSE/Runtime/API/FusePassengerStopNeighborResolver.cs
+++ b/FUSE/Runtime/API/FusePassengerStopNeighborResolver.cs
@@ -48,6 +48,59 @@ namespace FUSE.Runtime.API
                 .ToArray();
         }
 
+        internal static T[] ResolveIncoming<T>(
+            T source,
+            IEnumerable<T> candidates,
+            Func<T, IEnumerable<string>> neighborIdsSelector,
+            Func<T, string> identifierSelector,
+            Func<T, string> timetableCodeSelector)
+            where T : class
+        {
+            if (source == null || candidates == null)
+            {
+                return Array.Empty<T>();
+            }
+
+            if (neighborIdsSelector == null)
+            {
+                throw new ArgumentNullException(nameof(neighborIdsSelector));
+            }
+
+            if (identifierSelector == null)
+            {
+                throw new ArgumentNullException(nameof(identifierSelector));
+            }
+
+            if (timetableCodeSelector == null)
+            {
+                throw new ArgumentNullException(nameof(timetableCodeSelector));
+            }
+
+            var sourceIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            AddIfPresent(sourceIds, identifierSelector(source));
+            AddIfPresent(sourceIds, timetableCodeSelector(source));
+            if (sourceIds.Count == 0)
+            {
+                return Array.Empty<T>();
+            }
+
+            return candidates
+                .Where(candidate =>
+                    candidate != null &&
+                    !ReferenceEquals(candidate, source) &&
+                    (neighborIdsSelector(candidate) ?? Enumerable.Empty<string>())
+                    .Any(neighborId => !string.IsNullOrWhiteSpace(neighborId) && sourceIds.Contains(neighborId.Trim())))
+                .ToArray();
+        }
+
+        private static void AddIfPresent(HashSet<string> ids, string value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                ids.Add(value.Trim());
+            }
+        }
+
         private static bool Matches(HashSet<string> requestedIds, string candidateId)
         {
             return !string.IsNullOrWhiteSpace(candidateId) &&

--- a/FUSE/Runtime/API/FusePrefabSanitizer.cs
+++ b/FUSE/Runtime/API/FusePrefabSanitizer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Helpers;
 using KeyValue.Runtime;
 using Model;
 using Model.Ops;
@@ -67,6 +68,7 @@ namespace FUSE.Runtime.API
                 return result;
             }
 
+            DisableClonedSceneryStreaming(root, result);
             ReplaceGlobalObjectIds(root, id + ".loader", result);
             DisableTrackMarkers(root, result);
             ClearCachedIdentityFields(root, result);
@@ -78,6 +80,57 @@ namespace FUSE.Runtime.API
 
             ValidateRendererPresence(root, "loader", result);
             return result;
+        }
+
+        private static void DisableClonedSceneryStreaming(
+            GameObject root,
+            FusePrefabSanitizerResult result)
+        {
+            // Loader prefabs are cloned from live scene objects such as the Bryson
+            // coaling tower and water columns. Those source roots can contain a
+            // SceneryAssetInstance used to stream the vanilla visual. Keeping that
+            // component on the functional clone makes it enter FUSE's scenery load
+            // queue and lets culling tear down/recreate parts of an operational
+            // loader. LoaderAPI deliberately sanitizes clones while inactive, so
+            // disable the copied behaviour before the clone is activated and remove
+            // it at the end of the frame. The already-cloned model and loader
+            // components remain in place.
+            var sceneryInstances = root.GetComponentsInChildren<SceneryAssetInstance>(true);
+            if (sceneryInstances.Length == 0)
+            {
+                return;
+            }
+
+            // Do not freeze an incomplete scene-source clone. If culling had already
+            // removed its visual or functional loader before Resolve/Instantiate, the
+            // copied SceneryAssetInstance is still needed to materialize the missing
+            // content when the destination comes into range.
+            if (root.GetComponentInChildren<Renderer>(true) == null ||
+                root.GetComponentInChildren<CarLoadTargetLoader>(true) == null)
+            {
+                result.Warnings.Add(
+                    "kept cloned scenery streaming because the source loader was not fully materialized");
+                return;
+            }
+
+            var disabled = 0;
+            for (var index = 0; index < sceneryInstances.Length; index++)
+            {
+                var scenery = sceneryInstances[index];
+                if (scenery == null)
+                {
+                    continue;
+                }
+
+                scenery.enabled = false;
+                UnityEngine.Object.Destroy(scenery);
+                disabled++;
+            }
+
+            if (disabled > 0)
+            {
+                result.Actions.Add($"disabled {disabled} cloned scenery streaming component(s)");
+            }
         }
 
         public static FusePrefabSanitizerResult SanitizeStation(

--- a/FUSE/Runtime/API/LoaderAPI.cs
+++ b/FUSE/Runtime/API/LoaderAPI.cs
@@ -141,6 +141,8 @@ namespace FUSE.Runtime.API
                 loader.SetActive(false);
             }
 
+            var requiresIndustry = !string.IsNullOrWhiteSpace(definition.IndustryId);
+            Industry industry = null;
             try
             {
                 var instance = UnityEngine.Object.Instantiate(prefab, loader.transform);
@@ -169,13 +171,11 @@ namespace FUSE.Runtime.API
                     renderer.enabled = true;
                 }
 
-                var requiresIndustry = !string.IsNullOrWhiteSpace(definition.IndustryId);
-                var industry = AttachIndustry(instance, definition.IndustryId);
+                industry = AttachIndustry(instance, definition.IndustryId);
                 FusePrefabSanitizer.SanitizeLoader(instance, id, industry, requiresIndustry).Log($"FUSE loader '{id}'");
                 instance.SetActive(true);
                 FuseLoaderRuntimeIndex.Instance.Set(id, loader);
                 MapAPI.RefreshAttachedMapMasks(loader, $"loader '{id}' apply");
-                FusePrefabSanitizer.ValidateLoaderPostBind(loader, id, industry, requiresIndustry).Log($"FUSE loader '{id}' post-bind");
             }
             finally
             {
@@ -189,6 +189,11 @@ namespace FUSE.Runtime.API
                     loader.SetActive(true);
                 }
             }
+
+            // Validate after the parent has been restored. Validating inside the try
+            // reported every newly-created loader as inactive even though the finally
+            // block activated it immediately afterward.
+            FusePrefabSanitizer.ValidateLoaderPostBind(loader, id, industry, requiresIndustry).Log($"FUSE loader '{id}' post-bind");
         }
 
         private static Industry AttachIndustry(GameObject instance, string industryId)

--- a/FUSE/Runtime/API/ProgressionAPI.Apply.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.Apply.cs
@@ -171,6 +171,7 @@ namespace FUSE.Runtime.API
                     gameObject.transform.SetParent(progression.transform, false);
                     section = gameObject.AddComponent<Section>();
                     section.identifier = sectionDefinition.Key;
+                    EnsureSectionCollectionsInitialized(section);
                 }
 
                 FuseSectionRuntimeIndex.Instance.Set(section.identifier, section);
@@ -197,6 +198,16 @@ namespace FUSE.Runtime.API
             {
                 throw new ArgumentNullException(nameof(definition));
             }
+
+            // Resolve every phase before mutating the live Section. A missing
+            // component or load can throw here. In that case an existing
+            // section retains its last valid state, while a section created by
+            // ApplyProgressionDefinition remains safely initialized with empty
+            // collections instead of poisoning Progression.Configure with a
+            // null deliveryPhases array.
+            var deliveryPhases = (definition.DeliveryPhases ?? Array.Empty<FuseDeliveryPhase>())
+                .Select(CreateDeliveryPhase)
+                .ToArray();
 
             section.displayName = string.IsNullOrWhiteSpace(definition.DisplayName) ? section.identifier : definition.DisplayName;
             section.description = definition.Description ?? string.Empty;
@@ -239,23 +250,10 @@ namespace FUSE.Runtime.API
                 section.disableFeaturesOnUnlock = ResolveMapFeatures(definition.DisableFeaturesOnUnlock.ApplyTo(existingIds));
             }
 
-            section.deliveryPhases = (definition.DeliveryPhases ?? Array.Empty<FuseDeliveryPhase>()).Select(CreateDeliveryPhase).ToArray();
+            section.deliveryPhases = deliveryPhases;
             ApplyInterchangeTransfers(section, definition.InterchangeTransfers, packageId);
 
-            // Null-safety: a freshly-created Section MonoBehaviour starts with
-            // every array field null. If the mod's patch leaves a field as
-            // "no change" (definition.X null OR HasValue false), our
-            // conditional assignment above leaves the runtime field null
-            // too. The game's Progression.PrerequisitesMet calls
-            // section.prerequisiteSections.All(...) without a null check, so
-            // a null array crashes Configure with ArgumentNullException.
-            // Same exposure for every other Section[] / MapFeature[] field
-            // the game iterates. Default them to empty arrays so the game's
-            // existing null-naive .All / foreach calls survive.
-            section.prerequisiteSections = section.prerequisiteSections ?? Array.Empty<Section>();
-            section.enableFeaturesOnUnlock = section.enableFeaturesOnUnlock ?? Array.Empty<MapFeature>();
-            section.enableFeaturesOnAvailable = section.enableFeaturesOnAvailable ?? Array.Empty<MapFeature>();
-            section.disableFeaturesOnUnlock = section.disableFeaturesOnUnlock ?? Array.Empty<MapFeature>();
+            EnsureSectionCollectionsInitialized(section);
 
             if (FuseSettings.VerboseApplyReportDetails)
             {
@@ -271,6 +269,23 @@ namespace FUSE.Runtime.API
                     $"deliveryPhases={section.deliveryPhases?.Length ?? 0} " +
                     $"hasSectionUnlockFeature={(sectionUnlockFeature != null)}.");
             }
+        }
+
+        internal static void EnsureSectionCollectionsInitialized(Section section)
+        {
+            if (ReferenceEquals(section, null))
+            {
+                throw new ArgumentNullException(nameof(section));
+            }
+
+            // Railroader enumerates these fields without null checks during
+            // Progression.Configure. Keep a newly-created Section safe even
+            // when a later phase reference fails and aborts package apply.
+            section.deliveryPhases = section.deliveryPhases ?? Array.Empty<Section.DeliveryPhase>();
+            section.prerequisiteSections = section.prerequisiteSections ?? Array.Empty<Section>();
+            section.enableFeaturesOnUnlock = section.enableFeaturesOnUnlock ?? Array.Empty<MapFeature>();
+            section.enableFeaturesOnAvailable = section.enableFeaturesOnAvailable ?? Array.Empty<MapFeature>();
+            section.disableFeaturesOnUnlock = section.disableFeaturesOnUnlock ?? Array.Empty<MapFeature>();
         }
 
         private static void ApplyInterchangeTransfers(Section section, Dictionary<string, string> transfers, string packageId)

--- a/FUSE/Runtime/API/SceneryAPI.cs
+++ b/FUSE/Runtime/API/SceneryAPI.cs
@@ -23,7 +23,8 @@ namespace FUSE.Runtime.API
                 { "CabooseHouse", "ALWHouses_CabooseHouse" },
                 { "CitySignDeep", "ALW_Sign_CitySignDeep" },
                 { "CitySignEverett", "ALW_Sign_CitySignEverett" },
-                { "CitySignWalkerWoody", "ALW_Sign_CitySignWalkerWoody" }
+                { "CitySignWalkerWoody", "ALW_Sign_CitySignWalkerWoody" },
+                { "TurntableMeasurementTool", "ALW_ModRes_TurntableMeasurementTool" }
             };
 
         private static readonly HashSet<string> OptionalLegacySceneryAssets =

--- a/FUSE/Runtime/API/SplineyAPI.cs
+++ b/FUSE/Runtime/API/SplineyAPI.cs
@@ -238,49 +238,49 @@ namespace FUSE.Runtime.API
                     ReferenceEquals(FusePrefabResolver.ResolveScenePath(id), root);
             }
 
-            var riverPath = root.GetComponent<RiverPath>();
-            if (!isScenePathTarget || riverPath == null)
+            if (!isScenePathTarget)
             {
                 return false;
             }
 
-            var points = definition.Points ?? Array.Empty<FuseSplineyPoint>();
-            if (points.Length < 2)
-            {
-                throw new InvalidOperationException($"Spliney '{id}' requires at least two points.");
-            }
-
-            // A legacy partial patch inherits the base spline's profile,
+            // A legacy partial patch inherits the base spliney's profile,
             // style, offset, transform, and parent. Only replace the authored
-            // control points unless the fragment explicitly names a style or
-            // profile. This keeps roads such as Sylva's Chipper Curve asphalt
-            // instead of rebuilding them with FUSE's first generic road
-            // profile (the pale overlay seen in the field report).
-            var wasActive = root.activeSelf;
-            root.SetActive(false);
-            riverPath.points = points.Select(point => new RiverPath.Point(
-                root.transform.InverseTransformPoint(point.Position),
-                (Quaternion.Inverse(root.transform.rotation) * Quaternion.Euler(point.Rotation)).eulerAngles,
-                point.Width ?? 3.5f)).ToList();
-
-            if (!string.IsNullOrWhiteSpace(definition.Style))
+            // control points unless the fragment explicitly names a style,
+            // profile, or end style. This keeps roads such as Sylva's Chipper
+            // Curve asphalt instead of rebuilding them with FUSE's first
+            // generic road profile (the pale overlay seen in the field
+            // report), and keeps base-game trestles on their own profile,
+            // parent, and transform instead of letting ApplyDefinition
+            // reparent and re-center them.
+            var riverPath = root.GetComponent<RiverPath>();
+            if (riverPath != null)
             {
-                riverPath.style = string.Equals(definition.Style, "river", StringComparison.OrdinalIgnoreCase)
-                    ? RiverPath.RiverPathStyle.River
-                    : RiverPath.RiverPathStyle.Road;
-            }
-            else if (!string.IsNullOrWhiteSpace(definition.Type) &&
-                     !string.Equals(definition.Type, "unknown", StringComparison.OrdinalIgnoreCase))
-            {
-                riverPath.style = IsWaterSpline(ParseKind(definition.Type))
-                    ? RiverPath.RiverPathStyle.River
-                    : RiverPath.RiverPathStyle.Road;
+                PatchScenePathRiverPath(root, riverPath, marker, id, definition);
+                return true;
             }
 
+            var trestle = root.GetComponent<AutoTrestle.AutoTrestle>();
+            if (trestle != null)
+            {
+                PatchScenePathTrestle(root, trestle, marker, id, definition);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static void PatchScenePathRiverPath(GameObject root, RiverPath riverPath, FuseSplineyMarker marker, string id, FuseSpliney definition)
+        {
+            var points = RequirePatchPoints(id, definition);
+
+            // Resolve and validate everything that can fail before the scene
+            // object is deactivated or mutated, so a bad profile name leaves
+            // the base-game spline exactly as it was.
             var builder = root.GetComponent<RiverBuilder>();
+            SplineProfile profile = null;
             if (builder != null && !string.IsNullOrWhiteSpace(definition.Profile))
             {
-                var profile = ResolveSplineProfile(definition.Profile, ParseKind(definition.Type));
+                profile = ResolveSplineProfile(definition.Profile, ParseKind(definition.Type));
                 if (profile == null)
                 {
                     throw new InvalidOperationException($"Spline profile '{definition.Profile}' was not found for '{root.name}'.");
@@ -290,22 +290,132 @@ namespace FUSE.Runtime.API
                 {
                     throw new InvalidOperationException("RiverBuilder.splineProfile field was not found.");
                 }
-
-                RiverBuilderSplineProfileField.SetValue(builder, profile);
             }
 
-            marker = marker ?? root.AddComponent<FuseSplineyMarker>();
-            marker.Id = id;
-            marker.Kind = riverPath.style == RiverPath.RiverPathStyle.River ? "River" : "Road";
-            marker.PreserveExistingSceneObject = true;
-            root.SetActive(wasActive);
+            RiverPath.RiverPathStyle? style = null;
+            if (!string.IsNullOrWhiteSpace(definition.Style))
+            {
+                style = string.Equals(definition.Style, "river", StringComparison.OrdinalIgnoreCase)
+                    ? RiverPath.RiverPathStyle.River
+                    : RiverPath.RiverPathStyle.Road;
+            }
+            else if (!string.IsNullOrWhiteSpace(definition.Type) &&
+                     !string.Equals(definition.Type, "unknown", StringComparison.OrdinalIgnoreCase))
+            {
+                style = IsWaterSpline(ParseKind(definition.Type))
+                    ? RiverPath.RiverPathStyle.River
+                    : RiverPath.RiverPathStyle.Road;
+            }
+
+            var localPoints = points.Select(point => new RiverPath.Point(
+                root.transform.InverseTransformPoint(point.Position),
+                (Quaternion.Inverse(root.transform.rotation) * Quaternion.Euler(point.Rotation)).eulerAngles,
+                point.Width ?? 3.5f)).ToList();
+
+            var wasActive = root.activeSelf;
+            root.SetActive(false);
+            try
+            {
+                riverPath.points = localPoints;
+                if (style.HasValue)
+                {
+                    riverPath.style = style.Value;
+                }
+
+                if (profile != null)
+                {
+                    RiverBuilderSplineProfileField.SetValue(builder, profile);
+                }
+
+                marker = marker ?? root.AddComponent<FuseSplineyMarker>();
+                marker.Id = id;
+                marker.Kind = riverPath.style == RiverPath.RiverPathStyle.River ? "River" : "Road";
+                marker.PreserveExistingSceneObject = true;
+            }
+            finally
+            {
+                root.SetActive(wasActive);
+            }
+
             if (wasActive)
             {
                 builder?.BuildSpline();
             }
 
             FuseLog.Info($"FUSE replaced control points in existing scene spliney '{id}' while preserving its base profile and hierarchy.");
-            return true;
+        }
+
+        private static void PatchScenePathTrestle(GameObject root, AutoTrestle.AutoTrestle trestle, FuseSplineyMarker marker, string id, FuseSpliney definition)
+        {
+            var points = RequirePatchPoints(id, definition);
+
+            AutoTrestleProfile profile = null;
+            if (!string.IsNullOrWhiteSpace(definition.Profile))
+            {
+                profile = ResolveAutoTrestleProfile(definition.Profile);
+                if (profile == null)
+                {
+                    throw new InvalidOperationException($"Auto trestle profile '{definition.Profile}' was not found for '{root.name}'.");
+                }
+            }
+
+            // AutoTrestle control points are authored in the trestle's local
+            // space (see GetDefinition), so map the world-space patch points
+            // back through the existing transform instead of re-centering the
+            // object the way ConfigureTrestle does for FUSE-owned trestles.
+            var localPoints = points.Select(point => new AutoTrestle.AutoTrestle.ControlPoint
+            {
+                position = root.transform.InverseTransformPoint(point.Position),
+                rotation = Quaternion.Inverse(root.transform.rotation) * Quaternion.Euler(point.Rotation)
+            }).ToList();
+
+            var wasActive = root.activeSelf;
+            root.SetActive(false);
+            try
+            {
+                trestle.controlPoints = localPoints;
+                if (!string.IsNullOrWhiteSpace(definition.HeadStyle))
+                {
+                    trestle.headStyle = ParseEndStyle(definition.HeadStyle);
+                }
+
+                if (!string.IsNullOrWhiteSpace(definition.TailStyle))
+                {
+                    trestle.tailStyle = ParseEndStyle(definition.TailStyle);
+                }
+
+                if (profile != null)
+                {
+                    trestle.profile = profile;
+                }
+
+                marker = marker ?? root.AddComponent<FuseSplineyMarker>();
+                marker.Id = id;
+                marker.Kind = SplineyKind.Trestle.ToString();
+                marker.PreserveExistingSceneObject = true;
+            }
+            finally
+            {
+                root.SetActive(wasActive);
+            }
+
+            if (wasActive)
+            {
+                trestle.Generate();
+            }
+
+            FuseLog.Info($"FUSE replaced control points in existing scene trestle '{id}' while preserving its base profile and hierarchy.");
+        }
+
+        private static FuseSplineyPoint[] RequirePatchPoints(string id, FuseSpliney definition)
+        {
+            var points = definition.Points ?? Array.Empty<FuseSplineyPoint>();
+            if (points.Length < 2)
+            {
+                throw new InvalidOperationException($"Spliney '{id}' requires at least two points.");
+            }
+
+            return points;
         }
 
         private static bool TryResolveScenePathSpliney(string id, out GameObject spliney)

--- a/FUSE/Runtime/API/SplineyAPI.cs
+++ b/FUSE/Runtime/API/SplineyAPI.cs
@@ -48,7 +48,10 @@ namespace FUSE.Runtime.API
                 throw new ArgumentNullException(nameof(definition));
             }
 
-            ApplyDefinition(root, id, definition, true);
+            if (!TryApplyScenePathSplineyPatch(root, id, definition))
+            {
+                ApplyDefinition(root, id, definition, true);
+            }
             FuseSplineyRuntimeIndex.Instance.Set(id, root);
             FuseApiPersistence.RecordDefinition(FuseDefinitionKind.Spliney, id, definition);
         }
@@ -84,6 +87,19 @@ namespace FUSE.Runtime.API
             if (FuseSplineyRuntimeIndex.Instance.TryGetValue(id, out var cached))
             {
                 return (GameObject)cached;
+            }
+
+            // Strange Customs accepts a scene hierarchy path as a spliney id
+            // when a package patches an existing base-game road/river. FUSE
+            // previously looked only for its own markers, so a legacy
+            // `points: { "$replace": [...] }` patch created a second spline
+            // over the original instead of updating it. Resolve path-shaped
+            // ids before the ready-cache early-out and admit only actual
+            // spline roots so an arbitrary scene object cannot be captured.
+            if (TryResolveScenePathSpliney(id, out var sceneSpliney))
+            {
+                FuseSplineyRuntimeIndex.Instance.Set(id, sceneSpliney);
+                return sceneSpliney;
             }
 
             if (FuseCacheRegistry.IsReady)
@@ -205,6 +221,117 @@ namespace FUSE.Runtime.API
 
             var builder = root.GetComponent<RiverBuilder>();
             builder?.BuildSpline();
+        }
+
+        private static bool TryApplyScenePathSplineyPatch(GameObject root, string id, FuseSpliney definition)
+        {
+            if (root == null || definition == null)
+            {
+                return false;
+            }
+
+            var marker = root.GetComponent<FuseSplineyMarker>();
+            var isScenePathTarget = marker != null && marker.PreserveExistingSceneObject;
+            if (!isScenePathTarget)
+            {
+                isScenePathTarget = IsScenePathIdentifier(id) &&
+                    ReferenceEquals(FusePrefabResolver.ResolveScenePath(id), root);
+            }
+
+            var riverPath = root.GetComponent<RiverPath>();
+            if (!isScenePathTarget || riverPath == null)
+            {
+                return false;
+            }
+
+            var points = definition.Points ?? Array.Empty<FuseSplineyPoint>();
+            if (points.Length < 2)
+            {
+                throw new InvalidOperationException($"Spliney '{id}' requires at least two points.");
+            }
+
+            // A legacy partial patch inherits the base spline's profile,
+            // style, offset, transform, and parent. Only replace the authored
+            // control points unless the fragment explicitly names a style or
+            // profile. This keeps roads such as Sylva's Chipper Curve asphalt
+            // instead of rebuilding them with FUSE's first generic road
+            // profile (the pale overlay seen in the field report).
+            var wasActive = root.activeSelf;
+            root.SetActive(false);
+            riverPath.points = points.Select(point => new RiverPath.Point(
+                root.transform.InverseTransformPoint(point.Position),
+                (Quaternion.Inverse(root.transform.rotation) * Quaternion.Euler(point.Rotation)).eulerAngles,
+                point.Width ?? 3.5f)).ToList();
+
+            if (!string.IsNullOrWhiteSpace(definition.Style))
+            {
+                riverPath.style = string.Equals(definition.Style, "river", StringComparison.OrdinalIgnoreCase)
+                    ? RiverPath.RiverPathStyle.River
+                    : RiverPath.RiverPathStyle.Road;
+            }
+            else if (!string.IsNullOrWhiteSpace(definition.Type) &&
+                     !string.Equals(definition.Type, "unknown", StringComparison.OrdinalIgnoreCase))
+            {
+                riverPath.style = IsWaterSpline(ParseKind(definition.Type))
+                    ? RiverPath.RiverPathStyle.River
+                    : RiverPath.RiverPathStyle.Road;
+            }
+
+            var builder = root.GetComponent<RiverBuilder>();
+            if (builder != null && !string.IsNullOrWhiteSpace(definition.Profile))
+            {
+                var profile = ResolveSplineProfile(definition.Profile, ParseKind(definition.Type));
+                if (profile == null)
+                {
+                    throw new InvalidOperationException($"Spline profile '{definition.Profile}' was not found for '{root.name}'.");
+                }
+
+                if (RiverBuilderSplineProfileField == null)
+                {
+                    throw new InvalidOperationException("RiverBuilder.splineProfile field was not found.");
+                }
+
+                RiverBuilderSplineProfileField.SetValue(builder, profile);
+            }
+
+            marker = marker ?? root.AddComponent<FuseSplineyMarker>();
+            marker.Id = id;
+            marker.Kind = riverPath.style == RiverPath.RiverPathStyle.River ? "River" : "Road";
+            marker.PreserveExistingSceneObject = true;
+            root.SetActive(wasActive);
+            if (wasActive)
+            {
+                builder?.BuildSpline();
+            }
+
+            FuseLog.Info($"FUSE replaced control points in existing scene spliney '{id}' while preserving its base profile and hierarchy.");
+            return true;
+        }
+
+        private static bool TryResolveScenePathSpliney(string id, out GameObject spliney)
+        {
+            spliney = null;
+            if (!IsScenePathIdentifier(id))
+            {
+                return false;
+            }
+
+            var candidate = FusePrefabResolver.ResolveScenePath(id);
+            if (candidate == null ||
+                (candidate.GetComponent<RiverPath>() == null && candidate.GetComponent<AutoTrestle.AutoTrestle>() == null))
+            {
+                return false;
+            }
+
+            spliney = candidate;
+            return true;
+        }
+
+        private static bool IsScenePathIdentifier(string id)
+        {
+            return !string.IsNullOrWhiteSpace(id) &&
+                   id.IndexOf('/') >= 0 &&
+                   id.IndexOf("://", StringComparison.Ordinal) < 0;
         }
 
         private static void ConfigureFlowy(GameObject root, FuseSpliney definition, SplineyKind kind, IReadOnlyList<FuseSplineyPoint> points)
@@ -526,5 +653,6 @@ namespace FUSE.Runtime.API
     {
         public string Id;
         public string Kind;
+        public bool PreserveExistingSceneObject;
     }
 }

--- a/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
+++ b/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
@@ -270,7 +270,7 @@ namespace FUSE.Runtime.Lifecycle
             }
 
             // Second attempt for the third-party guards: FUSE loads before
-            // MapEnhancer and the rebill mod in UMM's order, so the
+            // MapEnhancer, the rebill mod, and BRSS in UMM's order, so the
             // plugin-load attempt resolves neither ("idle (not present)")
             // and the guards never engaged in the field. By map load every
             // mod assembly is up; the installer re-resolves absent targets

--- a/FUSE/Runtime/Lifecycle/FuseRuntimePump.cs
+++ b/FUSE/Runtime/Lifecycle/FuseRuntimePump.cs
@@ -79,6 +79,11 @@ namespace FUSE.Runtime.Lifecycle
                 Justification = "Unity invokes Update() as an instance message; a static method is never called.")]
             private void Update()
             {
+                // TimeSync Mod's ten-minute System.Threading.Timer callback
+                // arrives on a worker thread. Replay it here before it can
+                // touch StateManager and the Unity-backed in-game console.
+                FUSE.Patches.FuseTimeSyncMainThreadGuardPatches.DrainPending();
+
                 // Scenery load-failure records + broken-scenery quarantines:
                 // queued from task continuations / the log hook / the bundle
                 // audit (any thread), resolved and applied here.

--- a/tools/fuse_convert.py
+++ b/tools/fuse_convert.py
@@ -1254,9 +1254,6 @@ def has_load_component_binding_shape(item):
         "trackSpanIds",
         "trackSpans",
         "spans",
-        "loadId",
-        "LoadId",
-        "load",
     ))
 
 
@@ -1280,8 +1277,26 @@ def has_standalone_component_shape(item):
 def should_convert_component_as_partial(item):
     if not isinstance(item, dict):
         return False
-    if item.get("type") or item.get("Type"):
-        return False
+    explicit_type = item.get("type") or item.get("Type")
+    if explicit_type:
+        normalized_type = normalize_component_type(explicit_type)
+        is_legacy_runtime_type = str(explicit_type).strip().lower() != normalized_type.lower()
+        has_patch_payload = any(key.lower() not in {"type", "name"} for key in item)
+        return (
+            is_legacy_runtime_type
+            and has_patch_payload
+            and normalized_type in {
+                "loader",
+                "unloader",
+                "repairTrack",
+                "teamTrack",
+                "interchange",
+                "interchangedLoader",
+                "interchangedUnloader",
+                "progression",
+            }
+            and not has_load_component_binding_shape(item)
+        )
     if not has_standalone_component_shape(item):
         return True
     return has_legacy_load_operation_shape(item) and not has_load_component_binding_shape(item)
@@ -1968,13 +1983,33 @@ def convert_source(source, rail, source_name=None, order_state=None):
     order_state = order_state if order_state is not None else {}
 
     tracks = source.get("tracks") or {}
-    for node_id, node in (tracks.get("nodes") or {}).items():
+
+    # RailLoader accepts the original root-level node/segment/span
+    # dictionaries as well as the later `tracks` container. Merge aliases in
+    # legacy-to-canonical order so every FUSE conversion path behaves alike.
+    legacy_nodes = {}
+    root_nodes = source.get("nodes")
+    nested_nodes = tracks.get("nodes")
+    if isinstance(root_nodes, dict):
+        legacy_nodes.update(root_nodes)
+    if isinstance(nested_nodes, dict):
+        legacy_nodes.update(nested_nodes)
+
+    for node_id, node in legacy_nodes.items():
         if node is None:
             rail["tracks"]["removals"]["nodes"].append(node_id)
         elif isinstance(node, dict):
             rail["tracks"]["nodes"][node_id] = convert_node(node)
 
-    for segment_id, segment in (tracks.get("segments") or {}).items():
+    legacy_segments = {}
+    root_segments = source.get("segments")
+    nested_segments = tracks.get("segments")
+    if isinstance(root_segments, dict):
+        legacy_segments.update(root_segments)
+    if isinstance(nested_segments, dict):
+        legacy_segments.update(nested_segments)
+
+    for segment_id, segment in legacy_segments.items():
         if segment is None:
             rail["tracks"]["removals"]["segments"].append(segment_id)
         elif isinstance(segment, dict):
@@ -1982,7 +2017,15 @@ def convert_source(source, rail, source_name=None, order_state=None):
             if converted_segment:
                 rail["tracks"]["segments"][segment_id] = clean(converted_segment)
 
-    for span_id, span in (tracks.get("spans") or {}).items():
+    legacy_spans = {}
+    root_spans = source.get("spans")
+    nested_spans = tracks.get("spans")
+    if isinstance(root_spans, dict):
+        legacy_spans.update(root_spans)
+    if isinstance(nested_spans, dict):
+        legacy_spans.update(nested_spans)
+
+    for span_id, span in legacy_spans.items():
         if span is None:
             rail["tracks"]["removals"]["spans"].append(span_id)
         elif isinstance(span, dict):


### PR DESCRIPTION
## Summary
- contain malformed progression sections so one bad package cannot abort world restoration
- preserve legacy root-level track dictionaries, replacement graphs, patch-only industry components, and legacy location casing
- preserve AssetLoader discovery, patched scene splineys, generated loader transforms, and functional loader lifecycle state
- repair one-sided terminal passenger links such as Olive Hill -> MCA without inventing extra routes
- marshal third-party TimeSync callbacks to Unity's main thread and retain the runtime compatibility guards added during live testing
- keep the runtime, standalone C# converter, and Python converter behavior aligned

## Live-game verification
Validated against the reported Sutherland, Flying Spuds, Andrews power/loader, and Macon County passenger-stop failures. The final readiness report showed:

`68 loaded | faults 0 | conflicts 0 | assets 0 | brokenAssets 0 | graph 0 | transfers 0 | orphans 0 | modErrors 0`

## Validation
- `dotnet test FUSE.Tests/FUSE.Tests.csproj -v minimal` - 1,815 passed
- `dotnet build FUSE/FUSE.csproj -c Release -v minimal` - succeeded, 0 errors
- `dotnet slopwatch analyze -d .` - no new findings; one pre-existing timing-delay warning remains in `FUSE.ExternalEditor.UiTests/TerrainGenerationServiceTests.cs`
- merged current `origin/main` without conflicts before the final test pass