### PR TITLE
Progression: support enableFeaturesAtStart so map mods can seed career start features

### DIFF
--- a/FUSE.Converter/Conversion/LegacyConverterConstants.cs
+++ b/FUSE.Converter/Conversion/LegacyConverterConstants.cs
@@ -230,6 +230,13 @@ namespace FUSE.Converter.Conversion
         /// Progression fields whose legacy shape is a bool dictionary
         /// (<c>{ "FeatureX": true, "FeatureY": false }</c>) that the
         /// converter normalises to an array of enabled keys.
+        ///
+        /// Deliberately NOT listed: <c>enableFeaturesAtStart</c>. Flattening
+        /// it to an array would turn its FuseStringPatch semantics from
+        /// per-id MERGE into REPLACE, and a mod patching a base-game
+        /// progression (e.g. "ewh") would then wipe the base career's own
+        /// start features (wh-el, ewh-intch). It must pass through verbatim
+        /// so the object form reaches the runtime as a merge.
         /// </summary>
         public static readonly HashSet<string> BoolDictionaryArrayFields = new HashSet<string>(StringComparer.Ordinal)
         {

--- a/FUSE.Core.Tests/ProgressionEnableFeaturesAtStartTests.cs
+++ b/FUSE.Core.Tests/ProgressionEnableFeaturesAtStartTests.cs
@@ -106,6 +106,22 @@ namespace Fuse.Core.Tests
         }
 
         [Fact]
