### PR TITLE
fix(legacy): recognise root-level nodes/segments/spans files as legacy data sources

### DIFF
--- a/FUSE.Tests/Loading/FuseLegacyManifestSourceDetectionTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyManifestSourceDetectionTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Linq;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    /// <summary>
+    /// The runtime legacy-package reader filters candidate source files by their
+    /// top-level keys. RailLoader-era packages keep <c>nodes</c> / <c>segments</c> /
+    /// <c>spans</c> at the document root instead of under <c>tracks</c> (issue #210);
+    /// the converters merge those, so the filter must admit them too — otherwise a
+    /// file whose only payload is a root-level dictionary is dropped before
+    /// conversion ever runs.
+    /// </summary>
+    public sealed class FuseLegacyManifestSourceDetectionTests : IDisposable
+    {
+        private readonly string _root = Path.Combine(
+            Path.GetTempPath(), "fuse-legacy-source-detection-" + Guid.NewGuid().ToString("N"));
+
+        public FuseLegacyManifestSourceDetectionTests()
+        {
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+
+        [Theory]
+        [InlineData("segments", "{\"segments\":{\"S1\":{\"startId\":\"N1\",\"endId\":\"N2\"}}}")]
+        [InlineData("nodes", "{\"nodes\":{\"N1\":{\"position\":{\"x\":1,\"y\":2,\"z\":3}}}}")]
+        [InlineData("spans", "{\"spans\":{\"SP1\":{\"lower\":{\"segmentId\":\"S1\",\"end\":\"Start\"},\"upper\":{\"segmentId\":\"S1\",\"end\":\"End\"}}}}")]
+        public void RootLevelTrackDictionary_IsRecognisedAsALegacyDataSource(string key, string json)
+        {
+            var folder = CreatePackage("Root." + key, json);
+
+            var found = FuseLegacyDataConverter.TryReadLegacyManifest(folder, out var manifest);
+
+            Assert.True(found, $"a legacy file whose only top-level key is '{key}' must be admitted");
+            Assert.NotNull(manifest);
+            Assert.Contains(manifest.SourceFiles, path => Path.GetFileName(path) == "game-graph.json");
+        }
+
+        [Fact]
+        public void UnrelatedTopLevelKeys_AreStillIgnored()
+        {
+            var folder = CreatePackage("Root.Unrelated", "{\"somethingElse\":{\"a\":1}}");
+
+            var found = FuseLegacyDataConverter.TryReadLegacyManifest(folder, out _);
+
+            Assert.False(found);
+        }
+
+        private string CreatePackage(string id, string graphJson)
+        {
+            var folder = Path.Combine(_root, id);
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(
+                Path.Combine(folder, "Definition.json"),
+                "{\"id\":\"" + id + "\",\"name\":\"" + id + "\",\"version\":\"1.0.0\",\"author\":\"tester\"}");
+            File.WriteAllText(Path.Combine(folder, "game-graph.json"), graphJson);
+            return folder;
+        }
+    }
+}

--- a/FUSE/Loading/FuseLegacyDataConverter.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.cs
@@ -410,6 +410,16 @@ namespace FUSE.Loading
                 var dataKeys = new[]
                 {
                     "tracks",
+                    // RailLoader-era files keep these track dictionaries at
+                    // the document root instead of under "tracks" (Whittier
+                    // Industries' game-graph.json / KWIX_*.json, #210). The
+                    // converters merge them (MergeLegacyDictionaries), so a
+                    // file whose only payload is a root-level dictionary must
+                    // still be recognised as a data source here — parity with
+                    // FUSE.Converter's LegacyKindDetector.
+                    "nodes",
+                    "segments",
+                    "spans",
                     "loads",
                     "areas",
                     "industries",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,9 +77,9 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
   Whittier Industries. Explicit legacy `type` values on span-less industry
   component patches (such as `Model.Ops.IndustryLoader`) are converted as
   patches instead of failing validation and faulting the whole package. A
-  legacy file whose only top-level payload is one of those root-level
-  dictionaries is now also recognised as a data source by the in-game reader.
-  (#210, #223, part of #203)
+  legacy file whose only top-level payload is a root-level `nodes`, `segments`,
+  or `spans` dictionary is now also recognised as a data source by the in-game
+  reader. (#210, #223, part of #203)
 - Legacy `points: { "$replace": [...] }` patches addressed to a base-game road
   or river by scene path (e.g. `World/Roads Sylva/Chipper Curve`) now replace
   the control points of the existing spline in place, keeping its profile,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,8 +76,10 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
   loaded but no track was built and industries had no spans or locations, e.g.
   Whittier Industries. Explicit legacy `type` values on span-less industry
   component patches (such as `Model.Ops.IndustryLoader`) are converted as
-  patches instead of failing validation and faulting the whole package. (#210,
-  #223, part of #203)
+  patches instead of failing validation and faulting the whole package. A
+  legacy file whose only top-level payload is one of those root-level
+  dictionaries is now also recognised as a data source by the in-game reader.
+  (#210, #223, part of #203)
 - Legacy `points: { "$replace": [...] }` patches addressed to a base-game road
   or river by scene path (e.g. `World/Roads Sylva/Chipper Curve`) now replace
   the control points of the existing spline in place, keeping its profile,


### PR DESCRIPTION
## Summary

Small parity follow-up to #203 (found while verifying #210). The in-game legacy-package reader (`FuseLegacyDataConverter.LooksLikeLegacyDataSource`) admits a candidate JSON file only if it has a recognised top-level key. #203 taught the converters to merge RailLoader-era **root-level** `nodes` / `segments` / `spans` dictionaries, but the filter still only listed `tracks`, so a legacy file whose only payload is one of those root-level dictionaries was dropped before conversion ever ran. The standalone converter's `LegacyKindDetector` already recognises them; this brings the runtime in line.

- `FUSE/Loading/FuseLegacyDataConverter.cs`: add `nodes`, `segments`, `spans` to the data-key set.
- New `FuseLegacyManifestSourceDetectionTests` (temp-folder, via the public `TryReadLegacyManifest`): each of the three root-level dictionaries is admitted; an unrelated key is still ignored. Fails 3/4 without the change, passes 4/4 with it.
- CHANGELOG sentence added to the existing #210 entry.

Refs #210

## Validation

- `dotnet test FUSE.Tests --filter FuseLegacyManifestSourceDetectionTests` — 4/4
- `python tools/cs_lint.py` — clean
