### PR TITLE
Warn players on an outdated FUSE version (Nexus/GitHub provenance)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,43 @@ jobs:
             dist/FUSEConvertFolder.pyz
             FUSE.LiveBridge-v${{ steps.version.outputs.version }}.zip
 
+      # Provenance stamp for the update check. The core zip attached to the GitHub
+      # release above stays Source="github" (the committed Info.json default); the
+      # Nexus upload gets its own copy of the SAME contents with Source re-stamped
+      # to "nexus", so an out-of-date player who installed from Nexus is pointed
+      # back to Nexus while GitHub remains canonical (docs/RELEASING.md).
+      #
+      # GA only, and gated on NEXUS_FILE_GROUP_ID for the same reasons as the
+      # upload step below — no point building the variant when it will not ship.
+      - name: Package Nexus variant (Source=nexus)
+        id: nexus_package
+        if: ${{ vars.NEXUS_FILE_GROUP_ID != '' && steps.version.outputs.is_ga == 'true' }}
+        shell: powershell
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $nexusRoot = Join-Path $PWD "staging-nexus"
+          $modFolder = Join-Path $nexusRoot "FUSE"
+          # Same user-facing filename as the GitHub core zip; only the containing
+          # folder and the Info.json Source field differ.
+          $archivePath = Join-Path $nexusRoot "FUSE-v$version.zip"
+
+          if (Test-Path $nexusRoot) { Remove-Item $nexusRoot -Recurse -Force }
+          New-Item -ItemType Directory -Path $nexusRoot | Out-Null
+
+          # Reuse the exact staged mod folder the GitHub/core zip was built and
+          # validated from, so the Nexus zip can never drift from it; then flip
+          # only the provenance stamp.
+          Copy-Item -Recurse "staging\FUSE" $modFolder
+          powershell -NoProfile -ExecutionPolicy Bypass -File "scripts\stamp-info-source.ps1" -Path (Join-Path $modFolder "Info.json") -Source nexus
+
+          # Cheap guard: the stamp is a byte-faithful regex replace, so confirm the
+          # manifest still parses and actually reads "nexus" before it ships.
+          $info = Get-Content -LiteralPath (Join-Path $modFolder "Info.json") -Raw | ConvertFrom-Json
+          if ($info.Source -ne "nexus") { throw "Nexus variant Info.json Source is '$($info.Source)', expected 'nexus'." }
+
+          Compress-Archive -Path $modFolder -DestinationPath $archivePath -CompressionLevel Optimal
+          "archive_path=$archivePath" >> $env:GITHUB_OUTPUT
+
       # Uploads ONLY the core mod zip to the mod's Nexus Mods page — deliberately
       # not the complete bundle, the tools, or the Live Bridge. Players installing
       # from Nexus need exactly one file; keep the Files tab that way.
@@ -308,7 +345,8 @@ jobs:
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
           file_group_id: ${{ vars.NEXUS_FILE_GROUP_ID }}
-          filename: ${{ steps.package.outputs.archive_path }}
+          # The Source=nexus variant, not steps.package (which stays github).
+          filename: ${{ steps.nexus_package.outputs.archive_path }}
           version: ${{ steps.version.outputs.version }}
           display_name: FUSE v${{ steps.version.outputs.version }}
           description: |

--- a/FUSE.Core.Tests/Fixtures/github-releases.json
+++ b/FUSE.Core.Tests/Fixtures/github-releases.json
@@ -1,0 +1,178 @@
+[
+  {
+    "id": 371458140,
+    "tag_name": "mod-v1.0.2",
+    "name": "FUSE v1.0.2",
+    "draft": false,
+    "prerelease": false,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v1.0.2"
+  },
+  {
+    "id": 371420251,
+    "tag_name": "mod-v1.0.1-rc3",
+    "name": "FUSE v1.0.1-rc3",
+    "draft": false,
+    "prerelease": false,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v1.0.1-rc3"
+  },
+  {
+    "id": 371395128,
+    "tag_name": "mod-v1.0.1-rc2",
+    "name": "FUSE v1.0.1-rc2",
+    "draft": false,
+    "prerelease": false,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v1.0.1-rc2"
+  },
+  {
+    "id": 371435370,
+    "tag_name": "mod-v1.0.1",
+    "name": "FUSE v1.0.1",
+    "draft": false,
+    "prerelease": false,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v1.0.1"
+  },
+  {
+    "id": 371227612,
+    "tag_name": "mod-v1.0.0",
+    "name": "FUSE v1.0.0",
+    "draft": false,
+    "prerelease": false,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v1.0.0"
+  },
+  {
+    "id": 362114014,
+    "tag_name": "mod-v0.18.0",
+    "name": "FUSE v0.18.0",
+    "draft": false,
+    "prerelease": false,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v0.18.0"
+  },
+  {
+    "id": 359857706,
+    "tag_name": "mod-v0.17.0",
+    "name": "FUSE v0.17.0",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v0.17.0"
+  },
+  {
+    "id": 342049703,
+    "tag_name": "mod-v0.16.1",
+    "name": "FUSE v0.16.1",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v0.16.1"
+  },
+  {
+    "id": 341047559,
+    "tag_name": "mod-v0.16.0",
+    "name": "FUSE v0.16.0",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v0.16.0"
+  },
+  {
+    "id": 337478107,
+    "tag_name": "mod-v0.15.0",
+    "name": "FUSE v0.15.0",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v0.15.0"
+  },
+  {
+    "id": 335531242,
+    "tag_name": "mod-v0.14.1",
+    "name": "FUSE v0.14.1",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v0.14.1"
+  },
+  {
+    "id": 335457812,
+    "tag_name": "mod-v0.14.0",
+    "name": "FUSE v0.14.0",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v0.14.0"
+  },
+  {
+    "id": 333457057,
+    "tag_name": "mod-v0.13.1",
+    "name": "FUSE v0.13.1",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v0.13.1"
+  },
+  {
+    "id": 333383501,
+    "tag_name": "mod-v0.13.0",
+    "name": "FUSE v0.13.0",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/mod-v0.13.0"
+  },
+  {
+    "id": 329108684,
+    "tag_name": "v0.12.0",
+    "name": "FUSE v0.12.0",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/v0.12.0"
+  },
+  {
+    "id": 328401783,
+    "tag_name": "v0.11.4",
+    "name": "FUSE v0.11.4",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/v0.11.4"
+  },
+  {
+    "id": 328396165,
+    "tag_name": "v0.11.3",
+    "name": "FUSE v0.11.3",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/v0.11.3"
+  },
+  {
+    "id": 328391013,
+    "tag_name": "v0.11.2",
+    "name": "FUSE v0.11.2",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/v0.11.2"
+  },
+  {
+    "id": 328387337,
+    "tag_name": "v0.11.1",
+    "name": "FUSE v0.11.1",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/v0.11.1"
+  },
+  {
+    "id": 328330450,
+    "tag_name": "v0.11.0",
+    "name": "FUSE v0.11.0",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/v0.11.0"
+  },
+  {
+    "id": 323952913,
+    "tag_name": "v0.10.0",
+    "name": "FUSE v0.10.0",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/v0.10.0"
+  },
+  {
+    "id": 323949148,
+    "tag_name": "tools-v0.2.0",
+    "name": "FUSE Converter Tools v0.2.0",
+    "draft": false,
+    "prerelease": true,
+    "html_url": "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases/tag/tools-v0.2.0"
+  }
+]

--- a/FUSE.Core.Tests/Versioning/FuseGenerationGateTests.cs
+++ b/FUSE.Core.Tests/Versioning/FuseGenerationGateTests.cs
@@ -1,0 +1,66 @@
+using Fuse.Core.Versioning;
+using Xunit;
+
+namespace Fuse.Core.Tests;
+
+public class FuseGenerationGateTests
+{
+    [Fact]
+    public void Starts_at_zero()
+    {
+        var gate = new FuseGenerationGate();
+        Assert.Equal(0, gate.Current);
+        // Real checks always use a token from Begin() (>= 1); 0 is just the
+        // pre-start sentinel, trivially equal to the initial Current.
+        Assert.True(gate.IsCurrent(0));
+        Assert.False(gate.IsCurrent(1));
+    }
+
+    [Fact]
+    public void Begin_supersedes_the_prior_generation()
+    {
+        var gate = new FuseGenerationGate();
+
+        var g1 = gate.Begin();
+        Assert.Equal(1, g1);
+        Assert.True(gate.IsCurrent(g1));
+
+        // A newer check starts: the older generation is no longer current, so an
+        // older response completing out of order would be discarded.
+        var g2 = gate.Begin();
+        Assert.Equal(2, g2);
+        Assert.False(gate.IsCurrent(g1));
+        Assert.True(gate.IsCurrent(g2));
+    }
+
+    [Fact]
+    public void Out_of_order_completion_only_commits_the_latest_generation()
+    {
+        // Models three overlapping checks. Whatever order their responses land,
+        // only the newest generation's result may commit.
+        var gate = new FuseGenerationGate();
+        var g1 = gate.Begin();
+        var g2 = gate.Begin();
+        var g3 = gate.Begin();
+
+        // Responses arrive out of order: g1, then g3, then g2.
+        Assert.False(gate.IsCurrent(g1)); // stale — discard
+        Assert.True(gate.IsCurrent(g3));  // newest — commit
+        Assert.False(gate.IsCurrent(g2)); // stale — discard
+    }
+
+    [Fact]
+    public void Reset_returns_to_the_initial_state()
+    {
+        var gate = new FuseGenerationGate();
+        gate.Begin();
+        gate.Begin();
+
+        gate.Reset();
+        Assert.Equal(0, gate.Current);
+
+        var g = gate.Begin();
+        Assert.Equal(1, g);
+        Assert.True(gate.IsCurrent(g));
+    }
+}