+        public void ObjectForm_FalseRemovesOnlyThatFeature()
+        {
+            // The idPatch contract: false is a per-id removal. It must remove
+            // exactly the named id and leave every other existing entry alone
+            // (both the base game's and the mod's own additions).
+            var progression = Load(@"{ ""enableFeaturesAtStart"": { ""ewh-intch"": false, ""APPA-Start-Seed"": true }, ""sections"": {} }");
+
+            var result = progression.EnableFeaturesAtStart.ApplyTo(new[] { "wh-el", "ewh-intch" });
+
+            Assert.Equal(
+                new[] { "APPA-Start-Seed", "wh-el" },
+                result.OrderBy(id => id, StringComparer.OrdinalIgnoreCase));
+            Assert.DoesNotContain("ewh-intch", result, StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void ArrayForm_ReplacesBaseCareerStartFeatures()
         {
             // Documents the hazard the merge form exists to avoid: array form

--- a/FUSE.Core.Tests/ProgressionEnableFeaturesAtStartTests.cs
+++ b/FUSE.Core.Tests/ProgressionEnableFeaturesAtStartTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Linq;
+using Fuse.Core.Model;
+using Fuse.Core.Serialization;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Fuse.Core.Tests
+{
+    /// <summary>
+    /// Pins the wire contract of <c>progressions.&lt;id&gt;.enableFeaturesAtStart</c>.
+    /// The runtime maps this field onto the game's private
+    /// <c>Progression.enableFeaturesAtStart</c> array so a map mod can put its
+    /// starting trunk on at Company start (and heal existing saves) via the
+    /// same lever the base career uses. Two properties are load-bearing and
+    /// must not drift:
+    /// <list type="bullet">
+    ///   <item>Omitted → null (no change), so every existing mod is unaffected.</item>
+    ///   <item>Object form → per-id MERGE (union with the runtime's existing
+    ///   list). A mod patching the base career progression <c>ewh</c> relies
+    ///   on this so the base game's own start features (wh-el, ewh-intch)
+    ///   survive; array form is a REPLACE and would wipe them.</item>
+    /// </list>
+    /// </summary>
+    public class ProgressionEnableFeaturesAtStartTests
+    {
+        private const string Skeleton = @"{
+  ""schemaVersion"": ""1.0"",
+  ""id"": ""Test.EnableFeaturesAtStart"",
+  ""progression"": {
+    ""progressions"": {
+      ""ewh"": PROGRESSION
+    }
+  }
+}";
+
+        private static FuseProgression Load(string progressionJson)
+        {
+            var json = Skeleton.Replace("PROGRESSION", progressionJson);
+            var definition = FuseCoreSerializer.FromJson(json);
+            Assert.NotNull(definition?.Progression?.Progressions);
+            Assert.True(definition.Progression.Progressions.ContainsKey("ewh"));
+            return definition.Progression.Progressions["ewh"];
+        }
+
+        [Fact]
+        public void Omitted_IsNull_SoExistingModsAreUnaffected()
+        {
+            var progression = Load(@"{ ""sections"": {} }");
+
+            Assert.Null(progression.EnableFeaturesAtStart);
+        }
+
+        [Fact]
+        public void ObjectForm_DeserializesAsMergePatch()
+        {
+            var progression = Load(@"{ ""enableFeaturesAtStart"": { ""APPA-Start-Seed"": true, ""AR-Connelly"": true }, ""sections"": {} }");
+
+            var patch = progression.EnableFeaturesAtStart;
+            Assert.NotNull(patch);
+            Assert.True(patch.HasValue);
+            Assert.Null(patch.Set);
+            Assert.NotNull(patch.Patch);
+            Assert.True(patch.Patch["APPA-Start-Seed"]);
+            Assert.True(patch.Patch["AR-Connelly"]);
+        }
+
+        [Fact]
+        public void ArrayForm_DeserializesAsReplacementSet()
+        {
+            var progression = Load(@"{ ""enableFeaturesAtStart"": [ ""APPA-Start-Seed"" ], ""sections"": {} }");
+
+            var patch = progression.EnableFeaturesAtStart;
+            Assert.NotNull(patch);
+            Assert.True(patch.HasValue);
+            Assert.Null(patch.Patch);
+            Assert.Equal(new[] { "APPA-Start-Seed" }, patch.Set);
+        }
+
+        [Fact]
+        public void ObjectForm_MergesWithBaseCareerStartFeatures()
+        {
+            // The exact production case: the mod patches the base career
+            // progression 'ewh', whose runtime enableFeaturesAtStart already
+            // holds the base game's own start features. The merge must keep
+            // them and add the mod's trunk features.
+            var progression = Load(@"{ ""enableFeaturesAtStart"": {
+                ""APPA-Start-Seed"": true,
+                ""Ela-Whittier"": true,
+                ""AR-Whittier-Sawmill"": true,
+                ""AR-Connelly-Y"": true,
+                ""AR-Connelly"": true
+            }, ""sections"": {} }");
+
+            var existingBaseGame = new[] { "wh-el", "ewh-intch" };
+            var result = progression.EnableFeaturesAtStart.ApplyTo(existingBaseGame);
+
+            var expected = new[]
+            {
+                "wh-el", "ewh-intch",
+                "APPA-Start-Seed", "Ela-Whittier", "AR-Whittier-Sawmill", "AR-Connelly-Y", "AR-Connelly"
+            };
+            Assert.Equal(
+                expected.OrderBy(id => id, StringComparer.OrdinalIgnoreCase),
+                result.OrderBy(id => id, StringComparer.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void ArrayForm_ReplacesBaseCareerStartFeatures()
+        {
+            // Documents the hazard the merge form exists to avoid: array form
+            // is a wholesale replacement and drops the base game's entries.
+            var progression = Load(@"{ ""enableFeaturesAtStart"": [ ""APPA-Start-Seed"" ], ""sections"": {} }");
+
+            var result = progression.EnableFeaturesAtStart.ApplyTo(new[] { "wh-el", "ewh-intch" });
+
+            Assert.Equal(new[] { "APPA-Start-Seed" }, result);
+        }
+
+        [Fact]
+        public void RoundTrip_PreservesObjectForm()
+        {
+            // The converter passes the field through verbatim; the serializer
+            // must not degrade the merge dict into an array on re-emit, or a
+            // re-saved package would silently switch from merge to replace.
+            var progression = Load(@"{ ""enableFeaturesAtStart"": { ""APPA-Start-Seed"": true }, ""sections"": {} }");
+            var definition = new FuseModDefinition
+            {
+                Id = "Test.EnableFeaturesAtStart",
+                SchemaVersion = "1.0",
+                Progression = new FuseProgressionRoot()
+            };
+            definition.Progression.Progressions["ewh"] = progression;
+
+            var json = FuseCoreSerializer.ToJson(definition);
+            var reparsed = JObject.Parse(json);
+            var field = reparsed.SelectToken("progression.progressions.ewh.enableFeaturesAtStart");
+
+            Assert.NotNull(field);
+            Assert.Equal(JTokenType.Object, field.Type);
+            Assert.True(field.Value<bool>("APPA-Start-Seed"));
+        }
+    }
+}

--- a/FUSE.Core.Tests/ProgressionEnableFeaturesAtStartTests.cs
+++ b/FUSE.Core.Tests/ProgressionEnableFeaturesAtStartTests.cs
@@ -149,12 +149,23 @@ namespace Fuse.Core.Tests
             definition.Progression.Progressions["ewh"] = progression;
 
             var json = FuseCoreSerializer.ToJson(definition);
-            var reparsed = JObject.Parse(json);
-            var field = reparsed.SelectToken("progression.progressions.ewh.enableFeaturesAtStart");
 
+            // Wire shape: the emitted JSON must still be the object (merge) form.
+            var wire = JObject.Parse(json);
+            var field = wire.SelectToken("progression.progressions.ewh.enableFeaturesAtStart");
             Assert.NotNull(field);
             Assert.Equal(JTokenType.Object, field.Type);
             Assert.True(field.Value<bool>("APPA-Start-Seed"));
+
+            // Full round-trip: the serializer must read its own output back
+            // into a merge Patch, not just emit object-shaped JSON.
+            var reparsed = FuseCoreSerializer.FromJson(json);
+            var patch = reparsed.Progression.Progressions["ewh"].EnableFeaturesAtStart;
+            Assert.NotNull(patch);
+            Assert.True(patch.HasValue);
+            Assert.Null(patch.Set);
+            Assert.NotNull(patch.Patch);
+            Assert.True(patch.Patch["APPA-Start-Seed"]);
         }
     }
 }

--- a/FUSE.Core/Model/FuseProgressionRoot.cs
+++ b/FUSE.Core/Model/FuseProgressionRoot.cs
@@ -14,6 +14,19 @@ namespace Fuse.Core.Model
     public sealed class FuseProgression
     {
         public Dictionary<string, FuseSection> Sections { get; set; } = new Dictionary<string, FuseSection>();
+
+        /// <summary>
+        /// Map features force-enabled every time this progression is configured
+        /// in Company mode. Mirrors the game's Progression.enableFeaturesAtStart
+        /// (the same lever the base career uses for wh-el / ewh-intch): the game
+        /// calls SetFeatureEnabled(feature, true) for each entry on every load,
+        /// so the enable is persisted into the save and self-heals existing
+        /// saves. Array form replaces the list; object form merges per id — use
+        /// the object form when patching a base-game progression so its own
+        /// start features are preserved. Never fires in sandbox (the game does
+        /// not Configure a progression there).
+        /// </summary>
+        public FuseStringPatch EnableFeaturesAtStart { get; set; }
     }
 
     public sealed class FuseSection

--- a/FUSE/Authoring/Data/Progression/FuseProgressionRoot.cs
+++ b/FUSE/Authoring/Data/Progression/FuseProgressionRoot.cs
@@ -15,6 +15,19 @@ namespace FUSE.Authoring.Data
     public sealed class FuseProgression
     {
         public Dictionary<string, FuseSection> Sections { get; set; } = new Dictionary<string, FuseSection>();
+
+        /// <summary>
+        /// Map features force-enabled every time this progression is configured
+        /// in Company mode. Mirrors the game's Progression.enableFeaturesAtStart
+        /// (the same lever the base career uses for wh-el / ewh-intch): the game
+        /// calls SetFeatureEnabled(feature, true) for each entry on every load,
+        /// so the enable is persisted into the save and self-heals existing
+        /// saves. Array form replaces the list; object form merges per id — use
+        /// the object form when patching a base-game progression so its own
+        /// start features are preserved. Never fires in sandbox (the game does
+        /// not Configure a progression there).
+        /// </summary>
+        public FuseStringPatch EnableFeaturesAtStart { get; set; }
     }
 
     public sealed class FuseSection

--- a/FUSE/Runtime/API/ProgressionAPI.Apply.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.Apply.cs
@@ -190,6 +190,49 @@ namespace FUSE.Runtime.API
             }
 
             ProgressionSectionsField?.SetValue(progression, progression.GetComponentsInChildren<Section>());
