### PR TITLE
fix: quick fixes for open issues #219, #208, #207, #223 (+ CHANGELOG for #203/#205)

### DIFF
--- a/FUSE.Tests/Infrastructure/FuseModExceptionProblemThresholdTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseModExceptionProblemThresholdTests.cs
@@ -1,0 +1,47 @@
+using FUSE.Infrastructure;
+using Xunit;
+
+namespace FUSE.Tests.Infrastructure
+{
+    /// <summary>
+    /// Issue #208: the health report and the Status page must agree on when a
+    /// mod's observed exceptions count as a problem. A one-off third-party
+    /// exception is informational; only a recurring thrower is a problem.
+    /// </summary>
+    public sealed class FuseModExceptionProblemThresholdTests
+    {
+        [Theory]
+        [InlineData(1, 1, false)]
+        [InlineData(2, 9, false)]
+        [InlineData(3, 3, true)]
+        [InlineData(1, 10, true)]
+        [InlineData(0, 0, false)]
+        public void IsProblem_MatchesRegistryThresholds(long episodes, long count, bool expected)
+        {
+            var record = new FuseModExceptionSnapshot
+            {
+                ModId = "Some.Mod",
+                Episodes = episodes,
+                Count = count
+            };
+
+            Assert.Equal(expected, record.IsProblem);
+            Assert.Equal(expected, FuseModExceptionRegistry.IsProblem(record));
+        }
+
+        [Fact]
+        public void IsProblem_NullRecord_IsNotAProblem()
+        {
+            Assert.False(FuseModExceptionRegistry.IsProblem(null));
+        }
+
+        [Fact]
+        public void Thresholds_AreTheOnesTheReportDocuments()
+        {
+            // These values are quoted in the Status page copy; keep them in
+            // lockstep with the documented "3+ episodes or 10+ occurrences".
+            Assert.Equal(3, FuseModExceptionRegistry.ProblemEpisodeThreshold);
+            Assert.Equal(10, FuseModExceptionRegistry.ProblemCountThreshold);
+        }
+    }
+}

