### PR TITLE
Fix legacy span routing and ALW scenery aliases

### DIFF
--- a/FUSE.Tests/API/FusePassengerStopNeighborResolverTests.cs
+++ b/FUSE.Tests/API/FusePassengerStopNeighborResolverTests.cs
@@ -48,8 +48,8 @@ namespace FUSE.Tests.API
         public void ResolveIncoming_FindsStopThatReferencesSourceTimetableCode()
         {
             var oliveHill = new Stop("olivehill-station", "OH");
-            var airport = new Stop("mca-station", "MCA", "OH");
-            var iodla = new Stop("iodla-jct-station", "IJ", "MCA");
+            var airport = new Stop("mca-station", "MCA", neighborIds: new[] { "OH" });
+            var iodla = new Stop("iodla-jct-station", "IJ", neighborIds: new[] { "MCA" });
 
             var incoming = FusePassengerStopNeighborResolver.ResolveIncoming(
                 oliveHill,
@@ -64,9 +64,9 @@ namespace FUSE.Tests.API
         [Fact]
         public void ResolveIncoming_IgnoresSelfBlankAndUnrelatedReferences()
         {
-            var source = new Stop("olivehill-station", "OH", "OH");
-            var blank = new Stop("blank", "BLK", " ", null);
-            var unrelated = new Stop("mca-station", "MCA", "IJ");
+            var source = new Stop("olivehill-station", "OH", neighborIds: new[] { "OH" });
+            var blank = new Stop("blank", "BLK", neighborIds: new[] { " ", null });
+            var unrelated = new Stop("mca-station", "MCA", neighborIds: new[] { "IJ" });
 
             var incoming = FusePassengerStopNeighborResolver.ResolveIncoming(
                 source,
@@ -76,6 +76,46 @@ namespace FUSE.Tests.API
                 stop => stop.TimetableCode);
 
             Assert.Empty(incoming);
+        }
+
+        [Fact]
+        public void ResolveUnauthoredBranchNetwork_ReconstructsFontanaTerminalChain()
+        {
+            var noland = new Stop("noland", "ES", branch: "Fontana Branch", x: -2496.20, z: 6380.15);
+            var bushnell = new Stop("bushnell", "BU", branch: "Fontana Branch", x: -8193.13, z: 6099.52);
+            var collinwood = new Stop("collinwood", "CL", branch: "Fontana Branch", x: -10870.52, z: 5672.83);
+            var marcus = new Stop("marcus", "MA", branch: "Fontana Branch", x: -18809.48, z: 6805.44);
+            var ritter = new Stop("ritter", "RT", branch: "Fontana Branch", x: -23348.03, z: 6771.03);
+            var fontana = new Stop("fontana", "FT", branch: "Fontana Branch", x: -26336.90, z: 7213.35);
+
+            var network = ResolveBranchNetwork(noland, bushnell, collinwood, marcus, ritter, fontana);
+
+            Assert.Equal(new[] { bushnell }, network[noland]);
+            Assert.Equal(new[] { collinwood, noland }, network[bushnell]);
+            Assert.Equal(new[] { bushnell, marcus }, network[collinwood]);
+            Assert.Equal(new[] { collinwood, ritter }, network[marcus]);
+            Assert.Equal(new[] { fontana, marcus }, network[ritter]);
+            Assert.Equal(new[] { ritter }, network[fontana]);
+        }
+
+        [Fact]
+        public void ResolveUnauthoredBranchNetwork_DoesNotOverridePartiallyAuthoredBranch()
+        {
+            var first = new Stop("first", "A", branch: "Branch", x: 0, z: 0);
+            var second = new Stop("second", "B", branch: "Branch", x: 10, z: 0, neighborIds: new[] { "A" });
+
+            Assert.Empty(ResolveBranchNetwork(first, second));
+        }
+
+        [Fact]
+        public void ResolveUnauthoredBranchNetwork_RequiresNamedBranchAndDistinctPositions()
+        {
+            var unnamedA = new Stop("unnamed-a", "A", x: 0, z: 0);
+            var unnamedB = new Stop("unnamed-b", "B", x: 10, z: 0);
+            var coincidentA = new Stop("coincident-a", "C", branch: "Branch", x: 5, z: 5);
+            var coincidentB = new Stop("coincident-b", "D", branch: "Branch", x: 5, z: 5);
+
+            Assert.Empty(ResolveBranchNetwork(unnamedA, unnamedB, coincidentA, coincidentB));
         }
 
         private static Stop[] Resolve(string[] neighborIds, Stop source, Stop[] candidates)
@@ -88,17 +128,45 @@ namespace FUSE.Tests.API
                 stop => stop.TimetableCode);
         }
 
+        private static System.Collections.Generic.IReadOnlyDictionary<Stop, Stop[]> ResolveBranchNetwork(
+            params Stop[] candidates)
+        {
+            return FusePassengerStopNeighborResolver.ResolveUnauthoredBranchNetwork(
+                candidates,
+                stop => stop.Branch,
+                stop => stop.NeighborIds,
+                stop => stop.Identifier,
+                stop => stop.X,
+                stop => stop.Y,
+                stop => stop.Z);
+        }
+
         private sealed class Stop
         {
-            internal Stop(string identifier, string timetableCode, params string[] neighborIds)
+            internal Stop(
+                string identifier,
+                string timetableCode,
+                string branch = null,
+                double x = 0,
+                double y = 0,
+                double z = 0,
+                params string[] neighborIds)
             {
                 Identifier = identifier;
                 TimetableCode = timetableCode;
+                Branch = branch;
+                X = x;
+                Y = y;
+                Z = z;
                 NeighborIds = neighborIds;
             }
 
             internal string Identifier { get; }
             internal string TimetableCode { get; }
+            internal string Branch { get; }
+            internal double X { get; }
+            internal double Y { get; }
+            internal double Z { get; }
             internal string[] NeighborIds { get; }
         }
     }

