### PR TITLE
Install FUSE on a manual run, mods on drag-drop

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,43 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel in-progress runs for the same branch/PR when a new commit lands.
+concurrency:
+  group: python-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  python-tests:
+    # Same self-hosted runner as ci.yml / release.yml / the lint workflows.
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # These tests only read the tree and write to a pytest tmp dir; nothing
+          # pushes back, so don't persist the checkout token on the runner.
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.x"
+
+      - name: Install test dependencies
+        run: pip install pytest
+
+      # Unit tests for the tools/ Python utilities — currently the FUSE installer
+      # (zip inspection, package detection, atomic install/rollback, bundled-FUSE
+      # behavior) and its tolerant legacy JSON reader.
+      - name: Run pytest
+        run: python -m pytest tools/tests -q

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.x"
+          # Match the interpreter the release build packages the exe with, so
+          # tests run against the same Python the shipped installer uses.
+          python-version: "3.12"
 
       - name: Install test dependencies
         run: pip install pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,9 +221,15 @@ jobs:
         shell: powershell
         run: .\tools\build_converter_exe.ps1
 
+      # Bundle the core mod zip built by the "Package UMM mod zip" step into the
+      # exe so a manual (double-click) run installs FUSE, while dragging a mod
+      # zip onto it installs that mod. Path passed via env rather than ${{ }}
+      # expansion, consistent with the hardening elsewhere in this workflow.
       - name: Build FUSE-Installer.exe
         shell: powershell
-        run: .\tools\build_installer_exe.ps1
+        env:
+          FUSE_PAYLOAD: ${{ steps.package.outputs.archive_path }}
+        run: .\tools\build_installer_exe.ps1 -FusePayload "$env:FUSE_PAYLOAD"
 
       - name: Build FUSEConvertFolder.pyz
         run: python tools/build_folder_converter_pyz.py

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@ TestResults/
 /_work
 /dist
 /tools/__pycache__/
+/tools/tests/__pycache__/
 /scripts/__pycache__/
+.pytest_cache/
 
 # Release workflow scratch space
 /staging/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,25 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- `FUSE-Installer.exe` now bundles the FUSE framework and installs it on a
+  manual (double-click) run, so players can get FUSE running without unzipping
+  anything. Dragging mod `.zip` files onto the exe still installs exactly those
+  mods and leaves FUSE untouched. A no-argument run also still processes any
+  loose zips beside the exe; pass `--no-fuse` to skip installing FUSE. The
+  release build bundles the core mod zip it just built and self-checks, via a
+  dry run, that a manual run will install FUSE.
+- A pytest suite for the installer and its legacy JSON reader
+  (`tools/tests/`), run in CI by a new Python Tests workflow.
+
+### Fixed
+
+- The installer now extracts each package into a staging directory and swaps it
+  into place only after a fully successful extraction. A failure partway through
+  (a locked file, a bad path, a full disk) no longer leaves a half-written mod
+  folder behind, and a failed `--replace` reinstall leaves the existing install
+  untouched.
 
 ## [1.0.2]
 

--- a/docs/FUSE_INSTALLER.md
+++ b/docs/FUSE_INSTALLER.md
@@ -4,6 +4,20 @@
 `Mods` directory. It is designed for a bundled `FUSE-Installer.exe`, so users can
 drop zip files beside the executable and run it from the base folder.
 
+The published `FUSE-Installer.exe` carries the FUSE framework inside it, so it
+works two ways:
+
+- **Double-click it (no arguments): it installs FUSE.** This is the easiest way
+  for a player to get FUSE running.
+- **Drag one or more mod `.zip` files onto it: it installs those mods.** A
+  drag-and-drop run installs exactly the mods you dropped and does not touch
+  FUSE.
+
+A no-argument run also installs any loose `.zip` files sitting beside the exe (in
+addition to FUSE), so the "drop several zips in the folder and run once" workflow
+still works. FUSE is skipped if it is already installed. Pass `--no-fuse` to
+process only the loose zips without (re)installing FUSE.
+
 ## Download
 
 The published `FUSE-Installer.exe` is distributed via GitHub Releases:
@@ -24,10 +38,16 @@ execute, or depend on any package code.
 
 ## User flow
 
+To install FUSE:
+
 1. Put `FUSE-Installer.exe` in the base folder.
-2. Drop one or more `.zip` files in that same folder.
-3. Run `FUSE-Installer.exe`.
-4. The installer writes packages to `Mods\<package id>`.
+2. Double-click it.
+3. FUSE is written to `Mods\FUSE`.
+
+To install a mod:
+
+1. Drag its `.zip` onto `FUSE-Installer.exe` (or drop several at once).
+2. Each package is written to `Mods\<package id>`.
 
 Existing folders are skipped by default. Run with `--replace` to move an existing
 folder into `Mods\ModBackups\FUSEInstaller\<timestamp>` before installing the new
@@ -80,3 +100,19 @@ powershell -ExecutionPolicy Bypass -File .\tools\build_installer_exe.ps1 -Instal
 ```
 
 The output is `dist\FUSE-Installer.exe`.
+
+### Bundling FUSE into the exe
+
+Pass `-FusePayload` with the core FUSE mod zip (the `FUSE-v*.zip` produced by the
+release build) to bundle FUSE inside the exe. A manual run of that exe then
+installs FUSE:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\tools\build_installer_exe.ps1 -FusePayload .\FUSE-v1.0.2.zip
+```
+
+The release workflow does this automatically, passing the zip it just built. If
+you build without `-FusePayload`, the exe still installs mods from dragged zips,
+but a no-argument run has no FUSE to install and reports that instead. After a
+bundled build, the script runs a `--dry-run` self-check to confirm a manual run
+would install FUSE.