--- a/FUSE.Core.Tests/Versioning/FuseGitHubReleaseParserTests.cs
+++ b/FUSE.Core.Tests/Versioning/FuseGitHubReleaseParserTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using Fuse.Core.Versioning;
+using Xunit;
+
+namespace Fuse.Core.Tests;
+
+public class FuseGitHubReleaseParserTests
+{
+    // A real GitHub /releases payload for F-U-S-E-E/FuseDevelopmentGroup, captured
+    // anonymously and trimmed to the fields the parser reads (plus a few real
+    // extras it must ignore). This is the end-to-end proof: raw API JSON ->
+    // parse -> select must land on the newest stable mod release. Regenerate by
+    // re-fetching the API if the release history changes; the assertion below
+    // pins the expectation that was true at capture time.
+    private static string RealPayload()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "github-releases.json");
+        return File.ReadAllText(path);
+    }
+
+    [Fact]
+    public void Real_payload_selects_latest_stable_mod_release()
+    {
+        Assert.True(FuseGitHubReleaseParser.TryParse(RealPayload(), out var releases));
+        Assert.NotEmpty(releases);
+
+        // The captured feed interleaves three lanes and contains RC tags that are
+        // NOT flagged prerelease (they ship as full releases), old v0.x tags, a
+        // tools-v release, and prerelease-flagged mod builds. Only mod-v1.0.2
+        // qualifies as the newest stable mod release.
+        Assert.True(FuseReleaseSelection.TrySelectLatestStableMod(releases, out var latest, out var tag));
+        Assert.Equal(new FuseSemVer(1, 0, 2), latest);
+        Assert.Equal("mod-v1.0.2", tag);
+    }
+
+    [Fact]
+    public void Real_payload_marks_an_older_stable_build_outdated_but_not_a_current_one()
+    {
+        Assert.True(FuseGitHubReleaseParser.TryParse(RealPayload(), out var releases));
+        Assert.True(FuseReleaseSelection.TrySelectLatestStableMod(releases, out var latest, out _));
+
+        Assert.True(FuseSemVer.TryParse("1.0.1", out var older));
+        Assert.True(FuseReleaseSelection.IsOutdated(older, latest));
+
+        Assert.True(FuseSemVer.TryParse("1.0.2", out var current));
+        Assert.False(FuseReleaseSelection.IsOutdated(current, latest));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{\"message\":\"Not Found\"}")] // API error object, not an array
+    [InlineData("<html>502 Bad Gateway</html>")] // proxy/error page
+    [InlineData("[ this is not json")] // truncated
+    public void TryParse_returns_false_for_non_array_bodies(string? body)
+    {
+        Assert.False(FuseGitHubReleaseParser.TryParse(body!, out var releases));
+        Assert.Empty(releases);
+    }
+
+    [Fact]
+    public void TryParse_reads_fields_and_skips_entries_without_a_tag()
+    {
+        const string json = @"[
+            { ""tag_name"": ""mod-v1.0.2"", ""draft"": false, ""prerelease"": false, ""extra"": ""ignored"" },
+            { ""tag_name"": ""mod-v2.0.0"", ""draft"": true,  ""prerelease"": false },
+            { ""tag_name"": ""mod-v1.5.0"", ""prerelease"": true },
+            { ""name"": ""no tag here"" },
+            ""a bare string, not an object""
+        ]";
+
+        Assert.True(FuseGitHubReleaseParser.TryParse(json, out var releases));
+        Assert.Equal(3, releases.Count); // the tagless object and the bare string are skipped
+
+        // Selection then applies the draft/prerelease/stable-tag rules on top.
+        Assert.True(FuseReleaseSelection.TrySelectLatestStableMod(releases, out var latest, out _));
+        Assert.Equal(new FuseSemVer(1, 0, 2), latest);
+    }
+}

