### PR TITLE
Contain malformed asset pack definition failures

### DIFF
--- a/FUSE.Tests/Patches/FusePrefabStoreSourceIdentifierIndexTests.cs
+++ b/FUSE.Tests/Patches/FusePrefabStoreSourceIdentifierIndexTests.cs
@@ -107,6 +107,40 @@ namespace FUSE.Tests.Patches
         }
 
         [Fact]
+        public void TryReadCompleteTopLevelObjectIdentifiers_AcceptsPropertiesAfterObjectsArray()
+        {
+            var path = Path.Combine(
+                Path.GetTempPath(),
+                "fuse-prefab-index-trailing-properties-" + Guid.NewGuid().ToString("N") + ".json");
+            try
+            {
+                File.WriteAllText(
+                    path,
+                    "{\"objects\":[{\"identifier\":\"kept\"}]," +
+                    "\"metadata\":{\"identifier\":\"ignored\",\"nested\":{\"version\":1}}," +
+                    "\"version\":\"1.5\"}");
+
+                var success =
+                    FusePrefabStoreAssetPackContainingIdentifierTracePatch
+                        .TryReadCompleteTopLevelObjectIdentifiers(
+                            path,
+                            out var identifiers,
+                            out var jsonException);
+
+                Assert.True(success);
+                Assert.Equal(new[] { "kept" }, identifiers);
+                Assert.Null(jsonException);
+            }
+            finally
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+
+        [Fact]
         public void TryReadCompleteTopLevelObjectIdentifiers_PropagatesNonJsonFailures()
         {
             var missingPath = Path.Combine(

--- a/FUSE.Tests/Patches/FusePrefabStoreSourceIdentifierIndexTests.cs
+++ b/FUSE.Tests/Patches/FusePrefabStoreSourceIdentifierIndexTests.cs
@@ -38,5 +38,155 @@ namespace FUSE.Tests.Patches
                 }
             }
         }
+
+        [Fact]
+        public void TryReadCompleteTopLevelObjectIdentifiers_DiscardsIdentifiersFromMalformedFile()
+        {
+            var path = Path.Combine(
+                Path.GetTempPath(),
+                "fuse-prefab-index-malformed-" + Guid.NewGuid().ToString("N") + ".json");
+            try
+            {
+                File.WriteAllText(
+                    path,
+                    "{\"objects\":[" +
+                    "{\"identifier\":\"must-not-survive\"}," +
+                    "{\"identifier\":\"broken\",\"definition\":{\"components\":[" +
+                    "{\"name\":\"first\"} {\"name\":\"missing-comma\"}]}}]}");
+
+                var success =
+                    FusePrefabStoreAssetPackContainingIdentifierTracePatch
+                        .TryReadCompleteTopLevelObjectIdentifiers(
+                            path,
+                            out var identifiers,
+                            out var jsonException);
+
+                Assert.False(success);
+                Assert.Empty(identifiers);
+                Assert.NotNull(jsonException);
+            }
+            finally
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+
+        [Fact]
+        public void TryReadCompleteTopLevelObjectIdentifiers_RejectsTruncatedRootObject()
+        {
+            var path = Path.Combine(
+                Path.GetTempPath(),
+                "fuse-prefab-index-truncated-" + Guid.NewGuid().ToString("N") + ".json");
+            try
+            {
+                File.WriteAllText(
+                    path,
+                    "{\"objects\":[{\"identifier\":\"must-not-survive\"}]");
+
+                var success =
+                    FusePrefabStoreAssetPackContainingIdentifierTracePatch
+                        .TryReadCompleteTopLevelObjectIdentifiers(
+                            path,
+                            out var identifiers,
+                            out var jsonException);
+
+                Assert.False(success);
+                Assert.Empty(identifiers);
+                Assert.NotNull(jsonException);
+            }
+            finally
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+
+        [Fact]
+        public void TryReadCompleteTopLevelObjectIdentifiers_PropagatesNonJsonFailures()
+        {
+            var missingPath = Path.Combine(
+                Path.GetTempPath(),
+                "fuse-prefab-index-missing-" + Guid.NewGuid().ToString("N") + ".json");
+
+            Assert.Throws<FileNotFoundException>(() =>
+                FusePrefabStoreAssetPackContainingIdentifierTracePatch
+                    .TryReadCompleteTopLevelObjectIdentifiers(
+                        missingPath,
+                        out _,
+                        out _));
+        }
+
+        [Fact]
+        public void SourceStoreScanState_MalformedStoreDoesNotBlockLaterCandidate()
+        {
+            var state =
+                new FusePrefabStoreAssetPackContainingIdentifierTracePatch
+                    .SourceStoreScanState<string>();
+
+            Assert.True(state.MarkMalformed("malformed"));
+            Assert.False(state.MarkMalformed("malformed"));
+            Assert.False(state.ShouldProbe("malformed"));
+            Assert.True(state.ShouldProbe("later-valid"));
+            Assert.True(state.CanUseCandidate(2));
+            Assert.Equal(-1, state.FirstOpaqueStoreIndex);
+            Assert.Equal(1, state.MalformedStoreCount);
+        }
+
+        [Fact]
+        public void SourceStoreScanState_OpaqueStoreBlocksOnlyLaterCandidates()
+        {
+            var state =
+                new FusePrefabStoreAssetPackContainingIdentifierTracePatch
+                    .SourceStoreScanState<string>();
+
+            state.MarkOpaque(1);
+            state.MarkOpaque(3);
+
+            Assert.True(state.CanUseCandidate(0));
+            Assert.True(state.CanUseCandidate(1));
+            Assert.False(state.CanUseCandidate(2));
+            Assert.Equal(1, state.FirstOpaqueStoreIndex);
+        }
+
+        [Fact]
+        public void DefinitionStoreQuarantine_PersistsAcrossOwnerScanStates()
+        {
+            var quarantine =
+                new FusePrefabStoreAssetPackContainingIdentifierTracePatch
+                    .DefinitionStoreQuarantine<string>();
+            Assert.True(quarantine.Add("owner-a-malformed"));
+            Assert.True(quarantine.Add("owner-b-malformed"));
+            Assert.False(quarantine.Add("owner-a-malformed"));
+
+            var ownerAState = quarantine.CreateScanState(
+                new[] { "owner-a-malformed", "owner-a-valid" });
+            var ownerBState = quarantine.CreateScanState(
+                new[] { "owner-b-malformed", "owner-b-valid" });
+            var ownerARevisitedState = quarantine.CreateScanState(
+                new[] { "owner-a-malformed", "owner-a-valid" });
+
+            Assert.False(ownerAState.ShouldProbe("owner-a-malformed"));
+            Assert.True(ownerAState.ShouldProbe("owner-a-valid"));
+            Assert.False(ownerBState.ShouldProbe("owner-b-malformed"));
+            Assert.True(ownerBState.ShouldProbe("owner-b-valid"));
+            Assert.False(ownerARevisitedState.ShouldProbe("owner-a-malformed"));
+
+            var staleOtherOwnerState =
+                new FusePrefabStoreAssetPackContainingIdentifierTracePatch
+                    .SourceStoreScanState<string>();
+            Assert.False(quarantine.CanUseCandidate(
+                staleOtherOwnerState,
+                "owner-a-malformed",
+                0));
+            Assert.True(quarantine.CanUseCandidate(
+                staleOtherOwnerState,
+                "owner-b-valid",
+                0));
+        }
     }
 }

