### PR TITLE
fix(assets): fire old-loader Deserialize patches for direct asset packs (LLoS clones of mod-pack cars; #224, #222)

### DIFF
--- a/FUSE.Tests/Loading/FuseDirectStoreLegosLibraryReproTests.cs
+++ b/FUSE.Tests/Loading/FuseDirectStoreLegosLibraryReproTests.cs
@@ -1,0 +1,956 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using FUSE.Loading;
+using HarmonyLib;
+using Model.Definition;
+using Model.Definition.Data;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FUSE.Tests.Loading
+{
+    /// <summary>
+    /// Real-world reproduction of issues #224 / #222 with the REAL LegosLibraryOfStuff (LLoS)
+    /// assembly, its REAL Harmony patch classes, and REAL asset-pack / repaint-spec data
+    /// from a local Railroader install.
+    ///
+    /// What is exercised:
+    ///  - LegosLibraryOfStuff.dll is loaded into the test process; its actual
+    ///    <c>ContainerSerializationDeserializePatch</c> (postfix on
+    ///    <c>ContainerSerialization.Deserialize</c>) and <c>AddJsonSubTypesPatch</c> (postfix on
+    ///    JsonSubtypes.GetAttributes) are applied through Harmony, exactly the classes LLoS's
+    ///    <c>Load()</c> applies via PatchAll.
+    ///  - LLoS's component-kind registration is primed the way LLoS.Load() and
+    ///    LegosLogosAndDeco.Main.Load() do it (AddNewComponent for ComponentGroup /
+    ///    AttributeModifierComponent / CustomImage / ...), using the real component types.
+    ///  - LLoS's spec discovery (<c>LoadJsonDefinitions</c>) runs against
+    ///    <c>UnityModManager.modEntries</c>, populated with real UMM ModEntry objects for the
+    ///    real mod folders that ship <c>LegosLibraryOfStuff/Definitions/*.json</c>.
+    ///  - The base packs' real <c>Definitions.json</c> text is pushed through FUSE's private
+    ///    <c>LoadResilientDirectContainer</c> (PR #227's cold-load path) and through
+    ///    <c>BypassDeserialize</c> (main's cold-load path — main's LoadResilientDirectContainer
+    ///    body is exactly BypassDeserialize + the FilterUnbindableComponents retry).
+    ///
+    /// Not exercised (needs a Unity player): building prefabs from the definitions, PrefabStore
+    /// lookups, the ComponentGroup toggle runtime. The tests stop at "does the clone
+    /// ContainerItem exist in the Container FUSE hands to the game".
+    ///
+    /// Opt-in: the tests skip themselves unless FUSE_TEST_LLOS_GAME_DIR points at a local
+    /// install (game + LLoS + LogosAndDeco + the packs), so CI and a plain `dotnet test`
+    /// never load third-party mod assemblies.
+    /// </summary>
+    [Collection(FuseDirectStoreLegosLibraryReproCollection.Name)]
+    public sealed class FuseDirectStoreLegosLibraryReproTests : IClassFixture<LegosLibraryHarness>
+    {
+        private readonly LegosLibraryHarness _h;
+        private readonly ITestOutputHelper _out;
+
+        public FuseDirectStoreLegosLibraryReproTests(LegosLibraryHarness harness, ITestOutputHelper output)
+        {
+            _h = harness;
+            _out = output;
+        }
+
+        // ------------------------------------------------------------------
+        // Fixture: PS-1 40ft Boxcar Series / "PS-1-40ft-8ft p-s-door" (base pack, mod car
+        // "PS-1-40ft-boxcar-8ft-p-s-door") + PS-1 Midwest Boxcar Repaints (repaint specs that
+        // clone that mod car: CNW1, MP1, RI1, RI2, SOO1). Issue #224 population.
+        // ------------------------------------------------------------------
+        private const string Ps1BaseIdentifier = "PS-1-40ft-boxcar-8ft-p-s-door";
+
+        private string Ps1BasePackDefinitions =>
+            Path.Combine(_h.ModsRoot, "PS-1 40ft Boxcar Series", "PS-1-40ft-8ft p-s-door", "Definitions.json");
+
+        private string[] ExpectedPs1CloneIdentifiers()
+        {
+            // Read the expectation from the real spec files rather than hard-coding it, so the
+            // test tracks the data actually installed.
+            var specDir = Path.Combine(_h.ModsRoot, "PS-1 Midwest Boxcar Repaints", "LegosLibraryOfStuff", "Definitions");
+            return Directory.GetFiles(specDir, "*.json")
+                .Select(TryParseSpec)
+                .Where(j => j != null && (string)j["identifier"] == Ps1BaseIdentifier && (bool?)j["clone"] == true)
+                .Select(j => (string)j["newIdentifier"])
+                .OrderBy(s => s, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        // LLoS itself skips spec files it cannot parse ("Failed to load file"); e.g. the installed
+        // PS-1 Midwest pack ships an empty RI-ps1-3.json. Mirror that here.
+        private static JObject TryParseSpec(string path)
+        {
+            try { return JObject.Parse(File.ReadAllText(path)); }
+            catch (Exception) { return null; }
+        }
+
+        [LegosLibraryRealDataFact]
+        public void Harness_PrimedLikeTheRealPlugin()
+        {
+            _out.WriteLine(_h.Describe());
+            Assert.True(_h.SpecCount > 1, "LLoS found no clone specs");
+            Assert.Contains(Ps1BaseIdentifier, _h.SpecIdentifiers);
+            Assert.Contains("ls-462-p37", _h.SpecIdentifiers);
+            // The real spec files for the PS-1 Midwest repaints all parsed (they need the
+            // LogosAndDeco 'CustomImage' kind, which the harness registered like the plugin does).
+            var expected = ExpectedPs1CloneIdentifiers();
+            Assert.Equal(5, expected.Length);
+            foreach (var id in expected)
+            {
+                Assert.Contains(id, _h.SpecNewIdentifiers);
+            }
+        }
+
+        // (1) main's cold-load code path (BypassDeserialize): the real LLoS postfix never
+        //     runs, so no repaint clone exists in the container FUSE would hand the game.
+        [LegosLibraryRealDataFact]
+        public void MainCodePath_BypassDeserialize_RealPs1Pack_NoLlosClonesExist()
+        {
+            var text = File.ReadAllText(Ps1BasePackDefinitions);
+            var before = _h.PostfixInvocations;
+
+            var container = _h.BypassDeserialize(text);
+
+            Assert.NotNull(container);
+            Assert.Equal(before, _h.PostfixInvocations);
+            var ids = container.Objects.Select(o => o.Identifier).ToArray();
+            _out.WriteLine("main/bypass identifiers: " + string.Join(", ", ids));
+            Assert.Equal(new[] { Ps1BaseIdentifier }, ids);
+            foreach (var cloneId in ExpectedPs1CloneIdentifiers())
+            {
+                Assert.DoesNotContain(cloneId, ids);
+            }
+        }
+
+        // (2) PR #227's cold-load code path (LoadResilientDirectContainer -> public
+        //     ContainerSerialization.Deserialize): the real LLoS postfix runs once and the
+        //     repaint clones (issue #224) are present, carrying the spec's edits.
+        [LegosLibraryRealDataFact]
+        public void Pr227CodePath_ColdLoad_RealPs1Pack_LlosRepaintClonesExist()
+        {
+            var text = File.ReadAllText(Ps1BasePackDefinitions);
+            var before = _h.PostfixInvocations;
+            var dropped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            var container = _h.ColdLoad(text, "fuseasset://" + Uri.EscapeDataString(Path.GetDirectoryName(Ps1BasePackDefinitions)), dropped);
+
+            Assert.NotNull(container);
+            Assert.Equal(before + 1, _h.PostfixInvocations);
+            Assert.Empty(dropped); // native path bound every kind; no tolerant fallback
+            var ids = container.Objects.Select(o => o.Identifier).ToArray();
+            _out.WriteLine("PR#227/cold-load identifiers: " + string.Join(", ", ids));
+
+            Assert.Equal(Ps1BaseIdentifier, ids[0]);
+            var expected = ExpectedPs1CloneIdentifiers();
+            foreach (var cloneId in expected)
+            {
+                Assert.Contains(cloneId, ids);
+            }
+
+            // Spot-check one clone against its spec (CNW-ps1-1.json).
+            var cnw = container.Objects.Single(o => o.Identifier == Ps1BaseIdentifier + "-CNW1");
+            var spec = JObject.Parse(File.ReadAllText(Path.Combine(
+                _h.ModsRoot, "PS-1 Midwest Boxcar Repaints", "LegosLibraryOfStuff", "Definitions", "CNW-ps1-1.json")));
+            Assert.Equal((string)spec["name"], cnw.Metadata.Name);
+            var car = Assert.IsAssignableFrom<CarDefinition>(cnw.Definition);
+            Assert.Equal((string)spec["baseRoadNumber"], car.BaseRoadNumber);
+            Assert.Equal((string)spec["CarType"], car.CarType);
+            var kinds = car.Components.Select(c => c.Kind).ToArray();
+            _out.WriteLine("CNW1 clone component kinds: " + string.Join(", ", kinds));
+            // bulkAdds from the spec (2 Decal + 2 CustomImage) landed on the clone ...
+            Assert.Equal(2, car.Components.Count(c => c.Kind == "CustomImage"));
+            // ... and the 'removes' took the base's reporting-mark decals off the clone.
+            Assert.DoesNotContain(car.Components, c => c.Kind == "Decal" && c.Name == "Side Reporting Marks 1");
+            // The 'replace' add swapped the Colorable Sides colorizer for the spec's colours.
+            var sides = car.Components.Single(c => c.Kind == "Colorizer" && c.Name == "Colorable Sides");
+            var hex = (IEnumerable<string>)sides.GetType().GetProperty("HexColors").GetValue(sides);
+            Assert.Equal(spec["adds"][0]["component"]["hexColors"].Select(t => (string)t).ToArray(), hex.ToArray());
+
+            // Clone is a distinct object from the base (LLoS CloneItem JSON round-trip).
+            var baseItem = container.Objects[0];
+            Assert.NotSame(baseItem.Definition, cnw.Definition);
+        }
+
+        // (2b) Same evidence, but obtained by calling the game's public entry point directly —
+        //      proves the clones come from LLoS's postfix on that entry point and not from
+        //      anything FUSE-specific.
+        [LegosLibraryRealDataFact]
+        public void GamePublicDeserialize_RealPs1Pack_LlosRepaintClonesExist()
+        {
+            var text = File.ReadAllText(Ps1BasePackDefinitions);
+            var before = _h.PostfixInvocations;
+
+            var container = ContainerSerialization.Deserialize(text);
+
+            Assert.Equal(before + 1, _h.PostfixInvocations);
+            var ids = container.Objects.Select(o => o.Identifier).ToArray();
+            foreach (var cloneId in ExpectedPs1CloneIdentifiers())
+            {
+                Assert.Contains(cloneId, ids);
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Fixture: CNWClassE462 / ls-462-p37 (mod steam locomotive) + its own
+        // LegosLibraryOfStuff/Definitions/ClassEStreamlinedTender.json spec:
+        //   clone ls-462-p37 -> ls-462-p37ST, tenderIdentifier lt-462-p37ES, positionTail -5.5
+        // Issue #222 (LLW tender swap) population.
+        // ------------------------------------------------------------------
+        private string CnwBasePackDefinitions =>
+            Path.Combine(_h.ModsRoot, "CNWClassE462", "ls-462-p37", "Definitions.json");
+
+        [LegosLibraryRealDataFact]
+        public void MainCodePath_BypassDeserialize_RealCnwPacificPack_NoTenderSwapClone()
+        {
+            var text = File.ReadAllText(CnwBasePackDefinitions);
+            var before = _h.PostfixInvocations;
+
+            var container = _h.BypassDeserialize(text);
+
+            Assert.Equal(before, _h.PostfixInvocations);
+            var ids = container.Objects.Select(o => o.Identifier).ToArray();
+            _out.WriteLine("main/bypass identifiers: " + string.Join(", ", ids));
+            Assert.Contains("ls-462-p37", ids);
+            Assert.DoesNotContain("ls-462-p37ST", ids);
+        }
+
+        [LegosLibraryRealDataFact]
+        public void Pr227CodePath_ColdLoad_RealCnwPacificPack_TenderSwapCloneExists()
+        {
+            var text = File.ReadAllText(CnwBasePackDefinitions);
+            var before = _h.PostfixInvocations;
+            var dropped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            var container = _h.ColdLoad(text, "fuseasset://" + Uri.EscapeDataString(Path.GetDirectoryName(CnwBasePackDefinitions)), dropped);
+
+            Assert.Equal(before + 1, _h.PostfixInvocations);
+            Assert.Empty(dropped);
+            var ids = container.Objects.Select(o => o.Identifier).ToArray();
+            _out.WriteLine("PR#227/cold-load identifiers: " + string.Join(", ", ids));
+            Assert.Contains("ls-462-p37", ids);
+            Assert.Contains("ls-462-p37ST", ids);
+
+            var clone = container.Objects.Single(o => o.Identifier == "ls-462-p37ST");
+            var loco = Assert.IsAssignableFrom<SteamLocomotiveDefinition>(clone.Definition);
+            Assert.Equal("lt-462-p37ES", loco.TenderIdentifier);
+            Assert.Equal(-5.5f, loco.PositionTail);
+            Assert.Equal("CNW Class E Pacific (Streamlined Tender)", clone.Metadata.Name);
+
+            // The base item was not turned into the clone: it still points at its own tender.
+            var baseLoco = Assert.IsAssignableFrom<SteamLocomotiveDefinition>(
+                container.Objects.Single(o => o.Identifier == "ls-462-p37").Definition);
+            Assert.Equal("lt-462-p37", baseLoco.TenderIdentifier);
+        }
+
+        // ------------------------------------------------------------------
+        // The regression that motivated the original bypass (c188ad1): "ERIE LOGO going dead".
+        // Real data: MSLDecalPack/LegosLibraryOfStuff/Definitions/Erie_lt-282-k27.json is an
+        // in-place (clone:false) MakeComponentGroup spec targeting lt-282-k27, a MOD tender
+        // defined in "LLW Generic Locomotive Catalog/ls-282-k27/Definitions.json". LLoS adds
+        // its two shared CustomImage instances to the definition and renames them in place
+        // (GroupID + Name) on EVERY postfix pass, so the ComponentGroup written into an
+        // earlier container stops matching the shared instances' names as soon as a later
+        // pass runs. This test shows (a) one cold load through PR #227 yields a
+        // self-consistent group, and (b) any further pass through the public entry point
+        // (which is exactly what FUSE's re-deserialize paths must keep bypassing) invalidates
+        // the earlier container.
+        // ------------------------------------------------------------------
+        private string LlwK27PackDefinitions =>
+            Path.Combine(_h.ModsRoot, "LLW Generic Locomotive Catalog", "ls-282-k27", "Definitions.json");
+
+        private static (string[] activate, string[] present) ErieGroupState(Container c)
+        {
+            var tender = c.Objects.Single(o => o.Identifier == "lt-282-k27");
+            var group = tender.Definition.Components.Single(comp =>
+                comp.Kind == "ComponentGroup" && (string)comp.GetType().GetProperty("id").GetValue(comp) == "Erie_lt-282-k27");
+            var activate = (string[])group.GetType().GetProperty("ActivateComponents").GetValue(group);
+            var present = tender.Definition.Components.Where(comp => comp.Kind == "CustomImage").Select(comp => comp.Name).ToArray();
+            return (activate, present);
+        }
+
+        [LegosLibraryRealDataFact]
+        public void Pr227ColdLoad_RealErieLogoGroupSpec_SingleColdLoadIsSelfConsistent_SecondPassBreaksEarlierContainer()
+        {
+            if (!File.Exists(LlwK27PackDefinitions) ||
+                !File.Exists(Path.Combine(_h.ModsRoot, "MSLDecalPack", "LegosLibraryOfStuff", "Definitions", "Erie_lt-282-k27.json")))
+            {
+                _out.WriteLine("ERIE LOGO fixture not installed; nothing to check.");
+                return;
+            }
+            Assert.Contains("lt-282-k27", _h.SpecIdentifiers);
+
+            var text = File.ReadAllText(LlwK27PackDefinitions);
+
+            // main: no group at all (the in-place spec never applied to the mod tender).
+            var mainContainer = _h.BypassDeserialize(text);
+            var mainTender = mainContainer.Objects.Single(o => o.Identifier == "lt-282-k27");
+            Assert.DoesNotContain(mainTender.Definition.Components, comp =>
+                comp.Kind == "ComponentGroup" && (string)comp.GetType().GetProperty("id").GetValue(comp) == "Erie_lt-282-k27");
+
+            // PR #227 cold load, exactly once: group present and self-consistent.
+            var first = _h.ColdLoad(text, "fuseasset://" + Uri.EscapeDataString(Path.GetDirectoryName(LlwK27PackDefinitions)),
+                new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase));
+            var s1 = ErieGroupState(first);
+            _out.WriteLine("after cold load: ActivateComponents=" + string.Join(" | ", s1.activate) + "   CustomImage names=" + string.Join(" | ", s1.present));
+            Assert.Equal(2, s1.activate.Length);
+            Assert.All(s1.activate, name => Assert.Contains(name, s1.present));
+
+            // A second pass through the public entry point (what a native LocalLow mirror, a
+            // duplicate store, or a re-deserialize through Deserialize would do): the shared
+            // component instances are renamed again, so the FIRST container's group no longer
+            // resolves any of its components — that is the dead ERIE LOGO toggle.
+            var second = ContainerSerialization.Deserialize(text);
+            var s2 = ErieGroupState(second);
+            var s1After = ErieGroupState(first);
+            _out.WriteLine("after 2nd pass: first container ActivateComponents=" + string.Join(" | ", s1After.activate) +
+                           "   first container CustomImage names NOW=" + string.Join(" | ", s1After.present));
+            Assert.All(s2.activate, name => Assert.Contains(name, s2.present));       // the latest container is fine
+            Assert.All(s1After.activate, name => Assert.DoesNotContain(name, s1After.present)); // the earlier one is broken
+        }
+
+        // ------------------------------------------------------------------
+        // Whole-install census: every asset pack Definitions.json under Mods (root or one level
+        // deep, next to a Catalog.json — the folders FUSE mounts as direct stores) is loaded
+        // through both code paths. Reports how many clone identifiers exist only under PR
+        // #227, and which packs the native serializer rejected (fallback => no clones).
+        // ------------------------------------------------------------------
+        [LegosLibraryRealDataFact]
+        public void Census_AllInstalledPacks_ClonesOnlyExistOnPr227Path()
+        {
+            var packs = Directory.GetDirectories(_h.ModsRoot)
+                .SelectMany(m => new[] { m }.Concat(Directory.GetDirectories(m)))
+                .Where(d => File.Exists(Path.Combine(d, "Catalog.json")) && File.Exists(Path.Combine(d, "Definitions.json")))
+                .OrderBy(d => d, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            Assert.NotEmpty(packs);
+
+            int packsOk = 0, packsFallback = 0, packsFailed = 0;
+            int bypassItems = 0, coldItems = 0;
+            var clonesOnlyOnPr = new List<string>();
+            var fallbackReasons = new List<string>();
+            var unbindableKinds = new List<string>();
+            var identifierPacks = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+            foreach (var pack in packs)
+            {
+                var text = File.ReadAllText(Path.Combine(pack, "Definitions.json"));
+                var rel = pack.Substring(_h.ModsRoot.Length).TrimStart('\\', '/');
+                string[] bypassIds;
+                var mainDropped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                try
+                {
+                    bypassIds = _h.MainColdLoad(text, mainDropped).Objects.Select(o => o.Identifier).ToArray();
+                }
+                catch (Exception ex)
+                {
+                    packsFailed++;
+                    fallbackReasons.Add($"[main path threw] {rel}: {ex.GetBaseException().GetType().Name}: {Trim(ex.GetBaseException().Message)}");
+                    continue;
+                }
+                if (mainDropped.Count > 0)
+                {
+                    unbindableKinds.Add($"{rel}: {string.Join(", ", mainDropped.Select(kv => kv.Key + "=" + kv.Value))}");
+                }
+
+                var before = _h.PostfixInvocations;
+                var dropped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                string[] coldIds;
+                try
+                {
+                    coldIds = _h.ColdLoad(text, "fuseasset://" + Uri.EscapeDataString(pack), dropped).Objects.Select(o => o.Identifier).ToArray();
+                }
+                catch (Exception ex)
+                {
+                    packsFailed++;
+                    fallbackReasons.Add($"[PR#227 cold-load threw] {rel}: {ex.GetBaseException().GetType().Name}: {Trim(ex.GetBaseException().Message)}");
+                    continue;
+                }
+                Assert.Equal(mainDropped.OrderBy(kv => kv.Key).ToArray(), dropped.OrderBy(kv => kv.Key).ToArray());
+
+                var fired = _h.PostfixInvocations - before;
+                if (fired == 0)
+                {
+                    packsFallback++;
+                    string reason;
+                    try { ContainerSerialization.Deserialize(text); reason = "(native succeeded on retry?)"; }
+                    catch (Exception ex) { reason = ex.GetBaseException().GetType().Name + ": " + Trim(ex.GetBaseException().Message); }
+                    fallbackReasons.Add($"[native rejected -> tolerant bypass, no LLoS pass] {rel}: {reason}");
+                }
+                else
+                {
+                    packsOk++;
+                }
+
+                bypassItems += bypassIds.Length;
+                coldItems += coldIds.Length;
+                foreach (var id in bypassIds)
+                {
+                    if (!identifierPacks.TryGetValue(id, out var list)) identifierPacks[id] = list = new List<string>();
+                    list.Add(rel);
+                }
+                foreach (var extra in coldIds.Except(bypassIds))
+                {
+                    clonesOnlyOnPr.Add(extra + "  <=  " + rel);
+                }
+                // The base identifiers are always still there under PR #227.
+                Assert.Empty(bypassIds.Except(coldIds));
+            }
+
+            _out.WriteLine($"packs: {packs.Length}; native ok (LLoS pass ran once): {packsOk}; native rejected (tolerant fallback, no LLoS pass): {packsFallback}; both paths threw: {packsFailed}");
+            _out.WriteLine($"packs whose components could not all bind in this harness (kinds from mods the harness does not register; FUSE drops them on BOTH paths): {unbindableKinds.Count}");
+            foreach (var line in unbindableKinds) _out.WriteLine("  " + line);
+            _out.WriteLine($"items via main/bypass: {bypassItems}; items via PR#227 cold load: {coldItems}; clone items that exist ONLY under PR#227: {clonesOnlyOnPr.Count}");
+            _out.WriteLine($"identifiers defined by more than one mounted pack: {identifierPacks.Count(kv => kv.Value.Count > 1)}");
+            foreach (var line in fallbackReasons) _out.WriteLine("  " + line);
+            _out.WriteLine("clone identifiers only present under PR#227:");
+            foreach (var line in clonesOnlyOnPr) _out.WriteLine("  " + line);
+
+            Assert.True(clonesOnlyOnPr.Count > 0, "expected LLoS clones of mod-pack cars to exist under the PR #227 path");
+        }
+
+        private static string Trim(string s)
+        {
+            if (s == null) return "";
+            s = s.Replace("\r", " ").Replace("\n", " ");
+            return s.Length > 160 ? s.Substring(0, 160) + "..." : s;
+        }
+    }
+
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class FuseDirectStoreLegosLibraryReproCollection
+    {
+        public const string Name = "FuseDirectStoreLegosLibraryRepro";
+    }
+
+    /// <summary>Skips when the local Railroader install with LLoS + LogosAndDeco + the packs is absent.</summary>
+    public sealed class LegosLibraryRealDataFactAttribute : FactAttribute
+    {
+        public LegosLibraryRealDataFactAttribute()
+        {
+            var reason = LegosLibraryHarness.UnavailableReason();
+            if (reason != null)
+            {
+                Skip = reason;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Loads the real LegosLibraryOfStuff.dll, primes it the way its plugin init + LogosAndDeco
+    /// do, applies its real Harmony patch classes, and exposes FUSE's private cold-load /
+    /// bypass helpers.
+    /// </summary>
+    public sealed class LegosLibraryHarness : IDisposable
+    {
+        // Opt-in only. This harness loads real third-party mod assemblies into the
+        // test process and Harmony-patches the game's serializer, so it must never
+        // run implicitly (CI, a contributor's plain `dotnet test`). Point
+        // FUSE_TEST_LLOS_GAME_DIR at a Railroader install whose Mods folder holds
+        // LegosLibraryOfStuff, legotrainman.logosanddeco and the base/repaint packs
+        // named in the fixtures, e.g.
+        //   $env:FUSE_TEST_LLOS_GAME_DIR = "F:\SteamLibrary\steamapps\common\Railroader - MyMods"
+        //   dotnet test FUSE.Tests --filter FullyQualifiedName~FuseDirectStoreLegosLibraryReproTests
+        private static readonly string[] GameDirCandidates =
+        {
+            Environment.GetEnvironmentVariable("FUSE_TEST_LLOS_GAME_DIR"),
+        };
+
+        public static string FindGameDir()
+        {
+            foreach (var c in GameDirCandidates)
+            {
+                if (string.IsNullOrEmpty(c)) continue;
+                if (File.Exists(Path.Combine(c, "Railroader_Data", "Managed", "Definition.dll")) &&
+                    File.Exists(Path.Combine(c, "Mods", "LegosLibraryOfStuff", "LegosLibraryOfStuff.dll")))
+                {
+                    return c;
+                }
+            }
+            return null;
+        }
+
+        public static string UnavailableReason()
+        {
+            var game = FindGameDir();
+            if (game == null) return "Opt-in real-LLoS reproduction: set FUSE_TEST_LLOS_GAME_DIR to a Railroader install whose Mods folder has LegosLibraryOfStuff.";
+            var mods = Path.Combine(game, "Mods");
+            var needed = new[]
+            {
+                Path.Combine(mods, "legotrainman.logosanddeco", "LegosLogosAndDeco.dll"),
+                Path.Combine(mods, "PS-1 40ft Boxcar Series", "PS-1-40ft-8ft p-s-door", "Definitions.json"),
+                Path.Combine(mods, "PS-1 Midwest Boxcar Repaints", "LegosLibraryOfStuff", "Definitions", "CNW-ps1-1.json"),
+                Path.Combine(mods, "CNWClassE462", "ls-462-p37", "Definitions.json"),
+                Path.Combine(mods, "CNWClassE462", "LegosLibraryOfStuff", "Definitions", "ClassEStreamlinedTender.json"),
+            };
+            foreach (var n in needed)
+            {
+                if (!File.Exists(n)) return "Missing real fixture: " + n;
+            }
+            return null;
+        }
+
+        public string GameDir { get; }
+        public string ModsRoot { get; }
+        public Assembly LlosAssembly { get; }
+        public Assembly LadAssembly { get; }
+        public int SpecCount { get; private set; }
+        public IReadOnlyList<string> SpecIdentifiers { get; private set; } = Array.Empty<string>();
+        public IReadOnlyList<string> SpecNewIdentifiers { get; private set; } = Array.Empty<string>();
+        public IReadOnlyList<string> RegisteredSpecPacks { get; private set; } = Array.Empty<string>();
+        public IReadOnlyList<string> RegisteredKinds { get; private set; } = Array.Empty<string>();
+        public string SpecSource { get; private set; } = "(none)";
+        public string JsonSubtypesMode { get; private set; } = "(none)";
+
+        // Counts invocations of the REAL LLoS postfix (a tiny counting postfix installed on the
+        // same target; Harmony runs all postfixes, so this counts once per Deserialize call).
+        private static int _postfixInvocations;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Read through the fixture instance on purpose.")]
+        public int PostfixInvocations => System.Threading.Volatile.Read(ref _postfixInvocations);
+
+        private readonly Harmony _harmony;
+        private readonly ResolveEventHandler _resolver;
+        private readonly MethodInfo _loadResilient;
+        private readonly MethodInfo _bypass;
+        private readonly MethodInfo _canBind;
+        private readonly Action _restoreJsonSubtypesCache;
+        private readonly string _describe;
+
+        public LegosLibraryHarness()
+        {
+            var reason = UnavailableReason();
+            if (reason != null)
+            {
+                // Tests are skipped via the attribute; keep the fixture inert.
+                _describe = reason;
+                return;
+            }
+
+            GameDir = FindGameDir();
+            ModsRoot = Path.Combine(GameDir, "Mods");
+            var managed = Path.Combine(GameDir, "Railroader_Data", "Managed");
+            var llosDir = Path.Combine(ModsRoot, "LegosLibraryOfStuff");
+            var ladDir = Path.Combine(ModsRoot, "legotrainman.logosanddeco");
+            var lbrsDir = Path.Combine(ModsRoot, "LegosBetterRollingStock");
+
+            var probeDirs = new[] { AppDomain.CurrentDomain.BaseDirectory, managed, Path.Combine(managed, "UnityModManager"), llosDir, ladDir, lbrsDir };
+            _resolver = (sender, args) =>
+            {
+                var name = new AssemblyName(args.Name).Name;
+                foreach (var dir in probeDirs)
+                {
+                    var p = Path.Combine(dir, name + ".dll");
+                    if (File.Exists(p))
+                    {
+                        try { return Assembly.LoadFrom(p); } catch { /* try next */ }
+                    }
+                }
+                return null;
+            };
+            AppDomain.CurrentDomain.AssemblyResolve += _resolver;
+
+            LlosAssembly = Assembly.LoadFrom(Path.Combine(llosDir, "LegosLibraryOfStuff.dll"));
+            LadAssembly = Assembly.LoadFrom(Path.Combine(ladDir, "LegosLogosAndDeco.dll"));
+
+            var los = LlosAssembly.GetType("LegosLibraryOfStuff.LibraryOfStuff", throwOnError: true);
+            var deserPatch = LlosAssembly.GetType("LegosLibraryOfStuff.ContainerSerializationDeserializePatch", throwOnError: true);
+            var subtypesPatch = LlosAssembly.GetType("LegosLibraryOfStuff.AddJsonSubTypesPatch", throwOnError: true);
+
+            // --- UMM ModEntry plumbing (real UnityModManager types) ---
+            var myModEntryField = los.GetField("myModEntry", BindingFlags.Public | BindingFlags.Static);
+            var modEntryType = myModEntryField.FieldType;                       // UnityModManagerNet.UnityModManager+ModEntry
+            var ummType = modEntryType.DeclaringType;                            // UnityModManagerNet.UnityModManager
+            var modInfoType = ummType.GetNestedType("ModInfo");
+            var modLoggerType = modEntryType.GetNestedType("ModLogger");
+            Func<string, string, object> makeEntry = (id, path) =>
+            {
+                var info = Activator.CreateInstance(modInfoType);
+                modInfoType.GetField("Id").SetValue(info, id);
+                modInfoType.GetField("Version").SetValue(info, "1.0.0");
+                modInfoType.GetField("ManagerVersion").SetValue(info, "0.32.4");
+                modInfoType.GetField("DisplayName").SetValue(info, id);
+                try
+                {
+                    // Real ctor: ModEntry(ModInfo info, string path).
+                    return Activator.CreateInstance(modEntryType, info, path);
+                }
+                catch (Exception)
+                {
+                    // UnityModManager's static initializer is unavailable in this process
+                    // (it needs the UnityEngine facade). Build the entry without running the
+                    // ctor: the postfix path only reads Info, Path, Enabled and Logger.
+                    var entry = System.Runtime.Serialization.FormatterServices.GetUninitializedObject(modEntryType);
+                    modEntryType.GetField("Info").SetValue(entry, info);
+                    modEntryType.GetField("Path").SetValue(entry, path);
+                    modEntryType.GetField("Logger").SetValue(entry, Activator.CreateInstance(modLoggerType, id));
+                    modEntryType.GetField("Enabled").SetValue(entry, true);
+                    return entry;
+                }
+            };
+
+            // LibraryOfStuff.Load(): myModEntry = modEntry (Logger is used by the postfix).
+            myModEntryField.SetValue(null, makeEntry("LegosLibraryOfStuff", llosDir));
+
+            // LibraryOfStuff.Load(): AddNewComponent(AttributeModifierComponent, builder),
+            //                        AddNewComponent(ComponentGroupComponent, builder)
+            var addByTypes = los.GetMethod("AddNewComponent", new[] { typeof(Type), typeof(Type) });
+            var addByKind = los.GetMethods().Single(m => m.Name == "AddNewComponent" && m.GetParameters().Length == 4);
+            var kinds = new List<string>();
+            addByTypes.Invoke(null, new object[]
+            {
+                LlosAssembly.GetType("LegosLibraryOfStuff.AttributeModifierComponent", true),
+                LlosAssembly.GetType("LegosLibraryOfStuff.AttributeModifierComponentBuilder", true),
+            });
+            kinds.Add("AttributeModifierComponent");
+            addByTypes.Invoke(null, new object[]
+            {
+                LlosAssembly.GetType("LegosLibraryOfStuff.ComponentGroupComponent", true),
+                LlosAssembly.GetType("LegosLibraryOfStuff.ComponentGroupComponentBuilder", true),
+            });
+            kinds.Add("ComponentGroup");
+
+            // LegosLogosAndDeco.Main.Load(): the seven named kinds + PrefabModelComponent.
+            foreach (var pair in new[]
+            {
+                ("CustomImage", "CustomImageComponent"),
+                ("ColorPainterComponent", "ColorPainterComponent"),
+                ("SetTextDecalComponent", "SetTextDecalComponent"),
+                ("CustomTextDecalComponent", "CustomTextDecalComponent"),
+                ("DefaultLivelryComponent", "DefaultLivelryComponent"),
+                ("ColorableImageComponent", "ColorableImageComponent"),
+                ("MaterialColorizerComponent", "MaterialColorizerComponent"),
+            })
+            {
+                var compType = LadAssembly.GetType("LegosLogosAndDeco." + pair.Item2, true);
+                var builderType = LadAssembly.GetType("LegosLogosAndDeco." + pair.Item2 + "Builder", true);
+                addByKind.Invoke(null, new object[] { typeof(Component), pair.Item1, compType, Activator.CreateInstance(builderType) });
+                kinds.Add(pair.Item1);
+            }
+            addByTypes.Invoke(null, new object[]
+            {
+                LadAssembly.GetType("LegosLogosAndDeco.PrefabModelComponent", true),
+                LadAssembly.GetType("LegosLogosAndDeco.PrefabModelComponentBuilder", true),
+            });
+            kinds.Add("PrefabModelComponent");
+
+            // LegosBetterRollingStock.Main.Load() kinds (best effort; only matters for packs
+            // that use them — without them such packs fall back to the tolerant path).
+            var lbrsDll = Path.Combine(lbrsDir, "LegosBetterRollingStock.dll");
+            if (File.Exists(lbrsDll))
+            {
+                try
+                {
+                    var lbrs = Assembly.LoadFrom(lbrsDll);
+                    foreach (var pair in new[]
+                    {
+                        ("CustomTruckComponent", "CustomTruckComponent", "CustomTruckComponentBuilder"),
+                        ("CustomCompressorComponent", "CustomCompressorComponent", "CustomCompressorComponentBuilder"),
+                    })
+                    {
+                        var compType = lbrs.GetType("LegosBetterRollingStock." + pair.Item2, true);
+                        var builderType = lbrs.GetType("LegosBetterRollingStock." + pair.Item3, true);
+                        addByKind.Invoke(null, new object[] { typeof(Component), pair.Item1, compType, Activator.CreateInstance(builderType) });
+                        kinds.Add(pair.Item1);
+                    }
+                    foreach (var pair in new[]
+                    {
+                        ("CouplerMoverCompnent", "CouplerMoverComponentBuilder"),
+                        ("CustomAnimationControllerComponent", "CustomAnimationControllerBuilder"),
+                    })
+                    {
+                        var compType = lbrs.GetType("LegosBetterRollingStock." + pair.Item1, true);
+                        var builderType = lbrs.GetType("LegosBetterRollingStock." + pair.Item2, true);
+                        addByTypes.Invoke(null, new object[] { compType, builderType });
+                        kinds.Add(((Component)Activator.CreateInstance(compType)).Kind);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    kinds.Add("(LegosBetterRollingStock kinds NOT registered: " + ex.GetBaseException().Message + ")");
+                }
+            }
+            RegisteredKinds = kinds;
+
+            // --- Every real mod folder that ships LegosLibraryOfStuff/Definitions (what
+            //     LLoS.LoadJsonDefinitions scans through UnityModManager.modEntries) ---
+            var specPackDirs = new List<(string id, string dir)>();
+            foreach (var modDir in Directory.GetDirectories(ModsRoot).OrderBy(d => d, StringComparer.OrdinalIgnoreCase))
+            {
+                if (!Directory.Exists(Path.Combine(modDir, "LegosLibraryOfStuff", "Definitions"))) continue;
+                var id = Path.GetFileName(modDir);
+                var infoPath = Path.Combine(modDir, "info.json");
+                if (File.Exists(infoPath))
+                {
+                    try { id = (string)JObject.Parse(File.ReadAllText(infoPath))["Id"] ?? id; } catch { /* keep folder name */ }
+                }
+                specPackDirs.Add((id, modDir));
+            }
+            RegisteredSpecPacks = specPackDirs.Select(t => t.id).ToList();
+
+            IList modEntries = null;
+            try
+            {
+                modEntries = (IList)ummType.GetField("modEntries", BindingFlags.Public | BindingFlags.Static).GetValue(null);
+            }
+            catch (Exception)
+            {
+                // UnityModManager..cctor unavailable in this process (see makeEntry).
+                modEntries = null;
+            }
+            if (modEntries != null)
+            {
+                foreach (var t in specPackDirs)
+                {
+                    modEntries.Add(makeEntry(t.id, t.dir));
+                }
+            }
+
+            // --- Real Harmony patch classes (the two the postfix path needs) ---
+            _harmony = new Harmony("fuse.tests.legos-library-repro." + Guid.NewGuid().ToString("N"));
+            _harmony.CreateClassProcessor(subtypesPatch).Patch();
+            _harmony.CreateClassProcessor(deserPatch).Patch();
+            _harmony.Patch(
+                AccessTools.Method(typeof(ContainerSerialization), nameof(ContainerSerialization.Deserialize), new[] { typeof(string) }),
+                postfix: new HarmonyMethod(typeof(LegosLibraryHarness), nameof(CountingPostfix)));
+
+            // LLoS's AddJsonSubTypesPatch postfixes JsonSubtypes.GetAttributes(Type) — a
+            // two-line method that the .NET Framework JIT inlines into its generic callers.
+            // In-game LLoS patches it before anything deserializes a Component; in this test
+            // process another test class may already have JIT-compiled those callers, in
+            // which case the postfix can no longer intercept. Probe, and if so, install what
+            // the postfix would have returned straight into JsonSubtypes' attribute cache (a
+            // live view over LLoS's JsonSubTypeRegistry) — a harness shim, reported below.
+            if (ProbeKindBinds("ComponentGroup"))
+            {
+                JsonSubtypesMode = "LLoS AddJsonSubTypesPatch (real Harmony postfix) is effective";
+            }
+            else
+            {
+                var getAttributes = (MethodInfo)subtypesPatch.GetMethod("TargetMethod", BindingFlags.NonPublic | BindingFlags.Static).Invoke(null, null);
+                _harmony.Unpatch(getAttributes, HarmonyPatchType.Postfix, _harmony.Id);
+                _restoreJsonSubtypesCache = InstallLiveKnownSubTypeView(LlosAssembly, getAttributes.DeclaringType);
+                if (!ProbeKindBinds("ComponentGroup"))
+                {
+                    throw new InvalidOperationException("Could not make LLoS-registered component kinds bind in this process.");
+                }
+                JsonSubtypesMode = "harness shim: JsonSubtypes.GetAttributes was already JIT-inlined into its callers before LLoS's postfix was applied; " +
+                                   "seeded JsonSubtypes._attributesCache[Component] with a live view over LLoS's JsonSubTypeRegistry instead";
+            }
+
+            // Prime the spec cache now (the postfix would do it lazily on first Deserialize).
+            if (modEntries != null)
+            {
+                // The real thing: LLoS scans UnityModManager.modEntries itself.
+                los.GetMethod("LoadJsonDefinitions", BindingFlags.Public | BindingFlags.Static).Invoke(null, null);
+                SpecSource = "LibraryOfStuff.LoadJsonDefinitions() over UnityModManager.modEntries";
+            }
+            else
+            {
+                // Replica of LoadJsonDefinitions (same folders, same file glob, same
+                // JsonConvert call with LLoS's own jsonSettings and DefinitionEditorJsonObject),
+                // seeding LLoS's own static lists. With Count > 1 the real method returns
+                // early on every later postfix call, exactly as it does in-game after the
+                // first scan.
+                SeedSpecsLikeLoadJsonDefinitions(los, specPackDirs.Select(t => t.dir));
+                SpecSource = "replica of LoadJsonDefinitions (UnityModManager statics unavailable in this process)";
+            }
+            var newDefinitions = (IEnumerable)los.GetField("newDefinitions").GetValue(null);
+            var identifiers = new List<string>();
+            var newIdentifiers = new List<string>();
+            foreach (var wrapper in newDefinitions)
+            {
+                var json = wrapper.GetType().GetField("json").GetValue(wrapper);
+                identifiers.Add((string)json.GetType().GetField("identifier").GetValue(json));
+                newIdentifiers.Add((string)json.GetType().GetField("newIdentifier").GetValue(json));
+            }
+            SpecCount = identifiers.Count;
+            SpecIdentifiers = identifiers;
+            SpecNewIdentifiers = newIdentifiers;
+
+            _loadResilient = typeof(FuseAssetPackRegistry).GetMethod("LoadResilientDirectContainer",
+                BindingFlags.NonPublic | BindingFlags.Static, null,
+                new[] { typeof(string), typeof(string), typeof(IDictionary<string, int>) }, null);
+            _bypass = typeof(FuseAssetPackRegistry).GetMethod("BypassDeserialize",
+                BindingFlags.NonPublic | BindingFlags.Static, null, new[] { typeof(string) }, null);
+            _canBind = typeof(FuseAssetPackRegistry).GetMethod("CanBindComponent",
+                BindingFlags.NonPublic | BindingFlags.Static, null, new[] { typeof(JObject) }, null);
+            if (_loadResilient == null || _bypass == null || _canBind == null)
+            {
+                throw new InvalidOperationException("FUSE private helpers not found (LoadResilientDirectContainer / BypassDeserialize / CanBindComponent)");
+            }
+
+            _describe =
+                $"GameDir={GameDir}\nLLoS={LlosAssembly.Location} v{LlosAssembly.GetName().Version}\nLogosAndDeco={LadAssembly.Location}\n" +
+                $"kinds registered: {string.Join(", ", kinds)}\n" +
+                $"spec source: {SpecSource}\n" +
+                $"json subtypes: {JsonSubtypesMode}\n" +
+                $"spec packs registered ({RegisteredSpecPacks.Count}): {string.Join(", ", RegisteredSpecPacks)}\n" +
+                $"LLoS specs parsed: {SpecCount} (clone specs: {newIdentifiers.Count(s => !string.IsNullOrEmpty(s))})";
+        }
+
+        private static readonly MethodInfo GameSettingsMethod =
+            AccessTools.Method(typeof(ContainerSerialization), "JsonSerializerSettings");
+
+        private static bool ProbeKindBinds(string kind)
+        {
+            try
+            {
+                var settings = (Newtonsoft.Json.JsonSerializerSettings)GameSettingsMethod.Invoke(null, null);
+                var component = Newtonsoft.Json.JsonConvert.DeserializeObject<Component>("{\"kind\":\"" + kind + "\",\"name\":\"probe\"}", settings);
+                return component != null && component.Kind == kind;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        // Equivalent of LLoS's AddJsonSubTypesPatch.Postfix, materialised into the cache:
+        //   __result = __result.Concat(registry[Component].Select(s => new KnownSubTypeAttribute(s.Type, s.TypeIdentifier)))
+        private static Action InstallLiveKnownSubTypeView(Assembly llos, Type jsonSubtypesType)
+        {
+            var cache = (IDictionary<Type, IEnumerable<object>>)AccessTools.Field(jsonSubtypesType, "_attributesCache").GetValue(null);
+            var registry = llos.GetType("LegosLibraryOfStuff.JsonSubTypeRegistry", true);
+            var tryGet = registry.GetMethod("TryGetForBaseClass", BindingFlags.Public | BindingFlags.Static);
+            var baseType = typeof(Component);
+            var original = baseType.GetCustomAttributes(inherit: false);
+            var knownSubTypeAttributeType = original.Select(a => a.GetType()).First(t => t.Name == "KnownSubTypeAttribute");
+            var ctor = knownSubTypeAttributeType.GetConstructor(new[] { typeof(Type), typeof(object) });
+
+            IEnumerable<object> Live()
+            {
+                foreach (var a in original)
+                {
+                    yield return a;
+                }
+
+                var args = new object[] { baseType, null };
+                if ((bool)tryGet.Invoke(null, args) && args[1] is IEnumerable list)
+                {
+                    foreach (var tuple in list)
+                    {
+                        var id = (string)tuple.GetType().GetField("Item1").GetValue(tuple);
+                        var type = (Type)tuple.GetType().GetField("Item2").GetValue(tuple);
+                        yield return ctor.Invoke(new object[] { type, id });
+                    }
+                }
+            }
+
+            var hadOriginal = cache.TryGetValue(baseType, out var previous);
+            cache[baseType] = Live();
+            return () =>
+            {
+                if (hadOriginal) cache[baseType] = previous; else cache.Remove(baseType);
+            };
+        }
+
+        // Mirrors LegosLibraryOfStuff.LibraryOfStuff.LoadJsonDefinitions() body (1.4.6):
+        //   for each enabled mod entry: <Path>/LegosLibraryOfStuff/Definitions + its immediate
+        //   subdirectories, "*.json"; each file -> JsonConvert.DeserializeObject<DefinitionEditorJsonObject>(text, jsonSettings)
+        //   -> new DefinitionEditorWrapper { path, json } appended to newDefinitions, identifier to definitionIdentifiers;
+        //   per-file failures are logged "Failed to load file" and skipped.
+        private static void SeedSpecsLikeLoadJsonDefinitions(Type los, IEnumerable<string> modDirs)
+        {
+            var jsonSettings = (Newtonsoft.Json.JsonSerializerSettings)los.GetField("jsonSettings").GetValue(null);
+            var specType = los.Assembly.GetType("LegosLibraryOfStuff.DefinitionEditorJsonObject", true);
+            var wrapperType = los.Assembly.GetType("LegosLibraryOfStuff.DefinitionEditorWrapper", true);
+            var newDefinitions = (IList)los.GetField("newDefinitions").GetValue(null);
+            var definitionIdentifiers = (IList)los.GetField("definitionIdentifiers").GetValue(null);
+            var files = new List<string>();
+            foreach (var modDir in modDirs)
+            {
+                var text = Path.Combine(modDir, "LegosLibraryOfStuff", "Definitions");
+                if (!Directory.Exists(text)) continue;
+                var dirs = new List<string> { text };
+                dirs.AddRange(Directory.GetDirectories(text));
+                foreach (var d in dirs)
+                {
+                    files.AddRange(Directory.EnumerateFiles(d, "*.json"));
+                }
+            }
+            foreach (var file in files)
+            {
+                try
+                {
+                    var json = Newtonsoft.Json.JsonConvert.DeserializeObject(File.ReadAllText(file), specType, jsonSettings)
+                               ?? throw new Exception("No json Loaded");
+                    var wrapper = Activator.CreateInstance(wrapperType);
+                    wrapperType.GetField("path").SetValue(wrapper, file);
+                    wrapperType.GetField("json").SetValue(wrapper, json);
+                    newDefinitions.Add(wrapper);
+                    definitionIdentifiers.Add((string)specType.GetField("identifier").GetValue(json));
+                }
+                catch (Exception)
+                {
+                    System.Console.WriteLine("[LegosLibraryOfStuff-replica] Failed to load file " + file);
+                }
+            }
+        }
+
+        // Harmony postfix; static, tiny.
+        private static void CountingPostfix()
+        {
+            System.Threading.Interlocked.Increment(ref _postfixInvocations);
+        }
+
+        public string Describe() => _describe;
+
+        /// <summary>PR #227 cold-load path: FUSE's private LoadResilientDirectContainer.</summary>
+        public Container ColdLoad(string text, string storeIdentifier, IDictionary<string, int> dropped)
+        {
+            try
+            {
+                return (Container)_loadResilient.Invoke(null, new object[] { text, storeIdentifier, dropped });
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException != null)
+            {
+                throw ex.InnerException;
+            }
+        }
+
+        /// <summary>main's cold-load path: FUSE's private BypassDeserialize (main's
+        /// LoadResilientDirectContainer body is BypassDeserialize + FilterUnbindableComponents retry).</summary>
+        public Container BypassDeserialize(string text)
+        {
+            try
+            {
+                return (Container)_bypass.Invoke(null, new object[] { text });
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException != null)
+            {
+                throw ex.InnerException;
+            }
+        }
+
+        /// <summary>main's LoadResilientDirectContainer, verbatim: BypassDeserialize, and on
+        /// failure FilterUnbindableComponents(CanBindComponent) + BypassDeserialize again.</summary>
+        public Container MainColdLoad(string text, IDictionary<string, int> dropped)
+        {
+            try
+            {
+                return BypassDeserialize(text);
+            }
+            catch (Exception)
+            {
+                var canBind = (Func<JObject, bool>)Delegate.CreateDelegate(typeof(Func<JObject, bool>), _canBind);
+                var filtered = FuseAssetPackRegistry.FilterUnbindableComponents(text, dropped, canBind);
+                return BypassDeserialize(filtered);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_harmony != null)
+            {
+                _harmony.UnpatchAll(_harmony.Id);
+            }
+            _restoreJsonSubtypesCache?.Invoke();
+            if (_resolver != null)
+            {
+                AppDomain.CurrentDomain.AssemblyResolve -= _resolver;
+            }
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseDirectStoreNativeDeserializeTests.cs
+++ b/FUSE.Tests/Loading/FuseDirectStoreNativeDeserializeTests.cs
@@ -1,0 +1,426 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FUSE.Loading;
+using HarmonyLib;
+using Model.Definition;
+using Model.Definition.Components;
+using Model.Definition.Data;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    /// <summary>
+    /// In-process proof of the direct-store cold-load contract against the REAL game
+    /// assemblies (Definition.dll's <see cref="ContainerSerialization"/>, its Vec3Conv,
+    /// JsonSubtypes binding of <see cref="Component"/> kinds) and a REAL Harmony runtime.
+    ///
+    /// Background: FUSE mounts mod asset packs as fuseasset:// direct stores whose
+    /// <c>AssetPackRuntimeStore.Container()</c> body is replaced by a Harmony prefix, so the
+    /// game's own call to <c>ContainerSerialization.Deserialize</c> never runs for them.
+    /// Old-loader mods (LegosLibraryOfStuff) hang a Harmony POSTFIX on that public method to
+    /// inject clone definitions (repaint liveries, LLW tender swaps). If FUSE's cold load
+    /// does not go through the public entry point, those clones never exist for any
+    /// mod-pack car (issues #224 / #222). These tests install an LLoS-shaped postfix and
+    /// drive FUSE's real private cold-load and re-deserialize helpers through reflection.
+    /// </summary>
+    public sealed class FuseDirectStoreNativeDeserializeTests : IDisposable
+    {
+        // Unique identifiers so the postfix ignores any Deserialize call issued by another
+        // test class that happens to run concurrently in the same process.
+        private const string BaseIdentifier = "fuse-test-native-deser-boxcar";
+        private const string CloneSuffix = "-clone-test";
+        private const string CloneIdentifier = BaseIdentifier + CloneSuffix;
+        private const string StoreIdentifier = "fuseasset://fuse-test-native-deser-pack";
+
+        // Recorded per-call: the identifiers the container carried when the postfix saw it.
+        // Only calls that contain BaseIdentifier are counted (see PostfixCallCount).
+        private static readonly List<string[]> RecordedCalls = new List<string[]>();
+        private static readonly object RecordLock = new object();
+
+        private static readonly MethodInfo GameSettingsMethod =
+            AccessTools.Method(typeof(ContainerSerialization), "JsonSerializerSettings");
+
+        private static readonly MethodInfo LoadResilientDirectContainerMethod =
+            typeof(FuseAssetPackRegistry).GetMethod(
+                "LoadResilientDirectContainer",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                new[] { typeof(string), typeof(string), typeof(IDictionary<string, int>) },
+                null);
+
+        private static readonly MethodInfo BypassDeserializeMethod =
+            typeof(FuseAssetPackRegistry).GetMethod(
+                "BypassDeserialize",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                new[] { typeof(string) },
+                null);
+
+        private static readonly MethodInfo MixintoDeserializeItemMethod =
+            typeof(FuseLegacyContainerMixintoRegistry).GetMethod(
+                "DeserializeItem",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                new[] { typeof(JObject) },
+                null);
+
+        private readonly Harmony _harmony;
+        private readonly MethodInfo _target;
+
+        public FuseDirectStoreNativeDeserializeTests()
+        {
+            lock (RecordLock)
+            {
+                RecordedCalls.Clear();
+            }
+
+            _target = AccessTools.Method(typeof(ContainerSerialization), nameof(ContainerSerialization.Deserialize), new[] { typeof(string) });
+            Assert.NotNull(_target);
+
+            _harmony = new Harmony("fuse.tests.direct-store-native-deserialize." + Guid.NewGuid().ToString("N"));
+            _harmony.Patch(
+                _target,
+                postfix: new HarmonyMethod(typeof(FuseDirectStoreNativeDeserializeTests), nameof(LlosLikePostfix)));
+        }
+
+        public void Dispose()
+        {
+            _harmony.Unpatch(_target, HarmonyPatchType.Postfix, _harmony.Id);
+        }
+
+        // ------------------------------------------------------------------
+        // The LLoS-shaped postfix.
+        // Mirrors LegosLibraryOfStuff.ContainerSerializationDeserializePatch.Postfix: it
+        // walks __result.Objects, and for a matching identifier appends a clone produced by
+        // serialize -> deserialize with the game's own container settings (LLoS's CloneItem
+        // does exactly that with an identical settings factory), then re-identifies it.
+        // ------------------------------------------------------------------
+        private static void LlosLikePostfix(ref Container __result)
+        {
+            var identifiers = __result?.Objects?.Select(o => o?.Identifier).ToArray() ?? Array.Empty<string>();
+            lock (RecordLock)
+            {
+                RecordedCalls.Add(identifiers);
+            }
+
+            if (__result?.Objects == null)
+            {
+                return;
+            }
+
+            var toAdd = new List<ContainerItem>();
+            foreach (var item in __result.Objects)
+            {
+                if (item?.Identifier != BaseIdentifier)
+                {
+                    continue;
+                }
+
+                var settings = (JsonSerializerSettings)GameSettingsMethod.Invoke(null, null);
+                var clone = JsonConvert.DeserializeObject<ContainerItem>(
+                    JsonConvert.SerializeObject(item, settings), settings);
+                clone.Identifier = item.Identifier + CloneSuffix;
+                if (clone.Metadata != null)
+                {
+                    clone.Metadata.Name = (item.Metadata?.Name ?? string.Empty) + " (clone)";
+                }
+
+                toAdd.Add(clone);
+            }
+
+            __result.Objects.AddRange(toAdd);
+        }
+
+        private static int PostfixCallCount
+        {
+            get
+            {
+                lock (RecordLock)
+                {
+                    return RecordedCalls.Count(ids => ids.Contains(BaseIdentifier));
+                }
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Definitions.json fixtures. Trimmed from a real base pack
+        // ("PS-1 40ft Boxcar Series/PS-1-40ft-6ft-youngstown-door/Definitions.json"):
+        // Car definition with array-shaped Unity structs, PrefabControl + Colorizer
+        // components, load slots, metadata.
+        // ------------------------------------------------------------------
+        private static JObject BoxcarObject(JToken airHosePosition, string extraComponentKind = null)
+        {
+            var components = new JArray
+            {
+                new JObject
+                {
+                    ["kind"] = "PrefabControl",
+                    ["prefab"] = "HandbrakeWheel",
+                    ["name"] = "Handbrake",
+                    ["transform"] = new JObject
+                    {
+                        ["position"] = new JArray(0.473255, 4.10675049, 6.32707739),
+                        ["rotation"] = new JArray(0.0, 0.7071068, 0.0, -0.7071068),
+                        ["scale"] = new JArray(0.75, 0.75, 0.75),
+                    },
+                    ["parent"] = null,
+                    ["enabled"] = true,
+                },
+                new JObject
+                {
+                    ["kind"] = "Colorizer",
+                    ["hexColors"] = new JArray("#4A1F18", "#6e2828"),
+                    ["material"] = new JObject { ["materialName"] = "PS-1 Sides" },
+                    ["name"] = "Colorable Sides",
+                    ["transform"] = new JObject
+                    {
+                        ["position"] = new JArray(0.0, 0.0, 0.0),
+                        ["rotation"] = new JArray(0.0, 0.0, 0.0, 1.0),
+                        ["scale"] = new JArray(1.0, 1.0, 1.0),
+                    },
+                    ["parent"] = null,
+                    ["enabled"] = true,
+                },
+            };
+
+            if (extraComponentKind != null)
+            {
+                components.Add(new JObject
+                {
+                    ["kind"] = extraComponentKind,
+                    ["name"] = extraComponentKind + " instance",
+                    ["enabled"] = true,
+                });
+            }
+
+            return new JObject
+            {
+                ["identifier"] = BaseIdentifier,
+                ["metadata"] = new JObject
+                {
+                    ["name"] = "PS-1 40ft 6ft Youngstown Door Boxcar (test)",
+                    ["description"] = "trimmed test fixture",
+                    ["tags"] = new JArray("Boxcar"),
+                    ["credits"] = "Route of the Whippet",
+                },
+                ["definition"] = new JObject
+                {
+                    ["kind"] = "Car",
+                    ["modelIdentifier"] = "PS-1-40ft-6ft-youngstown-door",
+                    ["carType"] = "XM",
+                    ["archetype"] = "Boxcar",
+                    ["visibleInPlacer"] = true,
+                    ["basePrice"] = 1050,
+                    ["baseRoadNumber"] = "76000",
+                    ["weightEmpty"] = 46800,
+                    ["truckIdentifier"] = "truck.asf-a3b",
+                    ["loadSlots"] = new JArray(new JObject
+                    {
+                        ["maximumCapacity"] = 100000.0,
+                        ["loadUnits"] = "Pounds",
+                        ["requiredLoadIdentifier"] = "",
+                    }),
+                    ["truckSeparation"] = 9.5,
+                    ["length"] = 12.5,
+                    ["couplerHeight"] = 0.88,
+                    ["airHosePosition"] = airHosePosition,
+                    ["brakeAnimations"] = new JArray(),
+                    ["minimumCurveRadius"] = "ExtraSmall",
+                    ["components"] = components,
+                },
+            };
+        }
+
+        private static string Definitions(JObject singleObject)
+        {
+            return new JObject { ["objects"] = new JArray(singleObject) }.ToString(Formatting.Indented);
+        }
+
+        private static readonly JArray ArrayAirHose = new JArray(-0.37, 0.934, 0.09);
+
+        private static Container ColdLoad(string text, IDictionary<string, int> dropped = null)
+        {
+            Assert.NotNull(LoadResilientDirectContainerMethod);
+            dropped = dropped ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                return (Container)LoadResilientDirectContainerMethod.Invoke(null, new object[] { text, StoreIdentifier, dropped });
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException != null)
+            {
+                throw ex.InnerException;
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // (1) Cold load of a well-formed pack goes through the public entry point exactly
+        //     once, and the old-loader postfix's clone is present in what FUSE returns.
+        // ------------------------------------------------------------------
+        [Fact]
+        public void ColdLoad_WellFormedPack_FiresPublicDeserializePostfixOnce_AndKeepsInjectedClone()
+        {
+            var text = Definitions(BoxcarObject(ArrayAirHose));
+
+            var container = ColdLoad(text);
+
+            Assert.NotNull(container);
+            Assert.Equal(1, PostfixCallCount);
+
+            var identifiers = container.Objects.Select(o => o.Identifier).ToArray();
+            Assert.Equal(new[] { BaseIdentifier, CloneIdentifier }, identifiers);
+
+            // The base item bound through the game's real serializer: Car definition,
+            // JsonSubtypes-resolved components, array-shaped Vector3 via Vec3Conv.
+            var car = Assert.IsType<CarDefinition>(container.Objects[0].Definition);
+            Assert.Equal("PS-1-40ft-6ft-youngstown-door", car.ModelIdentifier);
+            Assert.Equal(new Vector3(-0.37f, 0.934f, 0.09f), car.AirHosePosition);
+            Assert.Collection(car.Components,
+                c => Assert.IsType<PrefabControlComponent>(c),
+                c => Assert.IsType<ColorizerComponent>(c));
+
+            // The clone is a deep copy carrying the same definition shape.
+            var clone = container.Objects[1];
+            var cloneCar = Assert.IsType<CarDefinition>(clone.Definition);
+            Assert.NotSame(car, cloneCar);
+            Assert.Equal(car.ModelIdentifier, cloneCar.ModelIdentifier);
+            Assert.Equal(car.AirHosePosition, cloneCar.AirHosePosition);
+            Assert.Equal(2, cloneCar.Components.Count);
+            Assert.EndsWith(" (clone)", clone.Metadata.Name, StringComparison.Ordinal);
+        }
+
+        // ------------------------------------------------------------------
+        // (1b) Two different packs each get their own single postfix pass — a pack is never
+        //      re-run through the public method during its own cold load.
+        // ------------------------------------------------------------------
+        [Fact]
+        public void ColdLoad_TwoPacks_EachFiresPostfixExactlyOnce()
+        {
+            var text = Definitions(BoxcarObject(ArrayAirHose));
+
+            ColdLoad(text);
+            ColdLoad(text);
+
+            Assert.Equal(2, PostfixCallCount);
+        }
+
+        // ------------------------------------------------------------------
+        // (2) A pack the stock serializer rejects (object-shaped Vector3: Vec3Conv does
+        //     JsonConvert.DeserializeObject<float[]>(token.ToString()) which throws on
+        //     {"x":..}) still loads via the tolerant bypass; because the native call threw,
+        //     the postfix never ran for it, so no clone exists for that pack.
+        // ------------------------------------------------------------------
+        [Fact]
+        public void ColdLoad_ObjectShapedVector3_NativeRejects_TolerantFallbackLoads_PostfixNotFired()
+        {
+            var objectAirHose = new JObject { ["x"] = -0.37, ["y"] = 0.934, ["z"] = 0.09 };
+            var text = Definitions(BoxcarObject(objectAirHose));
+
+            // Sanity: prove the premise directly against the game's serializer.
+            var nativeThrow = Record.Exception(() => ContainerSerialization.Deserialize(text));
+            Assert.NotNull(nativeThrow);
+            Assert.IsAssignableFrom<JsonException>(nativeThrow.GetBaseException());
+            Assert.Equal(0, PostfixCallCount); // original threw => Harmony ran no postfix
+
+            var container = ColdLoad(text);
+
+            Assert.NotNull(container);
+            Assert.Equal(0, PostfixCallCount);
+            var item = Assert.Single(container.Objects);
+            Assert.Equal(BaseIdentifier, item.Identifier);
+            var car = Assert.IsType<CarDefinition>(item.Definition);
+            // FUSE's TolerantUnityStructConverter read the object-shaped struct.
+            Assert.Equal(new Vector3(-0.37f, 0.934f, 0.09f), car.AirHosePosition);
+            Assert.Equal(2, car.Components.Count);
+        }
+
+        // ------------------------------------------------------------------
+        // (2b) An unbindable component kind (its library mod is absent) makes the
+        //      stock serializer throw. FUSE drops ONLY that component and then
+        //      re-runs the FILTERED text through the public entry point, so the
+        //      pack still gets its old-loader edits: postfix fires exactly once
+        //      (on the filtered text) and the clone is present. The first native
+        //      attempt threw before returning, so that call ran no postfix — the
+        //      total is still one pass, never two.
+        // ------------------------------------------------------------------
+        [Fact]
+        public void ColdLoad_UnbindableComponentKind_DropsOnlyThatComponent_ThenFiresPostfixOnceOnFilteredText()
+        {
+            var text = Definitions(BoxcarObject(ArrayAirHose, extraComponentKind: "FuseTestBogusComponentKind"));
+            var dropped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            var nativeThrow = Record.Exception(() => ContainerSerialization.Deserialize(text));
+            Assert.NotNull(nativeThrow);
+            Assert.Equal(0, PostfixCallCount);
+
+            var container = ColdLoad(text, dropped);
+
+            Assert.NotNull(container);
+            Assert.Equal(1, PostfixCallCount);
+            var identifiers = container.Objects.Select(o => o.Identifier).ToArray();
+            Assert.Equal(new[] { BaseIdentifier, CloneIdentifier }, identifiers);
+            var car = Assert.IsType<CarDefinition>(container.Objects[0].Definition);
+            Assert.Collection(car.Components,
+                c => Assert.IsType<PrefabControlComponent>(c),
+                c => Assert.IsType<ColorizerComponent>(c));
+            Assert.Equal(1, dropped["FuseTestBogusComponentKind"]);
+            Assert.Single(dropped);
+        }
+
+        // ------------------------------------------------------------------
+        // (3) The RE-deserialize paths must NOT re-fire the postfix (that is the
+        //     double-apply that broke LegosBetterRollingStock ComponentGroup toggles).
+        // ------------------------------------------------------------------
+        [Fact]
+        public void BypassDeserialize_DoesNotFirePublicDeserializePostfix()
+        {
+            Assert.NotNull(BypassDeserializeMethod);
+            var text = Definitions(BoxcarObject(ArrayAirHose));
+
+            var container = (Container)BypassDeserializeMethod.Invoke(null, new object[] { text });
+
+            Assert.NotNull(container);
+            Assert.Equal(0, PostfixCallCount);
+            var item = Assert.Single(container.Objects);
+            Assert.Equal(BaseIdentifier, item.Identifier);
+            Assert.IsType<CarDefinition>(item.Definition);
+        }
+
+        [Fact]
+        public void MixintoItemRedeserialize_DoesNotFirePublicDeserializePostfix()
+        {
+            Assert.NotNull(MixintoDeserializeItemMethod);
+
+            var item = (ContainerItem)MixintoDeserializeItemMethod.Invoke(null, new object[] { BoxcarObject(ArrayAirHose) });
+
+            Assert.NotNull(item);
+            Assert.Equal(BaseIdentifier, item.Identifier);
+            Assert.IsType<CarDefinition>(item.Definition);
+            Assert.Equal(0, PostfixCallCount);
+        }
+
+        // ------------------------------------------------------------------
+        // (3b) Full sequence as it happens in-game for one pack: cold load (1 postfix
+        //      pass) followed by a per-item mixinto re-deserialize and a bypass
+        //      re-deserialize (0 additional passes). Total stays at exactly one.
+        // ------------------------------------------------------------------
+        [Fact]
+        public void ColdLoadThenRedeserialize_PostfixTotalIsExactlyOne()
+        {
+            var text = Definitions(BoxcarObject(ArrayAirHose));
+
+            var cold = ColdLoad(text);
+            Assert.Equal(1, PostfixCallCount);
+            Assert.Contains(cold.Objects, o => o.Identifier == CloneIdentifier);
+
+            MixintoDeserializeItemMethod.Invoke(null, new object[] { BoxcarObject(ArrayAirHose) });
+            BypassDeserializeMethod.Invoke(null, new object[] { text });
+
+            Assert.Equal(1, PostfixCallCount);
+        }
+    }
+}

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -68,6 +68,13 @@ namespace FUSE.Infrastructure
         // a newer stable FUSE release exists and, if so, surfaces a non-blocking
         // notice. On by default; one switch turns off all network access for it.
         public const bool DefaultEnableUpdateCheck = true;
+        // The cold load of a direct (fuseasset://) asset pack goes through the
+        // game's public ContainerSerialization.Deserialize so old-loader
+        // Harmony postfixes (LegosLibraryOfStuff clone/edit injection) apply
+        // to mod packs exactly as they do to natively loaded packs. This is
+        // the escape hatch back to FUSE's Newtonsoft-only loader if a field
+        // regression ever needs it; it is not a normal user setting.
+        public const bool DefaultDirectStoreNativeDeserialize = true;
         public const float ExperimentalEarlyScenePathSuppressionTimeoutSeconds = 8f;
 
         public static bool EnableExperimentalEarlyScenePathSuppression { get; private set; } =
@@ -136,6 +143,8 @@ namespace FUSE.Infrastructure
 
         public static bool EnableUpdateCheck { get; private set; } = DefaultEnableUpdateCheck;
 
+        public static bool DirectStoreNativeDeserialize { get; private set; } = DefaultDirectStoreNativeDeserialize;
+
         public static void Load(UnityModManager.ModEntry modEntry)
         {
             EnableExperimentalEarlyScenePathSuppression = DefaultEnableExperimentalEarlyScenePathSuppression;
@@ -167,6 +176,7 @@ namespace FUSE.Infrastructure
             ForceConstrainedVramMode = DefaultForceConstrainedVramMode;
             EnableNativeLeakStackTraces = DefaultEnableNativeLeakStackTraces;
             EnableUpdateCheck = DefaultEnableUpdateCheck;
+            DirectStoreNativeDeserialize = DefaultDirectStoreNativeDeserialize;
             FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
 
             var infoPath = Path.Combine(modEntry?.Path ?? string.Empty, "Info.json");
@@ -238,6 +248,8 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, "EnableNativeLeakStackTraces", DefaultEnableNativeLeakStackTraces);
                 EnableUpdateCheck =
                     ReadBool(settings, "EnableUpdateCheck", DefaultEnableUpdateCheck);
+                DirectStoreNativeDeserialize =
+                    ReadBool(settings, "DirectStoreNativeDeserialize", DefaultDirectStoreNativeDeserialize);
                 ApplyUserOverrides();
                 FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
 
@@ -272,6 +284,7 @@ namespace FUSE.Infrastructure
                     $"ForceConstrainedVramMode={ForceConstrainedVramMode} " +
                     $"EnableNativeLeakStackTraces={EnableNativeLeakStackTraces} " +
                     $"EnableUpdateCheck={EnableUpdateCheck} " +
+                    $"DirectStoreNativeDeserialize={DirectStoreNativeDeserialize} " +
                     $"timeoutSeconds={ExperimentalEarlyScenePathSuppressionTimeoutSeconds}.");
             }
             catch (Exception ex)
@@ -305,6 +318,7 @@ namespace FUSE.Infrastructure
                 ForceConstrainedVramMode = DefaultForceConstrainedVramMode;
                 EnableNativeLeakStackTraces = DefaultEnableNativeLeakStackTraces;
                 EnableUpdateCheck = DefaultEnableUpdateCheck;
+                DirectStoreNativeDeserialize = DefaultDirectStoreNativeDeserialize;
                 FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
                 FuseLog.Exception($"FUSE failed to parse Info.json settings; experimental early scene-path suppression remains disabled", ex);
             }
@@ -767,6 +781,8 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, nameof(EnableNativeLeakStackTraces), EnableNativeLeakStackTraces);
                 EnableUpdateCheck =
                     ReadBool(settings, nameof(EnableUpdateCheck), EnableUpdateCheck);
+                DirectStoreNativeDeserialize =
+                    ReadBool(settings, nameof(DirectStoreNativeDeserialize), DirectStoreNativeDeserialize);
                 FuseLog.Info($"FUSE user setting overrides loaded from '{path}'.");
             }
             catch (Exception ex)

--- a/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
@@ -757,6 +757,9 @@ namespace FUSE.Loading
         private static readonly HashSet<string> DeserializeBypassFallbackWarnings =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        private static readonly HashSet<string> NativeDeserializeFallbackNotices =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         private static Container LoadResilientDirectContainer(string sourceText, string storeIdentifier, IDictionary<string, int> droppedByKind)
         {
             // No reflection-based strict bypass available (rare): defer to the legacy
@@ -766,9 +769,51 @@ namespace FUSE.Loading
                 return DeserializeContainerBypassingPostfix(sourceText, storeIdentifier);
             }
 
+            // Cold load of a direct (fuseasset://) store. The game's own
+            // AssetPackRuntimeStore.Container() never runs for these stores — the
+            // FuseAssetPackRuntimeStoreContainerPatch prefix replaces it — so this is
+            // the ONLY deserialization the pack ever gets. Route it through the public
+            // ContainerSerialization.Deserialize entry point exactly like the native
+            // loader would, so old-loader Harmony postfixes on that method fire once
+            // per pack: LegosLibraryOfStuff injects its clone definitions (repaint
+            // liveries, LLW tender swaps) there, and without this call clones of
+            // mod-pack cars never exist, which orphans every saved car that references
+            // one (issues #224, #222). Clones of vanilla cars were unaffected because
+            // vanilla stores still load natively.
+            //
+            // The double-apply concern that motivated the bypass (per-car
+            // ComponentGroup toggles going dead) applied when packs were also loaded
+            // natively via the LocalLow mirror; the bypass stays in force for every
+            // RE-deserialize path (sanitize, per-item mixinto re-deserialize, generated
+            // store refresh), which is where a second postfix pass would double-apply.
             try
             {
-                // Happy path: with the defining library mods loaded, the game's
+                var native = ContainerSerialization.Deserialize(sourceText);
+                if (native != null)
+                {
+                    return native;
+                }
+            }
+            catch (Exception ex)
+            {
+                // The stock serializer rejected the pack (unbindable component kind,
+                // object-shaped Unity structs, ...). Fall through to the tolerant
+                // bypass path below; note once so a pack that loses old-loader clones
+                // for this reason is visible in the log.
+                var key = storeIdentifier ?? "<unknown>";
+                if (NativeDeserializeFallbackNotices.Add(key))
+                {
+                    FuseLog.Info(
+                        $"FUSE direct asset pack '{key}' did not deserialize through the game's native path " +
+                        $"({ex.GetBaseException().GetType().Name}: {ex.GetBaseException().Message}); " +
+                        "using FUSE's tolerant loader instead. Old-loader definition edits (e.g. LegosLibraryOfStuff clones) " +
+                        "will not apply to this pack.");
+                }
+            }
+
+            try
+            {
+                // Tolerant path: with the defining library mods loaded, the game's
                 // JsonSubtypes converter binds every component kind — including the
                 // runtime-registered customization kinds (MaterialColorizerComponent,
                 // DefaultLivelryComponent, ComponentGroup, ...) the old static

--- a/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
@@ -770,44 +770,48 @@ namespace FUSE.Loading
             }
 
             // Cold load of a direct (fuseasset://) store. The game's own
-            // AssetPackRuntimeStore.Container() never runs for these stores — the
+            // AssetPackRuntimeStore.Container() body never runs for these stores — the
             // FuseAssetPackRuntimeStoreContainerPatch prefix replaces it — so this is
-            // the ONLY deserialization the pack ever gets. Route it through the public
-            // ContainerSerialization.Deserialize entry point exactly like the native
-            // loader would, so old-loader Harmony postfixes on that method fire once
-            // per pack: LegosLibraryOfStuff injects its clone definitions (repaint
-            // liveries, LLW tender swaps) there, and without this call clones of
-            // mod-pack cars never exist, which orphans every saved car that references
-            // one (issues #224, #222). Clones of vanilla cars were unaffected because
-            // vanilla stores still load natively.
+            // the ONLY deserialization the pack ever gets in this PrefabStore
+            // generation. Route it through the public ContainerSerialization.Deserialize
+            // entry point exactly like the native loader would, so old-loader Harmony
+            // patches on that method fire once per pack: LegosLibraryOfStuff's postfix
+            // injects its clone definitions (repaint liveries, LLW tender swaps) into
+            // the returned container, and without this call clones of mod-pack cars
+            // never exist, which orphans every saved car that references one (issues
+            // #224, #222). Clones of vanilla cars were unaffected because vanilla stores
+            // still load natively.
             //
-            // The double-apply concern that motivated the bypass (per-car
-            // ComponentGroup toggles going dead) applied when packs were also loaded
-            // natively via the LocalLow mirror; the bypass stays in force for every
-            // RE-deserialize path (sanitize, per-item mixinto re-deserialize, generated
-            // store refresh), which is where a second postfix pass would double-apply.
-            try
+            // The double-apply that motivated the bypass (commit c188ad1: per-car
+            // ComponentGroup toggles going dead) came from a SECOND pass over the same
+            // pack inside one PrefabStore generation — at the time AssetLoader's native
+            // store and FUSE's direct store both existed for one folder (physical-path
+            // reuse arrived later in 12d3f80) and the sanitize path re-entered
+            // Deserialize. The public entry point is now called exactly once per cold
+            // load; every RE-deserialize (per-item mixinto re-deserialize, whistle store
+            // refresh is itself a fresh cold load) stays on the Newtonsoft bypass.
+            // DirectStoreNativeDeserialize=false restores the old bypass-only cold load.
+            var nativeThrew = false;
+            if (FuseSettings.DirectStoreNativeDeserialize)
             {
-                var native = ContainerSerialization.Deserialize(sourceText);
-                if (native != null)
+                try
                 {
-                    return native;
+                    var native = ContainerSerialization.Deserialize(sourceText);
+                    if (native != null)
+                    {
+                        return native;
+                    }
                 }
-            }
-            catch (Exception ex)
-            {
-                // The stock serializer rejected the pack (unbindable component kind,
-                // object-shaped Unity structs, ...). Fall through to the tolerant
-                // bypass path below; note once so a pack that loses old-loader clones
-                // for this reason is visible in the log.
-                var key = storeIdentifier ?? "<unknown>";
-                if (NativeDeserializeFallbackNotices.Add(key))
+                catch (Exception ex)
                 {
-                    FuseLog.Info(
-                        $"FUSE direct asset pack '{key}' did not deserialize through the game's native path " +
-                        $"({ex.GetBaseException().GetType().Name}: {ex.GetBaseException().Message}); " +
-                        "using FUSE's tolerant loader instead. Old-loader definition edits (e.g. LegosLibraryOfStuff clones) " +
-                        "will not apply to this pack.");
+                    // The stock serializer rejected the pack — almost always an
+                    // unbindable component kind whose defining library mod is absent,
+                    // occasionally object-shaped Unity structs the game's Vec3Conv
+                    // rejects. Harmony runs no postfix for a throwing original, so
+                    // nothing was applied. Fall through to the tolerant path; a pack
+                    // that ends up losing old-loader clones is called out below.
+                    nativeThrew = true;
+                    NoteNativeDeserializeFallback(storeIdentifier, ex);
                 }
             }
 
@@ -829,8 +833,47 @@ namespace FUSE.Loading
                 // kind (so nothing is dropped), the retry throws again and the caller
                 // falls through to the game's native loader.
                 var filtered = FilterUnbindableComponents(sourceText, droppedByKind, CanBindComponent);
+                if (nativeThrew && droppedByKind.Count > 0)
+                {
+                    // The only thing wrong with the pack was one or more unbindable
+                    // kinds. Retry the FILTERED text through the public entry point so
+                    // the pack still gets its old-loader edits (a pack missing one
+                    // unrelated library must not forfeit its LegosLibraryOfStuff
+                    // clones). The first native call threw, so no postfix pass has run
+                    // yet and this cannot double-apply.
+                    try
+                    {
+                        var native = ContainerSerialization.Deserialize(filtered);
+                        if (native != null)
+                        {
+                            return native;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // Still not stock-deserializable (e.g. object-shaped structs);
+                        // the tolerant retry below is the last resort.
+                    }
+                }
+
                 return BypassDeserialize(filtered);
             }
+        }
+
+        private static void NoteNativeDeserializeFallback(string storeIdentifier, Exception ex)
+        {
+            var key = storeIdentifier ?? "<unknown>";
+            if (!NativeDeserializeFallbackNotices.Add(key))
+            {
+                return;
+            }
+
+            FuseLog.Warning(
+                $"FUSE direct asset pack '{key}' did not deserialize through the game's native path " +
+                $"({ex.GetBaseException().GetType().Name}: {ex.GetBaseException().Message}); " +
+                "retrying with unbindable components dropped, then FUSE's tolerant loader. If the tolerant " +
+                "loader ends up handling it, old-loader definition edits (e.g. LegosLibraryOfStuff clones) " +
+                "will not apply to this pack.");
         }
 
         /// <summary>

--- a/FUSE/Loading/FuseAssetPackRegistry.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.cs
@@ -103,15 +103,18 @@ namespace FUSE.Loading
         private static readonly FieldInfo RuntimeStoreContainerField =
             AccessTools.Field(typeof(AssetPackRuntimeStore), "_container");
 
-        // The direct-mount sanitize path used to call ContainerSerialization.Deserialize,
-        // but old-loader plugins (notably LegosLibraryOfStuff) install a Harmony postfix
-        // on that public entry point and mutate shared component instances on every call.
-        // The game already deserializes each pack once via its native path, so re-entering
-        // the public method here re-fires the postfix on the same identifiers and breaks
-        // per-car ComponentGroup toggles (e.g. ERIE LOGO going dead). We deserialize
-        // through Newtonsoft directly using the same settings the public method would have
-        // used. See FuseLegacyContainerMixintoRegistry for the same bypass on the per-item
-        // mixinto re-deserialize.
+        // Old-loader plugins (notably LegosLibraryOfStuff) install a Harmony postfix on
+        // the public ContainerSerialization.Deserialize entry point and mutate shared
+        // component instances on every call. A pack must therefore pass through that
+        // method exactly ONCE per load: the cold load of a direct store does so on
+        // purpose (see LoadResilientDirectContainer — the game's native path never runs
+        // for fuseasset:// stores, so that is the pack's only deserialization), while every
+        // RE-deserialize (sanitize, per-item mixinto re-deserialize, generated store
+        // refresh) goes through Newtonsoft directly using the same settings the public
+        // method would have used, so the postfix does not re-fire on the same identifiers
+        // and break per-car ComponentGroup toggles (e.g. ERIE LOGO going dead). See
+        // FuseLegacyContainerMixintoRegistry for the same bypass on the per-item mixinto
+        // re-deserialize.
         private static readonly MethodInfo ContainerSerializerSettingsMethod =
             AccessTools.Method(typeof(ContainerSerialization), "JsonSerializerSettings");
 

--- a/FUSE/Loading/FuseAssetPackRegistry.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.cs
@@ -106,15 +106,15 @@ namespace FUSE.Loading
         // Old-loader plugins (notably LegosLibraryOfStuff) install a Harmony postfix on
         // the public ContainerSerialization.Deserialize entry point and mutate shared
         // component instances on every call. A pack must therefore pass through that
-        // method exactly ONCE per load: the cold load of a direct store does so on
-        // purpose (see LoadResilientDirectContainer — the game's native path never runs
-        // for fuseasset:// stores, so that is the pack's only deserialization), while every
-        // RE-deserialize (sanitize, per-item mixinto re-deserialize, generated store
-        // refresh) goes through Newtonsoft directly using the same settings the public
-        // method would have used, so the postfix does not re-fire on the same identifiers
-        // and break per-car ComponentGroup toggles (e.g. ERIE LOGO going dead). See
-        // FuseLegacyContainerMixintoRegistry for the same bypass on the per-item mixinto
-        // re-deserialize.
+        // method exactly ONCE per PrefabStore generation: the cold load of a direct
+        // store does so on purpose (see LoadResilientDirectContainer — the game's native
+        // Container() body never runs for fuseasset:// stores, so that is the pack's only
+        // deserialization), while the per-item mixinto re-deserialize goes through
+        // Newtonsoft directly using the same settings the public method would have used,
+        // so the postfix does not re-fire on the same identifiers and break per-car
+        // ComponentGroup toggles (commit c188ad1: "ERIE LOGO" going dead when AssetLoader's
+        // native store and FUSE's direct store both existed for one folder). See
+        // FuseLegacyContainerMixintoRegistry for that bypass.
         private static readonly MethodInfo ContainerSerializerSettingsMethod =
             AccessTools.Method(typeof(ContainerSerialization), "JsonSerializerSettings");
 

--- a/FUSE/Loading/FuseLegacyContainerMixintoRegistry.cs
+++ b/FUSE/Loading/FuseLegacyContainerMixintoRegistry.cs
@@ -662,6 +662,8 @@ namespace FUSE.Loading
         private static readonly MethodInfo ContainerSerializerSettingsMethod =
             AccessTools.Method(typeof(ContainerSerialization), "JsonSerializerSettings");
 
+        private static readonly HashSet<string> PublicDeserializeFallbackWarned = new HashSet<string>();
+
         private static ContainerItem DeserializeItem(JObject item)
         {
             var wrapper = new JObject
@@ -673,21 +675,28 @@ namespace FUSE.Loading
 
             if (ContainerSerializerSettingsMethod != null)
             {
-                try
-                {
-                    var settings = (JsonSerializerSettings)ContainerSerializerSettingsMethod.Invoke(null, null);
-                    var container = JsonConvert.DeserializeObject<Container>(text, settings);
-                    container?.Awake();
-                    return container?.Objects?.FirstOrDefault();
-                }
-                catch (Exception ex)
-                {
-                    FuseLog.Warning(
-                        "FUSE legacy container mixinto fell back to ContainerSerialization.Deserialize " +
-                        $"because the reflection-based bypass failed: {ex.GetBaseException().Message}. " +
-                        "Old-loader Deserialize postfixes will re-fire for this item, which may double-apply " +
-                        "their edits.");
-                }
+                // Same serializer settings as the public entry point, without the
+                // entry point: this is a RE-deserialize of an item whose container
+                // already went through ContainerSerialization.Deserialize once on its
+                // cold load, so re-entering it here would re-fire old-loader postfixes
+                // on the same identifiers (the c188ad1 double-apply). If this throws,
+                // let it propagate — the caller warns once and skips the mixinto
+                // object, which is strictly better than a second postfix pass.
+                var settings = (JsonSerializerSettings)ContainerSerializerSettingsMethod.Invoke(null, null);
+                var container = JsonConvert.DeserializeObject<Container>(text, settings);
+                container?.Awake();
+                return container?.Objects?.FirstOrDefault();
+            }
+
+            // No reflected settings (a game update renamed the factory): the public
+            // entry point is the only deserializer left. Rare, and logged once so a
+            // double-apply report can be traced back here.
+            if (PublicDeserializeFallbackWarned.Add(string.Empty))
+            {
+                FuseLog.Warning(
+                    "FUSE legacy container mixinto is deserializing through ContainerSerialization.Deserialize " +
+                    "because ContainerSerialization.JsonSerializerSettings could not be resolved; old-loader " +
+                    "Deserialize postfixes will re-fire for patched items, which may double-apply their edits.");
             }
 
             return ContainerSerialization.Deserialize(text)?.Objects?.FirstOrDefault();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -119,6 +119,24 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
   `NOT INSTALLED (optional hint)` in grey, and only real missing requirements
   stay red. The matching "ignored legacy order reference" log lines are now
   informational instead of warnings. (#207, #223)
+- Saves lost cars to "orphaned car" prompts (`PrefabStore UnknownIdentifierException`)
+  and LLW tender swaps were missing for LLW locomotives, whenever the missing
+  definitions were LegosLibraryOfStuff clones (repaint liveries, tender-swap
+  variants) of cars that live in *mod* asset packs. FUSE mounts mod packs
+  directly and loaded them through its own Newtonsoft path, which never passed
+  through the game's `ContainerSerialization.Deserialize` entry point — the
+  method LegosLibraryOfStuff hooks to inject its clones — so clones of vanilla
+  cars existed but clones of mod-pack cars never did. The first load of each
+  directly mounted pack per map load now goes through the game's entry point,
+  exactly like a natively loaded pack; every re-deserialize FUSE does afterwards
+  still bypasses it, so old-loader edits are applied once and per-car component
+  toggles are unaffected. A pack whose only problem is a component kind from a
+  missing library mod is retried through the entry point with just that
+  component dropped, so it keeps its clones. As a consequence, LegosLibraryOfStuff
+  in-place edits (and any other mod's `Deserialize` patch, e.g. BellsAndWhistles'
+  connector extraction) now apply to mod asset packs the same way they do with
+  AssetLoader-native loading. New `DirectStoreNativeDeserialize` setting (default
+  on) restores the old behaviour if ever needed. (#224, #222)
 
 ## [1.0.2]
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -100,6 +100,23 @@ the current status or force a re-check.
 
 ## Multiplayer
 
+### `DirectStoreNativeDeserialize`
+
+**Default: `true`**
+
+Advanced. When FUSE mounts a mod asset pack directly (the normal case without
+AssetLoader), the pack's first deserialization each map load goes through the
+game's own `ContainerSerialization.Deserialize` entry point — exactly what the
+game does for a natively loaded pack — so old-loader Harmony patches on that
+method apply to mod packs too. LegosLibraryOfStuff injects its clone
+definitions (repaint liveries, LLW tender swaps) there; without this, clones of
+mod-pack cars never existed and saves referencing them showed "orphaned cars".
+
+Set to `false` to fall back to FUSE's Newtonsoft-only loader for the cold load
+(the pre-1.1 behaviour). Only useful as a diagnostic escape hatch if an
+old-loader patch misbehaves; expect LegosLibraryOfStuff variants of mod cars to
+disappear while it is off.
+
 ### `BlockNonHostMultiplayerClientWorldApply`
 
 **Default: `false`**

--- a/schemas/umm-info.schema.json
+++ b/schemas/umm-info.schema.json
@@ -157,6 +157,11 @@
           "type": "boolean",
           "default": true,
           "description": "On startup, asks GitHub whether a newer stable FUSE release exists and shows a non-blocking notice if so. Only a public list of release versions is fetched. Turning it off disables the automatic startup check; the manual /fuse.update console command still checks on demand."
+        },
+        "DirectStoreNativeDeserialize": {
+          "type": "boolean",
+          "default": true,
+          "description": "Advanced. Route the first deserialization of each directly mounted mod asset pack through the game's ContainerSerialization.Deserialize entry point so old-loader Harmony patches (e.g. LegosLibraryOfStuff clone definitions for repaint liveries and tender swaps) apply to mod packs as they do to natively loaded packs. Set to false only as a diagnostic escape hatch; LegosLibraryOfStuff variants of mod cars will not exist while it is off."
         }
       }
     }


### PR DESCRIPTION
## Summary

Root cause for **#224** ("Orphaned Cars" — 182 orphans, all LegosLibraryOfStuff livery/variant clones of *mod-pack* cars) and **#222** (LLW tender swaps missing for LLW locos but present for vanilla ones):

- `FuseAssetPackRuntimeStoreContainerPatch` (prefix on `AssetPackRuntimeStore.Container()`) returns FUSE's own container for every `fuseasset://` direct store, so the game's native `Container()` body — the only game code path that calls `ContainerSerialization.Deserialize` — **never runs for any mod asset pack** (the reporter's log shows `reusedExistingPhysicalStore=0; discovered=295`, i.e. no AssetLoader: every pack is a direct store).
- FUSE's cold load used `BypassDeserialize` (Newtonsoft with the game's settings), which skips the public entry point. LegosLibraryOfStuff's `ContainerSerializationDeserializePatch.Postfix` (verified by decompile) injects its clone `ContainerItem`s **only into the container passed to that method** — so clones of vanilla cars existed (vanilla stores load natively) and clones of mod-pack cars never did → `PrefabStore+UnknownIdentifierException` at snapshot load → orphan window.

## Change

- `LoadResilientDirectContainer` (cold load only): try `ContainerSerialization.Deserialize(sourceText)` first — byte-for-byte what the native loader does (`JsonConvert.DeserializeObject<Container>` + `Awake()`) — and on failure fall back to the existing tolerant path. If the only problem was an unbindable component kind, the **filtered** text is retried through the entry point before the tolerant bypass, so a pack missing one unrelated library still keeps its clones. The bypass stays in force for the per-item mixinto re-deserialize (now never re-enters the entry point on failure — it propagates and the caller warns once and skips the object).
- `DirectStoreNativeDeserialize` setting (default on) as an escape hatch; SETTINGS.md + schema.
- Fallback notice → Warning; comments corrected: the c188ad1 double-apply came from AssetLoader's native store + FUSE's direct store both existing for one folder (before physical-path reuse in 12d3f80), not the LocalLow mirror.

## Evidence (no game session available — verified offline against the real assemblies and real mod data)

- **Mechanism test** `FuseDirectStoreNativeDeserializeTests` (self-contained, runs in CI): a real Harmony postfix on the real `ContainerSerialization.Deserialize` driving FUSE's real private cold-load code. On this branch **7/7 pass**; the same file on `main` **fails 3/7** exactly as #224 predicts (postfix count 0, no clone), while every re-deserialize path (bypass, per-item mixinto) is identical on both — i.e. **exactly one** public `Deserialize` per cold load, cold + mixinto + bypass = 1.
- **Real LegosLibraryOfStuff reproduction** `FuseDirectStoreLegosLibraryReproTests` (opt-in via `FUSE_TEST_LLOS_GAME_DIR`; loads the real LLoS 1.4.6 dll + LogosAndDeco/BetterRollingStock, applies LLoS's real patch classes, primes it with the 65 real mods shipping `LegosLibraryOfStuff/Definitions` = 712 specs, and pushes real pack text through FUSE's real code): `PS-1 40ft Boxcar Series` → main path: base id only; **new path: base + the 5 Midwest repaint clones** (`…-CNW1/-MP1/-RI1/-RI2/-SOO1`, checked against their spec files) — #224. `CNWClassE462` Pacific → main: no `ls-462-p37ST`; **new: the streamlined-tender clone exists** — #222. **Census over all 877 installed packs: 877 take the native path (one LLoS pass), 0 fallbacks, 0 failures; 333 clone items exist only on this branch; no base identifier ever lost; drop-sets identical.** The c188ad1 "ERIE LOGO dead" mechanism was reproduced too — it requires a *second* pass over LLoS's shared spec instances within one PrefabStore generation, which the exactly-once cold load does not produce.
- **Lifecycle audit** (decompiled `AssetPackRuntimeStore`/`PrefabStore`/`TrainController`): `_container` is a per-store-instance cache and store instances live one `PrefabStore` generation (= one map load); native stores therefore already run the postfix once per map load, and this branch gives direct stores the same cadence.

Side effect worth knowing: any other mod's patch on `Deserialize` (e.g. BellsAndWhistles' `FlexibleConnectorDefinitionRegistry.ExtractAndStrip` prefix) now also fires for direct-store text — matching AssetLoader-native behavior; noted in the CHANGELOG.

## Validation

- `dotnet build FUSE` — 0 errors, no new warnings
- `dotnet test FUSE.Tests` — **1842 passed, 0 failed, 8 skipped** (the opt-in LLoS harness); with `FUSE_TEST_LLOS_GAME_DIR` set: 8/8 pass
- `cs_lint` / `json_lint` clean

Fixes #224
Fixes #222