+            ApplyEnableFeaturesAtStart(progression, definition, packageId);
+        }
+
+        /// <summary>
+        /// Patches the game's private Progression.enableFeaturesAtStart array.
+        /// Progression.Configure walks that array on every Company load and calls
+        /// SetFeatureEnabled(feature, true) for each entry, persisting the enable
+        /// into the save's feature KVO — the same mechanism the base 'ewh' career
+        /// uses for wh-el / ewh-intch. That makes it the correct lever for a map
+        /// mod that patches the base career progression and needs its trunk
+        /// features on at career start (and healed on existing saves), without
+        /// touching sandbox (Configure never runs there).
+        ///
+        /// Patch semantics follow FuseStringPatch: omitted = no change, array =
+        /// replace, object = per-id merge. Mods patching a base-game progression
+        /// should use the object form so the base progression's own start
+        /// features survive the merge. Unresolved ids warn-skip via
+        /// ResolveMapFeatures. The field is always written as a non-null array:
+        /// the game's Configure foreach has no null guard.
+        /// </summary>
+        private static void ApplyEnableFeaturesAtStart(Progression progression, FuseProgression definition, string packageId)
+        {
+            if (definition.EnableFeaturesAtStart == null || !definition.EnableFeaturesAtStart.HasValue)
+            {
+                return;
+            }
+
+            if (ProgressionEnableFeaturesAtStartField == null)
+            {
+                FuseLog.Warning($"FUSE progression '{progression.identifier}' declares enableFeaturesAtStart but Progression.enableFeaturesAtStart was not found on this game version; start features were not applied. package='{packageId}'");
+                return;
+            }
+
+            var existingIds = (ProgressionEnableFeaturesAtStartField.GetValue(progression) as MapFeature[] ?? Array.Empty<MapFeature>())
+                .Where(feature => feature != null)
+                .Select(feature => feature.identifier)
+                .ToArray();
+            var resolved = ResolveMapFeatures(definition.EnableFeaturesAtStart.ApplyTo(existingIds)) ?? Array.Empty<MapFeature>();
+            ProgressionEnableFeaturesAtStartField.SetValue(progression, resolved);
+
+            FuseLog.Info(
+                $"FUSE progression '{progression.identifier}' enableFeaturesAtStart=[{FormatFeatureIds(resolved)}] " +
+                $"(was [{string.Join(",", existingIds)}]) package='{packageId}'.");
         }
 
         private static void ApplySectionDefinition(Section section, FuseSection definition, string packageId)