--- a/FUSE.Tests/Patches/FuseSceneryAssetManagerEditorMenuPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseSceneryAssetManagerEditorMenuPatchTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FUSE.Patches;
 using Newtonsoft.Json;
 using Xunit;
@@ -70,6 +71,37 @@ namespace FUSE.Tests.Patches
                     _ => true,
                     _ => throw new InvalidOperationException("opaque failure"),
                     (_, __) => { }));
+        }
+
+        [Fact]
+        public void CollectSceneryIdentifiersSafely_MatchesStockDeduplicationAndSorting()
+        {
+            string[] sourceIdentifiers =
+            {
+                "duplicate",
+                null,
+                string.Empty,
+                "Duplicate",
+                "duplicate",
+                "z-scenery",
+                "a-scenery"
+            };
+
+            var identifiers =
+                FuseSceneryAssetManagerEditorMenuPatch.CollectSceneryIdentifiersSafely(
+                    new[] { "store" },
+                    _ => true,
+                    _ => sourceIdentifiers,
+                    (_, __) => { });
+
+            var expected = new HashSet<string>(sourceIdentifiers, StringComparer.Ordinal)
+                .OrderBy(identifier => identifier)
+                .ToList();
+            Assert.Equal(expected, identifiers);
+            Assert.Single(identifiers, identifier => identifier == "duplicate");
+            Assert.Contains("Duplicate", identifiers);
+            Assert.Contains(null, identifiers);
+            Assert.Contains(string.Empty, identifiers);
         }
     }
 }

--- a/FUSE.Tests/Patches/FuseSceneryAssetManagerEditorMenuPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseSceneryAssetManagerEditorMenuPatchTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using FUSE.Patches;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace FUSE.Tests.Patches
@@ -29,6 +31,45 @@ namespace FUSE.Tests.Patches
                 new HashSet<string>());
 
             Assert.Equal(identifiers, filtered);