--- a/FUSE.Tests/Compatibility/FuseLegacyUmmRecoveryTests.cs
+++ b/FUSE.Tests/Compatibility/FuseLegacyUmmRecoveryTests.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text;
+using FUSE.Compatibility;
+using Xunit;
+
+namespace FUSE.Tests.Compatibility
+{
+    public class FuseLegacyUmmRecoveryTests
+    {
+        [Theory]
+        [InlineData("prefix Railloader.Interchange suffix")]
+        [InlineData("prefix StrangeCustoms suffix")]
+        public void ReferencesLegacyLoader_DetectsSupportedLegacyAssemblyNames(string content)
+        {
+            Assert.True(FuseLegacyUmmRecovery.ReferencesLegacyLoader(Encoding.ASCII.GetBytes(content)));
+        }
+
+        [Fact]
+        public void ReferencesLegacyLoader_IgnoresUnrelatedAssemblies()
+        {
+            Assert.False(FuseLegacyUmmRecovery.ReferencesLegacyLoader(
+                Encoding.ASCII.GetBytes("Assembly-CSharp 0Harmony UnityModManager")));
+        }
+
+        [Fact]
+        public void ReferencesLegacyLoader_HandlesEmptyInput()
+        {
+            Assert.False(FuseLegacyUmmRecovery.ReferencesLegacyLoader(null));
+            Assert.False(FuseLegacyUmmRecovery.ReferencesLegacyLoader(Array.Empty<byte>()));
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseLoadReportModExceptionsTests.cs
+++ b/FUSE.Tests/Loading/FuseLoadReportModExceptionsTests.cs
@@ -56,6 +56,7 @@ namespace FUSE.Tests.Loading
                 GraphPostBindIssues = Array.Empty<string>(),
                 ProgressionTransferSkips = Array.Empty<string>(),
                 Notices = Array.Empty<string>(),
+                BlockingNotices = Array.Empty<string>(),
                 SceneryLoadFailures = Array.Empty<FuseLoadReport.SceneryLoadFailure>(),
                 OrphanedCars = Array.Empty<FuseSaveCarFault>(),
                 ModExceptions = FuseModExceptionRegistry.SnapshotForReport(),
@@ -158,6 +159,46 @@ namespace FUSE.Tests.Loading
             }
 
             Assert.True(CreateEmptySnapshot().HasProblems);
+        }
+
+        [Fact]
+        public void HasProblems_IgnoresInformationalNotices_ButPreservesTheAdvisory()
+        {
+            var snapshot = CreateEmptySnapshot();
+            snapshot.Notices = new[] { "Optional alias catalog could not be read." };
+
+            Assert.False(snapshot.HasProblems);
+            Assert.True(snapshot.HasAdvisories);
+
+            var details = FuseLoadReport.BuildDetailsForTests(snapshot);
+            Assert.Contains("Notices:", details);
+            Assert.Contains("Optional alias catalog could not be read.", details);
+
+            var json = JObject.Parse(FuseLoadReport.BuildJsonForTests(snapshot));
+            Assert.False((bool)json["hasProblems"]);
+            Assert.True((bool)json["hasAdvisories"]);
+            Assert.Equal(1, (int)json["counts"]["notices"]);
+            Assert.Equal(0, (int)json["counts"]["blockingNotices"]);
+        }
+
+        [Fact]
+        public void HasProblems_RetainsBlockingNoticeBehavior()
+        {
+            var snapshot = CreateEmptySnapshot();
+            const string message = "Map-load package pipeline failed.";
+            snapshot.Notices = new[] { message };
+            snapshot.BlockingNotices = new[] { message };
+
+            Assert.True(snapshot.HasProblems);
+            Assert.False(snapshot.HasAdvisories);
+
+            var details = FuseLoadReport.BuildDetailsForTests(snapshot);
+            Assert.Contains("Readiness notices:", details);
+            Assert.Contains(message, details);
+
+            var json = JObject.Parse(FuseLoadReport.BuildJsonForTests(snapshot));
+            Assert.True((bool)json["hasProblems"]);
+            Assert.Equal(1, (int)json["counts"]["blockingNotices"]);
         }
     }
 }