--- a/FUSE/Runtime/API/ProgressionAPI.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.cs
@@ -31,6 +31,11 @@ namespace FUSE.Runtime.API
         private static readonly PropertyInfo ManagerFeatureEnablesProperty = typeof(MapFeatureManager).GetProperty("FeatureEnables", BindingFlags.Instance | BindingFlags.NonPublic);
         private static readonly MethodInfo ManagerHandleFeatureEnablesChangedMethod = typeof(MapFeatureManager).GetMethod("HandleFeatureEnablesChanged", BindingFlags.Instance | BindingFlags.NonPublic);
         private static readonly FieldInfo ProgressionSectionsField = typeof(Progression).GetField("<Sections>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+        // Progression.enableFeaturesAtStart is a private [SerializeField] MapFeature[]
+        // (FormerlySerializedAs "enableAtStart"). Progression.Configure calls
+        // mapFeatureManager.SetFeatureEnabled(feature, true) for each entry when
+        // hosting, on every load — the base career's own start-feature lever.
+        private static readonly FieldInfo ProgressionEnableFeaturesAtStartField = typeof(Progression).GetField("enableFeaturesAtStart", BindingFlags.Instance | BindingFlags.NonPublic);
         private static readonly MethodInfo ProgressionUpdateSectionStatesMethod = typeof(Progression).GetMethod("UpdateSectionStates", BindingFlags.Instance | BindingFlags.NonPublic);
         private static readonly FieldInfo SectionInterchangeTransfersField = typeof(Section).GetField("<InterchangeTransfers>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
         private static readonly FieldInfo InterchangeTransferFromField = typeof(InterchangeTransfer).GetField("from", BindingFlags.Instance | BindingFlags.NonPublic);

--- a/FUSE/Runtime/API/ProgressionAPI.cs
+++ b/FUSE/Runtime/API/ProgressionAPI.cs
@@ -266,6 +266,16 @@ namespace FUSE.Runtime.API
             definition = definition ?? new FuseProgression();
             definition.Sections = definition.Sections ?? new Dictionary<string, FuseSection>();
 
+            // Snapshot the live start-feature list the same way the section
+            // fields below are snapshotted: FromSet, because the snapshot is
+            // the exact current runtime state, not a merge patch. Guarded so
+            // a game build without the field simply leaves the cached value.
+            if (ProgressionEnableFeaturesAtStartField != null)
+            {
+                var startFeatures = ProgressionEnableFeaturesAtStartField.GetValue(progression) as MapFeature[];
+                definition.EnableFeaturesAtStart = FuseStringPatch.FromSet(ToFeatureIds(startFeatures));
+            }
+
             var sections = ProgressionSectionsField?.GetValue(progression) as Section[] ??
                            progression.GetComponentsInChildren<Section>(true);
             foreach (var section in sections.Where(section => section != null && !string.IsNullOrWhiteSpace(section.identifier)))

--- a/schemas/FUSE_JSON_SCHEMA.md
+++ b/schemas/FUSE_JSON_SCHEMA.md
@@ -196,6 +196,25 @@ Progression can be authored either in the older keyed form under `progressions.<
 
 Section unlock payloads such as `areasEnableOnUnlock`, `gameObjectsEnableOnUnlock`, `unlockIncludeIndustries`, `unlockExcludeIndustries`, `unlockIncludeIndustryComponents`, `trackGroupsEnableOnUnlock`, and `trackGroupsAvailableOnUnlock` are materialized through a synthetic FUSE `MapFeature` that is enabled when the section unlocks. This keeps narrative packages on the base game's progression path instead of inventing a parallel unlock system.
 
+Declaring `progressions.<id>` for an id that already exists at runtime (for example the base career progression `ewh`) patches that progression in place: its sections are merged onto the live base progression instead of creating a parallel one. This is how a map mod's milestones ride the normal Company career.
+
+`progressions.<id>.enableFeaturesAtStart` lists map features that are force-enabled every time that progression is configured in Company mode. It mirrors the game's own `Progression.enableFeaturesAtStart` — the lever the base career uses for `wh-el` / `ewh-intch`: on every load the game calls `SetFeatureEnabled(feature, true)` for each entry, so the enable is persisted into the save and self-heals existing saves. It never fires in sandbox (the game does not configure a progression there; sandbox is covered by `initiallyEnabled`). This is the correct way to make a mod's starting trunk present at career start. Note that `initiallyEnabled` on a map feature is sandbox-only and cannot do this. The field follows FuseStringPatch semantics: an array replaces the list, an object (`{"id": true}`) merges per id — use the object form when patching a base-game progression so its own start features are preserved:
+
+```json
+{
+  "progression": {
+    "progressions": {
+      "ewh": {
+        "enableFeaturesAtStart": { "My-Start-Trunk": true, "My-Start-Yard": true },
+        "sections": { "...": {} }
+      }
+    }
+  }
+}
+```
+
+A feature granted through `enableFeaturesAtStart` must not also appear in any section's `enableFeaturesOnAvailable` / `enableFeaturesOnUnlock` / `disableFeaturesOnUnlock` arrays on that progression: the game rewrites those section-derived enables on every state update and would overwrite the start grant.
+
 Section `interchangeTransfers` maps source interchange component ids to destination interchange component ids. FUSE materializes these as child `InterchangeTransfer` components on the runtime `Section`, matching the base game's section-completion waybill rewrite path. Null or blank destinations are kept as no-op legacy entries.
 
 Progression delivery phases that contain deliveries should set `industryComponentId` when the target progression industry component is known. If omitted, FUSE can infer it when every delivery in the phase points at the same `destinationIndustryId` and that industry has exactly one `ProgressionIndustryComponent`.

--- a/schemas/fuse-mod.schema.json
+++ b/schemas/fuse-mod.schema.json
@@ -2186,6 +2186,10 @@
                         }
                     ],
                     "default": {}
+                },
+                "enableFeaturesAtStart": {
+                    "$ref": "#/$defs/idPatch",
+                    "description": "Map features force-enabled every time this progression is configured in Company mode. Mirrors the game's Progression.enableFeaturesAtStart: on every load the game calls SetFeatureEnabled(feature, true) for each entry, so the enable is persisted into the save and self-heals existing saves. Never fires in sandbox. Array form replaces the list; object form ({\"id\": true}) merges per id — use the object form when patching a base-game progression (e.g. \"ewh\") so its own start features (wh-el, ewh-intch) are preserved."
                 }
             }
         },
@@ -2423,6 +2427,20 @@
             },
             "uniqueItems": true,
             "default": []
+        },
+        "idPatch": {
+            "description": "An id list in either FuseStringPatch form: an array replaces the runtime list; an object of {\"id\": boolean} merges per id (true adds, false removes, anything else is kept).",
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/idArray"
+                },
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "boolean"
+                    }
+                }
+            ]
         },
         "stringListPatch": {
             "type": "object",


### PR DESCRIPTION
## Problem

A map mod that patches the base career progression (`ewh`) has no way to turn its starting track on in **Company** mode:

- a MapFeature's `initiallyEnabled` (`defaultEnableInSandbox`) is **sandbox-only** — `MapFeatureManager` gates it on `IsSandbox` at read time and never persists it;
- section grants (`enableFeaturesOnUnlock`) only fire after a paid delivery;
- `enableFeaturesOnAvailable` on a section is force-rewritten by `Progression.UpdateSectionStates` and flips back to `false` once the section unlocks, and a 0-phase "always available" grant section crashes the Goals panel (`deliveryPhases[PaidCount-1]` → index -1).

Concrete case: the Appalachian Railway mod's whole trunk (`APPA-Start-Seed` → `EWH`, `AR-C`, `AR-C-WYE`, `AR-CH`, `AR-CK`) is stripped by `RestoreDisabledTrackGroups` on every Company load, while sandbox works. Players currently work around it by flipping the save to sandbox and back.

## Fix

Model the game's **own** lever: `Progression.enableFeaturesAtStart` — the private serialized `MapFeature[]` that `Progression.Configure` walks on every Company load, calling `SetFeatureEnabled(feature, true)` under `IsHost`. It is exactly how the base career enables `wh-el` / `ewh-intch` (log-proven: caller `Game.State.RestoreNotifier.NotifyPending`).

FUSE now reads `progressions.<id>.enableFeaturesAtStart` (a `FuseStringPatch`: omitted = no change, array = replace, object = per-id merge) and patches the field via reflection at the end of `ApplyProgressionDefinition`. Because the game persists the enable into the save's feature KVO:

- works on **fresh** Company saves (fires at Configure, before the post-Configure `RestoreDisabledTrackGroups` replay);
- **self-heals existing** broken saves on next load;
- **never fires in sandbox** (the game does not Configure a progression there — sandbox stays on the read-time `IsSandbox` fallback + `PreEnableInitialTrackGroups`).

**The object/merge form is load-bearing.** A mod patching a base-game progression must not wipe the base's own start features; `FuseStringPatch.ApplyTo` unions the object form with the existing runtime list, so `wh-el`/`ewh-intch` survive. For the same reason the converter guard comment keeps `enableFeaturesAtStart` **out** of `BoolDictionaryArrayFields` (flattening it to an array would silently turn merge into replace).

The field is always written as a non-null array (`Configure`'s `foreach` has no null guard) and warn-skips if the game version lacks the field.

## Changes (118 insertions, 0 deletions)

- `FUSE.Core/Model/FuseProgressionRoot.cs`, `FUSE/Authoring/Data/Progression/FuseProgressionRoot.cs` — `FuseProgression.EnableFeaturesAtStart`
- `FUSE/Runtime/API/ProgressionAPI.cs` — reflection handle `ProgressionEnableFeaturesAtStartField`
- `FUSE/Runtime/API/ProgressionAPI.Apply.cs` — `ApplyEnableFeaturesAtStart`
- `FUSE.Converter/Conversion/LegacyConverterConstants.cs` — guard comment (no behaviour change; passthrough already preserves the field)
- `schemas/fuse-mod.schema.json` — `idPatch` `$def` + `progressionDefinition.enableFeaturesAtStart`; `schemas/FUSE_JSON_SCHEMA.md` — docs
- `FUSE.Core.Tests/ProgressionEnableFeaturesAtStartTests.cs` — 6 tests

## Testing

- FUSE runtime built against the real game (`Assembly-CSharp` from a full install), Debug + Release: **0 errors**.
- **FUSE.Tests (game-coupled): 1815/1815 pass. FUSE.Core.Tests: 120/120 pass** (6 new: omitted→null, object→merge, array→replace, the exact `ewh` union case preserving `wh-el`/`ewh-intch`, round-trip keeps object form).
- Reflection target verified in the decompiled shipped binary: `private MapFeature[] enableFeaturesAtStart` (`[FormerlySerializedAs("enableAtStart")]`), consumed by `Configure()` as `SetFeatureEnabled(feature, unlocked: true)`.
- Release zip packaged with `scripts/New-ModArchive.ps1` and `scripts/Validate-ModPackage.cs` reports **OK** against the real UMM DLL.
- Converting the Appalachian mod's legacy source with the built `fuse-convert` yields the field in object form (passthrough verified end-to-end).

## Usage

```json
{
  "progression": {
    "progressions": {
      "ewh": {
        "enableFeaturesAtStart": { "My-Start-Trunk": true },
        "sections": { "...": {} }
      }
    }
  }
}
```

A feature granted here must not also appear in any section's `enableFeaturesOnAvailable` / `enableFeaturesOnUnlock` / `disableFeaturesOnUnlock` on that progression, or `UpdateSectionStates` will overwrite the start grant (documented).

## Not in this PR

The unrelated in-tree spawn-point / CustomSpawnPoints career-start WIP (`SpawnPointAPI.CareerStart.cs` etc.) is **not** included — it was unwired, superseded by this approach for the reported problem, and did not compile against the game.