+        }
+
+        [Fact]
+        public void CollectSceneryIdentifiersSafely_SkipsMalformedStoreAndContinues()
+        {
+            var stores = new[] { "already-quarantined", "malformed", "later-valid" };
+            var probed = new List<string>();
+            var quarantined = new List<string>();
+
+            var identifiers =
+                FuseSceneryAssetManagerEditorMenuPatch.CollectSceneryIdentifiersSafely(
+                    stores,
+                    store => store != "already-quarantined",
+                    store =>
+                    {
+                        probed.Add(store);
+                        if (store == "malformed")
+                        {
+                            throw new JsonReaderException("invalid definitions");
+                        }
+
+                        return new[] { "z-scenery", "a-scenery" };
+                    },
+                    (store, _) => quarantined.Add(store));
+
+            Assert.Equal(new[] { "a-scenery", "z-scenery" }, identifiers);
+            Assert.Equal(new[] { "malformed", "later-valid" }, probed);
+            Assert.Equal(new[] { "malformed" }, quarantined);
+        }
+
+        [Fact]
+        public void CollectSceneryIdentifiersSafely_PropagatesNonJsonFailure()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                FuseSceneryAssetManagerEditorMenuPatch.CollectSceneryIdentifiersSafely(
+                    new[] { "opaque" },
+                    _ => true,
+                    _ => throw new InvalidOperationException("opaque failure"),
+                    (_, __) => { }));
         }
     }
 }

--- a/FUSE.Tests/Patches/FuseSceneryAssetManagerEditorMenuPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseSceneryAssetManagerEditorMenuPatchTests.cs
@@ -74,7 +74,7 @@ namespace FUSE.Tests.Patches
         }
 
         [Fact]
-        public void CollectSceneryIdentifiersSafely_MatchesStockDeduplicationAndSorting()
+        public void CollectSceneryIdentifiersSafely_DedupesDropsBlanksAndSortsOrdinal()
         {
             string[] sourceIdentifiers =
             {
@@ -94,14 +94,12 @@ namespace FUSE.Tests.Patches
                     _ => sourceIdentifiers,
                     (_, __) => { });
 
-            var expected = new HashSet<string>(sourceIdentifiers, StringComparer.Ordinal)
-                .OrderBy(identifier => identifier)
-                .ToList();
+            var expected = new[] { "Duplicate", "a-scenery", "duplicate", "z-scenery" };
             Assert.Equal(expected, identifiers);
             Assert.Single(identifiers, identifier => identifier == "duplicate");
             Assert.Contains("Duplicate", identifiers);
-            Assert.Contains(null, identifiers);
-            Assert.Contains(string.Empty, identifiers);
+            Assert.DoesNotContain(null, identifiers);
+            Assert.DoesNotContain(string.Empty, identifiers);
         }
     }
 }

--- a/FUSE/Patches/FusePrefabStoreAssetPackContainingIdentifierTracePatch.cs
+++ b/FUSE/Patches/FusePrefabStoreAssetPackContainingIdentifierTracePatch.cs
@@ -69,9 +69,33 @@ namespace FUSE.Patches
                 }
 
                 AssetPackRuntimeStore firstMatch = null;