--- a/FUSE.Tests/Interface/MenuWindow/DependencyGraphPageTests.cs
+++ b/FUSE.Tests/Interface/MenuWindow/DependencyGraphPageTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Interface.MenuWindow;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Interface.MenuWindow
+{
+    /// <summary>
+    /// Issues #207 / #223: the Dependency Graph page painted every load-order
+    /// target that is not a discovered FUSE data package as red MISSING — even
+    /// installed asset-only packs / code-only plugins, and even the advisory
+    /// hints on legacy-converted packages that the loader deliberately ignores.
+    /// </summary>
+    public sealed class DependencyGraphPageTests
+    {
+        private static readonly IDictionary<string, FusePackageManifestSnapshot> Packages =
+            new Dictionary<string, FusePackageManifestSnapshot>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Ready.Pkg"] = new FusePackageManifestSnapshot { Id = "Ready.Pkg" },
+                ["Disabled.Pkg"] = new FusePackageManifestSnapshot { Id = "Disabled.Pkg", Disabled = true },
+            };
+
+        private static readonly ICollection<string> PresentInModsRoot =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "C_L_B.ASSETS01" };
+
+        [Fact]
+        public void DiscoveredEnabledPackage_IsReady()
+        {
+            Assert.Equal(
+                "Ready.Pkg | <color=\"green\">READY",
+                DependencyGraphPage.FormatDependencyEdge("Ready.Pkg", Packages, PresentInModsRoot, advisory: false));
+        }
+
+        [Fact]
+        public void DiscoveredDisabledPackage_IsDisabled_OrOptionalWhenAdvisory()
+        {
+            Assert.Equal(
+                "Disabled.Pkg | <color=\"yellow\">DISABLED",
+                DependencyGraphPage.FormatDependencyEdge("Disabled.Pkg", Packages, PresentInModsRoot, advisory: false));
+            Assert.Equal(
+                "Disabled.Pkg | <color=\"grey\">DISABLED (optional hint)",
+                DependencyGraphPage.FormatDependencyEdge("Disabled.Pkg", Packages, PresentInModsRoot, advisory: true));
+        }
+
+        [Fact]
+        public void InstalledAssetOrPluginMod_IsPresent_NotMissing()
+        {
+            Assert.Equal(
+                "C_L_B.ASSETS01 | <color=\"green\">PRESENT (asset/plugin mod)",
+                DependencyGraphPage.FormatDependencyEdge("C_L_B.ASSETS01", Packages, PresentInModsRoot, advisory: false));
+            // Case-insensitive like the discovery matcher.
+            Assert.Equal(
+                "c_l_b.assets01 | <color=\"green\">PRESENT (asset/plugin mod)",
+                DependencyGraphPage.FormatDependencyEdge("c_l_b.assets01", Packages, PresentInModsRoot, advisory: true));
+        }
+
+        [Fact]
+        public void UnknownTarget_IsMissing_ForNativePackages_ButOptionalForLegacyHints()
+        {
+            Assert.Equal(
+                "Nope.Pkg | <color=\"red\">MISSING",
+                DependencyGraphPage.FormatDependencyEdge("Nope.Pkg", Packages, PresentInModsRoot, advisory: false));
+            Assert.Equal(
+                "Nope.Pkg | <color=\"grey\">NOT INSTALLED (optional hint)",
+                DependencyGraphPage.FormatDependencyEdge("Nope.Pkg", Packages, PresentInModsRoot, advisory: true));
+        }
+
+        [Fact]
+        public void BlankTarget_IsAlwaysMissing()
+        {
+            Assert.Equal(
+                "(blank) | <color=\"red\">MISSING",
+                DependencyGraphPage.FormatDependencyEdge(" ", Packages, PresentInModsRoot, advisory: true));
+            Assert.Equal(
+                "(blank) | <color=\"red\">MISSING",
+                DependencyGraphPage.FormatDependencyEdge(null, null, null, advisory: false));
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseLegacyConverterCultureTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyConverterCultureTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using FUSE.Loading;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    /// <summary>
+    /// Regression coverage for issue #219: the runtime legacy converter round-tripped
+    /// numeric tokens through <c>JValue.ToString()</c>, which formats with the current
+    /// culture. Under a comma-decimal locale every fractional coordinate failed the
+    /// invariant parse and collapsed to 0, so whole map mods folded onto the world
+    /// origin (zero-length segments, non-intersecting switches, scenery at the group
+    /// root).
+    /// </summary>
+    public sealed class FuseLegacyConverterCultureTests
+    {
+        [Theory]
+        [InlineData("pt-BR")]
+        [InlineData("de-DE")]
+        [InlineData("fr-FR")]
+        [InlineData("en-US")]
+        public void FractionalCoordinates_SurviveConversion_UnderCommaDecimalCultures(string cultureName)
+        {
+            var culture = CultureInfo.GetCultureInfo(cultureName);
+            var previousCulture = Thread.CurrentThread.CurrentCulture;
+            var previousUiCulture = Thread.CurrentThread.CurrentUICulture;
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+            try
+            {
+                // Sanity check that this culture would actually have exercised the bug:
+                // the double must format with a comma for the non-invariant cases.
+                if (culture.NumberFormat.NumberDecimalSeparator == ",")
+                {
+                    Assert.Contains(",", new JValue(12278.53).ToString());
+                }
+
+                var source = new JObject
+                {
+                    ["tracks"] = new JObject
+                    {
+                        ["nodes"] = new JObject
+                        {
+                            ["N_AWHI_1"] = new JObject
+                            {
+                                ["position"] = new JObject { ["x"] = 12278.53, ["y"] = 560.25, ["z"] = 5770.75 },
+                                ["rotation"] = new JObject { ["x"] = 0, ["y"] = 152.5, ["z"] = 0 }
+                            }
+                        }
+                    },
+                    ["scenery"] = new JObject
+                    {
+                        ["awhi-sign"] = new JObject
+                        {
+                            ["modelIdentifier"] = "sign",
+                            ["position"] = new JObject { ["x"] = 12299.28, ["y"] = 557.17, ["z"] = 5846.18 },
+                            ["rotation"] = new JObject { ["x"] = 0, ["y"] = 90.5, ["z"] = 0 },
+                            ["scale"] = new JObject { ["x"] = 1.5, ["y"] = 1.5, ["z"] = 1.5 }
+                        }
+                    }
+                };
+                var manifest = new FuseLegacyPackageManifest
+                {
+                    PackageId = "culture-pkg",
+                    DisplayName = "Culture Package",
+                    Author = "tester",
+                    Version = "1.0.0"
+                };
+                var root = FuseLegacyDataConverter.CreateSkeleton(manifest, "culture-fragment");
+
+                FuseLegacyDataConverter.ConvertSource(source, root, manifest);
+
+                var node = (JObject)root["tracks"]["nodes"]["N_AWHI_1"];
+                Assert.Equal(12278.53f, (float)node["position"]["x"], 2);
+                Assert.Equal(560.25f, (float)node["position"]["y"], 2);
+                Assert.Equal(5770.75f, (float)node["position"]["z"], 2);
+                Assert.Equal(152.5f, (float)node["rotation"]["y"], 2);
+
+                var scenery = (JObject)root["world"]["scenery"]["awhi-sign"];
+                Assert.Equal(12299.28f, (float)scenery["position"]["x"], 2);
+                Assert.Equal(557.17f, (float)scenery["position"]["y"], 2);
+                Assert.Equal(5846.18f, (float)scenery["position"]["z"], 2);
+                Assert.Equal(90.5f, (float)scenery["rotation"]["y"], 2);
+                Assert.Equal(1.5f, (float)scenery["scale"]["x"], 2);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = previousCulture;
+                Thread.CurrentThread.CurrentUICulture = previousUiCulture;
+            }
+        }
+    }
+}