--- a/FUSE.Core.Tests/Versioning/FuseReleaseSelectionTests.cs
+++ b/FUSE.Core.Tests/Versioning/FuseReleaseSelectionTests.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using Fuse.Core.Versioning;
+using Xunit;
+
+namespace Fuse.Core.Tests;
+
+public class FuseReleaseSelectionTests
+{
+    private static FuseGitHubRelease Rel(string tag, bool draft = false, bool prerelease = false) =>
+        new FuseGitHubRelease(tag, draft, prerelease);
+
+    // --- FuseSemVer.TryParse -------------------------------------------------
+
+    [Theory]
+    [InlineData("1.0.2", 1, 0, 2)]
+    [InlineData("0.0.0", 0, 0, 0)]
+    [InlineData("10.20.30", 10, 20, 30)]
+    [InlineData("  1.2.3  ", 1, 2, 3)]
+    public void TryParse_accepts_core_versions(string text, int major, int minor, int patch)
+    {
+        Assert.True(FuseSemVer.TryParse(text, out var version));
+        Assert.Equal(new FuseSemVer(major, minor, patch), version);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("1.2")]
+    [InlineData("1.2.3.4")]
+    [InlineData("v1.2.3")]
+    [InlineData("1.2.3-rc2")]
+    [InlineData("mod-v1.2.3")]
+    [InlineData("1.2.x")]
+    [InlineData("99999999999999999999.0.0")] // overflows Int32 -> malformed
+    public void TryParse_rejects_non_core_versions(string? text)
+    {
+        Assert.False(FuseSemVer.TryParse(text!, out _));
+    }
+
+    // --- FuseSemVer ordering -------------------------------------------------
+
+    [Theory]
+    [InlineData("1.0.0", "1.0.1")]
+    [InlineData("1.0.9", "1.0.10")] // numeric, not lexical
+    [InlineData("1.1.9", "1.2.0")]
+    [InlineData("1.9.9", "2.0.0")]
+    [InlineData("0.18.0", "1.0.0")]
+    public void Ordering_is_numeric(string lower, string higher)
+    {
+        Assert.True(FuseSemVer.TryParse(lower, out var a));
+        Assert.True(FuseSemVer.TryParse(higher, out var b));
+        Assert.True(a < b);
+        Assert.True(b > a);
+        Assert.True(FuseReleaseSelection.IsOutdated(a, b));
+        Assert.False(FuseReleaseSelection.IsOutdated(b, a));
+    }
+
+    [Fact]
+    public void Equal_versions_are_not_outdated()
+    {
+        Assert.True(FuseSemVer.TryParse("1.0.2", out var a));
+        Assert.True(FuseSemVer.TryParse("1.0.2", out var b));
+        Assert.Equal(a, b);
+        Assert.False(FuseReleaseSelection.IsOutdated(a, b));
+    }
+
+    // --- Stable mod tag parsing ---------------------------------------------
+
+    [Theory]
+    [InlineData("mod-v1.0.2", 1, 0, 2)]
+    [InlineData("mod-v0.13.0", 0, 13, 0)]
+    public void TryParseStableModTag_accepts_stable_mod_tags(string tag, int major, int minor, int patch)
+    {
+        Assert.True(FuseReleaseSelection.TryParseStableModTag(tag, out var version));
+        Assert.Equal(new FuseSemVer(major, minor, patch), version);
+    }
+
+    [Theory]
+    [InlineData("mod-v1.0.1-rc2")]   // release candidate: full release but not stable
+    [InlineData("mod-v1.0.0-beta.1")]
+    [InlineData("externaleditor-v1.0.0")] // other lane
+    [InlineData("tools-v0.2.0")]           // other lane
+    [InlineData("v1.0.2")]
+    [InlineData("1.0.2")]
+    [InlineData("mod-v1.0")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryParseStableModTag_rejects_other_tags(string? tag)
+    {
+        Assert.False(FuseReleaseSelection.TryParseStableModTag(tag!, out _));
+    }
+
+    // --- Latest-stable selection --------------------------------------------
+
+    [Fact]
+    public void SelectLatestStableMod_ignores_other_release_lanes()
+    {
+        // externaleditor-v* and tools-v* releases can be the single newest entry
+        // in the repo-wide feed; they must never be mistaken for a mod update.
+        var releases = new List<FuseGitHubRelease>
+        {
+            Rel("externaleditor-v2.0.0"),
+            Rel("tools-v9.9.9"),
+            Rel("mod-v1.0.2"),
+            Rel("mod-v1.0.1"),
+        };
+
+        Assert.True(FuseReleaseSelection.TrySelectLatestStableMod(releases, out var latest, out var tag));
+        Assert.Equal(new FuseSemVer(1, 0, 2), latest);
+        Assert.Equal("mod-v1.0.2", tag);
+    }
+
+    [Fact]
+    public void SelectLatestStableMod_skips_release_candidates()
+    {
+        // A newer RC is published as a full release, but a player on the stable
+        // 1.0.2 must be told 1.0.2 is current, not nudged onto 1.1.0-rc2.
+        var releases = new List<FuseGitHubRelease>
+        {
+            Rel("mod-v1.1.0-rc2"),
+            Rel("mod-v1.0.2"),
+        };
+
+        Assert.True(FuseReleaseSelection.TrySelectLatestStableMod(releases, out var latest, out var tag));
+        Assert.Equal(new FuseSemVer(1, 0, 2), latest);
+        Assert.Equal("mod-v1.0.2", tag);
+    }
+
+    [Fact]
+    public void SelectLatestStableMod_skips_drafts_and_prereleases()
+    {
+        var releases = new List<FuseGitHubRelease>
+        {
+            Rel("mod-v2.0.0", draft: true),
+            Rel("mod-v1.5.0", prerelease: true),
+            Rel("mod-v1.0.2"),
+        };
+
+        Assert.True(FuseReleaseSelection.TrySelectLatestStableMod(releases, out var latest, out _));
+        Assert.Equal(new FuseSemVer(1, 0, 2), latest);
+    }
+
+    [Fact]
+    public void SelectLatestStableMod_picks_highest_regardless_of_order()
+    {
+        var releases = new List<FuseGitHubRelease>
+        {
+            Rel("mod-v1.0.2"),
+            Rel("mod-v1.0.10"),
+            Rel("mod-v1.0.9"),
+        };
+
+        Assert.True(FuseReleaseSelection.TrySelectLatestStableMod(releases, out var latest, out var tag));
+        Assert.Equal(new FuseSemVer(1, 0, 10), latest);
+        Assert.Equal("mod-v1.0.10", tag);
+    }
+
+    [Fact]
+    public void SelectLatestStableMod_returns_false_when_no_stable_mod_release()
+    {
+        var releases = new List<FuseGitHubRelease>
+        {
+            Rel("mod-v1.0.0-rc.1"),
+            Rel("externaleditor-v1.0.0"),
+            Rel("tools-v0.2.0"),
+        };
+
+        Assert.False(FuseReleaseSelection.TrySelectLatestStableMod(releases, out _, out var tag));
+        Assert.Null(tag);
+    }
+
+    [Fact]
+    public void SelectLatestStableMod_handles_empty_and_null()
+    {
+        Assert.False(FuseReleaseSelection.TrySelectLatestStableMod(new List<FuseGitHubRelease>(), out _, out _));
+        Assert.False(FuseReleaseSelection.TrySelectLatestStableMod(null, out _, out _));
+    }
+
+    [Fact]
+    public void End_to_end_outdated_decision()
+    {
+        // Player on mod-v1.0.1; feed advertises 1.0.2 stable (plus noise).
+        Assert.True(FuseSemVer.TryParse("1.0.1", out var current));
+
+        var releases = new List<FuseGitHubRelease>
+        {
+            Rel("mod-v1.1.0-rc2"),
+            Rel("externaleditor-v3.0.0"),
+            Rel("mod-v1.0.2"),
+        };
+
+        Assert.True(FuseReleaseSelection.TrySelectLatestStableMod(releases, out var latest, out _));
+        Assert.True(FuseReleaseSelection.IsOutdated(current, latest));
+    }
+}

--- a/FUSE.Core/Versioning/FuseGenerationGate.cs
+++ b/FUSE.Core/Versioning/FuseGenerationGate.cs
@@ -1,0 +1,32 @@
+namespace Fuse.Core.Versioning
+{
+    /// <summary>
+    /// A monotonic "operation generation" used to discard results from a
+    /// superseded asynchronous check. Each <see cref="Begin"/> starts a new
+    /// generation and supersedes the prior one; a result tagged with a generation
+    /// is only valid while <see cref="IsCurrent"/> holds for it. An older response
+    /// that completes out of order — after a newer check has already started — is
+    /// therefore rejected instead of overwriting the newer result.
+    ///
+    /// Not thread-safe by design: FUSE drives it from the Unity main thread only
+    /// (the update-check coroutine and its callers all run there), so no lock is
+    /// needed and none is taken. Callers that touch it from other threads must
+    /// serialize access themselves.
+    /// </summary>
+    public sealed class FuseGenerationGate
+    {
+        private int _current;
+
+        /// <summary>The newest generation started, or 0 before the first <see cref="Begin"/>.</summary>
+        public int Current => _current;
+
+        /// <summary>Starts a new generation, supersedes any prior one, and returns its token.</summary>
+        public int Begin() => ++_current;
+
+        /// <summary>True while <paramref name="generation"/> is still the newest generation started.</summary>
+        public bool IsCurrent(int generation) => generation == _current;
+
+        /// <summary>Resets to the initial state (no generation started).</summary>
+        public void Reset() => _current = 0;
+    }
+}

--- a/FUSE.Core/Versioning/FuseGitHubReleaseParser.cs
+++ b/FUSE.Core/Versioning/FuseGitHubReleaseParser.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Fuse.Core.Versioning
+{
+    // Pure, game-free parsing of a GitHub Releases API response into the minimal
+    // projection FuseReleaseSelection compares. Compiled into FUSE.Core (tested in
+    // FUSE.Core.Tests against a real captured payload) AND linked into the in-game
+    // mod (see the <Compile Include> in FUSE/FUSE.csproj), so the exact parse the
+    // mod runs is the one under test. Newtonsoft.Json binds to the game's in-box
+    // copy in the mod and to the package copy in FUSE.Core; both expose the same
+    // JArray/JObject API used here.
+    public static class FuseGitHubReleaseParser
+    {
+        /// <summary>
+        /// Parses the releases from a Releases API body. Returns false — with an
+        /// empty list — for a null/blank body or one that is not a JSON array (an
+        /// error object, an HTML error page, a truncated response), so the caller
+        /// can tell "could not parse" apart from "parsed, but no stable release".
+        /// Never throws.
+        /// </summary>
+        public static bool TryParse(string json, out IReadOnlyList<FuseGitHubRelease> releases)
+        {
+            releases = Array.Empty<FuseGitHubRelease>();
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return false;
+            }
+
+            JArray array;
+            try
+            {
+                array = JArray.Parse(json);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            var list = new List<FuseGitHubRelease>();
+            foreach (var token in array)
+            {
+                if (!(token is JObject obj))
+                {
+                    continue;
+                }
+
+                var tag = obj.Value<string>("tag_name");
+                if (string.IsNullOrWhiteSpace(tag))
+                {
+                    continue;
+                }
+
+                // Absent flags default to false, matching the API's own default
+                // and treating a partial entry as an ordinary full release.
+                var draft = obj.Value<bool?>("draft") ?? false;
+                var prerelease = obj.Value<bool?>("prerelease") ?? false;
+                list.Add(new FuseGitHubRelease(tag, draft, prerelease));
+            }
+
+            releases = list;
+            return true;
+        }
+    }
+}

--- a/FUSE.Core/Versioning/FuseReleaseSelection.cs
+++ b/FUSE.Core/Versioning/FuseReleaseSelection.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Fuse.Core.Versioning
+{
+    // Pure, game-free logic for the outdated-version warning. This single source
+    // file is compiled into FUSE.Core (where FUSE.Core.Tests exercises it without
+    // a game install) AND linked into the in-game FUSE mod (see the <Compile
+    // Include> in FUSE/FUSE.csproj), so the tag-selection and comparison rules
+    // that decide whether a player is "outdated" have exactly one implementation.
+    //
+    // The mod's own version comes from Info.json's "Version", which the release
+    // flow always stamps as the version CORE (MAJOR.MINOR.PATCH — UMM cannot
+    // parse pre-release suffixes). The canonical latest version comes from the
+    // GitHub Releases API for F-U-S-E-E/FuseDevelopmentGroup.
+
+    /// <summary>
+    /// A three-part MAJOR.MINOR.PATCH version. This is the only shape a FUSE
+    /// Info.json <c>Version</c> ever carries and the only shape a stable
+    /// <c>mod-v</c> release tag carries, so a plain numeric triple is enough to
+    /// order releases.
+    /// </summary>
+    public readonly struct FuseSemVer : IComparable<FuseSemVer>, IEquatable<FuseSemVer>
+    {
+        public int Major { get; }
+        public int Minor { get; }
+        public int Patch { get; }
+
+        public FuseSemVer(int major, int minor, int patch)
+        {
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+        }
+
+        // Anchored, culture-invariant MAJOR.MINOR.PATCH with no pre-release or
+        // build suffix. Surrounding whitespace is tolerated; anything else
+        // (a leading 'v', an -rc suffix, four segments) is rejected so a
+        // non-stable or malformed value can never be read as a version.
+        private static readonly Regex CoreVersion = new Regex(
+            @"^\s*(\d+)\.(\d+)\.(\d+)\s*$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+        public static bool TryParse(string text, out FuseSemVer version)
+        {
+            version = default;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            var match = CoreVersion.Match(text);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            // int.TryParse guards against segments that overflow Int32; a version
+            // component that large is malformed rather than "very new".
+            if (!int.TryParse(match.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var major) ||
+                !int.TryParse(match.Groups[2].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var minor) ||
+                !int.TryParse(match.Groups[3].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var patch))
+            {
+                return false;
+            }
+
+            version = new FuseSemVer(major, minor, patch);
+            return true;
+        }
+
+        public int CompareTo(FuseSemVer other)
+        {
+            var major = Major.CompareTo(other.Major);
+            if (major != 0)
+            {
+                return major;
+            }
+
+            var minor = Minor.CompareTo(other.Minor);
+            if (minor != 0)
+            {
+                return minor;
+            }
+
+            return Patch.CompareTo(other.Patch);
+        }
+
+        public bool Equals(FuseSemVer other) =>
+            Major == other.Major && Minor == other.Minor && Patch == other.Patch;
+
+        public override bool Equals(object obj) => obj is FuseSemVer other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            // Simple, allocation-free combine. Version components are small
+            // non-negative integers, so a shift-and-xor spread is plenty.
+            var hash = 17;
+            hash = (hash * 31) + Major;
+            hash = (hash * 31) + Minor;
+            hash = (hash * 31) + Patch;
+            return hash;
+        }
+
+        public override string ToString() =>
+            Major.ToString(CultureInfo.InvariantCulture) + "." +
+            Minor.ToString(CultureInfo.InvariantCulture) + "." +
+            Patch.ToString(CultureInfo.InvariantCulture);
+
+        public static bool operator <(FuseSemVer left, FuseSemVer right) => left.CompareTo(right) < 0;
+        public static bool operator >(FuseSemVer left, FuseSemVer right) => left.CompareTo(right) > 0;
+        public static bool operator <=(FuseSemVer left, FuseSemVer right) => left.CompareTo(right) <= 0;
+        public static bool operator >=(FuseSemVer left, FuseSemVer right) => left.CompareTo(right) >= 0;
+        public static bool operator ==(FuseSemVer left, FuseSemVer right) => left.Equals(right);
+        public static bool operator !=(FuseSemVer left, FuseSemVer right) => !left.Equals(right);
+    }
+
+    /// <summary>
+    /// The subset of a GitHub Releases API entry the update check needs: the tag
+    /// and the two flags that mark a release as not-for-general-consumption.
+    /// </summary>
+    public sealed class FuseGitHubRelease
+    {
+        public FuseGitHubRelease(string tagName, bool draft, bool prerelease)
+        {
+            TagName = tagName ?? string.Empty;
+            Draft = draft;
+            Prerelease = prerelease;
+        }
+
+        public string TagName { get; }
+
+        public bool Draft { get; }
+
+        public bool Prerelease { get; }
+    }
+
+    /// <summary>
+    /// Chooses the version a running FUSE mod should be compared against and
+    /// decides whether it is outdated.
+    /// </summary>
+    public static class FuseReleaseSelection
+    {
+        /// <summary>Tag prefix for the mod release lane.</summary>
+        public const string ModTagPrefix = "mod-v";
+
+        // A STABLE mod release: mod-v<major>.<minor>.<patch> and nothing more.
+        //
+        // The repository publishes three independent release lanes into one
+        // Releases feed — mod-v*, externaleditor-v*, and tools-v* — so filtering
+        // to this prefix is what stops the external editor or the tools from
+        // being mistaken for a newer FUSE mod. Requiring the tag to END right
+        // after the patch number also excludes release candidates
+        // (mod-v1.0.1-rc2), which ship as full GitHub releases but must not, by
+        // product decision, tell a player on a stable build they are outdated.
+        private static readonly Regex StableModTag = new Regex(
+            @"^mod-v(\d+)\.(\d+)\.(\d+)$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Parses a stable mod release tag (<c>mod-v1.2.3</c>) into its version.
+        /// Returns false for other lanes, release candidates, pre-release
+        /// suffixes, and anything malformed.
+        /// </summary>
+        public static bool TryParseStableModTag(string tagName, out FuseSemVer version)
+        {
+            version = default;
+            if (string.IsNullOrWhiteSpace(tagName))
+            {
+                return false;
+            }
+
+            var match = StableModTag.Match(tagName.Trim());
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            if (!int.TryParse(match.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var major) ||
+                !int.TryParse(match.Groups[2].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var minor) ||
+                !int.TryParse(match.Groups[3].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var patch))
+            {
+                return false;
+            }
+
+            version = new FuseSemVer(major, minor, patch);
+            return true;
+        }
+
+        /// <summary>
+        /// Selects the newest stable mod release from a Releases API response.
+        /// Drafts and GitHub-flagged prereleases are skipped before the tag is
+        /// even parsed. Returns false when the list contains no qualifying
+        /// stable mod release.
+        /// </summary>
+        public static bool TrySelectLatestStableMod(
+            IEnumerable<FuseGitHubRelease> releases,
+            out FuseSemVer latest,
+            out string latestTag)
+        {
+            latest = default;
+            latestTag = null;
+            if (releases == null)
+            {
+                return false;
+            }
+
+            var found = false;
+            foreach (var release in releases)
+            {
+                if (release == null || release.Draft || release.Prerelease)
+                {
+                    continue;
+                }
+
+                if (!TryParseStableModTag(release.TagName, out var candidate))
+                {
+                    continue;
+                }
+
+                if (!found || candidate > latest)
+                {
+                    latest = candidate;
+                    latestTag = release.TagName.Trim();
+                    found = true;
+                }
+            }
+
+            return found;
+        }
+
+        /// <summary>
+        /// True when <paramref name="current"/> is strictly older than
+        /// <paramref name="latest"/>. A current version equal to or ahead of the
+        /// latest published release (e.g. a tester running an RC's core) is not
+        /// outdated.
+        /// </summary>
+        public static bool IsOutdated(FuseSemVer current, FuseSemVer latest) => current < latest;
+    }
+}

--- a/FUSE/FUSE.csproj
+++ b/FUSE/FUSE.csproj
@@ -172,6 +172,9 @@
     <Compile Include="..\FUSE.Core\Versioning\FuseGitHubReleaseParser.cs">
       <Link>Versioning\FuseGitHubReleaseParser.cs</Link>
     </Compile>
+    <Compile Include="..\FUSE.Core\Versioning\FuseGenerationGate.cs">
+      <Link>Versioning\FuseGenerationGate.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/FUSE/FUSE.csproj
+++ b/FUSE/FUSE.csproj
@@ -161,6 +161,20 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Shared, game-free version/release-selection logic. The single source of
+         truth lives in FUSE.Core, where FUSE.Core.Tests exercises it with no game
+         install. It is LINKED into the in-game mod (not referenced) so the mod
+         keeps its no-project-reference build and its use of the game's in-box
+         Newtonsoft.Json; because it is the same file, the two can never drift. -->
+    <Compile Include="..\FUSE.Core\Versioning\FuseReleaseSelection.cs">
+      <Link>Versioning\FuseReleaseSelection.cs</Link>
+    </Compile>
+    <Compile Include="..\FUSE.Core\Versioning\FuseGitHubReleaseParser.cs">
+      <Link>Versioning\FuseGitHubReleaseParser.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="Info.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/FUSE/FusePlugin.cs
+++ b/FUSE/FusePlugin.cs
@@ -102,6 +102,16 @@ namespace FUSE
                 FuseUmmInjector.ScheduleInjection(modEntry.Path, ReadInfoJsonString(Path.Combine(modEntry.Path ?? string.Empty, "Info.json"), "Version"));
                 FuseLegacyAssemblyHost.EnsureStartupHost();
 
+                if (FuseSettings.EnableUpdateCheck)
+                {
+                    // Non-blocking: asks GitHub for the newest stable release and
+                    // surfaces a notice if this build is behind. Skips itself for
+                    // an unstamped 0.0.0 dev build. See FuseVersionCheck.
+                    FuseVersionCheck.Start(
+                        modEntry.Path,
+                        ReadInfoJsonString(Path.Combine(modEntry.Path ?? string.Empty, "Info.json"), "Version"));
+                }
+
                 modEntry.OnUnload = OnUnload;
                 _isLoaded = true;
                 FuseEvents.RaiseFuseLoaded();
@@ -248,6 +258,7 @@ namespace FUSE
             FuseLegacyAssemblyHost.Shutdown();
             FuseLegacySupportAssemblyShim.Shutdown();
             FuseRuntimeRebindService.Shutdown();
+            FuseVersionCheck.Shutdown();
             FuseMenuWindow.Shutdown();
             FuseTrackDebugOverlay.Shutdown();
             FuseSceneryDebugOverlay.Shutdown();

--- a/FUSE/Info.json
+++ b/FUSE/Info.json
@@ -8,6 +8,7 @@
   "AssemblyName": "FUSE.dll",
   "EntryMethod": "FUSE.FusePlugin.Load",
   "HomePage": "",
+  "Source": "github",
   "Settings": {
     "EnableExperimentalEarlyScenePathSuppression": false,
     "MirrorAssetPacksToLocalLow": false,
@@ -21,6 +22,7 @@
     "EnableFrameSpikeDiagnostics": false,
     "FrameSpikeThresholdMs": 100,
     "ForceConstrainedVramMode": false,
-    "EnableNativeLeakStackTraces": false
+    "EnableNativeLeakStackTraces": false,
+    "EnableUpdateCheck": true
   }
 }

--- a/FUSE/Infrastructure/FuseInstallSource.cs
+++ b/FUSE/Infrastructure/FuseInstallSource.cs
@@ -1,0 +1,123 @@
+using System;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace FUSE.Infrastructure
+{
+    /// <summary>
+    /// Where a running FUSE install most likely came from. Used only to point an
+    /// out-of-date player at the right place to update.
+    /// </summary>
+    internal enum FuseInstallChannel
+    {
+        Unknown = 0,
+        GitHub,
+        Nexus,
+    }
+
+    /// <summary>
+    /// Reads the provenance stamp the release flow writes into a packaged
+    /// <c>Info.json</c> and resolves the update destination from it.
+    ///
+    /// GitHub is the canonical home: it holds the authoritative versioning and
+    /// always carries the newest build. Every GitHub-published artifact ships
+    /// <c>"Source": "github"</c>; the release flow re-stamps only the Nexus
+    /// upload to <c>"nexus"</c> (see <c>scripts/stamp-info-source.ps1</c> and
+    /// <c>.github/workflows/release.yml</c>). An absent, unreadable, or
+    /// unrecognized stamp reads as <see cref="FuseInstallChannel.Unknown"/>,
+    /// which the update check treats as GitHub.
+    /// </summary>
+    internal static class FuseInstallSource
+    {
+        internal const string RepositoryOwner = "F-U-S-E-E";
+        internal const string RepositoryName = "FuseDevelopmentGroup";
+
+        internal const string GitHubReleasesUrl =
+            "https://github.com/F-U-S-E-E/FuseDevelopmentGroup/releases";
+
+        internal const string NexusModUrl =
+            "https://www.nexusmods.com/railroader/mods/1645";
+
+        internal static FuseInstallChannel FromToken(string token)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return FuseInstallChannel.Unknown;
+            }
+
+            var trimmed = token.Trim();
+            if (string.Equals(trimmed, "nexus", StringComparison.OrdinalIgnoreCase))
+            {
+                return FuseInstallChannel.Nexus;
+            }
+
+            if (string.Equals(trimmed, "github", StringComparison.OrdinalIgnoreCase))
+            {
+                return FuseInstallChannel.GitHub;
+            }
+
+            return FuseInstallChannel.Unknown;
+        }
+
+        /// <summary>
+        /// Reads the <c>Source</c> field from the mod folder's <c>Info.json</c>.
+        /// </summary>
+        internal static FuseInstallChannel ReadChannel(string modPath)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(modPath))
+                {
+                    return FuseInstallChannel.Unknown;
+                }
+
+                var infoPath = Path.Combine(modPath, "Info.json");
+                if (!File.Exists(infoPath))
+                {
+                    return FuseInstallChannel.Unknown;
+                }
+
+                var info = JObject.Parse(File.ReadAllText(infoPath));
+                var source = info.Properties()
+                    .FirstOrDefault(candidate => string.Equals(candidate.Name, "Source", StringComparison.OrdinalIgnoreCase));
+                var token = source?.Value?.Type == JTokenType.String
+                    ? source.Value.Value<string>()
+                    : source?.Value?.ToString();
+                return FromToken(token);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning($"FUSE could not read install source from Info.json: {ex.GetBaseException().Message}");
+                return FuseInstallChannel.Unknown;
+            }
+        }
+
+        /// <summary>
+        /// Deep link to a specific GitHub release tag (e.g. <c>mod-v1.0.2</c>),
+        /// falling back to the releases list when no tag is known.
+        /// </summary>
+        internal static string GitHubReleaseTagUrl(string tag) =>
+            string.IsNullOrWhiteSpace(tag)
+                ? GitHubReleasesUrl
+                : GitHubReleasesUrl + "/tag/" + Uri.EscapeDataString(tag.Trim());
+
+        /// <summary>
+        /// The place to send an out-of-date player: the Nexus page for
+        /// Nexus-stamped installs, otherwise the canonical GitHub releases.
+        /// </summary>
+        internal static string PrimaryUpdateUrl(FuseInstallChannel channel) =>
+            channel == FuseInstallChannel.Nexus ? NexusModUrl : GitHubReleasesUrl;
+
+        internal static string DescribeChannel(FuseInstallChannel channel)
+        {
+            switch (channel)
+            {
+                case FuseInstallChannel.Nexus:
+                    return "Nexus Mods";
+                default:
+                    return "GitHub";
+            }
+        }
+    }
+}

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -64,6 +64,10 @@ namespace FUSE.Infrastructure
         // Unity's native-allocation leak stacks are process-wide and expensive.
         // Keep them opt-in and restore the host's prior mode when FUSE unloads.
         public const bool DefaultEnableNativeLeakStackTraces = false;