+                var skippedMalformedStore = false;
                 foreach (var store in stores)
                 {
-                    if (store == null || !store.ContainsIdentifier(identifier))
+                    if (store == null)
+                    {
+                        continue;
+                    }
+
+                    if (IsQuarantinedDefinitionStore(store))
+                    {
+                        skippedMalformedStore = true;
+                        continue;
+                    }
+
+                    bool containsIdentifier;
+                    try
+                    {
+                        containsIdentifier = store.ContainsIdentifier(identifier);
+                    }
+                    catch (JsonException ex)
+                    {
+                        QuarantineDefinitionStore(__instance, store, ex);
+                        skippedMalformedStore = true;
+                        continue;
+                    }
+
+                    if (!containsIdentifier)
                     {
                         continue;
                     }
@@ -126,6 +150,15 @@ namespace FUSE.Patches
                 if (firstMatch != null)
                 {
                     LogFuseFilteredIdentifierOnce(identifier, firstMatch);
+                    throw new Model.Database.PrefabStore.UnknownIdentifierException(identifier);
+                }
+
+                // The stock method would revisit every store and hit the same
+                // malformed Definitions.json again. We already completed the
+                // ordered scan of every usable store, so preserve the stock
+                // unknown-identifier outcome without re-entering the bad pack.
+                if (skippedMalformedStore)
+                {
                     throw new Model.Database.PrefabStore.UnknownIdentifierException(identifier);
                 }
 
@@ -184,7 +217,90 @@ namespace FUSE.Patches
         private static Dictionary<string, string> _sourceCanonicalIdentifierIndex;
         private static Dictionary<string, AssetPackRuntimeStore> _sourceLoserIndex;
         private static Dictionary<AssetPackRuntimeStore, int> _sourceStoreIndexes;
-        private static int _firstUnindexedStore;
+        private static SourceStoreScanState<AssetPackRuntimeStore> _sourceStoreScanState;
+        private static readonly DefinitionStoreQuarantine<AssetPackRuntimeStore> QuarantinedDefinitionStoreRegistry =
+            new DefinitionStoreQuarantine<AssetPackRuntimeStore>();
+
+        internal sealed class SourceStoreScanState<TStore>
+            where TStore : class
+        {
+            private readonly HashSet<TStore> _malformedStores = new HashSet<TStore>();
+
+            internal int FirstOpaqueStoreIndex { get; private set; } = -1;
+
+            internal int MalformedStoreCount => _malformedStores.Count;
+
+            internal bool MarkMalformed(TStore store)
+            {
+                return store != null && _malformedStores.Add(store);
+            }
+
+            internal void MarkOpaque(int storeIndex)
+            {
+                if (FirstOpaqueStoreIndex < 0)
+                {
+                    FirstOpaqueStoreIndex = storeIndex;
+                }
+            }
+
+            internal bool ShouldProbe(TStore store)
+            {
+                return store != null && !_malformedStores.Contains(store);
+            }
+
+            internal bool CanUseCandidate(int candidateIndex)
+            {
+                return candidateIndex >= 0 &&
+                       (FirstOpaqueStoreIndex < 0 || FirstOpaqueStoreIndex >= candidateIndex);
+            }
+
+        }
+
+        internal sealed class DefinitionStoreQuarantine<TStore>
+            where TStore : class
+        {
+            private readonly HashSet<TStore> _stores = new HashSet<TStore>();
+
+            internal bool Add(TStore store)
+            {
+                return store != null && _stores.Add(store);
+            }
+
+            internal bool Contains(TStore store)
+            {
+                return store != null && _stores.Contains(store);
+            }
+
+            internal SourceStoreScanState<TStore> CreateScanState(IEnumerable<TStore> stores)
+            {
+                var state = new SourceStoreScanState<TStore>();
+                foreach (var store in stores ?? Enumerable.Empty<TStore>())
+                {
+                    if (Contains(store))
+                    {
+                        state.MarkMalformed(store);
+                    }
+                }
+
+                return state;
+            }
+
+            internal bool CanUseCandidate(
+                SourceStoreScanState<TStore> scanState,
+                TStore store,
+                int storeIndex)
+            {
+                return !Contains(store) &&
+                       scanState != null &&
+                       scanState.ShouldProbe(store) &&
+                       scanState.CanUseCandidate(storeIndex);
+            }
+
+            internal void Clear()
+            {
+                _stores.Clear();
+            }
+        }
 
         private static bool TryResolveFromSourceIndex(
             PrefabStore prefabStore,
@@ -215,7 +331,10 @@ namespace FUSE.Patches
 
                 if (_sourceStoreIndexes == null ||
                     !_sourceStoreIndexes.TryGetValue(candidate, out var candidateIndex) ||
-                    (_firstUnindexedStore >= 0 && _firstUnindexedStore < candidateIndex))
+                    !QuarantinedDefinitionStoreRegistry.CanUseCandidate(
+                        _sourceStoreScanState,
+                        candidate,
+                        candidateIndex))
                 {
                     return false;
                 }
@@ -264,7 +383,8 @@ namespace FUSE.Patches
                     BuildSourceIndex(prefabStore, stores);
                 }
 
