### PR TITLE
fix(release): package mod zips with forward-slash entry names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,11 @@ jobs:
 
           Copy-Item 'LICENSE' $modFolder
 
-          Compress-Archive -Path $modFolder -DestinationPath $archivePath -CompressionLevel Optimal
+          # Not Compress-Archive — it writes backslash entry names under Windows
+          # PowerShell 5.1, which breaks updating through UMM. Packaging the CI zip
+          # the same way as the release zip is what lets the validation step below
+          # act as the regression gate for issue #209.
+          .\scripts\New-ModArchive.ps1 -Path $modFolder -DestinationPath $archivePath
 
       # Prove the freshly-packaged zip is actually loadable by Unity Mod Manager
       # before publishing it as an artifact. scripts/Validate-ModPackage.cs resolves

--- a/.github/workflows/release-externaleditor.yml
+++ b/.github/workflows/release-externaleditor.yml
@@ -86,7 +86,11 @@ jobs:
             if ($LASTEXITCODE -ne 0) { throw "publish failed for $rid" }
             $zip = "FUSE.ExternalEditor-v$version-$rid.zip"
             if (Test-Path $zip) { Remove-Item $zip -Force }
-            Compress-Archive -Path "$out/*" -DestinationPath $zip -CompressionLevel Optimal
+            # This lane runs on pwsh, where Compress-Archive already emits forward
+            # slashes, but route it through the shared packer anyway so archive
+            # layout does not depend on which shell a workflow happens to use.
+            # See issue #209.
+            ./scripts/New-ModArchive.ps1 -Path $out -DestinationPath $zip -ContentsOnly
           }
 
       - name: Create GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,11 @@ jobs:
             Remove-Item $archivePath -Force
           }
 
-          Compress-Archive -Path $modFolder -DestinationPath $archivePath -CompressionLevel Optimal
+          # Deliberately NOT Compress-Archive: under Windows PowerShell 5.1 (the
+          # `shell: powershell` default on this runner) it writes entry names with
+          # backslashes, which makes UMM fail to UPDATE an already-installed copy of
+          # the mod. See scripts/New-ModArchive.ps1 and issue #209.
+          .\scripts\New-ModArchive.ps1 -Path $modFolder -DestinationPath $archivePath
 
           "archive_name=$archiveName" >> $env:GITHUB_OUTPUT
           "archive_path=$archivePath" >> $env:GITHUB_OUTPUT
@@ -212,7 +216,9 @@ jobs:
           Copy-Item "LICENSE" $modFolder
           $zip = "FUSE.LiveBridge-v$version.zip"
           if (Test-Path $zip) { Remove-Item $zip -Force }
-          Compress-Archive -Path $modFolder -DestinationPath $zip -CompressionLevel Optimal
+          # Same forward-slash requirement as the core mod zip; the Live Bridge is
+          # installed and updated through UMM too. See issue #209.
+          .\scripts\New-ModArchive.ps1 -Path $modFolder -DestinationPath $zip
 
       - name: Install PyInstaller
         run: python -m pip install --upgrade pip pyinstaller
@@ -262,7 +268,8 @@ jobs:
           if (Test-Path $archivePath) { Remove-Item $archivePath -Force }
           # Zip the CONTENTS so Mods/ sits at the archive root, which is the
           # multi-package layout FUSE-Installer.exe already understands.
-          Compress-Archive -Path (Join-Path $stagingRoot '*') -DestinationPath $archivePath -CompressionLevel Optimal
+          # -ContentsOnly is the New-ModArchive equivalent of `Compress-Archive -Path dir\*`.
+          .\scripts\New-ModArchive.ps1 -Path $stagingRoot -DestinationPath $archivePath -ContentsOnly
 
           "archive_name=$archiveName" >> $env:GITHUB_OUTPUT
           "archive_path=$archivePath" >> $env:GITHUB_OUTPUT

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,28 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- Updating FUSE through Unity Mod Manager failed with "Error when unpacking"
+  and installed nothing, for every release from 1.0.0 through 1.0.2. The
+  published zips stored entry names with backslashes, because
+  `Compress-Archive` under Windows PowerShell 5.1 writes them that way. UMM
+  rewrites entry names when the mod is already installed, slicing each name at
+  its first forward slash; with backslashes there is none, so the unpack threw
+  and aborted. A *fresh* install skips that rewrite, which is why installing
+  worked and only updating broke. Archives are now built by
+  `scripts/New-ModArchive.ps1`, which always emits forward slashes.
+
+  Until a release carries the fix, update by deleting `Railroader/Mods/FUSE`
+  first (which makes UMM treat it as a fresh install) or by extracting the zip
+  by hand.
+
+### Changed
+
+- `scripts/Validate-ModPackage.cs` now fails the build if a packaged archive
+  contains a backslash entry name, simulating UMM's update-path rewrite rather
+  than only extracting the archive. Plain extraction tolerates backslashes on
+  Windows, which is why the release gate passed all three broken releases.
 
 ## [1.0.2]
 