+        // Startup check that asks GitHub (the canonical version authority) whether
+        // a newer stable FUSE release exists and, if so, surfaces a non-blocking
+        // notice. On by default; one switch turns off all network access for it.
+        public const bool DefaultEnableUpdateCheck = true;
         public const float ExperimentalEarlyScenePathSuppressionTimeoutSeconds = 8f;
 
         public static bool EnableExperimentalEarlyScenePathSuppression { get; private set; } =
@@ -130,6 +134,8 @@ namespace FUSE.Infrastructure
 
         public static bool EnableNativeLeakStackTraces { get; private set; } = DefaultEnableNativeLeakStackTraces;
 
+        public static bool EnableUpdateCheck { get; private set; } = DefaultEnableUpdateCheck;
+
         public static void Load(UnityModManager.ModEntry modEntry)
         {
             EnableExperimentalEarlyScenePathSuppression = DefaultEnableExperimentalEarlyScenePathSuppression;
@@ -160,6 +166,7 @@ namespace FUSE.Infrastructure
             FrameSpikeThresholdMs = DefaultFrameSpikeThresholdMs;
             ForceConstrainedVramMode = DefaultForceConstrainedVramMode;
             EnableNativeLeakStackTraces = DefaultEnableNativeLeakStackTraces;
+            EnableUpdateCheck = DefaultEnableUpdateCheck;
             FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
 
             var infoPath = Path.Combine(modEntry?.Path ?? string.Empty, "Info.json");
@@ -229,6 +236,8 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, "ForceConstrainedVramMode", DefaultForceConstrainedVramMode);
                 EnableNativeLeakStackTraces =
                     ReadBool(settings, "EnableNativeLeakStackTraces", DefaultEnableNativeLeakStackTraces);
+                EnableUpdateCheck =
+                    ReadBool(settings, "EnableUpdateCheck", DefaultEnableUpdateCheck);
                 ApplyUserOverrides();
                 FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
 
@@ -262,6 +271,7 @@ namespace FUSE.Infrastructure
                     $"FrameSpikeThresholdMs={FrameSpikeThresholdMs} " +
                     $"ForceConstrainedVramMode={ForceConstrainedVramMode} " +
                     $"EnableNativeLeakStackTraces={EnableNativeLeakStackTraces} " +
+                    $"EnableUpdateCheck={EnableUpdateCheck} " +
                     $"timeoutSeconds={ExperimentalEarlyScenePathSuppressionTimeoutSeconds}.");
             }
             catch (Exception ex)