-                indexComplete = _firstUnindexedStore < 0;
+                indexComplete = _sourceStoreScanState != null &&
+                                _sourceStoreScanState.FirstOpaqueStoreIndex < 0;
                 if (!indexComplete || _sourceCanonicalIdentifierIndex == null)
                 {
                     return false;
@@ -284,7 +404,7 @@ namespace FUSE.Patches
             var canonicalIndex = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var loserIndex = new Dictionary<string, AssetPackRuntimeStore>(StringComparer.Ordinal);
             var storeIndexes = new Dictionary<AssetPackRuntimeStore, int>();
-            var firstUnindexedStore = -1;
+            var scanState = QuarantinedDefinitionStoreRegistry.CreateScanState(stores);
 
             for (var storeIndex = 0; storeIndex < stores.Count; storeIndex++)
             {
@@ -295,26 +415,52 @@ namespace FUSE.Patches
                 }
 
                 storeIndexes[store] = storeIndex;
+                if (!scanState.ShouldProbe(store))
+                {
+                    continue;
+                }
+
+                string basePath;
+                try
+                {
+                    basePath = FuseAssetPackPatchHelpers.ResolveBasePath(store);
+                }
+                catch
+                {
+                    scanState.MarkOpaque(storeIndex);
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(basePath))
+                {
+                    scanState.MarkOpaque(storeIndex);
+                    continue;
+                }
 
                 try
                 {
-                    var basePath = FuseAssetPackPatchHelpers.ResolveBasePath(store);
-                    if (string.IsNullOrWhiteSpace(basePath))
-                    {
-                        if (firstUnindexedStore < 0)
-                        {
-                            firstUnindexedStore = storeIndex;
-                        }
-                        continue;
-                    }
-
                     var definitionsPath = Path.Combine(basePath, "Definitions.json");
                     if (!File.Exists(definitionsPath))
                     {
                         continue;
                     }
 
-                    foreach (var objectIdentifier in ReadTopLevelObjectIdentifiers(definitionsPath))
+                    if (!TryReadCompleteTopLevelObjectIdentifiers(
+                            definitionsPath,
+                            out var objectIdentifiers,
+                            out var jsonException))
+                    {
+                        QuarantinedDefinitionStoreRegistry.Add(store);
+                        scanState.MarkMalformed(store);
+                        LogQuarantinedDefinitionStoreOnce(store, basePath, jsonException);
+                        continue;
+                    }
+
+                    // Resolve collision status before committing any entries so
+                    // an opaque registry failure cannot leave a partial store in
+                    // the source index either.
+                    var isLoserFolder = FuseAssetCollisionRegistry.IsLoserFolder(basePath);
+                    foreach (var objectIdentifier in objectIdentifiers)
                     {
                         if (string.IsNullOrEmpty(objectIdentifier) ||
                             index.ContainsKey(objectIdentifier))
@@ -322,7 +468,7 @@ namespace FUSE.Patches
                             continue;
                         }
 
-                        if (FuseAssetCollisionRegistry.IsLoserFolder(basePath))
+                        if (isLoserFolder)
                         {
                             if (!loserIndex.ContainsKey(objectIdentifier))
                             {
@@ -342,10 +488,7 @@ namespace FUSE.Patches
                 {
                     // An incomplete earlier store makes later source-index hits
                     // ambiguous. The caller falls back to the stock ordered scan.
-                    if (firstUnindexedStore < 0)
-                    {
-                        firstUnindexedStore = storeIndex;
-                    }
+                    scanState.MarkOpaque(storeIndex);
                 }
             }
 
@@ -355,24 +498,59 @@ namespace FUSE.Patches
             _sourceCanonicalIdentifierIndex = canonicalIndex;
             _sourceLoserIndex = loserIndex;
             _sourceStoreIndexes = storeIndexes;
-            _firstUnindexedStore = firstUnindexedStore;
+            _sourceStoreScanState = scanState;
             FusePerformanceMetrics.RecordCount("prefab source identifier index count", index.Count);
             FuseLog.Info(
                 $"FUSE prefab source identifier index built identifiers={index.Count} " +
-                $"stores={stores.Count} firstUnindexedStore={firstUnindexedStore}.");
+                $"stores={stores.Count} quarantinedStores={scanState.MalformedStoreCount} " +
+                $"firstUnindexedStore={scanState.FirstOpaqueStoreIndex}.");
+        }
+
+        internal static bool TryReadCompleteTopLevelObjectIdentifiers(
+            string definitionsPath,
+            out string[] identifiers,
+            out JsonException jsonException)
+        {
+            identifiers = Array.Empty<string>();
+            jsonException = null;
+
+            try
+            {
+                identifiers = ReadTopLevelObjectIdentifiers(definitionsPath).ToArray();
+                return true;
+            }
+            catch (JsonException ex)
+            {
+                jsonException = ex;
+                return false;
+            }
         }
 
         internal static IEnumerable<string> ReadTopLevelObjectIdentifiers(string definitionsPath)
         {
+            var identifiers = new List<string>();
             using (var stream = File.OpenRead(definitionsPath))
             using (var textReader = new StreamReader(stream))
             using (var reader = new JsonTextReader(textReader))
             {
                 var objectsArrayDepth = -1;
                 var objectDepth = -1;
+                var objectsArrayFinished = false;
+                var rootObjectStarted = false;
+                var rootObjectFinished = false;
                 while (reader.Read())
                 {
-                    if (objectsArrayDepth < 0 &&
+                    if (reader.TokenType == JsonToken.StartObject && reader.Depth == 0)
+                    {
+                        rootObjectStarted = true;
+                    }
+                    else if (reader.TokenType == JsonToken.EndObject && reader.Depth == 0)
+                    {
+                        rootObjectFinished = true;
+                    }
+
+                    if (!objectsArrayFinished &&
+                        objectsArrayDepth < 0 &&
                         reader.TokenType == JsonToken.PropertyName &&
                         reader.Depth == 1 &&
                         string.Equals((string)reader.Value, "objects", StringComparison.Ordinal))
@@ -392,7 +570,10 @@ namespace FUSE.Patches
                     if (reader.TokenType == JsonToken.EndArray &&
                         reader.Depth == objectsArrayDepth)
                     {
-                        yield break;
+                        objectsArrayDepth = -1;
+                        objectDepth = -1;
+                        objectsArrayFinished = true;
+                        continue;
                     }
 
                     if (reader.TokenType == JsonToken.StartObject &&
@@ -409,7 +590,7 @@ namespace FUSE.Patches
                         reader.Read() &&
                         reader.TokenType == JsonToken.String)
                     {
-                        yield return reader.Value as string;
+                        identifiers.Add(reader.Value as string);
                     }
 
                     if (objectDepth >= 0 &&
@@ -419,6 +600,110 @@ namespace FUSE.Patches
                         objectDepth = -1;
                     }
                 }
+
+                if (!rootObjectStarted || !rootObjectFinished)
+                {
+                    throw new JsonReaderException(
+                        "Definitions.json must contain a complete root JSON object.");
+                }
+            }
+
+            return identifiers;
+        }
+
+        internal static bool IsQuarantinedDefinitionStore(AssetPackRuntimeStore store)
+        {
+            lock (SourceIndexSync)
+            {
+                return QuarantinedDefinitionStoreRegistry.Contains(store);
+            }
+        }
+
+        internal static void QuarantineDefinitionStore(
+            PrefabStore prefabStore,
+            AssetPackRuntimeStore store,
+            JsonException jsonException)
+        {
+            var added = false;
+            lock (SourceIndexSync)
+            {
+                added = QuarantinedDefinitionStoreRegistry.Add(store);
+                var activeIndexContainsStore = _sourceStoreIndexes != null &&
+                                               _sourceStoreIndexes.ContainsKey(store);
+                if (ReferenceEquals(_sourceIndexOwner, prefabStore) || activeIndexContainsStore)
+                {
+                    if (_sourceStoreScanState == null)
+                    {
+                        _sourceStoreScanState = new SourceStoreScanState<AssetPackRuntimeStore>();
+                    }
+
+                    if (_sourceStoreScanState.MarkMalformed(store) || activeIndexContainsStore)
+                    {
+                        // A store can become malformed after the index was built.
+                        // Rebuild on the next lookup so no stale entry can select it.
+                        _sourceIndex = null;
+                        _sourceCanonicalIdentifierIndex = null;
+                        _sourceLoserIndex = null;
+                        _sourceStoreIndexes = null;
+                    }
+                }
+            }
+
+            if (!added)
+            {
+                return;
+            }
+
+            string basePath = null;
+            try
+            {
+                basePath = FuseAssetPackPatchHelpers.ResolveBasePath(store);
+            }
+            catch
+            {
+                basePath = null;
+            }
+
+            LogQuarantinedDefinitionStoreOnce(store, basePath, jsonException);
+        }
+
+        private static readonly HashSet<string> LoggedQuarantinedDefinitionStores =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private static readonly object LoggedQuarantinedDefinitionStoresSync = new object();
+
+        private static void LogQuarantinedDefinitionStoreOnce(
+            AssetPackRuntimeStore store,
+            string basePath,
+            JsonException jsonException)
+        {
+            try
+            {
+                string definitionsPath = null;
+                if (!string.IsNullOrWhiteSpace(basePath))
+                {
+                    definitionsPath = Path.Combine(basePath, "Definitions.json");
+                }
+
+                var storeIdentifier = store?.Identifier;
+                var logKey = definitionsPath ?? storeIdentifier ?? "<unknown>";
+                lock (LoggedQuarantinedDefinitionStoresSync)
+                {
+                    if (!LoggedQuarantinedDefinitionStores.Add(logKey))
+                    {
+                        return;
+                    }
+                }
+
+                FuseLog.Warning(
+                    "FUSE quarantined malformed asset pack definitions at " +
+                    $"'{definitionsPath ?? storeIdentifier ?? "<unknown>"}' from prefab identifier lookup: " +
+                    $"{jsonException?.GetBaseException().Message ?? "invalid JSON"}. " +
+                    "Other asset packs will continue to resolve; the source file was not modified.");
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"FUSE could not log quarantined asset pack diagnostics: {ex.Message}");
             }
         }
 
@@ -494,7 +779,13 @@ namespace FUSE.Patches
                 _sourceCanonicalIdentifierIndex = null;
                 _sourceLoserIndex = null;
                 _sourceStoreIndexes = null;
-                _firstUnindexedStore = -1;
+                _sourceStoreScanState = null;
+                QuarantinedDefinitionStoreRegistry.Clear();
+            }
+
+            lock (LoggedQuarantinedDefinitionStoresSync)
+            {
+                LoggedQuarantinedDefinitionStores.Clear();
             }
         }
     }