--- a/FUSE/Infrastructure/FuseModExceptionRegistry.cs
+++ b/FUSE/Infrastructure/FuseModExceptionRegistry.cs
@@ -16,6 +16,16 @@ namespace FUSE.Infrastructure
         public string DisplayName { get; set; } = string.Empty;
         public long Count { get; set; }
         public long Episodes { get; set; }
+
+        /// <summary>
+        /// True when this mod's observations cross the report's problem
+        /// thresholds (<see cref="FuseModExceptionRegistry.IsProblem"/>). A
+        /// single one-off exception is informational; a per-cycle thrower
+        /// crosses the thresholds within seconds. Every surface that decides
+        /// "is this mod a problem" — the health report and the Status page —
+        /// must use this one predicate so they never disagree (issue #208).
+        /// </summary>
+        public bool IsProblem => FuseModExceptionRegistry.IsProblem(this);
         public DateTime FirstSeenUtc { get; set; }
         public DateTime LastSeenUtc { get; set; }
         public FuseModExceptionSignatureSnapshot[] Signatures { get; set; } =
@@ -70,6 +80,26 @@ namespace FUSE.Infrastructure
         private const string OverflowDisplayName = "(other mods)";
 
         private const int MaxTrackedMods = 32;
+
+        /// <summary>
+        /// A mod is reported as a problem once it has this many distinct
+        /// episodes (1-second coalesced bursts) ...
+        /// </summary>
+        internal const long ProblemEpisodeThreshold = 3;
+
+        /// <summary>... or this many total occurrences this session.</summary>
+        internal const long ProblemCountThreshold = 10;
+
+        /// <summary>
+        /// The single source of truth for "does this mod's exception record
+        /// count as a problem". A one-off third-party exception (for example
+        /// a first-frame-after-map-load NRE in another mod's window code)
+        /// must not flip the report or the Status page red; a repeating
+        /// thrower crosses these thresholds within seconds of starting.
+        /// </summary>
+        internal static bool IsProblem(FuseModExceptionSnapshot record) =>
+            record != null &&
+            (record.Episodes >= ProblemEpisodeThreshold || record.Count >= ProblemCountThreshold);
         private const int MaxSignaturesPerMod = 8;
         private const long EpisodeCoalesceWindowMs = 1000;
         private const int SampleMessageMaxLength = 200;

--- a/FUSE/Interface/MenuWindow/DependencyGraphPage.cs
+++ b/FUSE/Interface/MenuWindow/DependencyGraphPage.cs
@@ -15,6 +15,11 @@ namespace FUSE.Interface.MenuWindow
             builder.AddTitle("Mod Dependency Graph", "");
 
             builder.AddLabel("This page shows mod dependencies with load order requirements and any detected faults.");
+            AddWrappedLabel(
+                builder,
+                "Legacy (converted) packages list soft load-order hints: a hint whose target is not installed is optional and does not block loading. " +
+                "Asset-only packs and code-only plugins satisfy a dependency without being FUSE data packages.",
+                48f);
 
             builder.Spacer(24f);
 
@@ -28,6 +33,14 @@ namespace FUSE.Interface.MenuWindow
             var byId = manifests
                 .GroupBy(manifest => manifest.Id, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+            // Resolve every edge target that is not a discovered data package
+            // against the Mods root once, so installed asset-only packs and
+            // hosted code-only plugins render as PRESENT rather than MISSING
+            // (issues #207, #223).
+            var undiscovered = manifests
+                .SelectMany(manifest => manifest.LoadAfter.Concat(manifest.LoadBefore))
+                .Where(id => !string.IsNullOrWhiteSpace(id) && !byId.ContainsKey(id));
+            var presentInModsRoot = FuseDataPackageDiscovery.ResolvePackagesPresentInModsRoot(undiscovered);
             var rows = 0;
             foreach (var manifest in manifests)
             {
@@ -46,19 +59,19 @@ namespace FUSE.Interface.MenuWindow
                 AddWrappedLabel(builder, InsertBreakHints(manifest.Id), 28f);
                 foreach (var dependencyId in manifest.LoadAfter)
                 {
-                    builder.AddField("load after", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId))));
+                    builder.AddField("load after", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId, presentInModsRoot, manifest.IsLegacyConverted))));
                     rows++;
                 }
 
                 foreach (var dependencyId in manifest.LoadBefore)
                 {
-                    builder.AddField("load before", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId))));
+                    builder.AddField("load before", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId, presentInModsRoot, manifest.IsLegacyConverted))));
                     rows++;
                 }
 
                 foreach (var fault in manifest.Faults)
                 {
-                    builder.AddField("fault detected", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(fault, byId))));
+                    builder.AddField("fault detected", builder.AddLabelMarkup(InsertBreakHints(FormatFault(fault))));
                     rows++;
                 }
 