@@ -294,6 +304,7 @@ namespace FUSE.Infrastructure
                 FrameSpikeThresholdMs = DefaultFrameSpikeThresholdMs;
                 ForceConstrainedVramMode = DefaultForceConstrainedVramMode;
                 EnableNativeLeakStackTraces = DefaultEnableNativeLeakStackTraces;
+                EnableUpdateCheck = DefaultEnableUpdateCheck;
                 FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
                 FuseLog.Exception($"FUSE failed to parse Info.json settings; experimental early scene-path suppression remains disabled", ex);
             }
@@ -528,6 +539,15 @@ namespace FUSE.Infrastructure
             FuseNativeLeakDiagnostic.Apply(enabled);
         }
 
+        public static void SetEnableUpdateCheck(bool enabled)
+        {
+            EnableUpdateCheck = enabled;
+            SaveUserOverride(nameof(EnableUpdateCheck), enabled);
+            FuseLog.Info(
+                $"FUSE setting changed: {nameof(EnableUpdateCheck)}={enabled}. " +
+                "Takes effect on the next game start.");
+        }
+
         public static string GetUserSettingsPath()
         {
             return Path.Combine(Application.persistentDataPath, "FUSE", "settings.json");
@@ -745,6 +765,8 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, nameof(ForceConstrainedVramMode), ForceConstrainedVramMode);
                 EnableNativeLeakStackTraces =
                     ReadBool(settings, nameof(EnableNativeLeakStackTraces), EnableNativeLeakStackTraces);
+                EnableUpdateCheck =
+                    ReadBool(settings, nameof(EnableUpdateCheck), EnableUpdateCheck);
                 FuseLog.Info($"FUSE user setting overrides loaded from '{path}'.");
             }
             catch (Exception ex)

--- a/FUSE/Interface/Console/FuseConsoleCommands.cs
+++ b/FUSE/Interface/Console/FuseConsoleCommands.cs
@@ -9,10 +9,12 @@ using FUSE.Runtime.Cache;
 using FUSE.Infrastructure;
 using FUSE.Loading;
 using FUSE.Patches;
+using FUSE.Runtime.Lifecycle;
 using FUSE.Runtime.Registry;
 using FUSE.Authoring.Data;
 using FUSE.Authoring.Validation;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using Track;
 using UnityEngine;
@@ -29,6 +31,7 @@ namespace FUSE.Interface.Console
             {
                 new FuseReportCommand(),
                 new FuseLoadedCommand(),
+                new FuseUpdateCommand(),
                 new FuseMapsCommand(),
                 new FuseMapLaunchCommand(),
                 new FuseAssetsCommand(),
@@ -703,6 +706,74 @@ namespace FUSE.Interface.Console
             }
 
             return FuseLoadReport.GetLastDetailReport();
+        }
+    }
+
+    [ConsoleCommand("/fuse.update", "Report FUSE update status and re-check GitHub for a newer stable release.")]
+    public sealed class FuseUpdateCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            var modPath = FusePlugin.ModEntry?.Path ?? string.Empty;
+            var version = ReadInfoVersion(modPath);
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"FUSE version: {version}");
+            sb.AppendLine($"Install source: {FuseInstallSource.DescribeChannel(FuseVersionCheck.Channel)}");
+
+            if (string.IsNullOrWhiteSpace(version) || string.Equals(version, "0.0.0", StringComparison.Ordinal))
+            {
+                sb.AppendLine("This is a local/development build (0.0.0); the update check does not run for it.");
+                return sb.ToString().TrimEnd();
+            }
+
+            if (!FuseSettings.EnableUpdateCheck)
+            {
+                sb.AppendLine("The update check is turned off (FUSE window > Settings > Updates > Check for Updates).");
+            }
+
+            if (FuseVersionCheck.CheckComplete)
+            {
+                if (FuseVersionCheck.UpdateAvailable)
+                {
+                    sb.AppendLine($"Update available: FUSE {FuseVersionCheck.LatestVersionText} is out.");
+                    sb.AppendLine($"Get it from: {FuseVersionCheck.ResolveUpdateUrl()}");
+                }
+                else
+                {
+                    sb.AppendLine($"Up to date (latest stable is {FuseVersionCheck.LatestVersionText}).");
+                }
+            }
+            else
+            {
+                sb.AppendLine("No completed check this session yet.");
+            }
+
+            // Kick a fresh check; its result lands in FUSE.log and the FUSE Status page.
+            FuseVersionCheck.RequestRecheck(modPath, version);
+            sb.AppendLine("Re-checking now — run /fuse.update again shortly, or open the FUSE window for the result.");
+
+            return sb.ToString().TrimEnd();
+        }
+
+        private static string ReadInfoVersion(string modPath)
+        {
+            try
+            {
+                var infoPath = Path.Combine(modPath ?? string.Empty, "Info.json");
+                if (!File.Exists(infoPath))
+                {
+                    return "unknown";
+                }
+
+                var info = JObject.Parse(File.ReadAllText(infoPath));
+                var value = info["Version"]?.ToString();
+                return string.IsNullOrWhiteSpace(value) ? "unknown" : value.Trim();
+            }
+            catch
+            {
+                return "unknown";
+            }
         }
     }
 

--- a/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using FUSE.Infrastructure;
+using FUSE.Runtime.Lifecycle;
 using Helpers;
 using System;
 using System.Collections.Generic;
@@ -76,6 +77,22 @@ namespace FUSE.Interface.MenuWindow
                 }));
 
             builder.AddLabel("Staged progress and current-step labels during loading; takes effect on the next load.");
+
+            builder.AddSection("Updates");
+
+            builder.AddField("Check for Updates", control: BuildToggleBoxWithButton(
+                builder,
+                FuseSettings.EnableUpdateCheck,
+                () =>
+                {
+                    FuseSettings.SetEnableUpdateCheck(!FuseSettings.EnableUpdateCheck);
+                    builder.Rebuild();
+                }));
+
+            builder.AddLabel(
+                FuseVersionCheck.UpdateAvailable
+                    ? $"Update available: FUSE {FuseVersionCheck.LatestVersionText} (you have {FuseVersionCheck.CurrentVersionText}). See the Status page for the download link."
+                    : "On startup, asks GitHub whether a newer stable FUSE release exists and shows a notice if so. Only a version list is fetched; no data about you is sent. Takes effect on the next game start.");
 
             builder.AddSection("Reporting");
 

--- a/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
@@ -92,7 +92,7 @@ namespace FUSE.Interface.MenuWindow
             builder.AddLabel(
                 FuseVersionCheck.UpdateAvailable
                     ? $"Update available: FUSE {FuseVersionCheck.LatestVersionText} (you have {FuseVersionCheck.CurrentVersionText}). See the Status page for the download link."
-                    : "On startup, asks GitHub whether a newer stable FUSE release exists and shows a notice if so. Only a version list is fetched; no data about you is sent. Takes effect on the next game start.");
+                    : "On startup, asks GitHub whether a newer stable FUSE release exists and shows a notice if so. The request carries no FUSE account, save, or mod-list data — only the normal metadata of an HTTPS request to GitHub's public API. Takes effect on the next game start.");
 
             builder.AddSection("Reporting");
 

--- a/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using FUSE.Infrastructure;
 using FUSE.Loading;
+using FUSE.Runtime.Lifecycle;
 using FUSE.Authoring.Migrations;
 using Newtonsoft.Json.Linq;
 using System;
@@ -59,6 +60,7 @@ namespace FUSE.Interface.MenuWindow
 
             builder.AddField("Version", "FUSE " + ReadVersion() + " - Schema " + FuseMigration.CurrentVersion + " - Converter 0.2.0");
 
+            AddUpdateNotice(builder);
 
             builder.AddSection("Checklist");
             AddReadinessRow(builder, "Packages", data.FaultCount == 0, $"{data.AppliedPackagesCount}/{data.LoadedPackagesCount} applied", data.FaultCount + " fault(s)");
@@ -168,6 +170,32 @@ namespace FUSE.Interface.MenuWindow
                     var message = ExportActiveModManifest(openFolder: true);
                     Toast.Present(message);
                     builder.Rebuild();
+                });
+            }, 6f).Height(32f);
+        }
+
+        // Renders the "an update is available" row when the startup check found a
+        // newer stable release. Silent otherwise (up to date, disabled, offline,
+        // or still checking), so the Status page never nags a current install.
+        private static void AddUpdateNotice(UIPanelBuilder builder)
+        {
+            if (!FuseVersionCheck.UpdateAvailable)
+            {
+                return;
+            }
+
+            var where = FuseInstallSource.DescribeChannel(FuseVersionCheck.Channel);
+            builder.AddField(
+                "Update",
+                builder.AddLabelMarkup(
+                    $"<color=\"yellow\">Available</color> - FUSE {FuseVersionCheck.LatestVersionText} is out " +
+                    $"(you have {FuseVersionCheck.CurrentVersionText})."));
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact($"Get it from {where}", () =>
+                {
+                    Application.OpenURL(FuseVersionCheck.ResolveUpdateUrl());
+                    Toast.Present($"Opening the FUSE {where} download page in your browser.");
                 });
             }, 6f).Height(32f);
         }

--- a/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
+++ b/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
@@ -88,6 +88,17 @@ namespace FUSE.Runtime.Lifecycle
                 {
                     FuseLog.Exception("FUSE enhanced loading screen pipeline-complete signal failed", ex);
                 }
+
+                // A loaded map is the first point the toast UI is guaranteed
+                // alive, so flush any pending "you're outdated" notice here.
+                try
+                {
+                    FuseVersionCheck.NotifyMapDidLoad();
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception("FUSE update-notice map-load flush failed", ex);
+                }
             }
         }
 