--- a/FUSE/Patches/FuseSceneryAssetManagerEditorMenuPatch.cs
+++ b/FUSE/Patches/FuseSceneryAssetManagerEditorMenuPatch.cs
@@ -117,10 +117,13 @@ namespace FUSE.Patches
             Action<TStore, JsonException> quarantine)
             where TStore : class
         {
-            // PrefabStore.AllDefinitionInfosOfType<T> first collects matching
-            // identifiers in a case-sensitive HashSet, then the manager applies
-            // comparer-less OrderBy. Keep that contract, including null/empty
-            // values and the current-culture sort, while isolating JSON failures.
+            // Stock PrefabStore.AllDefinitionInfosOfType<T> collects into a
+            // case-sensitive HashSet then applies a comparer-less OrderBy,
+            // keeping null/empty values and sorting by current culture. We
+            // intentionally diverge for determinism (per CodeRabbit review):
+            // drop null/empty identifiers and sort with StringComparer.Ordinal
+            // so the editor menu and identifier resolver are locale-independent,
+            // while still isolating JSON failures per store.
             var identifiers = new HashSet<string>(StringComparer.Ordinal);
             if (stores == null)
             {
@@ -141,7 +144,10 @@ namespace FUSE.Patches
                     {
                         foreach (var identifier in storeIdentifiers)
                         {
-                            identifiers.Add(identifier);
+                            if (!string.IsNullOrEmpty(identifier))
+                            {
+                                identifiers.Add(identifier);
+                            }
                         }
                     }
                 }
@@ -151,7 +157,7 @@ namespace FUSE.Patches
                 }
             }
 