@@ -73,7 +86,11 @@ namespace FUSE.Interface.MenuWindow
             }
         }
 
-        private static string FormatDependencyEdge(string dependencyId, IDictionary<string, FusePackageManifestSnapshot> packages)
+        internal static string FormatDependencyEdge(
+            string dependencyId,
+            IDictionary<string, FusePackageManifestSnapshot> packages,
+            ICollection<string> presentInModsRoot,
+            bool advisory)
         {
             if (string.IsNullOrWhiteSpace(dependencyId))
             {
@@ -82,12 +99,32 @@ namespace FUSE.Interface.MenuWindow
 
             if (packages != null && packages.TryGetValue(dependencyId, out var dependency))
             {
-                return dependency.Disabled
-                    ? dependencyId + " | <color=\"yellow\">DISABLED"
-                    : dependencyId + " | <color=\"green\">READY";
+                if (!dependency.Disabled)
+                {
+                    return dependencyId + " | <color=\"green\">READY";
+                }
+
+                return advisory
+                    ? dependencyId + " | <color=\"grey\">DISABLED (optional hint)"
+                    : dependencyId + " | <color=\"yellow\">DISABLED";
             }
 
-            return dependencyId + " | <color=\"red\">MISSING";
+            if (presentInModsRoot != null && presentInModsRoot.Contains(dependencyId))
+            {
+                return dependencyId + " | <color=\"green\">PRESENT (asset/plugin mod)";
+            }
+
+            // Legacy-converted packages' loadAfter/loadBefore are advisory: the
+            // loader ignores an unresolved target without recording a fault, so
+            // the page must not paint it as an error either.
+            return advisory
+                ? dependencyId + " | <color=\"grey\">NOT INSTALLED (optional hint)"
+                : dependencyId + " | <color=\"red\">MISSING";
+        }
+
+        private static string FormatFault(string fault)
+        {
+            return "<color=\"red\">" + (string.IsNullOrWhiteSpace(fault) ? "(blank)" : fault);
         }
     }
 }

--- a/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
@@ -84,12 +84,19 @@ namespace FUSE.Interface.MenuWindow
             // concurrent log event can never render contradictory rows.
             var modExceptionState = FuseModExceptionRegistry.CaptureReportState();
             var modExceptions = modExceptionState.Mods;
+            // Same threshold as the health report (FuseLoadReport
+            // HasModExceptionProblem): a one-off third-party exception is
+            // informational, not a "Review" — only a recurring thrower flips
+            // this row (issue #208).
+            var problemModCount = modExceptions.Count(record => record.IsProblem);
             AddReadinessRow(
                 builder,
                 "Mod Health",
-                modExceptionState.Total == 0,
-                "0 exceptions observed",
-                $"{modExceptionState.Total} exception(s) across {modExceptions.Length} mod(s)");
+                problemModCount == 0,
+                modExceptionState.Total == 0
+                    ? "0 exceptions observed"
+                    : $"{modExceptionState.Total} one-off exception(s) observed across {modExceptions.Length} mod(s) (informational)",
+                $"{modExceptionState.Total} exception(s) across {modExceptions.Length} mod(s); {problemModCount} recurring");
             builder.Spacer(6f);
 
             // Full per-guard breakdown (this window is the only UI surface, so
@@ -134,7 +141,11 @@ namespace FUSE.Interface.MenuWindow
                 builder,
                 modExceptionState.Total == 0
                     ? "All idle — no third-party mod exceptions were observed this session."
-                    : "Non-zero counts are third-party mod faults FUSE observed or contained; offenders are named in FUSE.log and the health report.",
+                    : problemModCount == 0
+                        ? "One-off third-party exceptions were observed and logged for reference; they only count as a problem if they recur (" +
+                          FuseModExceptionRegistry.ProblemEpisodeThreshold + "+ episodes or " +
+                          FuseModExceptionRegistry.ProblemCountThreshold + "+ occurrences). Details are in FUSE.log and the health report."
+                        : "Recurring counts are third-party mod faults FUSE observed or contained; offenders are named in FUSE.log and the health report.",
                 48f);
             builder.Spacer(6f);
 