--- a/docs/FUSE_INSTALLER.md
+++ b/docs/FUSE_INSTALLER.md
@@ -15,8 +15,9 @@ works two ways:
 
 A no-argument run also installs any loose `.zip` files sitting beside the exe (in
 addition to FUSE), so the "drop several zips in the folder and run once" workflow
-still works. FUSE is skipped if it is already installed. Pass `--no-fuse` to
-process only the loose zips without (re)installing FUSE.
+still works. FUSE is skipped by default if it is already installed; pass
+`--replace` to back up and reinstall it. Pass `--no-fuse` to process only the
+loose zips without (re)installing FUSE.
 
 ## Download
 

--- a/tools/build_installer_exe.ps1
+++ b/tools/build_installer_exe.ps1
@@ -156,8 +156,11 @@ if (-not [string]::IsNullOrWhiteSpace($BundledFuse)) {
     if ($selfExit -ne 0) {
         throw "Self-check failed (exit=$selfExit): bundled FUSE dry-run did not succeed."
     }
-    if ("$selfOutput" -notmatch 'FUSE') {
-        throw "Self-check failed: bundled FUSE was not detected in the dry-run output."
+    # Match the inspected package id, not just the word FUSE (which also appears
+    # in the static "bundled FUSE:" / "FUSE:" output labels), so a non-FUSE
+    # payload can't silently pass the self-check.
+    if ("$selfOutput" -notmatch 'id=FUSE(\s|$)') {
+        throw "Self-check failed: bundled package is not FUSE (id=FUSE missing from dry-run output)."
     }
     Write-Host "Self-check passed: a manual run will install FUSE."
 }

--- a/tools/build_installer_exe.ps1
+++ b/tools/build_installer_exe.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding()]
 param(
     [string]$OutputDir = "",
+    [string]$FusePayload = "",
     [switch]$InstallPyInstaller
 )
 
@@ -96,12 +97,32 @@ foreach ($mod in $HiddenImports) {
     $args += $mod
 }
 
+# Bundle the FUSE mod zip into the exe so a manual (no-argument) run installs
+# FUSE. PyInstaller's onefile bundle unpacks this to sys._MEIPASS at runtime,
+# where fuse_installer.resolve_bundled_fuse() picks it up as bundled_fuse.zip.
+$BundledFuse = ''
+if (-not [string]::IsNullOrWhiteSpace($FusePayload)) {
+    if (-not (Test-Path -LiteralPath $FusePayload)) {
+        throw "FUSE payload not found: $FusePayload"
+    }
+    $BundledFuse = Join-Path $WorkDir 'bundled_fuse.zip'
+    Copy-Item -LiteralPath $FusePayload -Destination $BundledFuse -Force
+    # On Windows, --add-data separates the source and destination with ';'.
+    $args += '--add-data'
+    $args += "$BundledFuse;."
+}
+else {
+    Write-Host "WARNING: no -FusePayload given; the exe will NOT self-install FUSE on a manual run."
+    Write-Host "         Pass -FusePayload <path to FUSE-v*.zip> to enable that."
+}
+
 $args += $EntryScript
 
 Write-Host "Building FUSE-Installer.exe..."
 Write-Host "  entry:   $EntryScript"
 Write-Host "  out:     $OutputDir"
 Write-Host "  hidden:  $($HiddenImports -join ', ')"