-            return identifiers.OrderBy(identifier => identifier).ToList();
+            return identifiers.OrderBy(identifier => identifier, StringComparer.Ordinal).ToList();
         }
 
         private static IEnumerable<string> ReadSceneryIdentifiers(AssetPackRuntimeStore store)

--- a/FUSE/Patches/FuseSceneryAssetManagerEditorMenuPatch.cs
+++ b/FUSE/Patches/FuseSceneryAssetManagerEditorMenuPatch.cs
@@ -27,9 +27,10 @@ namespace FUSE.Patches
         }
 
         // The stock method enumerates every PrefabStore container before our
-        // editor-menu Postfix can run. Build the same registration-order list
-        // here so one quarantined Definitions.json cannot abort the entire
-        // scenery catalog; the Postfix still applies the direct-only filter.
+        // editor-menu Postfix can run. Build the same exact-deduplicated,
+        // default-sorted list here so one quarantined Definitions.json cannot
+        // abort the entire scenery catalog; the Postfix still applies the
+        // direct-only filter.
         private static bool Prefix(SceneryAssetManager __instance, ref List<string> __result)
         {
             PrefabStore prefabStore;
@@ -116,10 +117,14 @@ namespace FUSE.Patches
             Action<TStore, JsonException> quarantine)
             where TStore : class
         {
-            var identifiers = new List<string>();
+            // PrefabStore.AllDefinitionInfosOfType<T> first collects matching
+            // identifiers in a case-sensitive HashSet, then the manager applies
+            // comparer-less OrderBy. Keep that contract, including null/empty
+            // values and the current-culture sort, while isolating JSON failures.
+            var identifiers = new HashSet<string>(StringComparer.Ordinal);
             if (stores == null)
             {
-                return identifiers;
+                return new List<string>();
             }
 
             foreach (var store in stores)
@@ -134,7 +139,10 @@ namespace FUSE.Patches
                     var storeIdentifiers = readIdentifiers(store);
                     if (storeIdentifiers != null)
                     {
-                        identifiers.AddRange(storeIdentifiers);
+                        foreach (var identifier in storeIdentifiers)
+                        {
+                            identifiers.Add(identifier);
+                        }
                     }
                 }
                 catch (JsonException ex)

--- a/FUSE/Patches/FuseSceneryAssetManagerEditorMenuPatch.cs
+++ b/FUSE/Patches/FuseSceneryAssetManagerEditorMenuPatch.cs
@@ -8,6 +8,7 @@ using Helpers;
 using Model.Database;
 using Model.Definition;
 using Model.Definition.Data;
+using Newtonsoft.Json;
 using FUSE.Infrastructure;
 using FUSE.Loading;
 