--- a/scripts/New-ModArchive.ps1
+++ b/scripts/New-ModArchive.ps1
@@ -1,0 +1,142 @@
+#requires -Version 5
+# Creates a .zip whose entry names always use forward slashes.
+#
+# This exists because `Compress-Archive` under Windows PowerShell 5.1 — the
+# `shell: powershell` default on the self-hosted runner — writes entry names with
+# BACKSLASHES, which violates ZIP APPNOTE 4.4.17.1. Nothing noticed for three
+# releases, because backslashes happen to work everywhere the archive is merely
+# extracted: .NET's ZipFile.ExtractToDirectory and Windows Explorer both accept
+# '\' as a separator.
+#
+# Unity Mod Manager does not merely extract. When the mod is ALREADY INSTALLED,
+# its installer rewrites every entry name (UnityModManagerApp/Mods.cs, InstallMod):
+#
+#     var pos = filename.IndexOf(Path.AltDirectorySeparatorChar);   // '/'
+#     filename = replaceModDir + filename.Substring(pos, filename.Length - pos);
+#
+# With backslash entries there is no '/', so pos is -1, Substring throws
+# ArgumentOutOfRangeException, and UMM aborts the whole unpack with
+# "Error when unpacking '<zip>'" having extracted nothing. A FRESH install skips
+# that rewrite entirely, so it succeeds — which is why FUSE 1.0.0-1.0.2 installed
+# fine for new users and could not be UPDATED by anyone. See issue #209.
+#
+# scripts/Validate-ModPackage.cs fails the build if a packaged archive ever
+# regains a backslash entry, so this cannot silently come back.
+#
+# Ordering is sorted by entry name so repeated packaging runs are reproducible.
+
+[CmdletBinding()]
+param(
+  # Directory to archive.
+  [Parameter(Mandatory)][string]$Path,
+  # Destination .zip. Overwritten if it already exists.
+  [Parameter(Mandatory)][string]$DestinationPath,
+  # Archive the CONTENTS of -Path rather than -Path itself. Mirrors the
+  # difference between `Compress-Archive -Path dir` and `-Path dir\*`.
+  [switch]$ContentsOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Present by default on PowerShell 7; needs loading on Windows PowerShell 5.1.
+foreach ($assembly in @('System.IO.Compression', 'System.IO.Compression.FileSystem')) {
+  try { Add-Type -AssemblyName $assembly -ErrorAction Stop } catch { }
+}
+
+if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+  throw "Source directory not found: $Path"
+}
+
+$root = (Resolve-Path -LiteralPath $Path).ProviderPath.TrimEnd('\', '/')
+
+# Entry names are relative to this. Including the source folder itself (the
+# default) yields 'FUSE/FUSE.dll'; -ContentsOnly yields 'Mods/FUSE/FUSE.dll'
+# from a staging root that holds Mods/ and Tools/.
+$baseDir = if ($ContentsOnly) { $root } else { Split-Path -Parent $root }
+if ([string]::IsNullOrEmpty($baseDir)) {
+  throw "Cannot determine a parent directory for '$root'; pass -ContentsOnly or a nested path."
+}
+
+function Resolve-OutputPath([string]$value) {
+  if ([System.IO.Path]::IsPathRooted($value)) {
+    return [System.IO.Path]::GetFullPath($value)
+  }
+  # .NET resolves relative paths against the process working directory, which is
+  # not necessarily PowerShell's current location. Anchor explicitly.
+  return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).ProviderPath $value))
+}
+
+function ConvertTo-EntryName([string]$fullName, [string]$base) {
+  $relative = $fullName.Substring($base.Length).TrimStart('\', '/')
+  return $relative -replace '\\', '/'
+}
+
+$destination = Resolve-OutputPath $DestinationPath
+$destinationDir = Split-Path -Parent $destination
+if ($destinationDir -and -not (Test-Path -LiteralPath $destinationDir)) {
+  New-Item -ItemType Directory -Force -Path $destinationDir | Out-Null
+}
+if (Test-Path -LiteralPath $destination) {
+  Remove-Item -LiteralPath $destination -Force
+}
+
+$files = @(Get-ChildItem -LiteralPath $root -Recurse -File -Force |
+  Sort-Object -Property FullName)
+
+# Compress-Archive records empty directories; preserve that so this stays a
+# drop-in replacement rather than a subtly lossy one.
+$emptyDirs = @(Get-ChildItem -LiteralPath $root -Recurse -Directory -Force |
+  Where-Object { -not (Get-ChildItem -LiteralPath $_.FullName -Force | Select-Object -First 1) } |
+  Sort-Object -Property FullName)
+
+if ($files.Count -eq 0 -and $emptyDirs.Count -eq 0) {
+  throw "Refusing to write an empty archive: '$root' contains no files."
+}
+
+$archive = [System.IO.Compression.ZipFile]::Open(
+  $destination, [System.IO.Compression.ZipArchiveMode]::Create)
+try {
+  foreach ($dir in $emptyDirs) {
+    $archive.CreateEntry((ConvertTo-EntryName $dir.FullName $baseDir) + '/') | Out-Null
+  }
+  foreach ($file in $files) {
+    [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+      $archive,
+      $file.FullName,
+      (ConvertTo-EntryName $file.FullName $baseDir),
+      [System.IO.Compression.CompressionLevel]::Optimal) | Out-Null
+  }
+}
+catch {
+  # Dispose before deleting, to release the file handle. In Create mode Dispose()
+  # writes a valid central directory for whatever was added before the fault, so
+  # an undeleted partial is a well-formed but TRUNCATED archive that looks
+  # complete — the worst possible artifact to leave in dist/. Compress-Archive
+  # removed its partial output on failure; match that.
+  $archive.Dispose()
+  $archive = $null
+  if (Test-Path -LiteralPath $destination) {
+    Remove-Item -LiteralPath $destination -Force
+  }
+  throw
+}
+finally {
+  if ($archive) { $archive.Dispose() }
+}
+
+# Self-check. Cheap, and it turns "we shipped a broken zip" into "packaging failed".
+$verify = [System.IO.Compression.ZipFile]::OpenRead($destination)
+try {
+  $bad = @($verify.Entries | Where-Object { $_.FullName.Contains('\') })
+  $count = $verify.Entries.Count
+}
+finally {
+  $verify.Dispose()
+}
+if ($bad.Count -gt 0) {
+  Remove-Item -LiteralPath $destination -Force
+  throw "Archive contained backslash entry names: $(($bad | ForEach-Object { $_.FullName }) -join ', ')"
+}
+
+Write-Host "Packaged $destination ($count entries, forward-slash separators)."

--- a/scripts/New-ModArchive.ps1
+++ b/scripts/New-ModArchive.ps1
@@ -84,6 +84,16 @@ function ConvertTo-EntryName([string]$fullName, [string]$base) {
 }
 
 $destination = Resolve-OutputPath $DestinationPath
+
+# Refuse to write the archive inside the tree being archived. Otherwise creating
+# the destination's parent (below) could add an empty directory that the source
+# enumeration then picks up, and the growing archive would sit in its own input.
+# No shipping call site does this; reject it plainly rather than half-handle it.
+$rootPrefix = $root.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+if ($destination.StartsWith($rootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+  throw "DestinationPath '$destination' is inside the source directory '$root'; write the archive somewhere outside it."
+}
+
 $destinationDir = Split-Path -Parent $destination
 if ($destinationDir -and -not (Test-Path -LiteralPath $destinationDir)) {
   New-Item -ItemType Directory -Force -Path $destinationDir | Out-Null
@@ -178,13 +188,26 @@ finally {
 }
 
 # Self-check. Cheap, and it turns "we shipped a broken zip" into "packaging failed".
-$verify = [System.IO.Compression.ZipFile]::OpenRead($destination)
+# Same shape as the archive-writing block above: open inside the try and delete the
+# output on any failure, so a failed verification never leaves an unverified zip.
+$verify = $null
 try {
+  $verify = [System.IO.Compression.ZipFile]::OpenRead($destination)
   $bad = @($verify.Entries | Where-Object { $_.FullName.Contains('\') })
   $count = $verify.Entries.Count
 }
+catch {
+  if ($verify) {
+    try { $verify.Dispose() } catch { }
+    $verify = $null
+  }
+  if (Test-Path -LiteralPath $destination) {
+    Remove-Item -LiteralPath $destination -Force
+  }
+  throw
+}
 finally {
-  $verify.Dispose()
+  if ($verify) { $verify.Dispose() }
 }
 if ($bad.Count -gt 0) {
   Remove-Item -LiteralPath $destination -Force

--- a/scripts/New-ModArchive.ps1
+++ b/scripts/New-ModArchive.ps1
@@ -83,6 +83,20 @@ function ConvertTo-EntryName([string]$fullName, [string]$base) {
   return $relative -replace '\\', '/'
 }
 
+function Remove-OutputBestEffort([string]$path) {
+  # Cleanup used on error paths. It must NEVER throw: with
+  # $ErrorActionPreference = 'Stop' a Remove-Item failure would otherwise replace
+  # the original packaging error (the real cause) with a misleading "could not
+  # remove" error, or suppress the intended bad-entry error. Downgrade a cleanup
+  # failure to a warning so the original failure is what surfaces.
+  try {
+    if (Test-Path -LiteralPath $path) { Remove-Item -LiteralPath $path -Force }
+  }
+  catch {
+    Write-Warning "Failed to remove '$path' during cleanup: $($_.Exception.Message)"
+  }
+}
+
 $destination = Resolve-OutputPath $DestinationPath
 
 # Refuse to write the archive inside the tree being archived. Otherwise creating
@@ -134,7 +148,10 @@ foreach ($file in $files) {
       LastWriteTime = $file.LastWriteTime
     })
 }
-$plan = @($plan | Sort-Object -Property Name)
+# Sort by the final entry name with an ORDINAL comparer rather than Sort-Object's
+# culture-sensitive default, so entry order is identical on every runner whatever
+# its locale. Entry names are unique full paths, so no tie-breaker is needed.
+$plan.Sort([System.Comparison[object]] { param($x, $y) [string]::CompareOrdinal($x.Name, $y.Name) })
 
 $archive = $null
 try {
@@ -171,20 +188,20 @@ catch {
   # Compress-Archive deletes its partial on failure; match that. Disposal and
   # deletion are kept independent so a Dispose() that throws cannot skip the
   # delete, and both Open() and the finalize above are inside the try so their
-  # failures clean up too.
+  # failures clean up too. Capture and rethrow the ORIGINAL error so a cleanup
+  # failure can never mask the real cause.
+  $original = $_
   if ($archive) {
     try { $archive.Dispose() } catch { }
     $archive = $null
   }
-  if (Test-Path -LiteralPath $destination) {
-    Remove-Item -LiteralPath $destination -Force
-  }
-  throw
+  Remove-OutputBestEffort $destination
+  throw $original
 }
 finally {
   # Defensive net for any path that still holds an open handle (the success and
   # catch paths both null $archive, so this is normally a no-op).
-  if ($archive) { $archive.Dispose() }
+  if ($archive) { try { $archive.Dispose() } catch { } }
 }
 
 # Self-check. Cheap, and it turns "we shipped a broken zip" into "packaging failed".
@@ -197,20 +214,24 @@ try {
   $count = $verify.Entries.Count
 }
 catch {
+  $original = $_
   if ($verify) {
-    try { $verify.Dispose() } catch { }
+    try { $verify.Dispose() }
+    catch { Write-Warning "Failed to dispose the verification handle: $($_.Exception.Message)" }
     $verify = $null
   }
-  if (Test-Path -LiteralPath $destination) {
-    Remove-Item -LiteralPath $destination -Force
-  }
-  throw
+  Remove-OutputBestEffort $destination
+  throw $original
 }
 finally {
-  if ($verify) { $verify.Dispose() }
+  if ($verify) {
+    try { $verify.Dispose() }
+    catch { Write-Warning "Failed to dispose the verification handle: $($_.Exception.Message)" }
+  }
 }
 if ($bad.Count -gt 0) {
-  Remove-Item -LiteralPath $destination -Force
+  # Best-effort so a delete failure can't mask the bad-entry error below.
+  Remove-OutputBestEffort $destination
   throw "Archive contained backslash entry names: $(($bad | ForEach-Object { $_.FullName }) -join ', ')"
 }
 

--- a/scripts/New-ModArchive.ps1
+++ b/scripts/New-ModArchive.ps1
@@ -48,7 +48,17 @@ if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
   throw "Source directory not found: $Path"
 }
 
-$root = (Resolve-Path -LiteralPath $Path).ProviderPath.TrimEnd('\', '/')
+# Trim trailing separators so Split-Path/Substring below behave, but NOT off a
+# filesystem root: 'C:\'.TrimEnd('\') is 'C:', which PowerShell treats as
+# DRIVE-RELATIVE — Get-ChildItem -LiteralPath 'C:' enumerates the current
+# directory on C:, not the drive root. No shipping call site passes a drive root,
+# but this packer is reusable, so keep it honest.
+$resolvedRoot = (Resolve-Path -LiteralPath $Path).ProviderPath
+$root = if ($resolvedRoot -eq [System.IO.Path]::GetPathRoot($resolvedRoot)) {
+  $resolvedRoot
+} else {
+  $resolvedRoot.TrimEnd('\', '/')
+}
 
 # Entry names are relative to this. Including the source folder itself (the
 # default) yields 'FUSE/FUSE.dll'; -ContentsOnly yields 'Mods/FUSE/FUSE.dll'

--- a/scripts/New-ModArchive.ps1
+++ b/scripts/New-ModArchive.ps1
@@ -146,6 +146,13 @@ try {
         [System.IO.Compression.CompressionLevel]::Optimal) | Out-Null
     }
   }
+  # Finalize INSIDE the try. Dispose() is what writes the ZIP central directory,
+  # so a failure there (e.g. the disk fills as the directory is flushed) must be
+  # caught and cleaned up -- if it ran only in the finally below, that failure
+  # would bypass the catch and leave a partial at $destination. Null only after a
+  # clean finalize, so the finally stays a no-op on the success path.
+  $archive.Dispose()
+  $archive = $null
 }
 catch {
   # Never leave a partial behind: in Create mode Dispose() finalizes a valid
@@ -153,7 +160,8 @@ catch {
   # but TRUNCATED archive that looks complete -- the worst artifact to ship.
   # Compress-Archive deletes its partial on failure; match that. Disposal and
   # deletion are kept independent so a Dispose() that throws cannot skip the
-  # delete, and Open() itself is inside the try so its failures clean up too.
+  # delete, and both Open() and the finalize above are inside the try so their
+  # failures clean up too.
   if ($archive) {
     try { $archive.Dispose() } catch { }
     $archive = $null
@@ -164,6 +172,8 @@ catch {
   throw
 }
 finally {
+  # Defensive net for any path that still holds an open handle (the success and
+  # catch paths both null $archive, so this is normally a no-op).
   if ($archive) { $archive.Dispose() }
 }
 

--- a/scripts/New-ModArchive.ps1
+++ b/scripts/New-ModArchive.ps1
@@ -1,8 +1,8 @@
 #requires -Version 5
 # Creates a .zip whose entry names always use forward slashes.
 #
-# This exists because `Compress-Archive` under Windows PowerShell 5.1 — the
-# `shell: powershell` default on the self-hosted runner — writes entry names with
+# This exists because `Compress-Archive` under Windows PowerShell 5.1 -- the
+# `shell: powershell` default on the self-hosted runner -- writes entry names with
 # BACKSLASHES, which violates ZIP APPNOTE 4.4.17.1. Nothing noticed for three
 # releases, because backslashes happen to work everywhere the archive is merely
 # extracted: .NET's ZipFile.ExtractToDirectory and Windows Explorer both accept
@@ -17,7 +17,7 @@
 # With backslash entries there is no '/', so pos is -1, Substring throws
 # ArgumentOutOfRangeException, and UMM aborts the whole unpack with
 # "Error when unpacking '<zip>'" having extracted nothing. A FRESH install skips
-# that rewrite entirely, so it succeeds — which is why FUSE 1.0.0-1.0.2 installed
+# that rewrite entirely, so it succeeds -- which is why FUSE 1.0.0-1.0.2 installed
 # fine for new users and could not be UPDATED by anyone. See issue #209.
 #
 # scripts/Validate-ModPackage.cs fails the build if a packaged archive ever
@@ -50,7 +50,7 @@ if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
 
 # Trim trailing separators so Split-Path/Substring below behave, but NOT off a
 # filesystem root: 'C:\'.TrimEnd('\') is 'C:', which PowerShell treats as
-# DRIVE-RELATIVE — Get-ChildItem -LiteralPath 'C:' enumerates the current
+# DRIVE-RELATIVE -- Get-ChildItem -LiteralPath 'C:' enumerates the current
 # directory on C:, not the drive root. No shipping call site passes a drive root,
 # but this packer is reusable, so keep it honest.
 $resolvedRoot = (Resolve-Path -LiteralPath $Path).ProviderPath
@@ -69,12 +69,13 @@ if ([string]::IsNullOrEmpty($baseDir)) {
 }
 
 function Resolve-OutputPath([string]$value) {
-  if ([System.IO.Path]::IsPathRooted($value)) {
-    return [System.IO.Path]::GetFullPath($value)
-  }
-  # .NET resolves relative paths against the process working directory, which is
-  # not necessarily PowerShell's current location. Anchor explicitly.
-  return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).ProviderPath $value))
+  # Provider-aware resolution of a path that need not exist yet. [Path]::GetFullPath
+  # has two traps this avoids: it anchors a relative path to the process working
+  # directory rather than PowerShell's current location, and it treats a
+  # drive-relative value like 'C:out.zip' (for which IsPathRooted returns true) as
+  # relative to drive C:'s own current directory. GetUnresolvedProviderPathFromPSPath
+  # resolves both against the PowerShell location instead.
+  return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($value)
 }
 
 function ConvertTo-EntryName([string]$fullName, [string]$base) {
@@ -91,41 +92,72 @@ if (Test-Path -LiteralPath $destination) {
   Remove-Item -LiteralPath $destination -Force
 }
 
-$files = @(Get-ChildItem -LiteralPath $root -Recurse -File -Force |
-  Sort-Object -Property FullName)
+$files = @(Get-ChildItem -LiteralPath $root -Recurse -File -Force)
 
 # Compress-Archive records empty directories; preserve that so this stays a
 # drop-in replacement rather than a subtly lossy one.
 $emptyDirs = @(Get-ChildItem -LiteralPath $root -Recurse -Directory -Force |
-  Where-Object { -not (Get-ChildItem -LiteralPath $_.FullName -Force | Select-Object -First 1) } |
-  Sort-Object -Property FullName)
+  Where-Object { -not (Get-ChildItem -LiteralPath $_.FullName -Force | Select-Object -First 1) })
 
 if ($files.Count -eq 0 -and $emptyDirs.Count -eq 0) {
   throw "Refusing to write an empty archive: '$root' contains no files."
 }
 
-$archive = [System.IO.Compression.ZipFile]::Open(
-  $destination, [System.IO.Compression.ZipArchiveMode]::Create)
+# Build one ordered plan -- empty directories and files together -- sorted by the
+# final forward-slash entry name, so ordering is byte-stable across repackages no
+# matter how the filesystem enumerated. Sorting the two kinds separately would
+# emit every directory before every file, letting 'z/' precede 'a.txt'.
+$plan = New-Object System.Collections.Generic.List[object]
+foreach ($dir in $emptyDirs) {
+  $plan.Add([pscustomobject]@{
+      Name          = (ConvertTo-EntryName $dir.FullName $baseDir) + '/'
+      IsDirectory   = $true
+      FullName      = $dir.FullName
+      LastWriteTime = $dir.LastWriteTime
+    })
+}
+foreach ($file in $files) {
+  $plan.Add([pscustomobject]@{
+      Name          = (ConvertTo-EntryName $file.FullName $baseDir)
+      IsDirectory   = $false
+      FullName      = $file.FullName
+      LastWriteTime = $file.LastWriteTime
+    })
+}
+$plan = @($plan | Sort-Object -Property Name)
+
+$archive = $null
 try {
-  foreach ($dir in $emptyDirs) {
-    $archive.CreateEntry((ConvertTo-EntryName $dir.FullName $baseDir) + '/') | Out-Null
-  }
-  foreach ($file in $files) {
-    [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
-      $archive,
-      $file.FullName,
-      (ConvertTo-EntryName $file.FullName $baseDir),
-      [System.IO.Compression.CompressionLevel]::Optimal) | Out-Null
+  $archive = [System.IO.Compression.ZipFile]::Open(
+    $destination, [System.IO.Compression.ZipArchiveMode]::Create)
+  foreach ($item in $plan) {
+    if ($item.IsDirectory) {
+      # CreateEntry stamps DateTime.Now, which would make an otherwise-untouched
+      # repackage differ byte-for-byte. Use the directory's own mtime, mirroring
+      # how CreateEntryFromFile carries each file's mtime.
+      $entry = $archive.CreateEntry($item.Name)
+      $entry.LastWriteTime = [System.DateTimeOffset]$item.LastWriteTime
+    }
+    else {
+      [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+        $archive,
+        $item.FullName,
+        $item.Name,
+        [System.IO.Compression.CompressionLevel]::Optimal) | Out-Null
+    }
   }
 }
 catch {
-  # Dispose before deleting, to release the file handle. In Create mode Dispose()
-  # writes a valid central directory for whatever was added before the fault, so
-  # an undeleted partial is a well-formed but TRUNCATED archive that looks
-  # complete — the worst possible artifact to leave in dist/. Compress-Archive
-  # removed its partial output on failure; match that.
-  $archive.Dispose()
-  $archive = $null
+  # Never leave a partial behind: in Create mode Dispose() finalizes a valid
+  # central directory over whatever was written, so a survivor is a well-formed
+  # but TRUNCATED archive that looks complete -- the worst artifact to ship.
+  # Compress-Archive deletes its partial on failure; match that. Disposal and
+  # deletion are kept independent so a Dispose() that throws cannot skip the
+  # delete, and Open() itself is inside the try so its failures clean up too.
+  if ($archive) {
+    try { $archive.Dispose() } catch { }
+    $archive = $null
+  }
   if (Test-Path -LiteralPath $destination) {
     Remove-Item -LiteralPath $destination -Force
   }

--- a/scripts/Validate-ModPackage.cs
+++ b/scripts/Validate-ModPackage.cs
@@ -14,6 +14,9 @@
 // Run with: dotnet run scripts/Validate-ModPackage.cs -- <zip> <expected-version> [mod-id] [ref-dir]
 //
 // Checks:
+//   - Entry-name separators: every archive entry uses '/', never '\'. This is the
+//     check that catches issue #209 — extraction tolerates backslashes, but UMM's
+//     UPDATE path does not (see the block below for the mechanism).
 //   - Archive layout: exactly one top-level folder named <mod-id> containing the
 //     runtime DLL (FUSE.dll), Info.json, a non-empty schemas/ tree and
 //     assets/fuse_icon.png. No stray files, no *.pdb.
@@ -114,6 +117,52 @@ Directory.CreateDirectory(tempRoot);
 
 try
 {
+    // 0. Entry-name separators. ZIP APPNOTE 4.4.17.1 requires '/', but
+    // Compress-Archive under Windows PowerShell 5.1 writes '\'. Every consumer that
+    // merely EXTRACTS the archive tolerates that on Windows — including
+    // ZipFile.ExtractToDirectory a few lines below, which is why this validator was
+    // blind to it for three releases.
+    //
+    // UMM does not merely extract. When the mod is already installed, its installer
+    // rewrites every entry name (UnityModManagerApp/Mods.cs, InstallMod):
+    //
+    //     var pos = filename.IndexOf(Path.AltDirectorySeparatorChar);   // '/'
+    //     filename = replaceModDir + filename.Substring(pos, filename.Length - pos);
+    //
+    // With backslash entries pos is -1, Substring throws, and UMM aborts the unpack
+    // with "Error when unpacking '<zip>'" having written nothing. A fresh install
+    // skips the rewrite, so the archive installs but can never be UPDATED. Simulate
+    // the rewrite rather than just grepping for '\', so this check keeps testing the
+    // behaviour that actually matters. See issue #209.
+    using (var raw = ZipFile.OpenRead(zipPath))
+    {
+        var backslashed = raw.Entries
+            .Where(e => e.FullName.Contains('\\'))
+            .Select(e => e.FullName)
+            .ToList();
+        if (backslashed.Count > 0)
+        {
+            Fail($"Archive entries use '\\' separators, which breaks updating the mod through UMM: " +
+                 string.Join(", ", backslashed.Take(5)) +
+                 (backslashed.Count > 5 ? $", +{backslashed.Count - 5} more" : "") +
+                 ". Package with scripts/New-ModArchive.ps1, not Compress-Archive.");
+        }
+
+        // One aggregated finding, not one per entry: a separator regression trips
+        // every entry at once and a wall of identical failures buries the rest of
+        // the report.
+        var unrewritable = raw.Entries
+            .Where(e => e.FullName.IndexOf('/') < 0)
+            .Select(e => e.FullName)
+            .ToList();
+        if (unrewritable.Count > 0)
+        {
+            Fail($"{unrewritable.Count} archive entr{(unrewritable.Count == 1 ? "y has" : "ies have")} no '/' " +
+                 $"separator (first: '{unrewritable[0]}'), so UMM's update-path rewrite would throw " +
+                 "ArgumentOutOfRangeException and extract nothing.");
+        }
+    }
+
     ZipFile.ExtractToDirectory(zipPath, tempRoot);
 
     // 1. Layout: exactly one top-level folder, named <mod-id>.

--- a/tools/package_debug_zip.ps1
+++ b/tools/package_debug_zip.ps1
@@ -73,7 +73,10 @@ if (Test-Path -LiteralPath $zipPath) {
     Remove-Item -LiteralPath $zipPath -Force
 }
 
-Compress-Archive -Path $PackageRoot -DestinationPath $zipPath -CompressionLevel Optimal
+# Not Compress-Archive: under Windows PowerShell 5.1 it writes backslash entry
+# names, and a debug zip dropped on UMM would then fail to update an existing
+# install exactly the way the shipped ones did. See issue #209.
+& (Join-Path $RepoRoot 'scripts\New-ModArchive.ps1') -Path $PackageRoot -DestinationPath $zipPath
 
 $resolvedZip = [System.IO.Path]::GetFullPath($zipPath)
 Write-Host "Packaged: $resolvedZip"


### PR DESCRIPTION
## 🔗 Related Issue

Fixes #209 — "Reports that 1.0.2 isn't installing through UMM"

## 📝 Description of the Change

The reports are real, but the symptom was mis-stated: **installing works, updating does not**, and it has been broken since 1.0.0 rather than being a 1.0.2 regression. 1.0.1 and 1.0.2 are byte-identical in archive layout — 1.0.2 is simply the first release where enough players already had FUSE installed to hit the update path in numbers.

**Root cause.** `Compress-Archive` under Windows PowerShell 5.1 — the `shell: powershell` default on the self-hosted runner — writes zip entry names with **backslashes** (`FUSE\FUSE.dll`), violating ZIP APPNOTE 4.4.17.1. I confirmed this in the raw central directory of the published `FUSE-v1.0.1.zip` and `FUSE-v1.0.2.zip`.

That is invisible to anything that merely *extracts* the archive: `ZipFile.ExtractToDirectory` and Windows Explorer both accept `\` as a separator. UMM does not merely extract. When the mod is **already installed**, its installer rewrites every entry name (`UnityModManagerApp/Mods.cs`, `InstallMod`):

```csharp
var replaceModDir = "";
if (zip.EntriesSorted.Count(x => x.FileName.Equals(selectedGame.ModInfo, ...)) == 0)
{
    modPath = modsPath;
    if (modInstalled) { replaceModDir = modInstalled.Path.Split(Path.DirectorySeparatorChar).Last(); }
}

foreach (var entry in zip.EntriesSorted)
{
    var filename = entry.FileName;
    if (!string.IsNullOrEmpty(replaceModDir))
    {
        var pos = filename.IndexOf(Path.AltDirectorySeparatorChar);   // '/'
        filename = replaceModDir + filename.Substring(pos, filename.Length - pos);
    }
    ...
}
```

With backslash entries there is no `/`, so `pos` is `-1`, `Substring` throws `ArgumentOutOfRangeException`, and the outer `catch` aborts the unpack with *"Error when unpacking '&lt;zip&gt;'"* having written **nothing**. On a fresh install `modInstalled` is null, `replaceModDir` stays empty, the rewrite never runs, and Windows `Path.Combine` happily treats `\` as a separator — so the archive installs perfectly. Hence: install ✅, update ❌.

**The fix.** New `scripts/New-ModArchive.ps1` builds archives via `System.IO.Compression` with entry names normalised to `/`, on both PowerShell editions. It has a `-ContentsOnly` switch mirroring `Compress-Archive -Path dir\*`, preserves empty-directory entries so it is a drop-in replacement, sorts entries for reproducible output, deletes any partial archive if packaging faults mid-write, and self-checks its own output before returning. All six packaging call sites now use it:

| File | Call site |
| --- | --- |
| `.github/workflows/release.yml` | core mod zip, Live Bridge zip, Complete bundle (`-ContentsOnly`) |
| `.github/workflows/ci.yml` | CI mod zip |
| `.github/workflows/release-externaleditor.yml` | per-RID editor zips (`-ContentsOnly`) |
| `tools/package_debug_zip.ps1` | local debug zip |

**The gate.** `scripts/Validate-ModPackage.cs` gains check #0: reject backslash entry names, and simulate UMM's update-path rewrite rather than only extracting. This is the check that was *supposed* to guarantee UMM installability and could not, because it validated through `ExtractToDirectory`. CI already packages a zip and runs this validator on every PR and push, so the regression cannot come back silently.

## 🔄 Alternatives Considered

- **Ship a flat zip with `Info.json` at the archive root.** UMM's `rootInfoCount != 0` branch then sets `modPath = Mods/<Id>` and never runs the buggy rewrite, on install *or* update. Rejected: it breaks the documented manual-install path in `INSTALL.md` (extract so `FUSE/` lands in `Mods/`), would dump loose files into `Mods/` for anyone extracting by hand, and contradicts the validator's "exactly one top-level folder" layout rule. Fixing the separators keeps the layout users already know.
- **Switch the affected steps to `shell: pwsh`.** Would work today — pwsh 7's `Compress-Archive` emits forward slashes — but it leaves the archive layout dependent on which shell a workflow happens to declare, and the .NET Framework build of `ZipFile.CreateFromDirectory` has the same defect. A dedicated packer makes the guarantee explicit and shell-independent.
- **Only grep for `\` in the validator.** Kept, but paired with an actual simulation of UMM's rewrite so the check keeps testing the behaviour that matters rather than a proxy for it.

## ⚠️ Possible Drawbacks

- **Nothing ships until a release is tagged.** Players on 1.0.0–1.0.2 still cannot update through UMM until `mod-v1.0.3` goes out. Workaround for the issue thread: delete `Railroader/Mods/FUSE` first (which makes UMM treat it as a fresh install), or extract the zip by hand.
- `New-ModArchive.ps1` enumerates with `-Force`, so hidden/system files in a staging tree would now be included where `Compress-Archive` silently dropped them. No call site can produce such a file — every archived root is a purpose-built staging directory populated by explicit `Copy-Item` calls — and the direction is fail-safe: the old behaviour could have silently shipped a mod zip missing its entry assembly. `Validate-ModPackage.cs`'s stray-file allow-list remains the real constraint on archive contents.
- No save-format or runtime behaviour changes; this is packaging only. Fully backwards compatible with existing saves.
- **Out of scope, worth a follow-up:** `FUSE-Complete-v<ver>.zip` is laid out as `Mods/FUSE/...` for `FUSE-Installer.exe`. If a player drags *that* onto UMM, UMM finds the nested `Info.json` and extracts to `Mods/Mods/FUSE/`. It is documented as an optional extra, but it is the more-downloaded asset (13 vs 4 for the actual UMM zip on 1.0.2), so the naming likely deserves a second look.

## ✅ Verification Process

Everything below was run against the **actually published** `FUSE-v1.0.2.zip`, downloaded from the `mod-v1.0.2` release.

1. **Reproduced the bug with UMM's own library.** Wrote a harness replicating `InstallMod`'s rewrite verbatim using DotNetZip (`Ionic.Zip`, the library UMM uses). Against the shipped 1.0.2 zip on the update path: `pos = -1` and `ArgumentOutOfRangeException` on all 9 entries. Confirmed the backslashes at the byte level in the zip central directory for both 1.0.1 and 1.0.2.
2. **Confirmed the fresh/update asymmetry.** With `replaceModDir` empty the same harness passes every entry through untouched, matching the field reports that installing works.
3. **Repacked under both shells.** Extracted the shipped 1.0.2 payload and repackaged it with `New-ModArchive.ps1` under `powershell.exe` (Windows PowerShell 5.1, matching the runner) and `pwsh` 7. Both produced 9 forward-slash entries. Re-ran the harness on the 5.1 output: all 9 entries rewrite to the correct path.
4. **Exercised `-ContentsOnly`** against a fixture mirroring the Complete bundle. Produced `Mods/FUSE/...`, `Mods/FUSE.LiveBridge/...`, `Tools/...`, root `LICENSE`/`INSTALL.md`, with an empty directory preserved and all separators correct.
5. **Proved the gate works in both directions**, running the real validator with the game's `UnityModManager.dll` as the reference dir:
   - shipped `FUSE-v1.0.2.zip` → `FAILED (2 issues)`, exit 1, naming the separator defect.
   - rebuilt zip → `Mod package validation OK`, exit 0.
6. **Failure-path check.** Held a source file open with `FileShare.None` mid-package: the script fails loudly with exit 1 and leaves **no** partial zip behind (`ZipArchive.Dispose()` in `Create` mode would otherwise write a valid central directory, leaving a truncated archive that looks complete). Re-running unlocked succeeds.
7. **Adversarial review.** Ran a multi-agent review over the diff across four lenses (PowerShell 5.1 compatibility, call-site equivalence, validator correctness, completeness against the root cause) with independent refutation of each finding. Eight findings raised, seven refuted with concrete reproduction; the one that survived — the partial-archive-on-failure issue — is fixed in this branch and re-verified in step 6.

## 💡 Additional Information

`tools/package_debug_zip.ps1` has a separate, pre-existing problem: it resolves `FUSE.csproj`, `Info.json`, and `bin/Debug/net48` against the repo root, but those moved into `FUSE/`, so it throws "Required package input missing" before it reaches any packaging. Its `Compress-Archive` call is converted here for consistency (and the new invocation resolves correctly), but the stale paths are deliberately left alone as unrelated scope — tracked separately.