--- a/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
@@ -95,7 +95,7 @@ namespace FUSE.Interface.MenuWindow
                 problemModCount == 0,
                 modExceptionState.Total == 0
                     ? "0 exceptions observed"
-                    : $"{modExceptionState.Total} one-off exception(s) observed across {modExceptions.Length} mod(s) (informational)",
+                    : $"{modExceptionState.Total} below-threshold exception(s) observed across {modExceptions.Length} mod(s) (informational)",
                 $"{modExceptionState.Total} exception(s) across {modExceptions.Length} mod(s); {problemModCount} recurring");
             builder.Spacer(6f);
 
@@ -142,7 +142,7 @@ namespace FUSE.Interface.MenuWindow
                 modExceptionState.Total == 0
                     ? "All idle — no third-party mod exceptions were observed this session."
                     : problemModCount == 0
-                        ? "One-off third-party exceptions were observed and logged for reference; they only count as a problem if they recur (" +
+                        ? "Below-threshold third-party exceptions were observed and logged for reference; a mod counts as a problem at (" +
                           FuseModExceptionRegistry.ProblemEpisodeThreshold + "+ episodes or " +
                           FuseModExceptionRegistry.ProblemCountThreshold + "+ occurrences). Details are in FUSE.log and the health report."
                         : "Recurring counts are third-party mod faults FUSE observed or contained; offenders are named in FUSE.log and the health report.",