--- a/FUSE/Compatibility/FuseLegacyUmmRecovery.cs
+++ b/FUSE/Compatibility/FuseLegacyUmmRecovery.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using FUSE.Infrastructure;
+using UnityModManagerNet;
+
+namespace FUSE.Compatibility
+{
+    /// <summary>
+    /// Recovers dual-format mods whose UMM entry was loaded before FUSE and
+    /// failed while resolving a legacy Railloader assembly. UMM leaves the
+    /// rejected assembly assigned to the entry, so an ordinary Load retry
+    /// immediately returns the cached failure. FUSE clears that failed state
+    /// and asks UMM to use its normal uniquely-renamed reload path after the
+    /// legacy assembly resolver has been installed.
+    /// </summary>
+    internal static class FuseLegacyUmmRecovery
+    {
+        private static readonly FieldInfo ModEntriesField =
+            typeof(UnityModManager).GetField("modEntries", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        private static readonly FieldInfo AssemblyField =
+            typeof(UnityModManager.ModEntry).GetField("mAssembly", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo FirstLoadingField =
+            typeof(UnityModManager.ModEntry).GetField("mFirstLoading", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo ErrorOnLoadingField =
+            typeof(UnityModManager.ModEntry).GetField("mErrorOnLoading", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly HashSet<string> RecoveredPackageKeys =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        internal static int RecoverFailedEntries()
+        {
+            if (ModEntriesField == null || AssemblyField == null || FirstLoadingField == null || ErrorOnLoadingField == null)
+            {
+                FuseLog.Warning("FUSE legacy UMM recovery is unavailable because this Unity Mod Manager build has an unsupported ModEntry layout.");
+                return 0;
+            }
+
+            var entries = ModEntriesField.GetValue(null) as IEnumerable;
+            if (entries == null)
+            {
+                return 0;
+            }
+
+            var recovered = 0;
+            foreach (var value in entries)
+            {
+                if (!(value is UnityModManager.ModEntry entry) || !IsRecoveryCandidate(entry))
+                {
+                    continue;
+                }
+
+                var id = entry.Info?.Id ?? Path.GetFileName(entry.Path);
+                try
+                {
+                    // The failed Assembly.LoadFrom result is still attached to
+                    // the entry. Clear it and force UMM's reload branch, which
+                    // gives the replacement assembly a unique identity and
+                    // avoids the CLR's cached TypeLoadException.
+                    AssemblyField.SetValue(entry, null);
+                    ErrorOnLoadingField.SetValue(entry, false);
+                    FirstLoadingField.SetValue(entry, false);
+
+                    if (!entry.Load() || entry.ErrorOnLoading || !entry.Loaded)
+                    {
+                        FuseLog.Warning(
+                            $"FUSE could not recover legacy UMM mod '{id}' after installing compatibility shims; " +
+                            "the mod remains inactive for this session.");
+                        continue;
+                    }
+
+                    RecoveredPackageKeys.Add(BuildPackageKey(entry.Path, id));
+                    recovered++;
+                    FuseLog.Info(
+                        $"FUSE recovered legacy UMM mod '{id}' after its early Railloader assembly-resolution failure. " +
+                        "Its UMM entry is now active; FUSE will not host its legacy plugin class a second time.");
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception($"FUSE legacy UMM recovery failed for '{id}'", ex);
+                }
+            }
+
+            return recovered;
+        }
+
+        internal static bool WasRecovered(string folderPath, string packageId)
+        {
+            return RecoveredPackageKeys.Contains(BuildPackageKey(folderPath, packageId));
+        }
+
+        private static bool IsRecoveryCandidate(UnityModManager.ModEntry entry)
+        {
+            if (entry == null ||
+                !entry.Enabled ||
+                !entry.ErrorOnLoading ||
+                entry.Started ||
+                !entry.HasAssembly ||
+                entry.Assembly == null ||
+                string.IsNullOrWhiteSpace(entry.Info?.EntryMethod) ||
+                string.Equals(entry.Info?.Id, "FUSE", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var assemblyPath = Path.Combine(entry.Path ?? string.Empty, entry.Info.AssemblyName ?? string.Empty);
+            try
+            {
+                return File.Exists(assemblyPath) && ReferencesLegacyLoader(File.ReadAllBytes(assemblyPath));
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not inspect failed UMM assembly '{assemblyPath}' for legacy references: " +
+                    ex.GetBaseException().Message);
+                return false;
+            }
+        }
+
+        internal static bool ReferencesLegacyLoader(byte[] assemblyBytes)
+        {
+            return ContainsAscii(assemblyBytes, "Railloader.Interchange") ||
+                   ContainsAscii(assemblyBytes, "StrangeCustoms");
+        }
+
+        private static bool ContainsAscii(byte[] source, string value)
+        {
+            if (source == null || source.Length == 0 || string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            var pattern = Encoding.ASCII.GetBytes(value);
+            for (var offset = 0; offset <= source.Length - pattern.Length; offset++)
+            {
+                var matched = true;
+                for (var index = 0; index < pattern.Length; index++)
+                {
+                    if (source[offset + index] == pattern[index])
+                    {
+                        continue;
+                    }
+
+                    matched = false;
+                    break;
+                }
+
+                if (matched)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string BuildPackageKey(string folderPath, string packageId)
+        {
+            string normalizedPath;
+            try
+            {
+                normalizedPath = Path.GetFullPath(folderPath ?? string.Empty)
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+            catch
+            {
+                normalizedPath = (folderPath ?? string.Empty).Trim();
+            }
+
+            return normalizedPath + "|" + (packageId ?? string.Empty).Trim();
+        }
+    }
+}

--- a/FUSE/FusePlugin.cs
+++ b/FUSE/FusePlugin.cs
@@ -65,6 +65,7 @@ namespace FUSE
             try
             {
                 FuseLegacySupportAssemblyShim.Initialize();
+                FuseLegacyUmmRecovery.RecoverFailedEntries();
                 WarnIfLegacyRailloaderInstallPresent();
                 LogStartupVersions(modEntry);
                 FuseSettings.Load(modEntry);

--- a/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
@@ -26,6 +26,7 @@ namespace FUSE.Interface.MenuWindow
             public int GraphIssueCount;
             public int ProgressionTransferSkipCount;
             public int NoticesCount;
+            public int BlockingNoticesCount;
         }
 
         public static void Build(UIPanelBuilder builder)
@@ -50,13 +51,16 @@ namespace FUSE.Interface.MenuWindow
                 return;
             }
             var data = checklistData.Value;
+            var hasAdvisories = data.NoticesCount > data.BlockingNoticesCount || !FuseRuntimeGuardCounters.AllIdle;
 
             builder.AddSection("Overview");
 
             builder.AddField("Status",
                 builder.AddLabelMarkup(data.HasProblems
                 ? "<color=\"red\">Needs Attention</color> - FUSE found items that need review before a clean session."
-                : "<color=\"green\">OK</color> - Full stack loaded cleanly. No package faults, asset misses, graph issues, or transfer skips are reported."));
+                : hasAdvisories
+                    ? "<color=\"green\">Ready</color> - No blocking problems. Informational notices and contained compatibility events are listed below."
+                    : "<color=\"green\">Ready</color> - Full stack loaded cleanly. No package faults, asset misses, graph issues, or transfer skips are reported."));
 
             builder.AddField("Version", "FUSE " + ReadVersion() + " - Schema " + FuseMigration.CurrentVersion + " - Converter 0.2.0");
 
@@ -68,14 +72,14 @@ namespace FUSE.Interface.MenuWindow
             AddReadinessRow(builder, "Track Graph", data.GraphIssueCount == 0, "0 graph issues", data.GraphIssueCount + " issue(s)");
             AddReadinessRow(builder, "Progression", data.ProgressionTransferSkipCount == 0, "0 transfer skips", data.ProgressionTransferSkipCount + " skip(s)");
             AddReadinessRow(builder, "Registry", data.ConflictCount == 0, "0 conflicts", data.ConflictCount + " conflict(s)");
-            AddReadinessRow(builder, "Notices", data.NoticesCount == 0, "0 notices", data.NoticesCount + " notice(s)");
+            AddNoticeRow(builder, data.NoticesCount, data.BlockingNoticesCount);
             // Live session counters, not snapshot state.
-            AddReadinessRow(
+            AddAdvisoryRow(
                 builder,
                 "Guards",
                 FuseRuntimeGuardCounters.AllIdle,
                 "idle",
-                FuseRuntimeGuardCounters.GuardTotal + " contained event(s)");
+                FuseRuntimeGuardCounters.GuardTotal + " compatibility event(s) contained");
             // Session-cumulative third-party exception observations — same
             // live-counter semantics as Guards, sourced from the exception
             // registry rather than the load snapshot. One atomic capture here
@@ -110,7 +114,7 @@ namespace FUSE.Interface.MenuWindow
                 builder,
                 FuseRuntimeGuardCounters.AllIdle
                     ? "All idle — no broken content needed containing this session."
-                    : "Non-zero counters are content problems FUSE is containing; offenders are named in FUSE.log and the health report.",
+                    : "Non-zero counters show compatibility events FUSE handled successfully. They remain visible for troubleshooting but do not make the session unhealthy by themselves.",
                 48f);
             builder.Spacer(6f);
 
@@ -272,6 +276,33 @@ namespace FUSE.Interface.MenuWindow
             builder.AddField(label, builder.AddLabelMarkup(value));
         }
 
+        private static void AddAdvisoryRow(UIPanelBuilder builder, string label, bool idle, string idleText, string advisoryText)
+        {
+            var value = idle
+                ? $"<color=\"green\">OK</color> - {idleText}"
+                : $"<color=\"yellow\">Info</color> - {advisoryText}";
+            builder.AddField(label, builder.AddLabelMarkup(value));
+        }
+
+        private static void AddNoticeRow(UIPanelBuilder builder, int total, int blocking)
+        {
+            if (total == 0)
+            {
+                AddReadinessRow(builder, "Notices", true, "0 notices", string.Empty);
+                return;
+            }
+
+            if (blocking > 0)
+            {
+                var informational = Math.Max(0, total - blocking);
+                var suffix = informational == 0 ? string.Empty : $"; {informational} informational";
+                AddReadinessRow(builder, "Notices", false, string.Empty, $"{blocking} readiness issue(s){suffix}");
+                return;
+            }
+
+            AddAdvisoryRow(builder, "Notices", false, string.Empty, total + " informational notice(s)");
+        }
+
         private static StatusChecklistData? GetStatusChecklistData(FuseLoadReport.ReportSnapshot reportSnapshot)
         {
             if (reportSnapshot == null)
@@ -289,6 +320,7 @@ namespace FUSE.Interface.MenuWindow
                     GraphIssueCount = reportSnapshot.GraphPostBindIssues.Length,
                     LoadedPackagesCount = reportSnapshot.LoadedPackageIds.Length,
                     NoticesCount = reportSnapshot.Notices.Length,
+                    BlockingNoticesCount = reportSnapshot.BlockingNoticeCount,
                     ProgressionTransferSkipCount = reportSnapshot.ProgressionTransferSkips.Length,
                     UnknownAssetCount = reportSnapshot.UnknownSceneryAssets.Length
                 };

--- a/FUSE/Loading/FuseLegacyAssemblyHost.cs
+++ b/FUSE/Loading/FuseLegacyAssemblyHost.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Remoting.Messaging;
 using System.Runtime.Remoting.Proxies;
+using FUSE.Compatibility;
 using FUSE.Infrastructure;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -727,6 +728,14 @@ namespace FUSE.Loading
                 FuseLog.Info(
                     $"FUSE legacy support skipped old-loader package '{manifest.Id}' " +
                     "because native FUSE compatibility replaces it.");
+                return false;
+            }
+
+            if (FuseLegacyUmmRecovery.WasRecovered(manifest.FolderPath, manifest.Id))
+            {
+                FuseLog.Info(
+                    $"FUSE legacy support skipped old-loader plugin hosting for '{manifest.Id}' " +
+                    "because FUSE already recovered and activated its UMM entry.");
                 return false;
             }
 

--- a/FUSE/Loading/FuseLoadReport.cs
+++ b/FUSE/Loading/FuseLoadReport.cs
@@ -17,6 +17,7 @@ namespace FUSE.Loading
         private static readonly Dictionary<string, UnknownSceneryAsset> UnknownSceneryAssets =
             new Dictionary<string, UnknownSceneryAsset>(StringComparer.OrdinalIgnoreCase);
         private static readonly List<string> Notices = new List<string>();
+        private static readonly List<string> BlockingNotices = new List<string>();
         private static readonly List<string> GraphPostBindIssues = new List<string>();
         private static readonly List<string> ProgressionTransferSkips = new List<string>();
         private static readonly Dictionary<string, SceneryLoadFailure> SceneryLoadFailures =
@@ -73,6 +74,7 @@ namespace FUSE.Loading
             {
                 UnknownSceneryAssets.Clear();
                 Notices.Clear();
+                BlockingNotices.Clear();
                 GraphPostBindIssues.Clear();
                 ProgressionTransferSkips.Clear();
                 SceneryLoadFailures.Clear();
@@ -144,6 +146,10 @@ namespace FUSE.Loading
                 if (!Notices.Contains(message))
                 {
                     Notices.Add(message);
+                }
+                if (!BlockingNotices.Contains(message))
+                {
+                    BlockingNotices.Add(message);
                 }
             }
         }
@@ -362,6 +368,7 @@ namespace FUSE.Loading
 
             UnknownSceneryAsset[] unknownScenery;
             string[] notices;
+            string[] blockingNotices;
             string[] graphPostBindIssues;
             string[] progressionTransferSkips;
             SceneryLoadFailure[] sceneryLoadFailures;
@@ -372,6 +379,7 @@ namespace FUSE.Loading
                     .ThenBy(item => item.SceneryId, StringComparer.OrdinalIgnoreCase)
                     .ToArray();
                 notices = Notices.ToArray();
+                blockingNotices = BlockingNotices.ToArray();
                 graphPostBindIssues = GraphPostBindIssues.ToArray();
                 progressionTransferSkips = ProgressionTransferSkips.ToArray();
                 sceneryLoadFailures = SceneryLoadFailures.Values
@@ -431,6 +439,7 @@ namespace FUSE.Loading
                 GraphPostBindIssues = graphPostBindIssues,
                 ProgressionTransferSkips = progressionTransferSkips,
                 Notices = notices,
+                BlockingNotices = blockingNotices,
                 SceneryLoadFailures = sceneryLoadFailures,
                 OrphanedCars = orphanedCars,
                 ModExceptions = modExceptions,
@@ -515,7 +524,11 @@ namespace FUSE.Loading
 
             AppendList(sb, "Graph post-bind issues", snapshot.GraphPostBindIssues);
             AppendList(sb, "Progression transfer skips", snapshot.ProgressionTransferSkips);
-            AppendList(sb, "Notices", snapshot.Notices);
+            AppendList(sb, "Readiness notices", snapshot.BlockingNotices);
+            AppendList(
+                sb,
+                "Notices",
+                snapshot.Notices.Except(snapshot.BlockingNotices ?? Array.Empty<string>(), StringComparer.Ordinal));
 
             if (snapshot.SceneryLoadFailureCount > 0)
             {
@@ -600,6 +613,7 @@ namespace FUSE.Loading
                 ["summary"] = summary ?? string.Empty,
                 ["reason"] = snapshot.Reason ?? string.Empty,
                 ["hasProblems"] = snapshot.HasProblems,
+                ["hasAdvisories"] = snapshot.HasAdvisories,
                 ["counts"] = new JObject
                 {
                     ["loadedFromDiskThisPass"] = snapshot.LoadedFromDiskThisPass,
@@ -617,6 +631,7 @@ namespace FUSE.Loading
                     ["progressionTransferSkips"] = snapshot.ProgressionTransferSkips.Length,
                     ["suppressions"] = suppressionCount,
                     ["notices"] = snapshot.Notices.Length,
+                    ["blockingNotices"] = snapshot.BlockingNoticeCount,
                     ["sceneryLoadFailures"] = snapshot.SceneryLoadFailureCount,
                     ["orphanedCars"] = snapshot.OrphanedCarCount
                 },
@@ -678,6 +693,7 @@ namespace FUSE.Loading
                 ["graphPostBindIssues"] = ToArray(snapshot.GraphPostBindIssues),
                 ["progressionTransferSkips"] = ToArray(snapshot.ProgressionTransferSkips),
                 ["notices"] = ToArray(snapshot.Notices),
+                ["blockingNotices"] = ToArray(snapshot.BlockingNotices),
                 ["sceneryLoadFailures"] = new JArray((snapshot.SceneryLoadFailures ?? Array.Empty<SceneryLoadFailure>()).Select(item => new JObject
                 {
                     ["assetIdentifier"] = item.AssetIdentifier ?? string.Empty,
@@ -853,6 +869,7 @@ namespace FUSE.Loading
             public string[] GraphPostBindIssues { get; set; }
             public string[] ProgressionTransferSkips { get; set; }
             public string[] Notices { get; set; }
+            public string[] BlockingNotices { get; set; }
             public SceneryLoadFailure[] SceneryLoadFailures { get; set; }
             public FuseSaveCarFault[] OrphanedCars { get; set; }
             public FuseModExceptionSnapshot[] ModExceptions { get; set; }
@@ -868,6 +885,10 @@ namespace FUSE.Loading
 
             public int SceneryLoadFailureCount => SceneryLoadFailures?.Length ?? 0;
 
+            public int BlockingNoticeCount => BlockingNotices?.Length ?? 0;
+
+            public int AdvisoryNoticeCount => Math.Max(0, (Notices?.Length ?? 0) - BlockingNoticeCount);
+
             public bool HasProblems =>
                 FaultedPackageCount > 0 ||
                 (Conflicts != null && Conflicts.Length > 0) ||
@@ -875,10 +896,18 @@ namespace FUSE.Loading
                 (GraphPostBindIssues != null && GraphPostBindIssues.Length > 0) ||
                 (ProgressionTransferSkips != null && ProgressionTransferSkips.Length > 0) ||
                 (SkippedPackages != null && SkippedPackages.Any(item => !FusePackageFaultRegistry.IsOptionalSkipReason(item.Value))) ||
-                (Notices != null && Notices.Length > 0) ||
+                BlockingNoticeCount > 0 ||
                 SceneryLoadFailureCount > 0 ||
                 OrphanedCarCount > 0 ||
                 HasModExceptionProblem;
+
+            // Notices preserve useful diagnostics (for example, a malformed
+            // optional alias catalog) but do not by themselves mean the
+            // running stack is unhealthy. If a notice has a runtime impact,
+            // the resulting fault, unknown asset, load failure, graph issue,
+            // or transfer skip is already represented by a blocking bucket
+            // above.
+            public bool HasAdvisories => AdvisoryNoticeCount > 0;
 
             // A single one-off third-party exception must not flip the report
             // red, but a per-cycle thrower (world moves, update ticks) crosses

--- a/FUSE/Loading/FuseModLoader.TrackMerging.cs
+++ b/FUSE/Loading/FuseModLoader.TrackMerging.cs
@@ -49,6 +49,7 @@ namespace FUSE.Loading
             public T Value { get; }
             public FuseStagedApplyCandidate Owner { get; }
             public int Sequence { get; }
+            public bool ApplyFailed { get; set; }
         }
 
         private sealed class FuseMergedTrackRemoval
@@ -1116,6 +1117,15 @@ namespace FUSE.Loading
             {
                 foreach (var entry in plan.Spans.Values.OrderBy(item => item.Sequence))
                 {
+                    // Reconciliation recovers spans that were successfully
+                    // created and then lost during the collection refresh. It
+                    // must not retry a definition that already failed to apply;
+                    // doing so reports the same content error twice.
+                    if (entry.ApplyFailed)
+                    {
+                        continue;
+                    }
+
                     var packageId = entry.Owner?.Loaded?.Definition?.Id;
                     if (!ShouldReconcileMergedSpan(
                             packageId,
@@ -1463,7 +1473,7 @@ namespace FUSE.Loading
                 ShouldRecreateMergedSpanRuntime(
                     TrackAPI.GetDefinition(runtimeSpan),
                     entry.Value);
-            transaction.TryApply("track span", entry.Id, exists, () =>
+            entry.ApplyFailed = !transaction.TryApply("track span", entry.Id, exists, () =>
             {
                 if (recreateForTopologyChange)
                 {

--- a/FUSE/Loading/FuseModLoader.Validation.cs
+++ b/FUSE/Loading/FuseModLoader.Validation.cs
@@ -439,8 +439,9 @@ namespace FUSE.Loading
                         continue;
                     }
 
-                    FuseLoadReport.RecordGraphPostBindIssue(definition.Id, "track segment", segmentId, "missing after apply");
-                    transaction.Warning("track segment", segmentId, "missing after apply");
+                    var missingReason = DescribeMissingSegmentAfterApply(segmentDefinition, mergedTrackPlan);
+                    FuseLoadReport.RecordGraphPostBindIssue(definition.Id, "track segment", segmentId, missingReason);
+                    transaction.Warning("track segment", segmentId, missingReason);
                 }
             }
 
@@ -460,8 +461,9 @@ namespace FUSE.Loading
                         continue;
                     }
 
-                    FuseLoadReport.RecordGraphPostBindIssue(definition.Id, "track span", spanId, "missing after apply");
-                    transaction.Warning("track span", spanId, "missing after apply");
+                    var missingReason = DescribeMissingSpanAfterApply(spanEntry.Value, mergedTrackPlan);
+                    FuseLoadReport.RecordGraphPostBindIssue(definition.Id, "track span", spanId, missingReason);
+                    transaction.Warning("track span", spanId, missingReason);
                 }
             }
 
@@ -552,6 +554,62 @@ namespace FUSE.Loading
             }
 
             transaction.PostBind("scene", definition.Id, $"industries={IndustryAPI.GetAllIndustries().Count()} components={UnityEngine.Object.FindObjectsOfType<IndustryComponent>(true).Length}");
+        }
+
+        private static string DescribeMissingSegmentAfterApply(
+            FuseSegment segment,
+            FuseMergedTrackPlan mergedTrackPlan)
+        {
+            if (segment == null || mergedTrackPlan == null)
+            {
+                return "missing after apply";
+            }
+
+            var causes = new List<string>();
+            AddRemovalCause(causes, "endpoint node", segment.StartNodeId, mergedTrackPlan.RemovedNodes);
+            AddRemovalCause(causes, "endpoint node", segment.EndNodeId, mergedTrackPlan.RemovedNodes);
+            return causes.Count == 0
+                ? "missing after apply"
+                : "missing after apply; " + string.Join("; ", causes);
+        }
+
+        private static string DescribeMissingSpanAfterApply(
+            FuseSpan span,
+            FuseMergedTrackPlan mergedTrackPlan)
+        {
+            if (span == null || mergedTrackPlan == null)
+            {
+                return "missing after apply";
+            }
+
+            var causes = new List<string>();
+            AddRemovalCause(causes, "endpoint segment", span.Upper?.SegmentId, mergedTrackPlan.RemovedSegments);
+            AddRemovalCause(causes, "endpoint segment", span.Lower?.SegmentId, mergedTrackPlan.RemovedSegments);
+            return causes.Count == 0
+                ? "missing after apply"
+                : "missing after apply; " + string.Join("; ", causes);
+        }
+
+        private static void AddRemovalCause(
+            List<string> causes,
+            string kind,
+            string id,
+            IReadOnlyDictionary<string, FuseMergedTrackRemoval> removals)
+        {
+            if (causes == null || removals == null || string.IsNullOrWhiteSpace(id) ||
+                !removals.TryGetValue(id, out var removal))
+            {
+                return;
+            }
+
+            var removingPackage = removal.Owner?.Loaded?.Definition?.Id;
+            var cause = string.IsNullOrWhiteSpace(removingPackage)
+                ? $"{kind} '{id}' was removed by another package"
+                : $"{kind} '{id}' was removed by '{removingPackage}'";
+            if (!causes.Contains(cause))
+            {
+                causes.Add(cause);
+            }
         }
 
         private static FuseSegment GetPostBindSegmentDefinition(

--- a/FUSE/Runtime/API/FusePassengerStopComponent.cs
+++ b/FUSE/Runtime/API/FusePassengerStopComponent.cs
@@ -312,11 +312,21 @@ namespace FUSE.Runtime.API
             var fuseComponents = UnityEngine.Object.FindObjectsOfType<FusePassengerStopComponent>(true)
                 .Where(component => component != null)
                 .ToArray();
+            var liveStopsByComponent = fuseComponents.ToDictionary(
+                component => component,
+                component => FindLiveStop(component, liveStops));
+            var inferredBranchNeighbors = FusePassengerStopNeighborResolver.ResolveUnauthoredBranchNetwork(
+                fuseComponents.Where(component => liveStopsByComponent[component] != null),
+                component => component.Branch,
+                component => component.NeighborIds,
+                component => component.GetStopIdentifier(),
+                component => liveStopsByComponent[component].CenterPoint.x,
+                component => liveStopsByComponent[component].CenterPoint.y,
+                component => liveStopsByComponent[component].CenterPoint.z);
             foreach (var component in fuseComponents)
             {
                 var stopIdentifier = component.GetStopIdentifier();
-                var sourceStop = liveStops.FirstOrDefault(stop =>
-                    string.Equals(stop.identifier, stopIdentifier, StringComparison.OrdinalIgnoreCase));
+                var sourceStop = liveStopsByComponent[component];
                 if (sourceStop == null)
                 {
                     continue;
@@ -343,6 +353,16 @@ namespace FUSE.Runtime.API
                             candidate => candidate.GetStopIdentifier(),
                             candidate => candidate.TimetableCode)
                         .Select(candidate => FindLiveStop(candidate, liveStops))
+                        .Where(stop => stop != null && !ReferenceEquals(stop, sourceStop))
+                        .Distinct()
+                        .ToArray();
+                }
+
+                if (neighbors.Length == 0 &&
+                    inferredBranchNeighbors.TryGetValue(component, out var inferredComponents))
+                {
+                    neighbors = inferredComponents
+                        .Select(candidate => liveStopsByComponent[candidate])
                         .Where(stop => stop != null && !ReferenceEquals(stop, sourceStop))
                         .Distinct()
                         .ToArray();

--- a/FUSE/Runtime/API/FusePassengerStopNeighborResolver.cs
+++ b/FUSE/Runtime/API/FusePassengerStopNeighborResolver.cs
@@ -93,6 +93,152 @@ namespace FUSE.Runtime.API
                 .ToArray();
         }
 
+        internal static IReadOnlyDictionary<T, T[]> ResolveUnauthoredBranchNetwork<T>(
+            IEnumerable<T> candidates,
+            Func<T, string> branchSelector,
+            Func<T, IEnumerable<string>> neighborIdsSelector,
+            Func<T, string> identifierSelector,
+            Func<T, double> xSelector,
+            Func<T, double> ySelector,
+            Func<T, double> zSelector)
+            where T : class
+        {
+            if (candidates == null)
+            {
+                return new Dictionary<T, T[]>();
+            }
+
+            if (branchSelector == null)
+            {
+                throw new ArgumentNullException(nameof(branchSelector));
+            }
+
+            if (neighborIdsSelector == null)
+            {
+                throw new ArgumentNullException(nameof(neighborIdsSelector));
+            }
+
+            if (identifierSelector == null)
+            {
+                throw new ArgumentNullException(nameof(identifierSelector));
+            }
+
+            if (xSelector == null)
+            {
+                throw new ArgumentNullException(nameof(xSelector));
+            }
+
+            if (ySelector == null)
+            {
+                throw new ArgumentNullException(nameof(ySelector));
+            }
+
+            if (zSelector == null)
+            {
+                throw new ArgumentNullException(nameof(zSelector));
+            }
+
+            var result = new Dictionary<T, T[]>();
+            var branchCandidates = candidates
+                .Where(candidate => candidate != null)
+                .Select(candidate => new BranchCandidate<T>(
+                    candidate,
+                    branchSelector(candidate)?.Trim(),
+                    identifierSelector(candidate)?.Trim(),
+                    xSelector(candidate),
+                    ySelector(candidate),
+                    zSelector(candidate),
+                    (neighborIdsSelector(candidate) ?? Enumerable.Empty<string>())
+                    .Any(id => !string.IsNullOrWhiteSpace(id))))
+                .Where(candidate =>
+                    !string.IsNullOrWhiteSpace(candidate.Branch) &&
+                    candidate.Branch.IndexOf(':') < 0)
+                .ToArray();
+
+            foreach (var branchGroup in branchCandidates.GroupBy(
+                         candidate => candidate.Branch,
+                         StringComparer.OrdinalIgnoreCase))
+            {
+                var branchStops = branchGroup
+                    .OrderBy(candidate => candidate.Identifier, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                if (branchStops.Length < 2 ||
+                    branchStops.Any(candidate => candidate.HasAuthoredNeighbors) ||
+                    branchStops.Any(candidate => !candidate.HasFinitePosition) ||
+                    !HasDistinctPositions(branchStops))
+                {
+                    continue;
+                }
+
+                var neighbors = branchStops.ToDictionary(
+                    candidate => candidate,
+                    candidate => new List<BranchCandidate<T>>());
+                var visited = new HashSet<BranchCandidate<T>> { branchStops[0] };
+                while (visited.Count < branchStops.Length)
+                {
+                    BranchCandidate<T> bestFrom = null;
+                    BranchCandidate<T> bestTo = null;
+                    var bestDistance = double.MaxValue;
+
+                    foreach (var from in visited.OrderBy(
+                                 candidate => candidate.Identifier,
+                                 StringComparer.OrdinalIgnoreCase))
+                    {
+                        foreach (var to in branchStops.Where(candidate => !visited.Contains(candidate)))
+                        {
+                            var distance = SquaredDistance(from, to);
+                            if (distance < bestDistance)
+                            {
+                                bestDistance = distance;
+                                bestFrom = from;
+                                bestTo = to;
+                            }
+                        }
+                    }
+
+                    if (bestFrom == null || bestTo == null)
+                    {
+                        break;
+                    }
+
+                    neighbors[bestFrom].Add(bestTo);
+                    neighbors[bestTo].Add(bestFrom);
+                    visited.Add(bestTo);
+                }
+
+                if (visited.Count != branchStops.Length)
+                {
+                    continue;
+                }
+
+                foreach (var branchStop in branchStops)
+                {
+                    result[branchStop.Value] = neighbors[branchStop]
+                        .OrderBy(candidate => candidate.Identifier, StringComparer.OrdinalIgnoreCase)
+                        .Select(candidate => candidate.Value)
+                        .ToArray();
+                }
+            }
+
+            return result;
+        }
+
+        private static bool HasDistinctPositions<T>(IReadOnlyList<BranchCandidate<T>> candidates)
+            where T : class
+        {
+            var first = candidates[0];
+            return candidates.Skip(1).Any(candidate => SquaredDistance(first, candidate) > 0.01d);
+        }
+
+        private static double SquaredDistance<T>(BranchCandidate<T> first, BranchCandidate<T> second)
+            where T : class
+        {
+            var x = first.X - second.X;
+            var y = first.Y - second.Y;
+            var z = first.Z - second.Z;
+            return x * x + y * y + z * z;
+        }
+
         private static void AddIfPresent(HashSet<string> ids, string value)
         {
             if (!string.IsNullOrWhiteSpace(value))
@@ -105,6 +251,40 @@ namespace FUSE.Runtime.API
         {
             return !string.IsNullOrWhiteSpace(candidateId) &&
                    requestedIds.Contains(candidateId.Trim());
+        }
+
+        private sealed class BranchCandidate<T>
+            where T : class
+        {
+            internal BranchCandidate(
+                T value,
+                string branch,
+                string identifier,
+                double x,
+                double y,
+                double z,
+                bool hasAuthoredNeighbors)
+            {
+                Value = value;
+                Branch = branch;
+                Identifier = identifier ?? string.Empty;
+                X = x;
+                Y = y;
+                Z = z;
+                HasAuthoredNeighbors = hasAuthoredNeighbors;
+            }
+
+            internal T Value { get; }
+            internal string Branch { get; }
+            internal string Identifier { get; }
+            internal double X { get; }
+            internal double Y { get; }
+            internal double Z { get; }
+            internal bool HasAuthoredNeighbors { get; }
+            internal bool HasFinitePosition =>
+                !double.IsNaN(X) && !double.IsInfinity(X) &&
+                !double.IsNaN(Y) && !double.IsInfinity(Y) &&
+                !double.IsNaN(Z) && !double.IsInfinity(Z);
         }
     }
 }

--- a/FUSE/Runtime/API/SceneryAPI.cs
+++ b/FUSE/Runtime/API/SceneryAPI.cs
@@ -24,7 +24,20 @@ namespace FUSE.Runtime.API
                 { "CitySignDeep", "ALW_Sign_CitySignDeep" },
                 { "CitySignEverett", "ALW_Sign_CitySignEverett" },
                 { "CitySignWalkerWoody", "ALW_Sign_CitySignWalkerWoody" },
-                { "TurntableMeasurementTool", "ALW_ModRes_TurntableMeasurementTool" }
+                { "FullServiceMailboxBlack", "ALW_SA_FullServiceMailboxBlack" },
+                { "FullServiceMailboxGreen", "ALW_SA_FullServiceMailboxGreen" },
+                { "FullServiceMailboxWhite", "ALW_SA_FullServiceMailboxWhite" },
+                { "MultiMailbox", "ALW_SA_MultiMailbox" },
+                { "RampBrick", "ALW_IndScenery_RampBrick" },
+                { "RampWood", "ALW_IndScenery_RampWood" },
+                { "RegMailboxBlack", "ALW_SA_RegMailboxBlack" },
+                { "RegMailboxGreen", "ALW_SA_RegMailboxGreen" },
+                { "RegMailboxWhite", "ALW_SA_RegMailboxWhite" },
+                { "Stockyard4Pen", "ALW_StockY_Stockyard4Pen" },
+                { "TurntableMeasurementTool", "ALW_ModRes_TurntableMeasurementTool" },
+                { "WoodDock10M", "ALW_IndScenery_WoodDock10M" },
+                { "WoodDock20M", "ALW_IndScenery_WoodDock20M" },
+                { "WoodDock50M", "ALW_IndScenery_WoodDock50M" }
             };
 
         private static readonly HashSet<string> OptionalLegacySceneryAssets =

--- a/FUSE/Runtime/API/TrackAPI.Graph.cs
+++ b/FUSE/Runtime/API/TrackAPI.Graph.cs
@@ -377,6 +377,11 @@ namespace FUSE.Runtime.API
             var points = span.GetPoints();
             if (points == null || points.Count < 2 || span.Length <= SpanDistanceTolerance)
             {
+                if (TryRepairSpanEndpointFacing(spanId, span))
+                {
+                    return;
+                }
+
                 var upper = span.upper.HasValue ? DescribeLocation(span.upper.Value) : "missing";
                 var lower = span.lower.HasValue ? DescribeLocation(span.lower.Value) : "missing";
                 throw new InvalidOperationException(
@@ -384,6 +389,91 @@ namespace FUSE.Runtime.API
                     $"upper=({upper}) lower=({lower}). Check that upper/lower arrows face each other, " +
                     "distances are inside segment length, and endpoint segments are connected.");
             }
+        }
+
+        /// <summary>
+        /// Some legacy AlinasMapMod spans store the correct physical points but
+        /// face one or both endpoint arrows away from the connecting route. The
+        /// legacy loader tolerated that data. Preserve each endpoint's physical
+        /// position and try only the three possible facing corrections; select
+        /// the shortest valid route so a nearby switch cannot send the span
+        /// around an unrelated branch.
+        /// </summary>
+        private static bool TryRepairSpanEndpointFacing(string spanId, TrackSpan span)
+        {
+            if (span == null || !span.upper.HasValue || !span.lower.HasValue)
+            {
+                return false;
+            }
+
+            var originalUpper = span.upper.Value;
+            var originalLower = span.lower.Value;
+            Location? bestUpper = null;
+            Location? bestLower = null;
+            var bestLength = float.PositiveInfinity;
+            var bestFacing = string.Empty;
+
+            for (var trial = 1; trial <= 3; trial++)
+            {
+                var trialFacing = trial == 1
+                    ? "upper"
+                    : trial == 2
+                        ? "lower"
+                        : "upper+lower";
+                try
+                {
+                    span.upper = (trial & 1) != 0
+                        ? FlipLocationEndPreservingPosition(originalUpper)
+                        : originalUpper;
+                    span.lower = (trial & 2) != 0
+                        ? FlipLocationEndPreservingPosition(originalLower)
+                        : originalLower;
+                    span.NormalizeUpperLower();
+
+                    var points = span.GetPoints();
+                    var length = span.Length;
+                    if (points == null || points.Count < 2 ||
+                        length <= SpanDistanceTolerance || length >= bestLength)
+                    {
+                        continue;
+                    }
+
+                    bestUpper = span.upper;
+                    bestLower = span.lower;
+                    bestLength = length;
+                    bestFacing = trialFacing;
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Info(
+                        $"FUSE track span '{spanId}' endpoint-facing trial '{trialFacing}' was rejected: " +
+                        ex.GetBaseException().Message);
+                }
+            }
+
+            if (!bestUpper.HasValue || !bestLower.HasValue)
+            {
+                span.upper = originalUpper;
+                span.lower = originalLower;
+                return false;
+            }
+
+            span.upper = bestUpper;
+            span.lower = bestLower;
+            FuseLog.Info(
+                $"FUSE auto-repaired track span '{spanId}': reversed {bestFacing} endpoint facing " +
+                $"without moving either physical endpoint; resolvedLength={bestLength:0.###}. " +
+                "Legacy AlinasMapMod tolerated this facing pattern.");
+            return true;
+        }
+
+        private static Location FlipLocationEndPreservingPosition(Location location)
+        {
+            var length = location.segment.GetLength();
+            var distanceFromA = DistanceFromSegmentA(location);
+            var flippedEnd = location.EndIsA ? TrackSegment.End.B : TrackSegment.End.A;
+            var flippedDistance = location.EndIsA ? length - distanceFromA : distanceFromA;
+            return new Location(location.segment, Mathf.Clamp(flippedDistance, 0f, length), flippedEnd);
         }
 
         private static string DescribeLocation(Location location)


### PR DESCRIPTION
## Summary
- repair legacy track spans whose physical endpoints are valid but whose endpoint arrows face away from the route
- recognize legacy ALW mailbox, dock, ramp, and stockyard scenery names
- identify the package that removed a required node or segment in graph diagnostics
- avoid counting a failed span twice during final reconciliation

## Validation
- dotnet test FUSE.Tests/FUSE.Tests.csproj -c Release --no-restore (1,824 passed)
- dotnet slopwatch analyze -d . (no new findings; one pre-existing UI-test delay warning)