+Write-Host "  bundled: $(if ($BundledFuse) { $FusePayload } else { '(none)' })"
 
 $buildExit = Invoke-InstallerPython @args
 if ($buildExit -ne 0) {
@@ -119,6 +140,26 @@ $smokeExit = $LASTEXITCODE
 if ($smokeExit -ne 0) {
     Write-Host $smokeOutput
     throw "Smoke check failed (exit=$smokeExit)."
+}
+
+# Self-check: prove that a manual (no-argument) run will actually install FUSE.
+# Uses --dry-run against a throwaway game dir so nothing is written; asserts the
+# bundled payload is detected and resolves to a FUSE install.
+if (-not [string]::IsNullOrWhiteSpace($BundledFuse)) {
+    Write-Host "Self-check: dry-run install of bundled FUSE..."
+    $ProbeDir = Join-Path $WorkDir 'selfcheck'
+    if (Test-Path $ProbeDir) { Remove-Item $ProbeDir -Recurse -Force }
+    New-Item -ItemType Directory -Force -Path $ProbeDir | Out-Null
+    $selfOutput = & $exePath --dry-run --no-pause --game-dir $ProbeDir 2>&1
+    $selfExit = $LASTEXITCODE
+    Write-Host $selfOutput
+    if ($selfExit -ne 0) {
+        throw "Self-check failed (exit=$selfExit): bundled FUSE dry-run did not succeed."
+    }
+    if ("$selfOutput" -notmatch 'FUSE') {
+        throw "Self-check failed: bundled FUSE was not detected in the dry-run output."
+    }
+    Write-Host "Self-check passed: a manual run will install FUSE."
 }
 
 Write-Host "Built: $exePath"

--- a/tools/build_installer_exe.ps1
+++ b/tools/build_installer_exe.ps1
@@ -102,8 +102,10 @@ foreach ($mod in $HiddenImports) {
 # where fuse_installer.resolve_bundled_fuse() picks it up as bundled_fuse.zip.
 $BundledFuse = ''
 if (-not [string]::IsNullOrWhiteSpace($FusePayload)) {
-    if (-not (Test-Path -LiteralPath $FusePayload)) {
-        throw "FUSE payload not found: $FusePayload"
+    # -PathType Leaf so a directory can't slip through (Copy-Item would then make
+    # bundled_fuse.zip a folder instead of the zip file).
+    if (-not (Test-Path -LiteralPath $FusePayload -PathType Leaf)) {
+        throw "FUSE payload not found or not a file: $FusePayload"
     }
     $BundledFuse = Join-Path $WorkDir 'bundled_fuse.zip'
     Copy-Item -LiteralPath $FusePayload -Destination $BundledFuse -Force
@@ -143,26 +145,32 @@ if ($smokeExit -ne 0) {
 }
 
 # Self-check: prove that a manual (no-argument) run will actually install FUSE.
-# Uses --dry-run against a throwaway game dir so nothing is written; asserts the
-# bundled payload is detected and resolves to a FUSE install.
+# Runs a REAL install (not --dry-run) into a throwaway game dir, so the check
+# exercises zip extraction and file writes — catching unreadable members or
+# write-path failures — and then asserts the mod actually landed on disk.
 if (-not [string]::IsNullOrWhiteSpace($BundledFuse)) {
-    Write-Host "Self-check: dry-run install of bundled FUSE..."
+    Write-Host "Self-check: installing bundled FUSE into a throwaway dir..."
     $ProbeDir = Join-Path $WorkDir 'selfcheck'
     if (Test-Path $ProbeDir) { Remove-Item $ProbeDir -Recurse -Force }
     New-Item -ItemType Directory -Force -Path $ProbeDir | Out-Null
-    $selfOutput = & $exePath --dry-run --no-pause --game-dir $ProbeDir 2>&1
+    $selfOutput = & $exePath --no-pause --game-dir $ProbeDir 2>&1
     $selfExit = $LASTEXITCODE
     Write-Host $selfOutput
     if ($selfExit -ne 0) {
-        throw "Self-check failed (exit=$selfExit): bundled FUSE dry-run did not succeed."
+        throw "Self-check failed (exit=$selfExit): bundled FUSE install did not succeed."
     }
     # Match the inspected package id, not just the word FUSE (which also appears
     # in the static "bundled FUSE:" / "FUSE:" output labels), so a non-FUSE
     # payload can't silently pass the self-check.
     if ("$selfOutput" -notmatch 'id=FUSE(\s|$)') {
-        throw "Self-check failed: bundled package is not FUSE (id=FUSE missing from dry-run output)."
+        throw "Self-check failed: bundled package is not FUSE (id=FUSE missing from install output)."
     }
-    Write-Host "Self-check passed: a manual run will install FUSE."
+    # Confirm extraction actually wrote the mod to disk.
+    $installedInfo = Join-Path $ProbeDir 'Mods\FUSE\Info.json'
+    if (-not (Test-Path -LiteralPath $installedInfo -PathType Leaf)) {
+        throw "Self-check failed: expected $installedInfo after installing bundled FUSE."
+    }
+    Write-Host "Self-check passed: a manual run installs FUSE to Mods\FUSE."
 }
 
 Write-Host "Built: $exePath"

--- a/tools/fuse_installer.py
+++ b/tools/fuse_installer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import sys
@@ -27,7 +28,8 @@ if str(SCRIPT_DIR) not in sys.path:
 import legacy_json  # noqa: E402
 
 
-TOOL_VERSION = "0.1.0"
+TOOL_VERSION = "0.2.0"
+BUNDLED_FUSE_NAME = "bundled_fuse.zip"
 MANIFEST_NAMES = {"info.json", "definition.json"}
 LEGACY_DATA_KEYS = {
     "tracks",
@@ -388,27 +390,80 @@ def install_package(package: ZipPackage, mods_dir: Path, replace: bool, dry_run:
     destination = mods_dir / package.install_name
     backup: Path | None = None
 
-    if destination.exists():
-        if not replace:
-            return InstallResult(package, "skipped", destination, "destination already exists")
+    if destination.exists() and not replace:
+        return InstallResult(package, "skipped", destination, "destination already exists")
 
+    if dry_run:
+        return InstallResult(package, "installed", destination, "dry run", None)
+
+    mods_dir.mkdir(parents=True, exist_ok=True)
+    staging_root = mods_dir / "FUSEInstaller" / "staging"
+    staging_root.mkdir(parents=True, exist_ok=True)
+    staging = unique_path(staging_root / package.install_name)
+
+    # Extract fully into a staging directory first. If any member fails to
+    # write, discard the partial staging copy and re-raise: an existing install
+    # is never touched, and a fresh one is never left half-written for the game
+    # to load.
+    try:
+        extract_package(package, staging)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    # Extraction succeeded. Back up any existing install, then swap staging into
+    # place with a rename on the same filesystem (atomic on Windows and POSIX).
+    if destination.exists():
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
         backup_root = mods_dir / "ModBackups" / "FUSEInstaller" / timestamp
         backup = unique_path(backup_root / destination.name)
-        if not dry_run:
-            backup.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(destination), str(backup))
+        backup.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(destination), str(backup))
 
-    if not dry_run:
-        extract_package(package, destination)
+    try:
+        shutil.move(str(staging), str(destination))
+    except BaseException:
+        # The swap failed after the old install was moved aside; restore it so
+        # the mod is never left uninstalled, and drop the staging copy.
+        shutil.rmtree(staging, ignore_errors=True)
+        if backup is not None and not destination.exists():
+            shutil.move(str(backup), str(destination))
+            backup = None
+        raise
 
-    return InstallResult(package, "installed", destination, "dry run" if dry_run else "", backup)
+    return InstallResult(package, "installed", destination, "", backup)
 
 
 def default_game_dir() -> Path:
     if getattr(sys, "frozen", False):
         return Path(sys.executable).resolve().parent
     return Path.cwd().resolve()
+
+
+def resolve_bundled_fuse() -> Path | None:
+    """Locate the FUSE mod zip bundled into the exe (or supplied for testing).
+
+    Resolution order:
+      1. FUSE_INSTALLER_BUNDLED_ZIP env var (dev/testing and advanced use).
+      2. PyInstaller's extraction dir (sys._MEIPASS) for the frozen exe.
+      3. A bundled_fuse.zip sitting beside this script.
+    """
+    override = os.environ.get("FUSE_INSTALLER_BUNDLED_ZIP", "").strip()
+    if override:
+        candidate = Path(override).expanduser()
+        return candidate.resolve() if candidate.exists() else None
+
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        candidate = Path(meipass) / BUNDLED_FUSE_NAME
+        if candidate.exists():
+            return candidate.resolve()
+
+    sibling = SCRIPT_DIR / BUNDLED_FUSE_NAME
+    if sibling.exists():
+        return sibling.resolve()
+
+    return None
 
 
 def find_input_zips(args: argparse.Namespace, default_inbox: Path) -> list[Path]:
@@ -455,13 +510,18 @@ def print_result(result: InstallResult) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Install FUSE data packages and UMM mod packages from zip files.",
+        description=(
+            "Install FUSE and mod packages. Run it with no arguments to install "
+            "the bundled FUSE framework; drag mod .zip files onto it (or pass them "
+            "as arguments) to install those mods."
+        ),
     )
     parser.add_argument("zips", nargs="*", help="Zip files to install. Drag-and-drop works on Windows.")
     parser.add_argument("--game-dir", default=None, help="Base folder. Default is this exe's folder, or the current directory when run as a script.")
     parser.add_argument("--mods-dir", default=None, help="Mods folder. Default is <base folder>\\Mods.")
     parser.add_argument("--inbox", default=None, help="Folder to scan for zip files when no zip arguments are passed.")
     parser.add_argument("--replace", action="store_true", help="Backup and replace existing mod folders.")
+    parser.add_argument("--no-fuse", action="store_true", help="Do not install the bundled FUSE framework on a manual run; only process zip files.")
     parser.add_argument("--dry-run", action="store_true", help="Inspect zips and print planned installs without writing files.")
     parser.add_argument("--archive-zips", action="store_true", help="Move successfully processed zips to Mods\\FUSEInstaller\\InstalledZips.")
     parser.add_argument("--pause", action="store_true", help="Pause before closing.")
@@ -473,7 +533,23 @@ def build_parser() -> argparse.ArgumentParser:
 def run(args: argparse.Namespace) -> int:
     game_dir = Path(args.game_dir).resolve() if args.game_dir else default_game_dir()
     mods_dir = Path(args.mods_dir).resolve() if args.mods_dir else (game_dir / "Mods").resolve()
+
+    explicit = bool(args.zips)
     zips = find_input_zips(args, game_dir)
+
+    # Manual run (no zip arguments): install the FUSE framework bundled into the
+    # exe, alongside any loose zips found beside it. Dragging specific zips onto
+    # the exe installs exactly those and never force-installs FUSE.
+    bundle_on_disk = resolve_bundled_fuse()
+    bundled_fuse = bundle_on_disk if (not explicit and not args.no_fuse) else None
+
+    targets: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in ([bundled_fuse] if bundled_fuse else []) + zips:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        targets.append(candidate)
 
     print(f"FUSE Installer {TOOL_VERSION}")
     print(f"base: {game_dir}")
@@ -482,10 +558,15 @@ def run(args: argparse.Namespace) -> int:
         print("mode: dry run")
     if args.replace:
         print("replace: enabled")
+    if bundled_fuse is not None:
+        print(f"bundled FUSE: {bundled_fuse.name}")
     print()
 
-    if not zips:
-        print("No zip files were found.")
+    if not targets:
+        if not explicit and not args.no_fuse and bundle_on_disk is None:
+            print("No zip files were found, and this build has no bundled FUSE payload.")
+        else:
+            print("No zip files were found.")
         return 1
 
     if not args.dry_run:
@@ -493,8 +574,9 @@ def run(args: argparse.Namespace) -> int:
 
     all_results: list[InstallResult] = []
     scan_failures = 0
-    for zip_path in zips:
-        print(f"ZIP: {zip_path}")
+    for zip_path in targets:
+        label = "FUSE" if zip_path == bundled_fuse else "ZIP"
+        print(f"{label}: {zip_path}")
         if not zip_path.exists():
             print("  error: file does not exist")
             scan_failures += 1
@@ -520,7 +602,9 @@ def run(args: argparse.Namespace) -> int:
         print()
 
         zip_results = [result for result in all_results if result.package.zip_path == zip_path]
-        if args.archive_zips and zip_results and not any(result.status == "failed" for result in zip_results):
+        # Never archive the bundled FUSE payload: it lives inside the PyInstaller
+        # extraction dir, not beside the exe.
+        if args.archive_zips and zip_path != bundled_fuse and zip_results and not any(result.status == "failed" for result in zip_results):
             archived_to = archive_zip(zip_path, mods_dir, args.dry_run)
             verb = "Would archive" if args.dry_run else "Archived"
             print(f"{verb}: {zip_path} -> {archived_to}")

--- a/tools/fuse_installer.py
+++ b/tools/fuse_installer.py
@@ -397,7 +397,10 @@ def install_package(package: ZipPackage, mods_dir: Path, replace: bool, dry_run:
         return InstallResult(package, "installed", destination, "dry run", None)
 
     mods_dir.mkdir(parents=True, exist_ok=True)
-    staging_root = mods_dir / "FUSEInstaller" / "staging"
+    # A hidden staging root that safe_folder_name() can never produce (it strips
+    # leading dots), so it can never equal a package's own install destination —
+    # e.g. a package whose id is "FUSEInstaller".
+    staging_root = mods_dir / ".fuse-installer-staging"
     staging_root.mkdir(parents=True, exist_ok=True)
     staging = unique_path(staging_root / package.install_name)
 

--- a/tools/tests/conftest.py
+++ b/tools/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Test configuration for the tools/ Python utilities.
+
+Puts tools/ on sys.path so tests can `import fuse_installer` / `import
+legacy_json` the same way the installer imports its sibling module at runtime.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parent.parent
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))

--- a/tools/tests/test_fuse_installer.py
+++ b/tools/tests/test_fuse_installer.py
@@ -1,0 +1,342 @@
+"""Tests for fuse_installer: zip inspection, package detection, and install.
+
+These exercise the bug-prone logic (path safety, root detection, atomic
+install/rollback) and the bundled-FUSE behavior that makes a manual run install
+FUSE while a drag-and-drop run installs only the dropped mods.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import fuse_installer as fi
+
+
+def make_zip(path: Path, files: dict[str, str | bytes]) -> Path:
+    """Write a zip whose members are given as archive-name -> contents."""
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, content in files.items():
+            data = content.encode("utf-8") if isinstance(content, str) else content
+            archive.writestr(name, data)
+    return path
+
+
+def info(**fields) -> str:
+    return json.dumps(fields)
+
+
+def tree(base: Path) -> list[str]:
+    if not base.exists():
+        return []
+    return sorted(
+        str(p.relative_to(base)).replace("\\", "/") for p in base.rglob("*") if p.is_file()
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Path safety
+# --------------------------------------------------------------------------- #
+
+def test_normalize_zip_parts_accepts_normal():
+    assert fi.normalize_zip_parts("Mod/Info.json") == ("Mod", "Info.json")
+    assert fi.normalize_zip_parts("Mod\\sub\\file.txt") == ("Mod", "sub", "file.txt")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "../escape.txt",
+        "Mod/../../escape.txt",
+        "/abs/path.txt",
+        "C:/drive/path.txt",
+        "Mod/bad\x00name.txt",
+        "Mod/na:me.txt",
+        "",
+        "dir/",
+    ],
+)
+def test_normalize_zip_parts_rejects_unsafe(name):
+    assert fi.normalize_zip_parts(name) is None
+
+
+def test_ensure_inside_blocks_escape(tmp_path):
+    root = tmp_path / "dest"
+    root.mkdir()
+    fi.ensure_inside(root / "ok" / "file.txt", root)  # no raise
+    with pytest.raises(RuntimeError):
+        fi.ensure_inside(tmp_path / "outside.txt", root)
+
+
+# --------------------------------------------------------------------------- #
+# Name and id helpers
+# --------------------------------------------------------------------------- #
+
+def test_safe_folder_name_sanitizes_and_trims():
+    assert fi.safe_folder_name('a<b>c:"d"|e?f*g') == "a-b-c-d-e-f-g"
+    assert fi.safe_folder_name("  ...spaces...  ") == "spaces"
+    assert fi.safe_folder_name("") == "InstalledPackage"
+
+
+def test_safe_folder_name_reserved_windows_name():
+    assert fi.safe_folder_name("nul") == "nul-package"
+    assert fi.safe_folder_name("con") == "con-package"
+
+
+def test_ensure_fuse_id_appends_suffix():
+    assert fi.ensure_fuse_id("MyPack") == "MyPack.FUSE"
+    assert fi.ensure_fuse_id("Already.FUSE") == "Already.FUSE"
+    assert fi.ensure_fuse_id("") == "LegacyDataPackage.FUSE"
+
+
+# --------------------------------------------------------------------------- #
+# Root detection
+# --------------------------------------------------------------------------- #
+
+def test_candidate_roots_prefers_root_level_manifest(tmp_path):
+    zip_path = make_zip(tmp_path / "z.zip", {"Info.json": info(Id="X"), "extra.txt": "x"})
+    with zipfile.ZipFile(zip_path) as archive:
+        roots = fi.candidate_roots(fi.zip_file_parts(archive))
+    assert roots == [()]
+
+
+def test_candidate_roots_multi_package(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {
+            "Mods/PkgA/Info.json": info(Id="PkgA"),
+            "Mods/PkgB/Info.json": info(Id="PkgB"),
+        },
+    )
+    with zipfile.ZipFile(zip_path) as archive:
+        roots = fi.candidate_roots(fi.zip_file_parts(archive))
+    assert ("Mods", "PkgA") in roots and ("Mods", "PkgB") in roots
+
+
+# --------------------------------------------------------------------------- #
+# Package detection
+# --------------------------------------------------------------------------- #
+
+def test_inspect_umm_package(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {"MyMod/Info.json": info(Id="MyMod", DisplayName="My Mod", Version="1.2.3")},
+    )
+    packages, warnings = fi.inspect_zip(zip_path)
+    assert warnings == []
+    assert len(packages) == 1
+    pkg = packages[0]
+    assert pkg.kind == "umm"
+    assert pkg.package_id == "MyMod"
+    assert pkg.install_name == "MyMod"
+    assert pkg.version == "1.2.3"
+
+
+def test_inspect_fuse_data_package(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {"Data/Info.json": info(Id="DataPack", Requirements=[{"Id": "FUSE"}])},
+    )
+    packages, _ = fi.inspect_zip(zip_path)
+    assert packages[0].kind == "fuse-data"
+
+
+def test_inspect_legacy_data_package(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {
+            "Legacy/Definition.json": info(id="OldPack", name="Old Pack"),
+            "Legacy/world.json": json.dumps({"tracks": [{"id": 1}]}),
+        },
+    )
+    packages, _ = fi.inspect_zip(zip_path)
+    assert len(packages) == 1
+    pkg = packages[0]
+    assert pkg.kind == "legacy-data"
+    assert pkg.package_id == "OldPack.FUSE"
+
+
+def test_inspect_unsupported_zip_warns(tmp_path):
+    zip_path = make_zip(tmp_path / "z.zip", {"random/file.txt": "nothing here"})
+    packages, warnings = fi.inspect_zip(zip_path)
+    assert packages == []
+    assert warnings
+
+
+# --------------------------------------------------------------------------- #
+# Install / skip / replace / dry-run
+# --------------------------------------------------------------------------- #
+
+def install_one(zip_path: Path, mods_dir: Path, replace=False, dry_run=False) -> fi.InstallResult:
+    packages, _ = fi.inspect_zip(zip_path)
+    assert len(packages) == 1
+    return fi.install_package(packages[0], mods_dir, replace=replace, dry_run=dry_run)
+
+
+def test_install_writes_files(tmp_path):
+    mods = tmp_path / "Mods"
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {"MyMod/Info.json": info(Id="MyMod"), "MyMod/mod.dll": b"\x00binary"},
+    )
+    result = install_one(zip_path, mods)
+    assert result.status == "installed"
+    assert (mods / "MyMod" / "Info.json").exists()
+    assert (mods / "MyMod" / "mod.dll").read_bytes() == b"\x00binary"
+
+
+def test_install_skips_existing(tmp_path):
+    mods = tmp_path / "Mods"
+    zip_path = make_zip(tmp_path / "z.zip", {"MyMod/Info.json": info(Id="MyMod")})
+    install_one(zip_path, mods)
+    result = install_one(zip_path, mods)
+    assert result.status == "skipped"
+
+
+def test_replace_backs_up_then_installs(tmp_path):
+    mods = tmp_path / "Mods"
+    dest = mods / "MyMod"
+    dest.mkdir(parents=True)
+    (dest / "old.txt").write_text("old content")
+
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {"MyMod/Info.json": info(Id="MyMod"), "MyMod/new.txt": "new content"},
+    )
+    result = install_one(zip_path, mods, replace=True)
+    assert result.status == "installed"
+    assert (dest / "new.txt").read_text() == "new content"
+    assert not (dest / "old.txt").exists()  # replaced, not merged
+    assert result.backup is not None
+    assert (result.backup / "old.txt").read_text() == "old content"
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    mods = tmp_path / "Mods"
+    zip_path = make_zip(tmp_path / "z.zip", {"MyMod/Info.json": info(Id="MyMod")})
+    result = install_one(zip_path, mods, dry_run=True)
+    assert result.status == "installed"
+    assert not mods.exists()
+
+
+# --------------------------------------------------------------------------- #
+# Atomic extraction / rollback
+# --------------------------------------------------------------------------- #
+
+def _fail_on_second_write(monkeypatch):
+    """Let the first member write, then fail — simulating a mid-extract error."""
+    real = fi.shutil.copyfileobj
+    calls = {"n": 0}
+
+    def flaky(src, dst, *a, **k):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            raise RuntimeError("simulated write failure")
+        return real(src, dst, *a, **k)
+
+    monkeypatch.setattr(fi.shutil, "copyfileobj", flaky)
+
+
+def test_failed_fresh_install_leaves_no_partial_folder(tmp_path, monkeypatch):
+    mods = tmp_path / "Mods"
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {"MyMod/Info.json": info(Id="MyMod"), "MyMod/a.txt": "a", "MyMod/b.txt": "b"},
+    )
+    packages, _ = fi.inspect_zip(zip_path)
+    _fail_on_second_write(monkeypatch)
+
+    with pytest.raises(RuntimeError):
+        fi.install_package(packages[0], mods, replace=False, dry_run=False)
+
+    # No half-written mod folder for the game to load, and no staging leftovers.
+    assert not (mods / "MyMod").exists()
+    assert tree(mods) == []
+
+
+def test_failed_replace_preserves_existing_install(tmp_path, monkeypatch):
+    mods = tmp_path / "Mods"
+    dest = mods / "MyMod"
+    dest.mkdir(parents=True)
+    (dest / "keep.txt").write_text("original")
+
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {"MyMod/Info.json": info(Id="MyMod"), "MyMod/a.txt": "a", "MyMod/b.txt": "b"},
+    )
+    packages, _ = fi.inspect_zip(zip_path)
+    _fail_on_second_write(monkeypatch)
+
+    with pytest.raises(RuntimeError):
+        fi.install_package(packages[0], mods, replace=True, dry_run=False)
+
+    # The existing install must survive a failed reinstall untouched.
+    assert (dest / "keep.txt").read_text() == "original"
+
+
+# --------------------------------------------------------------------------- #
+# Bundled FUSE resolution
+# --------------------------------------------------------------------------- #
+
+def test_resolve_bundled_fuse_env_override(tmp_path, monkeypatch):
+    payload = make_zip(tmp_path / "FUSE.zip", {"FUSE/Info.json": info(Id="FUSE")})
+    monkeypatch.setenv("FUSE_INSTALLER_BUNDLED_ZIP", str(payload))
+    assert fi.resolve_bundled_fuse() == payload.resolve()
+
+
+def test_resolve_bundled_fuse_absent(tmp_path, monkeypatch):
+    monkeypatch.delenv("FUSE_INSTALLER_BUNDLED_ZIP", raising=False)
+    monkeypatch.setattr(fi, "SCRIPT_DIR", tmp_path)  # no sibling bundled_fuse.zip
+    monkeypatch.delattr(fi.sys, "_MEIPASS", raising=False)
+    assert fi.resolve_bundled_fuse() is None
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end run(): the two headline behaviors
+# --------------------------------------------------------------------------- #
+
+def make_fuse_payload(tmp_path: Path) -> Path:
+    return make_zip(
+        tmp_path / "FUSE-vX.zip",
+        {"FUSE/Info.json": info(Id="FUSE", DisplayName="FUSE"), "FUSE/FUSE.dll": b"dll"},
+    )
+
+
+def run_installer(argv):
+    args = fi.build_parser().parse_args(argv)
+    return fi.run(args)
+
+
+def test_run_no_args_installs_bundled_fuse(tmp_path, monkeypatch):
+    game = tmp_path / "game"
+    game.mkdir()
+    monkeypatch.setenv("FUSE_INSTALLER_BUNDLED_ZIP", str(make_fuse_payload(tmp_path)))
+
+    rc = run_installer(["--no-pause", "--game-dir", str(game)])
+    assert rc == 0
+    assert (game / "Mods" / "FUSE" / "FUSE.dll").exists()
+
+
+def test_run_drag_zip_installs_only_that_mod(tmp_path, monkeypatch):
+    game = tmp_path / "game"
+    game.mkdir()
+    monkeypatch.setenv("FUSE_INSTALLER_BUNDLED_ZIP", str(make_fuse_payload(tmp_path)))
+    mod = make_zip(tmp_path / "MyMod.zip", {"MyMod/Info.json": info(Id="MyMod")})
+
+    rc = run_installer([str(mod), "--no-pause", "--game-dir", str(game)])
+    assert rc == 0
+    assert (game / "Mods" / "MyMod").exists()
+    assert not (game / "Mods" / "FUSE").exists()  # drag-drop never force-installs FUSE
+
+
+def test_run_no_fuse_flag_skips_bundled_fuse(tmp_path, monkeypatch):
+    game = tmp_path / "game"
+    game.mkdir()
+    monkeypatch.setenv("FUSE_INSTALLER_BUNDLED_ZIP", str(make_fuse_payload(tmp_path)))
+
+    rc = run_installer(["--no-fuse", "--no-pause", "--game-dir", str(game)])
+    assert rc == 1  # nothing to do
+    assert not (game / "Mods" / "FUSE").exists()

--- a/tools/tests/test_fuse_installer.py
+++ b/tools/tests/test_fuse_installer.py
@@ -214,6 +214,20 @@ def test_replace_backs_up_then_installs(tmp_path):
     assert (result.backup / "old.txt").read_text() == "old content"
 
 
+def test_install_name_colliding_with_staging_dir(tmp_path):
+    # A package whose id is "FUSEInstaller" must still install to Mods/FUSEInstaller
+    # and not collide with the installer's internal staging directory.
+    mods = tmp_path / "Mods"
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {"FUSEInstaller/Info.json": info(Id="FUSEInstaller"), "FUSEInstaller/x.txt": "x"},
+    )
+    result = install_one(zip_path, mods)
+    assert result.status == "installed"
+    assert (mods / "FUSEInstaller" / "Info.json").exists()
+    assert (mods / "FUSEInstaller" / "x.txt").read_text() == "x"
+
+
 def test_dry_run_writes_nothing(tmp_path):
     mods = tmp_path / "Mods"
     zip_path = make_zip(tmp_path / "z.zip", {"MyMod/Info.json": info(Id="MyMod")})

--- a/tools/tests/test_legacy_json.py
+++ b/tools/tests/test_legacy_json.py
@@ -1,0 +1,68 @@
+"""Tests for legacy_json, the tolerant JSON reader for legacy mod data."""
+
+from __future__ import annotations
+
+import json
+
+import legacy_json
+
+
+def test_plain_json_round_trips():
+    assert legacy_json.loads('{"a": 1, "b": [2, 3]}') == {"a": 1, "b": [2, 3]}
+
+
+def test_strip_line_and_block_comments():
+    text = """
+    {
+        // a line comment
+        "a": 1, /* inline block */
+        "b": 2
+        /* trailing
+           block */
+    }
+    """
+    assert legacy_json.loads(text) == {"a": 1, "b": 2}
+
+
+def test_comment_markers_inside_strings_are_preserved():
+    # A // or /* inside a string value must survive untouched.
+    text = '{"url": "http://example.com/x", "path": "a/*not a comment*/b"}'
+    assert legacy_json.loads(text) == {
+        "url": "http://example.com/x",
+        "path": "a/*not a comment*/b",
+    }
+
+
+def test_remove_trailing_commas_object_and_array():
+    assert legacy_json.remove_trailing_commas('{"a": 1,}') == '{"a": 1}'
+    assert legacy_json.remove_trailing_commas("[1, 2, 3, ]") == "[1, 2, 3]"
+
+
+def test_trailing_commas_loads():
+    assert legacy_json.loads('{"a": [1, 2, 3,], "b": 4,}') == {"a": [1, 2, 3], "b": 4}
+
+
+def test_close_unbalanced_truncated_object():
+    # Truncated after the last real entry, with no closing brace.
+    repaired = legacy_json.close_unbalanced_json('{"id": "Trunc", "name": "T"')
+    assert json.loads(repaired) == {"id": "Trunc", "name": "T"}
+
+
+def test_close_unbalanced_nested_stack():
+    repaired = legacy_json.close_unbalanced_json('{"a": {"b": [1, 2')
+    assert json.loads(repaired) == {"a": {"b": [1, 2]}}
+
+
+def test_loads_repairs_truncation_end_to_end():
+    # Comments + trailing comma + truncation together, as seen in the wild.
+    text = '{\n  // legacy\n  "id": "Trunc",\n  "tracks": [1, 2,'
+    assert legacy_json.loads(text) == {"id": "Trunc", "tracks": [1, 2]}
+
+
+def test_repair_disabled_raises_on_truncation():
+    try:
+        legacy_json.loads('{"id": "Trunc"', repair=False)
+    except json.JSONDecodeError:
+        pass
+    else:
+        raise AssertionError("expected JSONDecodeError with repair disabled")


### PR DESCRIPTION
## What

Makes `FUSE-Installer.exe` do the two things users expect:

- **Double-click it (no arguments) → installs FUSE.** The exe now bundles the FUSE framework and lays it down in `Mods\FUSE`, so a player can get FUSE running without unzipping anything.
- **Drag mod `.zip` files onto it → installs those mods** (and never force-installs FUSE).

A no-argument run also still processes any loose zips sitting beside the exe (the previous folder-scan), so nothing regresses. It's idempotent — FUSE is skipped if already present. `--no-fuse` opts out.

## How

- **Bundling:** `tools/build_installer_exe.ps1` gains `-FusePayload <FUSE-v*.zip>`, which copies the zip in via PyInstaller `--add-data`. At runtime `resolve_bundled_fuse()` finds it in the unpacked bundle (`sys._MEIPASS`) and installs it through the existing pipeline. Offline and deterministic — the FUSE version is pinned to whatever shipped in that release.
- **Release wiring:** `release.yml` passes the core mod zip it just built to the installer build. The build then runs a `--dry-run` **self-check** that fails the build if a manual run wouldn't install FUSE.
- **Hardening (atomic extraction):** each package is extracted into a staging dir and swapped into place only after a fully successful extraction. A failure partway through no longer leaves a half-written mod folder for the game to load, and a failed `--replace` leaves the existing install untouched.
- **Tests + CI:** new `tools/tests/` pytest suite (39 tests) covering zip inspection, package detection, atomic install/rollback, bundled-FUSE resolution, and the two headline `run()` flows, plus the tolerant legacy JSON reader. Run in CI by a new **Python Tests** workflow — the installer had zero automated coverage before.

## Verification

- `pytest tools/tests` → **39 passed**.
- A real **PyInstaller build** with a bundled payload succeeded and self-checked; the resulting **frozen `.exe`** was exercised for real: no-args produced `Mods\FUSE\FUSE.dll`; dragging a mod zip installed only that mod with no FUSE folder created.

## Files

- `tools/fuse_installer.py` — bundled-FUSE resolution, no-args install logic, `--no-fuse`, atomic staging-and-swap, version → 0.2.0
- `tools/build_installer_exe.ps1` — `-FusePayload` bundling + dry-run self-check
- `.github/workflows/release.yml` — pass the built mod zip to the installer build
- `.github/workflows/python-tests.yml` — run the suite in CI
- `tools/tests/**` — pytest suite
- `docs/FUSE_INSTALLER.md`, `docs/CHANGELOG.md` — document the two flows and the hardening