--- a/FUSE/Loading/FuseDataPackageDiscovery.cs
+++ b/FUSE/Loading/FuseDataPackageDiscovery.cs
@@ -503,7 +503,7 @@ namespace FUSE.Loading
                             var message = $"Package '{package.Id}' declares FuseLoadAfter '{dependencyId}', but that package is disabled.";
                             if (package.IsLegacyDataPackage)
                             {
-                                FuseLog.Warning($"FUSE ignored legacy order reference because it is advisory: {message}");
+                                FuseLog.Info($"FUSE ignored legacy order reference because it is advisory: {message}");
                             }
                             else
                             {
@@ -520,7 +520,7 @@ namespace FUSE.Loading
                         var message = $"Package '{package.Id}' declares FuseLoadAfter '{dependencyId}', but no matching FUSE data package was discovered.";
                         if (package.IsLegacyDataPackage)
                         {
-                            FuseLog.Warning($"FUSE ignored legacy order reference because it is advisory: {message}");
+                            FuseLog.Info($"FUSE ignored legacy order reference because it is advisory: {message}");
                         }
                         else
                         {
@@ -539,7 +539,7 @@ namespace FUSE.Loading
                             var message = $"Package '{package.Id}' declares FuseLoadBefore '{dependencyId}', but that package is disabled.";
                             if (package.IsLegacyDataPackage)
                             {
-                                FuseLog.Warning($"FUSE ignored legacy order reference because it is advisory: {message}");
+                                FuseLog.Info($"FUSE ignored legacy order reference because it is advisory: {message}");
                             }
                             else
                             {
@@ -556,7 +556,7 @@ namespace FUSE.Loading
                         var message = $"Package '{package.Id}' declares FuseLoadBefore '{dependencyId}', but no matching FUSE data package was discovered.";
                         if (package.IsLegacyDataPackage)
                         {
-                            FuseLog.Warning($"FUSE ignored legacy order reference because it is advisory: {message}");
+                            FuseLog.Info($"FUSE ignored legacy order reference because it is advisory: {message}");
                         }
                         else
                         {
@@ -637,6 +637,74 @@ namespace FUSE.Loading
                     ? idCompare
                     : string.Compare(left.FolderPath, right.FolderPath, StringComparison.OrdinalIgnoreCase);
             });
+        }
+
+        /// <summary>
+        /// Batch form of <see cref="IsPackagePresentInModsRoot"/> for UI: scans the
+        /// Mods root once and returns which of <paramref name="dependencyIds"/>
+        /// resolve to an enabled mod folder that is *not* a discovered FUSE data
+        /// package (asset-only packs, hosted code-only plugins). The Dependency
+        /// Graph page uses this to stop painting installed asset/plugin mods as
+        /// MISSING (issues #207, #223).
+        /// </summary>
+        internal static HashSet<string> ResolvePackagesPresentInModsRoot(IEnumerable<string> dependencyIds)
+        {
+            var present = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var wanted = (dependencyIds ?? Enumerable.Empty<string>())
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (wanted.Length == 0)
+            {
+                return present;
+            }
+
+            var modsRoot = GetModsRoot();
+            if (string.IsNullOrWhiteSpace(modsRoot) || !Directory.Exists(modsRoot))
+            {
+                return present;
+            }
+
+            try
+            {
+                foreach (var packagePath in Directory.GetDirectories(modsRoot))
+                {
+                    var packageId = TryReadPackageId(packagePath);
+                    if (FuseUmmState.TryGetDisabledReason(packagePath, packageId, out _) ||
+                        !FuseModSetService.IsPackageEnabledByActiveSet(packageId, packagePath))
+                    {
+                        continue;
+                    }
+
+                    var folderName = Path.GetFileName(packagePath);
+                    foreach (var dependencyId in wanted)
+                    {
+                        if (present.Contains(dependencyId))
+                        {
+                            continue;
+                        }
+
+                        var legacyNormalizedDependency = FuseLegacyDataConverter.EnsureFusePackageId(dependencyId);
+                        if (PackageIdMatches(packageId, dependencyId, legacyNormalizedDependency) ||
+                            PackageIdMatches(folderName, dependencyId, legacyNormalizedDependency))
+                        {
+                            present.Add(dependencyId);
+                        }
+                    }
+
+                    if (present.Count == wanted.Length)
+                    {
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                FuseLog.Exception("FUSE could not inspect Mods folder while resolving dependency graph rows", ex);
+            }
+
+            return present;
         }
 
         private static bool IsPackagePresentInModsRoot(string dependencyId)

--- a/FUSE/Loading/FuseLegacyDataConverter.Helpers.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.Helpers.cs
@@ -326,6 +326,19 @@ namespace FUSE.Loading
                 return defaultValue;
             }
 
+            // Numeric tokens must be read through the typed accessor. JValue.ToString()
+            // formats with the current culture, so a comma-decimal locale (pt-BR, de-DE,
+            // fr-FR, ...) turns 12.5 into "12,5", which the invariant parse below
+            // rejects. That silently collapsed every fractional legacy coordinate to the
+            // default (issue #219).
+            switch (token.Type)
+            {
+                case JTokenType.Integer:
+                    return token.Value<int>();
+                case JTokenType.Float:
+                    return (int)Math.Round(token.Value<double>());
+            }
+
             return int.TryParse(token.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
                 ? parsed
                 : defaultValue;
@@ -336,6 +349,12 @@ namespace FUSE.Loading
             if (token == null || token.Type == JTokenType.Null)
             {
                 return defaultValue;
+            }
+
+            // See ReadInt: never round-trip a numeric token through ToString().
+            if (token.Type == JTokenType.Float || token.Type == JTokenType.Integer)
+            {
+                return token.Value<float>();
             }
 
             return float.TryParse(token.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)

--- a/FUSE/Loading/FuseLoadReport.cs
+++ b/FUSE/Loading/FuseLoadReport.cs
@@ -882,10 +882,11 @@ namespace FUSE.Loading
 
             // A single one-off third-party exception must not flip the report
             // red, but a per-cycle thrower (world moves, update ticks) crosses
-            // these thresholds within seconds of the fault starting.
+            // the registry's thresholds within seconds of the fault starting.
+            // The Status page shares this predicate (issue #208).
             public bool HasModExceptionProblem =>
                 ModExceptions != null &&
-                ModExceptions.Any(record => record.Episodes >= 3 || record.Count >= 10);
+                ModExceptions.Any(record => record.IsProblem);
         }
 
         private static JArray ToArray(IEnumerable<string> values)

--- a/FUSE/Loading/FuseSplineyPluginHost.cs
+++ b/FUSE/Loading/FuseSplineyPluginHost.cs
@@ -371,6 +371,8 @@ namespace FUSE.Loading
         {
             var builders = new Dictionary<string, StrangeCustoms.ISplineyBuilder>(StringComparer.OrdinalIgnoreCase);
             var fuseAssembly = typeof(FuseSplineyPluginHost).Assembly;
+            var unloadableTypeCount = 0;
+            string firstUnloadableType = null;
 
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
@@ -395,12 +397,33 @@ namespace FUSE.Loading
 
                 foreach (var type in types)
                 {
-                    if (type == null || !type.IsClass || type.IsAbstract)
+                    // Type inspection itself can throw for a foreign type whose
+                    // field/base types cannot be resolved (Mono raises
+                    // TypeLoadException from IsAssignableFrom, e.g. a stray real
+                    // Railloader.dll whose types bind against FUSE's shim). One
+                    // such type must not abort the whole scan and drop every
+                    // queued builder task (issue #207) — skip it and keep going.
+                    bool isBuilder;
+                    try
                     {
+                        isBuilder = type != null &&
+                            type.IsClass &&
+                            !type.IsAbstract &&
+                            typeof(StrangeCustoms.ISplineyBuilder).IsAssignableFrom(type);
+                    }
+                    catch (Exception ex)
+                    {
+                        unloadableTypeCount++;
+                        if (firstUnloadableType == null)
+                        {
+                            firstUnloadableType =
+                                $"{assembly.GetName().Name}:{type?.FullName ?? "?"} ({ex.GetBaseException().GetType().Name}: {ex.GetBaseException().Message})";
+                        }
+
                         continue;
                     }
 
-                    if (!typeof(StrangeCustoms.ISplineyBuilder).IsAssignableFrom(type))
+                    if (!isBuilder)
                     {
                         continue;
                     }
@@ -421,6 +444,14 @@ namespace FUSE.Loading
                             $"ISplineyBuilder '{type.FullName}': {ex.GetBaseException().Message}");
                     }
                 }
+            }
+
+            if (unloadableTypeCount > 0)
+            {
+                FuseLog.Warning(
+                    $"FUSE spliney plugin host skipped {unloadableTypeCount} unloadable type(s) while scanning " +
+                    $"for ISplineyBuilder implementations; first: {firstUnloadableType}. If this names a " +
+                    "Railloader assembly, a stray legacy Railloader.dll is still being loaded from a mod folder.");
             }
 
             return builders;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,62 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
   folder behind, and a failed `--replace` reinstall leaves the existing install
   untouched.
 