--- a/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
+++ b/FUSE/Runtime/Lifecycle/FuseLifecycle.cs
@@ -371,6 +371,9 @@ namespace FUSE.Runtime.Lifecycle
         {
             try
             {
+                // A pending "you're outdated" toast must not fire at the main menu
+                // after the player leaves the map; re-arm it for the next load.
+                FuseVersionCheck.NotifyMapWillUnload();
                 // FUSE does not own the unload screen (the stock "Tyin' down…"
                 // progress is fine), and the post-load pipeline never runs on an
                 // unload — so hide our screen immediately rather than letting the

--- a/FUSE/Runtime/Lifecycle/FuseVersionCheck.cs
+++ b/FUSE/Runtime/Lifecycle/FuseVersionCheck.cs
@@ -325,7 +325,10 @@ namespace FUSE.Runtime.Lifecycle
                 StartCoroutine(Run(currentVersion));
             }
 
-            private IEnumerator Run(string currentVersion)
+            // Static: the coroutine touches only static state (unlike a Unity
+            // message such as Update, which must stay an instance method). Keeps
+            // CA1822 quiet without a suppression.
+            private static IEnumerator Run(string currentVersion)
             {
                 // `using` compiles to try/finally (no catch), which is the only
                 // shape C# allows a `yield return` to live inside. The request is

--- a/FUSE/Runtime/Lifecycle/FuseVersionCheck.cs
+++ b/FUSE/Runtime/Lifecycle/FuseVersionCheck.cs
@@ -44,6 +44,14 @@ namespace FUSE.Runtime.Lifecycle
 
         private static readonly object Gate = new object();
 
+        // Supersession guard: each check gets a generation token; a response only
+        // commits its result while its generation is still the newest. This makes
+        // overlapping checks (a slow startup check plus a manual /fuse.update, or
+        // repeated /fuse.update calls) safe — an older response that finishes out
+        // of order is discarded instead of clobbering the newer result. Touched
+        // only on the Unity main thread, always while holding Gate.
+        private static readonly FuseGenerationGate Generation = new FuseGenerationGate();
+
         private static GameObject _host;
         private static bool _started;
         private static bool _checkComplete;
@@ -118,9 +126,15 @@ namespace FUSE.Runtime.Lifecycle
             }
 
             _started = true;
+            int generation;
+            string versionToCheck;
             lock (Gate)
             {
+                // Bump the generation so any check still in flight is superseded:
+                // its response will be discarded when it lands.
+                generation = Generation.Begin();
                 _currentVersionText = currentVersion.Trim();
+                versionToCheck = _currentVersionText;
                 _channel = FuseInstallSource.ReadChannel(modPath);
                 if (force)
                 {
@@ -140,7 +154,7 @@ namespace FUSE.Runtime.Lifecycle
             }
 
             FuseLog.Info($"FUSE update check started against {ReleasesApiUrl}.");
-            runner.Begin(_currentVersionText);
+            runner.Begin(versionToCheck, generation);
         }
 
         /// <summary>
@@ -199,6 +213,7 @@ namespace FUSE.Runtime.Lifecycle
                 _latestVersionText = null;
                 _latestTag = null;
                 _channel = FuseInstallChannel.Unknown;
+                Generation.Reset();
             }
         }
 
@@ -232,8 +247,9 @@ namespace FUSE.Runtime.Lifecycle
         }
 
         // Parses the check result (no coroutine/yield here, so it can guard
-        // everything in a try/catch) and records the outcome.
-        private static void Evaluate(string currentVersion, string body)
+        // everything in a try/catch) and records the outcome — unless a newer
+        // check has superseded this one, in which case the result is discarded.
+        private static void Evaluate(string currentVersion, string body, int generation)
         {
             try
             {
@@ -262,13 +278,30 @@ namespace FUSE.Runtime.Lifecycle
                 }
 
                 var outdated = FuseReleaseSelection.IsOutdated(current, latest);
+                bool committed;
                 lock (Gate)
                 {
-                    _checkComplete = true;
-                    _latestVersionText = latest.ToString();
-                    _latestTag = latestTag;
-                    _outdated = outdated;
-                    _toastPending = outdated;
+                    // Discard the result if a newer check started while this
+                    // request was in flight — its response is the authority now.
+                    if (!Generation.IsCurrent(generation))
+                    {
+                        committed = false;
+                    }
+                    else
+                    {
+                        _checkComplete = true;
+                        _latestVersionText = latest.ToString();
+                        _latestTag = latestTag;
+                        _outdated = outdated;
+                        _toastPending = outdated;
+                        committed = true;
+                    }
+                }
+
+                if (!committed)
+                {
+                    FuseLog.Info("FUSE update check: a newer check superseded this response; discarding it.");
+                    return;
                 }
 
                 if (outdated)
@@ -334,15 +367,15 @@ namespace FUSE.Runtime.Lifecycle
 
         private sealed class FuseVersionCheckRunner : MonoBehaviour
         {
-            internal void Begin(string currentVersion)
+            internal void Begin(string currentVersion, int generation)
             {
-                StartCoroutine(Run(currentVersion));
+                StartCoroutine(Run(currentVersion, generation));
             }
 
             // Static: the coroutine touches only static state (unlike a Unity
             // message such as Update, which must stay an instance method). Keeps
             // CA1822 quiet without a suppression.
-            private static IEnumerator Run(string currentVersion)
+            private static IEnumerator Run(string currentVersion, int generation)
             {
                 // `using` compiles to try/finally (no catch), which is the only
                 // shape C# allows a `yield return` to live inside. The request is
@@ -375,7 +408,7 @@ namespace FUSE.Runtime.Lifecycle
                             FuseLog.Warning($"FUSE update check could not read the GitHub response: {ex.GetBaseException().Message}");
                         }
 
-                        Evaluate(currentVersion, body);
+                        Evaluate(currentVersion, body, generation);
                     }
                 }
             }

--- a/FUSE/Runtime/Lifecycle/FuseVersionCheck.cs
+++ b/FUSE/Runtime/Lifecycle/FuseVersionCheck.cs
@@ -157,6 +157,20 @@ namespace FUSE.Runtime.Lifecycle
             TryShowToast();
         }
 