@@ -23,6 +24,40 @@ namespace FUSE.Patches
         private static MethodInfo TargetMethod()
         {
             return AccessTools.Method(typeof(SceneryAssetManager), "GetSceneryDefinitionIdentifiers");
+        }
+
+        // The stock method enumerates every PrefabStore container before our
+        // editor-menu Postfix can run. Build the same registration-order list
+        // here so one quarantined Definitions.json cannot abort the entire
+        // scenery catalog; the Postfix still applies the direct-only filter.
+        private static bool Prefix(SceneryAssetManager __instance, ref List<string> __result)
+        {
+            PrefabStore prefabStore;
+            IEnumerable<AssetPackRuntimeStore> stores;
+            try
+            {
+                prefabStore = PrefabStoreProperty?.GetValue(__instance, null) as PrefabStore;
+                stores = StoresField?.GetValue(prefabStore) as IEnumerable<AssetPackRuntimeStore>;
+            }
+            catch
+            {
+                return true;
+            }
+
+            if (prefabStore == null || stores == null)
+            {
+                return true;
+            }
+
+            __result = CollectSceneryIdentifiersSafely(
+                stores,
+                store => !FusePrefabStoreAssetPackContainingIdentifierTracePatch
+                    .IsQuarantinedDefinitionStore(store),
+                ReadSceneryIdentifiers,
+                (store, jsonException) =>
+                    FusePrefabStoreAssetPackContainingIdentifierTracePatch
+                        .QuarantineDefinitionStore(prefabStore, store, jsonException));
+            return false;
         }
 
         private static void Postfix(SceneryAssetManager __instance, ref List<string> __result)
@@ -74,6 +109,51 @@ namespace FUSE.Patches
                 .ToList();
         }
 
+        internal static List<string> CollectSceneryIdentifiersSafely<TStore>(
+            IEnumerable<TStore> stores,
+            Func<TStore, bool> shouldProbe,
+            Func<TStore, IEnumerable<string>> readIdentifiers,
+            Action<TStore, JsonException> quarantine)
+            where TStore : class
+        {
+            var identifiers = new List<string>();
+            if (stores == null)
+            {
+                return identifiers;
+            }
+
+            foreach (var store in stores)
+            {
+                if (store == null || !shouldProbe(store))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var storeIdentifiers = readIdentifiers(store);
+                    if (storeIdentifiers != null)
+                    {
+                        identifiers.AddRange(storeIdentifiers);
+                    }
+                }
+                catch (JsonException ex)
+                {
+                    quarantine(store, ex);
+                }
+            }
+
+            return identifiers.OrderBy(identifier => identifier).ToList();
+        }
+
+        private static IEnumerable<string> ReadSceneryIdentifiers(AssetPackRuntimeStore store)
+        {
+            var container = store.Container();
+            return (container?.Objects ?? Enumerable.Empty<ContainerItem>())
+                .Where(item => item?.Definition is SceneryDefinition)
+                .Select(item => item.Identifier);
+        }
+
         private static HashSet<string> ComputeDirectOnlySceneryIdentifiers(PrefabStore prefabStore)
         {
             var directIdentifiers = new HashSet<string>(StringComparer.Ordinal);
@@ -86,7 +166,9 @@ namespace FUSE.Patches
 
             foreach (var store in stores)
             {
-                if (store == null)
+                if (store == null ||
+                    FusePrefabStoreAssetPackContainingIdentifierTracePatch
+                        .IsQuarantinedDefinitionStore(store))
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary

- atomically validate each `Definitions.json` before committing its identifiers to the prefab source index
- quarantine only stores that fail with `JsonException`, without treating them as opaque registration-order barriers
- skip quarantined stores in ordered identifier lookup and scenery-catalog enumeration so later valid packs still resolve
- preserve existing collision-loser handling and opaque behavior for path, I/O, reflection, and other non-JSON failures
- log the exact malformed `Definitions.json` path once; no third-party source file is modified

## Context

The diagnostics attached to #201 identify one failed definition store:

`Mods\USRA-BSC 42ft Flatcar\USRA BSC 42ft Flatcar\Definitions.json`

It fails at `objects[0].definition.components[11].name` (line 771, position 12). The invalid JSON remains a mod-author issue, but the failed store was also becoming an index-order barrier and repeatedly aborting scenery enumeration. That prevented valid stores registered later from resolving and produced the broader scenery-loss cascade reported in #196.

Quarantine is session-wide by runtime-store reference, while opaque ordering state remains owner-specific. This also covers alternating runtime/editor prefab stores and prevents stale indexes from selecting a store quarantined by another owner.

## Validation

- `python tools/cs_lint.py` — passed
- `git diff --check` — passed
- `dotnet slopwatch analyze -d .` — no new findings; one pre-existing timing-test warning remains in `FUSE.ExternalEditor.UiTests/TerrainGenerationServiceTests.cs`
- focused xUnit coverage added for late/truncated JSON failures, non-JSON propagation, opaque barriers, cross-owner quarantine persistence, stale-owner candidate rejection, and safe scenery enumeration
- local `dotnet test` restore succeeded, but this workstation lacks the repository-target Unity Mod Manager/legacy game reference set, so the project reference guard stopped before compilation; PR CI is the authoritative net48 build/test run

Addresses #196.
Uses the diagnostics consolidated from duplicate #201.