+- Legacy map mods collapsed onto the world origin on comma-decimal locales
+  (pt-BR, de-DE, fr-FR, ...): spaghetti track on the map, "zero length" track
+  spans, "Switch tracks do not intersect", scenery and scene clones piled at
+  their group's origin. The in-game legacy converter round-tripped numeric JSON
+  values through `ToString()`, which formats with the current culture, so every
+  fractional coordinate failed the invariant parse and became 0 while integer
+  coordinates survived. Numeric tokens are now read through the typed accessor.
+  The standalone converters were never affected. (#219)
+- Legacy Railloader/StrangeCustoms packages that keep `segments` (in
+  `game-graph.json`) or `spans` (in industry files) at the top level of the file
+  instead of under `tracks` now convert completely; previously nodes and scenery
+  loaded but no track was built and industries had no spans or locations, e.g.
+  Whittier Industries. Explicit legacy `type` values on span-less industry
+  component patches (such as `Model.Ops.IndustryLoader`) are converted as
+  patches instead of failing validation and faulting the whole package. (#210,
+  #223, part of #203)
+- Legacy `points: { "$replace": [...] }` patches addressed to a base-game road
+  or river by scene path (e.g. `World/Roads Sylva/Chipper Curve`) now replace
+  the control points of the existing spline in place, keeping its profile,
+  style, and hierarchy, instead of building a second generic road over the
+  original. Existing scene trestles are patched the same way. (#220, part of
+  #203)
+- World restoration is now contained per package: a malformed progression
+  section, an unbindable legacy component, or a third-party `TimeSync`
+  callback on the wrong thread no longer aborts loading for every other
+  package. One-sided terminal passenger links (such as Olive Hill → MCA) are
+  repaired without inventing extra routes, legacy location id casing is
+  preserved, and AssetLoader discovery, generated loader transforms, and
+  loader lifecycle state survive the compatibility guards added during live
+  testing. (#203)
+- One asset pack with a malformed `Definitions.json` no longer knocks out
+  unrelated packs. The failed store used to become an ordering barrier in the
+  prefab source index and abort scenery enumeration, so valid packs registered
+  after it stopped resolving and buildings went missing across the map. Such a
+  store is now quarantined by itself, its path is logged once, and later packs
+  resolve normally; the bad file itself is still the mod author's to fix. (#196)
+- The Status page's "Mod Health" row flagged a mod as needing review after a
+  single one-off third-party exception (for example another mod's
+  first-frame-after-load `NullReferenceException`), contradicting the health
+  report, which only counts a mod as a problem once it recurs (3+ episodes or
+  10+ occurrences). Both surfaces now share that one threshold; one-off
+  exceptions are listed as informational. (#208)
+- A single unloadable type in some other assembly (typically a stray, real
+  `Railloader.dll` still being loaded from a mod folder) aborted FUSE's scan for
+  legacy `ISplineyBuilder` implementations, so every queued builder task —
+  DKW switch meshes, for example — was silently dropped. The scan now skips the
+  offending type, keeps going, and logs which assembly it came from. (#207)
+- The Dependency Graph page painted every load-order target that is not a FUSE
+  data package as red `MISSING`, including installed asset-only packs and
+  code-only plugins that satisfy the dependency, and the optional load-order
+  hints on legacy-converted packages that the loader deliberately ignores.
+  Installed asset/plugin mods now show `PRESENT`, optional legacy hints show
+  `NOT INSTALLED (optional hint)` in grey, and only real missing requirements
+  stay red. The matching "ignored legacy order reference" log lines are now
+  informational instead of warnings. (#207, #223)
+
 ## [1.0.2]
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -102,8 +102,8 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
   single one-off third-party exception (for example another mod's
   first-frame-after-load `NullReferenceException`), contradicting the health
   report, which only counts a mod as a problem once it recurs (3+ episodes or
-  10+ occurrences). Both surfaces now share that one threshold; one-off
-  exceptions are listed as informational. (#208)
+  10+ occurrences). Both surfaces now share that one threshold; anything
+  below it is listed as informational. (#208)
 - A single unloadable type in some other assembly (typically a stray, real
   `Railloader.dll` still being loaded from a mod folder) aborted FUSE's scan for
   legacy `ISplineyBuilder` implementations, so every queued builder task —


### PR DESCRIPTION
## Summary

Quick, low-risk fixes rolled in from an open-issue triage ahead of today's release. Each fix was verified against the reporters' logs and the current code, built locally against the game assemblies, and comes with unit coverage where the code is testable.

- **#219 — legacy map mods collapse onto the world origin on comma-decimal locales.** `FuseLegacyDataConverter.Helpers.ReadFloat/ReadInt` round-tripped numeric tokens through `JValue.ToString()`, which formats with the *current* culture (`12278.53` → `"12278,53"` under pt-BR/de-DE/fr-FR); the invariant `TryParse` then failed and every fractional coordinate became 0 while integer ones survived — exactly the "spaghetti track", zero-length spans, non-intersecting switches, and scenery-at-group-origin pattern in the report. Numeric tokens are now read via `Value<float>()` / `Value<int>()`. Regression test runs the converter under pt-BR/de-DE/fr-FR/en-US (fails 3/4 without the fix, passes 4/4 with it).
- **#208 — Status page flags a mod after one benign exception.** `FuseLoadReport.HasModExceptionProblem` requires 3+ episodes or 10+ occurrences, but `StatusPanelBuilder` used `Total == 0`, so a single first-frame NRE in another mod rendered "Review". Added `FuseModExceptionSnapshot.IsProblem` / `FuseModExceptionRegistry.IsProblem` as the single source of truth; both surfaces use it, one-offs render as informational. Unit test for the thresholds.
- **#207(A) — one unloadable foreign type aborts the whole `ISplineyBuilder` scan.** `typeof(ISplineyBuilder).IsAssignableFrom(type)` was unguarded; Mono throws `TypeLoadException` for a foreign type whose field types can't resolve (a stray real `Railloader.dll` binding against FUSE's shim), the exception escaped `DiscoverSplineyBuilders`, and every queued builder task (DKW switch meshes) was dropped. Now per-type guarded; one warning names the assembly/type.
- **#207(B) / #223 — Dependency Graph paints installed asset/plugin mods and optional legacy hints as red MISSING.** New `FuseDataPackageDiscovery.ResolvePackagesPresentInModsRoot` scans the Mods root once per page build; edges now render `READY` / `PRESENT (asset/plugin mod)` / `NOT INSTALLED (optional hint)` (legacy-converted packages, whose loadAfter/loadBefore the loader already treats as advisory) / `MISSING`. Fault rows render as plain red text instead of `<message> | MISSING`. The four "ignored legacy order reference because it is advisory" log lines are demoted from Warning to Info. Unit tests for the label matrix.
- **CHANGELOG** — entries for the above, plus the previously unlisted #203 (legacy map-loading hardening; also covers #210/#220) and #205 (malformed `Definitions.json` quarantine; #196) so the release notes are complete.

Fixes #219
Fixes #208
Fixes #207
Fixes #223

## Validation

- `dotnet build FUSE/FUSE.csproj -c Release` against the game assemblies — 0 errors, no new warnings
- `dotnet test FUSE.Tests` — **1831 passed, 0 failed** (includes 16 new tests)
- `python tools/cs_lint.py` — all checks passed

## Not included (needs in-game verification)

#224 / #222 share a real root cause (LegosLibraryOfStuff clone definitions of *mod-pack* cars never register because FUSE's direct asset-pack mounting bypasses `ContainerSerialization.Deserialize`, so old-loader postfixes never fire for those packs). It's a contained change in `FuseAssetPackRegistry.DirectStore.cs` but a runtime-behavior change that should be checked in-game with LLoS + a repaint pack before it ships; tracked separately.