+        /// <summary>
+        /// Called when the active map unloads. Clears the "UI is alive" flag so a
+        /// response that lands back at the main menu never presents a toast
+        /// outside a live map; a still-pending toast simply waits for the next
+        /// map load.
+        /// </summary>
+        internal static void NotifyMapWillUnload()
+        {
+            lock (Gate)
+            {
+                _mapActive = false;
+            }
+        }
+
         internal static void Shutdown()
         {
             if (_host != null)

--- a/FUSE/Runtime/Lifecycle/FuseVersionCheck.cs
+++ b/FUSE/Runtime/Lifecycle/FuseVersionCheck.cs
@@ -1,0 +1,367 @@
+using System;
+using System.Collections;
+using Fuse.Core.Versioning;
+using FUSE.Infrastructure;
+using UI.Common;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace FUSE.Runtime.Lifecycle
+{
+    /// <summary>
+    /// Warns a player who is running an out-of-date FUSE build. On startup it
+    /// asks GitHub — the canonical version authority — for the newest STABLE
+    /// mod release and compares it against the running version. If the player is
+    /// behind, it surfaces a non-blocking notice: a single toast on the next map
+    /// load, plus a line in the FUSE Status panel with a link to the right place
+    /// to update (Nexus for a Nexus-stamped install, GitHub otherwise).
+    ///
+    /// Nothing here blocks the game. Every failure mode — no network, a 403, a
+    /// malformed response, a version that will not parse — is logged and dropped;
+    /// a player is only ever told they are behind when a newer stable release is
+    /// confirmed. Selection and comparison live in the game-free
+    /// <see cref="FuseReleaseSelection"/> (unit-tested in FUSE.Core.Tests); this
+    /// type is the thin Unity glue that fetches, parses, and presents.
+    /// </summary>
+    internal static class FuseVersionCheck
+    {
+        // The source Info.json is pinned at 0.0.0 so an unstamped local/debug
+        // build is recognizable in UMM (see docs/RELEASING.md). Nagging a
+        // developer that their working copy is "outdated" would be wrong, so the
+        // check never runs for it.
+        private const string DevBuildVersion = "0.0.0";
+
+        // Unauthenticated GitHub REST. The repo is public, so this needs no
+        // token; the previous private repo answered anonymous release queries
+        // with 404, which is exactly why this feature could not ship before.
+        // The feed is newest-first, so the current stable mod-v release is always
+        // near the top; per_page=100 (GitHub's max) is far more than enough head-
+        // room even with the external-editor and tools lanes interleaved, so the
+        // newest stable can't be pushed off the single page we fetch.
+        private static readonly string ReleasesApiUrl =
+            "https://api.github.com/repos/" + FuseInstallSource.RepositoryOwner +
+            "/" + FuseInstallSource.RepositoryName + "/releases?per_page=100";
+
+        private static readonly object Gate = new object();
+
+        private static GameObject _host;
+        private static bool _started;
+        private static bool _checkComplete;
+        private static bool _outdated;
+        private static bool _toastPending;
+        private static bool _toastShown;
+        // Set once the first map has loaded — the point the toast UI is alive.
+        // The toast is only ever presented while this is true, so a check that
+        // completes at the splash/menu can never burn the one-shot on a no-op.
+        private static bool _mapActive;
+        private static string _currentVersionText;
+        private static string _latestVersionText;
+        private static string _latestTag;
+        private static FuseInstallChannel _channel = FuseInstallChannel.Unknown;
+
+        internal static bool CheckComplete { get { lock (Gate) { return _checkComplete; } } }
+
+        internal static bool UpdateAvailable { get { lock (Gate) { return _outdated; } } }
+
+        internal static string CurrentVersionText { get { lock (Gate) { return _currentVersionText; } } }
+
+        internal static string LatestVersionText { get { lock (Gate) { return _latestVersionText; } } }
+
+        internal static FuseInstallChannel Channel { get { lock (Gate) { return _channel; } } }
+
+        /// <summary>The place to send the player to update, resolved from the install channel.</summary>
+        internal static string ResolveUpdateUrl()
+        {
+            lock (Gate)
+            {
+                return _channel == FuseInstallChannel.Nexus
+                    ? FuseInstallSource.NexusModUrl
+                    : FuseInstallSource.GitHubReleaseTagUrl(_latestTag);
+            }
+        }
+
+        /// <summary>One-line summary for the Status panel / console, or null when up to date or unchecked.</summary>
+        internal static string DescribeUpdateNotice()
+        {
+            lock (Gate)
+            {
+                if (!_outdated)
+                {
+                    return null;
+                }
+
+                var where = _channel == FuseInstallChannel.Nexus ? "Nexus" : "GitHub";
+                return $"Update available: FUSE {_latestVersionText} (you have {_currentVersionText}). Get it from {where}.";
+            }
+        }
+
+        /// <summary>Starts the one-shot startup check. A no-op if already started or a dev build.</summary>
+        internal static void Start(string modPath, string currentVersion) =>
+            BeginCheck(modPath, currentVersion, force: false);
+
+        /// <summary>Re-runs the check on demand (used by the console command).</summary>
+        internal static void RequestRecheck(string modPath, string currentVersion) =>
+            BeginCheck(modPath, currentVersion, force: true);
+
+        private static void BeginCheck(string modPath, string currentVersion, bool force)
+        {
+            if (_started && !force)
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(currentVersion) ||
+                string.Equals(currentVersion.Trim(), DevBuildVersion, StringComparison.Ordinal))
+            {
+                FuseLog.Info("FUSE update check skipped: running a local/development build (version 0.0.0).");
+                return;
+            }
+
+            _started = true;
+            lock (Gate)
+            {
+                _currentVersionText = currentVersion.Trim();
+                _channel = FuseInstallSource.ReadChannel(modPath);
+                if (force)
+                {
+                    _checkComplete = false;
+                    _outdated = false;
+                    _toastPending = false;
+                    _toastShown = false;
+                    _latestVersionText = null;
+                    _latestTag = null;
+                }
+            }
+
+            var runner = EnsureHost();
+            if (runner == null)
+            {
+                return;
+            }
+
+            FuseLog.Info($"FUSE update check started against {ReleasesApiUrl}.");
+            runner.Begin(_currentVersionText);
+        }
+
+        /// <summary>
+        /// Called from the map-load lifecycle (a point where the toast UI is
+        /// guaranteed alive) to flush a pending "you're outdated" toast.
+        /// </summary>
+        internal static void NotifyMapDidLoad()
+        {
+            lock (Gate)
+            {
+                _mapActive = true;
+            }
+
+            TryShowToast();
+        }
+
+        internal static void Shutdown()
+        {
+            if (_host != null)
+            {
+                try
+                {
+                    UnityEngine.Object.Destroy(_host);
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception("FUSE version-check host shutdown failed", ex);
+                }
+
+                _host = null;
+            }
+
+            lock (Gate)
+            {
+                _started = false;
+                _checkComplete = false;
+                _outdated = false;
+                _toastPending = false;
+                _toastShown = false;
+                _mapActive = false;
+                _currentVersionText = null;
+                _latestVersionText = null;
+                _latestTag = null;
+                _channel = FuseInstallChannel.Unknown;
+            }
+        }
+
+        private static FuseVersionCheckRunner EnsureHost()
+        {
+            if (_host != null)
+            {
+                return _host.GetComponent<FuseVersionCheckRunner>();
+            }
+
+            GameObject host = null;
+            try
+            {
+                host = new GameObject("FUSE.VersionCheck");
+                host.hideFlags = HideFlags.HideAndDontSave;
+                var runner = host.AddComponent<FuseVersionCheckRunner>();
+                UnityEngine.Object.DontDestroyOnLoad(host);
+                _host = host;
+                return runner;
+            }
+            catch (Exception ex)
+            {
+                if (host != null)
+                {
+                    UnityEngine.Object.Destroy(host);
+                }
+
+                FuseLog.Exception("FUSE version-check host creation failed", ex);
+                return null;
+            }
+        }
+
+        // Parses the check result (no coroutine/yield here, so it can guard
+        // everything in a try/catch) and records the outcome.
+        private static void Evaluate(string currentVersion, string body)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(body))
+                {
+                    FuseLog.Info("FUSE update check: empty response from GitHub; skipping.");
+                    return;
+                }
+
+                if (!FuseSemVer.TryParse(currentVersion, out var current))
+                {
+                    FuseLog.Info($"FUSE update check: running version '{currentVersion}' is not a comparable release version; skipping.");
+                    return;
+                }
+
+                if (!FuseGitHubReleaseParser.TryParse(body, out var releases))
+                {
+                    FuseLog.Info("FUSE update check: could not parse the GitHub releases response; skipping.");
+                    return;
+                }
+
+                if (!FuseReleaseSelection.TrySelectLatestStableMod(releases, out var latest, out var latestTag))
+                {
+                    FuseLog.Info("FUSE update check: no stable mod release found in the releases feed; skipping.");
+                    return;
+                }
+
+                var outdated = FuseReleaseSelection.IsOutdated(current, latest);
+                lock (Gate)
+                {
+                    _checkComplete = true;
+                    _latestVersionText = latest.ToString();
+                    _latestTag = latestTag;
+                    _outdated = outdated;
+                    _toastPending = outdated;
+                }
+
+                if (outdated)
+                {
+                    FuseLog.Warning(
+                        $"FUSE is out of date: running {current}, latest stable is {latest} ({latestTag}). " +
+                        $"Update from {ResolveUpdateUrl()}.");
+                    // Shows now only if a map is already loaded (e.g. a manual
+                    // re-check mid-session); otherwise it is a no-op and the next
+                    // map load flushes it via NotifyMapDidLoad.
+                    TryShowToast();
+                }
+                else
+                {
+                    FuseLog.Info($"FUSE is up to date: running {current}, latest stable is {latest}.");
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning($"FUSE update check failed while evaluating releases: {ex.GetBaseException().Message}");
+            }
+        }
+
+        private static void TryShowToast()
+        {
+            bool present;
+            string current, latest;
+            FuseInstallChannel channel;
+            lock (Gate)
+            {
+                present = _toastPending && !_toastShown && _outdated && _mapActive;
+                current = _currentVersionText;
+                latest = _latestVersionText;
+                channel = _channel;
+            }
+
+            if (!present)
+            {
+                return;
+            }
+
+            try
+            {
+                var where = channel == FuseInstallChannel.Nexus ? "Nexus" : "GitHub";
+                Toast.Present(
+                    $"FUSE {latest} is available (you have {current}). " +
+                    $"Update from {where} — open the FUSE window for the link.");
+                lock (Gate)
+                {
+                    _toastShown = true;
+                    _toastPending = false;
+                }
+
+                FuseLog.Info("FUSE update-available toast presented.");
+            }
+            catch (Exception ex)
+            {
+                // The toast surface may not be alive yet (splash / main menu).
+                // Leave the toast pending so the next map load presents it.
+                FuseLog.Info($"FUSE update toast deferred until UI is ready: {ex.GetBaseException().Message}");
+            }
+        }
+
+        private sealed class FuseVersionCheckRunner : MonoBehaviour
+        {
+            internal void Begin(string currentVersion)
+            {
+                StartCoroutine(Run(currentVersion));
+            }
+
+            private IEnumerator Run(string currentVersion)
+            {
+                // `using` compiles to try/finally (no catch), which is the only
+                // shape C# allows a `yield return` to live inside. The request is
+                // always disposed; the parse below runs after the yield with its
+                // own try/catch.
+                using (var request = UnityWebRequest.Get(ReleasesApiUrl))
+                {
+                    // GitHub rejects requests with no User-Agent (HTTP 403).
+                    request.SetRequestHeader("User-Agent", "FUSE-Mod-UpdateCheck");
+                    request.SetRequestHeader("Accept", "application/vnd.github+json");
+                    request.timeout = 15;
+
+                    yield return request.SendWebRequest();
+
+                    if (request.isNetworkError || request.isHttpError)
+                    {
+                        FuseLog.Info(
+                            $"FUSE update check skipped (could not reach GitHub): {request.error} " +
+                            $"[HTTP {request.responseCode}].");
+                    }
+                    else
+                    {
+                        string body = null;
+                        try
+                        {
+                            body = request.downloadHandler != null ? request.downloadHandler.text : null;
+                        }
+                        catch (Exception ex)
+                        {
+                            FuseLog.Warning($"FUSE update check could not read the GitHub response: {ex.GetBaseException().Message}");
+                        }
+
+                        Evaluate(currentVersion, body);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,22 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- FUSE checks GitHub on startup for a newer stable release and, if the running
+  build is behind, shows a non-blocking notice — a one-time toast on the next map
+  load plus an "Update available" line with a download link on the Status page. It
+  compares against the newest stable `mod-v` release only (release candidates and
+  the external-editor/tools lanes are ignored), skips local `0.0.0` dev builds,
+  and can be turned off with the new `EnableUpdateCheck` setting. The new
+  `/fuse.update` console command reports status and re-checks on demand. This was
+  blocked until the repository went public, since GitHub answers anonymous release
+  queries only for public repositories.
+- Nexus uploads are stamped `"Source": "nexus"` in `Info.json` so the update
+  notice can point a Nexus-installed player back to Nexus, while GitHub-published
+  artifacts keep the canonical `"github"` stamp. The release flow builds a
+  Nexus-only copy of the core zip with the flipped stamp
+  (`scripts/stamp-info-source.ps1`); the two zips are otherwise identical.
 
 ## [1.0.2]
 

--- a/docs/CONSOLE_COMMANDS.md
+++ b/docs/CONSOLE_COMMANDS.md
@@ -70,8 +70,9 @@ GitHub. The result also lands in `FUSE.log` and on the FUSE window's Status page
 
 A newer *stable* release shows a download link; release candidates are ignored,
 and a local or development build (version `0.0.0`) reports that the check does not
-run for it. Requires the `EnableUpdateCheck` setting to be on for the automatic
-startup check — see [SETTINGS.md](SETTINGS.md#enableupdatecheck).
+run for it. The `EnableUpdateCheck` setting only governs the automatic startup
+check; this command always checks on demand — see
+[SETTINGS.md](SETTINGS.md#enableupdatecheck).
 
 ### `/fuse.conflicts`
 

--- a/docs/CONSOLE_COMMANDS.md
+++ b/docs/CONSOLE_COMMANDS.md
@@ -13,6 +13,7 @@ recovery commands at the end of this page.
 | --- | --- |
 | [`/fuse.report`](#fusereport) | Last map-load report (human or JSON) |
 | [`/fuse.loaded`](#fuseloaded) | Loaded packages and applied/faulted state |
+| [`/fuse.update`](#fuseupdate) | Version/update status and re-check |
 | [`/fuse.conflicts`](#fuseconflicts) | Recorded ownership collisions |
 | [`/fuse.validate`](#fusevalidate) | Re-run the validator for one package |
 | [`/fuse.graph`](#fusegraph) | Track graph summary |
@@ -56,6 +57,21 @@ command to run when a package's content is missing from the world — a package
 that faulted during apply still appears here, with the fault recorded.
 
 A faulted package does not stop unrelated packages from loading.
+
+### `/fuse.update`
+
+Reports the running FUSE version, the detected install source (GitHub or Nexus),
+and whether a newer stable release is available, then kicks a fresh check against
+GitHub. The result also lands in `FUSE.log` and on the FUSE window's Status page.
+
+```
+/fuse.update
+```
+
+A newer *stable* release shows a download link; release candidates are ignored,
+and a local or development build (version `0.0.0`) reports that the check does not
+run for it. Requires the `EnableUpdateCheck` setting to be on for the automatic
+startup check — see [SETTINGS.md](SETTINGS.md#enableupdatecheck).
 
 ### `/fuse.conflicts`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ New to FUSE, or installing it on a fresh setup.
 | --- | --- |
 | [Getting Started](GETTING_STARTED.md) | Install FUSE and your first packages, verify the load, update, uninstall |
 | [FAQ](FAQ.md) | Common questions — legacy mods, multiplayer, saves, performance |
-| [Settings](SETTINGS.md) | All 28 settings, their defaults, and where they live |
+| [Settings](SETTINGS.md) | All 29 settings, their defaults, and where they live |
 | [Console Commands](CONSOLE_COMMANDS.md) | Every `/fuse.*` command |
 | [Troubleshooting](TROUBLESHOOTING.md) | Symptom → diagnostic → what to attach to a report |
 | [Known Issues](KNOWN_ISSUES.md) | Current limitations and unsupported content |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -30,6 +30,17 @@ Nexus receives the core zip alone, on purpose. A player installing from Nexus
 needs one file; the converter, installer and dev bridge only belong in front of
 package authors, who get them from GitHub.
 
+The Nexus upload also carries a **provenance stamp** so the in-game update check
+can send an out-of-date player back to where they installed. Every GitHub artifact
+ships the committed `Info.json` default `"Source": "github"`; the release builds a
+second copy of the core zip with `Source` re-stamped to `"nexus"` (via
+`scripts/stamp-info-source.ps1`) and uploads *that* one to Nexus. The two zips
+share a name and their entire contents — only that one field differs. GitHub stays
+canonical for versioning; the stamp only decides which download link the notice
+shows. The stamp step is GA-only and gated on `NEXUS_FILE_GROUP_ID`, so only stable
+builds are ever stamped `nexus`. The runtime reads it in
+`FUSE.Infrastructure.FuseInstallSource`.
+
 The mod version flows in via `-p:ModVersion=<ver>`, which stamps the assemblies
 and `Info.json` (see `Directory.Build.targets`). The release flow is the only
 place a real version is set.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,6 +1,6 @@
 # Settings Reference
 
-FUSE has 28 settings. Most players never need to change any of them — the
+FUSE has 29 settings. Most players never need to change any of them — the
 defaults are the supported configuration, and the majority of these switches are
 diagnostic tools rather than features.
 
@@ -11,7 +11,7 @@ Settings resolve from three layers, each overriding the one before it:
 1. **Built-in defaults** — compiled into FUSE. Used when nothing else specifies a
    value.
 2. **`Info.json`** — the `Settings` object in `Railroader/Mods/FUSE/Info.json`.
-   The shipped file lists 13 of the 28; any setting absent from the file falls back
+   The shipped file lists 14 of the 29; any setting absent from the file falls back
    to its built-in default, and you can add a missing one by name to set it.
 3. **User settings** — `settings.json`, written by the in-game FUSE menu.
 
@@ -74,6 +74,27 @@ Adds a synthetic UMM row for every legacy data package, putting them in UMM's
 global mod list. Kept opt-in for a performance reason: UMM walks that list from
 several per-frame callbacks. FUSE's own Mods page is the primary place to inspect
 legacy packages.
+
+## Update Check
+
+### `EnableUpdateCheck`
+
+**Default: `true`**
+
+On startup, FUSE asks GitHub — which holds the canonical versioning — whether a
+newer *stable* release exists. If one does, it shows a non-blocking notice: a
+one-time toast on the next map load, plus an "Update available" line with a
+download button on the FUSE window's Status page. It never blocks play, and a
+build is only ever flagged when a newer stable release is confirmed.
+
+Only a public list of release versions is fetched; nothing about you or your game
+is sent. Release candidates do not trigger the notice, and a local or development
+build (version `0.0.0`) skips the check entirely. The download link points at
+Nexus for a Nexus-installed copy and at GitHub otherwise.
+
+Turn this off to stop the automatic startup check from making any network
+request. The manual `/fuse.update` command still checks on demand — run it to see
+the current status or force a re-check.
 
 ## Multiplayer
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -87,10 +87,12 @@ one-time toast on the next map load, plus an "Update available" line with a
 download button on the FUSE window's Status page. It never blocks play, and a
 build is only ever flagged when a newer stable release is confirmed.
 
-Only a public list of release versions is fetched; nothing about you or your game
-is sent. Release candidates do not trigger the notice, and a local or development
-build (version `0.0.0`) skips the check entirely. The download link points at
-Nexus for a Nexus-installed copy and at GitHub otherwise.
+Only a public list of release versions is fetched. The request carries no FUSE
+account, save, or mod-list data; GitHub sees only the normal metadata of any
+HTTPS request, such as your IP address. Release candidates do not trigger the
+notice, and a local or development build (version `0.0.0`) skips the check
+entirely. The download link points at Nexus for a Nexus-installed copy and at
+GitHub otherwise.
 
 Turn this off to stop the automatic startup check from making any network
 request. The manual `/fuse.update` command still checks on demand — run it to see

--- a/schemas/umm-info.schema.json
+++ b/schemas/umm-info.schema.json
@@ -52,6 +52,12 @@
     "Repository": {
       "type": "string"
     },
+    "Source": {
+      "type": "string",
+      "enum": ["github", "nexus", "local"],
+      "default": "github",
+      "description": "FUSE-specific provenance stamp used by the in-game update check to point an out-of-date player at the place they installed. The committed manifest ships \"github\"; the release flow re-stamps only the Nexus upload to \"nexus\". GitHub remains canonical for versioning."
+    },
     "Requirements": {
       "type": "array",
       "items": {
@@ -146,6 +152,11 @@
           "type": "boolean",
           "default": false,
           "description": "Shows advanced diagnostics across the FUSE menu pages such as asset duplicate winners, full asset store paths, registry internals, and advanced mod settings. Disabled by default to keep the public UI curated."
+        },
+        "EnableUpdateCheck": {
+          "type": "boolean",
+          "default": true,
+          "description": "On startup, asks GitHub whether a newer stable FUSE release exists and shows a non-blocking notice if so. Only a public list of release versions is fetched. Turn off to disable all network access for the check."
         }
       }
     }

--- a/schemas/umm-info.schema.json
+++ b/schemas/umm-info.schema.json
@@ -156,7 +156,7 @@
         "EnableUpdateCheck": {
           "type": "boolean",
           "default": true,
-          "description": "On startup, asks GitHub whether a newer stable FUSE release exists and shows a non-blocking notice if so. Only a public list of release versions is fetched. Turn off to disable all network access for the check."
+          "description": "On startup, asks GitHub whether a newer stable FUSE release exists and shows a non-blocking notice if so. Only a public list of release versions is fetched. Turning it off disables the automatic startup check; the manual /fuse.update console command still checks on demand."
         }
       }
     }

--- a/scripts/stamp-info-source.ps1
+++ b/scripts/stamp-info-source.ps1
@@ -1,0 +1,48 @@
+#requires -Version 5
+# Rewrites the "Source" field in a UMM Info.json file.
+#
+# The running mod reads this provenance stamp (FUSE.Infrastructure.FuseInstallSource)
+# to point an out-of-date player at the place they most likely downloaded FUSE.
+# Every GitHub-published artifact ships the source default ("github"); the release
+# flow runs this script on the Nexus-bound copy ONLY, flipping it to "nexus", so a
+# Nexus install links back to Nexus while GitHub stays canonical. See
+# .github/workflows/release.yml and docs/RELEASING.md.
+#
+# The replacement is byte-faithful: only the source value changes; whitespace,
+# line endings, key order, and encoding are preserved. The "Source" field must
+# already exist (it is committed in FUSE/Info.json) — this script re-stamps it,
+# it does not add it.
+
+param(
+  [Parameter(Mandatory)][string]$Path,
+  [Parameter(Mandatory)][ValidateSet('github', 'nexus', 'local')][string]$Source
+)
+
+if (-not (Test-Path -LiteralPath $Path)) {
+  Write-Error "File not found: $Path"
+  exit 1
+}
+
+$resolved = (Resolve-Path -LiteralPath $Path).ProviderPath
+$content  = Get-Content -LiteralPath $resolved -Raw
+
+if ($content -notmatch '"Source"\s*:\s*"[^"]*"') {
+  Write-Error "No 'Source' field found in $resolved. It must be present in the source Info.json."
+  exit 1
+}
+
+# Lookbehind/lookahead so the surrounding quotes are preserved. The literal
+# '"Source"' anchor avoids matching any neighboring field. The lookbehind
+# tolerates whitespace around the colon (.NET allows variable-length lookbehind)
+# so it stays symmetric with the existence guard above — otherwise a manifest
+# formatted as '"Source" : "..."' would pass the guard yet silently not stamp.
+$updated = $content -replace '(?<="Source"\s*:\s*")[^"]*(?=")', $Source
+
+if ($content -eq $updated) {
+  Write-Host "$resolved already at Source=$Source; no change."
+  exit 0
+}
+
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText($resolved, $updated, $utf8NoBom)
+Write-Host "Stamped $resolved Source=$Source"


### PR DESCRIPTION
## What

On startup FUSE asks the **public** GitHub Releases API for the newest *stable* `mod-v` release and, if the running build is behind, shows a **non-blocking** notice — one toast on the next map load plus an "Update available" line on the FUSE Status page with a download link. This was designed earlier but couldn't ship while the repo was private (anonymous release queries returned 404); it works now that `F-U-S-E-E/FuseDevelopmentGroup` is public.

## How the pieces fit

- **Version selection** lives in game-free `FUSE.Core` (`Fuse.Core.Versioning`) and is **linked** into the mod (no project reference, no runtime dependency). It picks the newest **stable** `mod-v` tag only — ignoring the `externaleditor-v*`/`tools-v*` lanes, release candidates, drafts, and prereleases. The repo-wide `/releases/latest` is unusable here precisely because of the multi-lane feed, so the list is filtered by tag.
- **Provenance link:** the notice points at Nexus for a Nexus-installed copy and GitHub otherwise, resolved from an `Info.json` `"Source"` stamp. Every GitHub artifact ships the committed default `"github"`; the release flow builds a **Nexus-only** copy of the core zip re-stamped `"nexus"` (`scripts/stamp-info-source.ps1`, GA-only step). The two zips are otherwise byte-identical, and GitHub stays canonical for versioning.
- **Controls:** new `EnableUpdateCheck` setting (default on, with a Settings-page toggle) and a `/fuse.update` console command.
- **Fails safe:** `0.0.0` dev builds skip the check entirely; every network failure (down, timeout, 4xx/5xx, junk body) is logged at `Info`/`Warning` and dropped — it never blocks play and never false-claims a version. The async request runs on a coroutine, so the ≤15s wait costs the player nothing.

## Testing

- **110/110** `FUSE.Core.Tests` pass, including a fixture built from the **real** captured `/releases` payload proving raw JSON → parse → select lands on `mod-v1.0.2` while correctly ignoring the `-rc2`/`-rc3` tags (which GitHub reports as `prerelease=false`, so only the tag-regex excludes them), the old `v0.x` tags, `tools-v0.2.0`, and the `prerelease=true` builds.
- Confirmed anonymous `/releases` returns **HTTP 200** (the core premise).
- The `stamp-info-source.ps1` byte-faithful rewrite is verified for both colon-spacing forms.
- Ran an adversarial multi-agent review across four dimensions (net48 compile-correctness, runtime logic/concurrency, release flow, docs/schema). No code defects survived verification; the two confirmed docs-consistency findings are fixed, plus two cheap hardening items taken (`per_page=100`, whitespace-symmetric stamp regex).

## Note for reviewers

The net48 mod (`FUSE.dll`) can't be compiled in the authoring environment (no local Railroader install), which is why the bug-prone logic was pushed into `FUSE.Core` and tested there; the thin Unity glue mirrors existing patterns (`FuseAudioAPI`'s coroutine + `isNetworkError/isHttpError` shape, `Toast`/`Messenger`/`UIPanelBuilder` conventions). CI's self-hosted runner compiles it on build. Please give the net48 glue a compile-time sanity read.
