### PR TITLE
Review: FUSE compatibility, authoring, diagnostics, and installer overhaul

### DIFF
--- a/FUSE.Converter/Conversion/LegacyConverterConstants.cs
+++ b/FUSE.Converter/Conversion/LegacyConverterConstants.cs
@@ -157,10 +157,27 @@ namespace FUSE.Converter.Conversion
         public static readonly HashSet<string> CoreLegacyRequirements = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "railroader", "railloader", "rail-loader",
+            "railloader.injector", "railloader.interchange",
+            "assetloader",
+            "alinanova21.mapeditor", "mapeditor", "mmapeditor",
             "zamu.strangecustoms", "strangecustoms",
             "zamu.confusingsupplements", "confusingsupplements",
+            "zamu.foryourconvenience", "foryourconvenience",
+            "alinanova21.alinasmapmod", "alinasmapmod", "alinamapmod",
             "fuse",
         };
+
+        public static bool IsCoreLegacyRequirement(string packageId)
+        {
+            var value = (packageId ?? string.Empty).Trim();
+            while (value.EndsWith(".FUSE", StringComparison.OrdinalIgnoreCase) ||
+                   value.EndsWith(".RAIL", StringComparison.OrdinalIgnoreCase))
+            {
+                value = value.Substring(0, value.Length - 5);
+            }
+
+            return CoreLegacyRequirements.Contains(value);
+        }
 
         /// <summary>
         /// Component type alias table — port of the dictionary

--- a/FUSE.Converter/Conversion/LegacyDefinitionConverter.cs
+++ b/FUSE.Converter/Conversion/LegacyDefinitionConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
@@ -42,13 +43,18 @@ namespace FUSE.Converter.Conversion
         /// </summary>
         public static JObject ConvertRequirement(JToken item)
         {
+            return ConvertReference(item, true);
+        }
+
+        private static JObject ConvertReference(JToken item, bool filterReplacementCapabilities)
+        {
             if (item == null) return null;
 
             if (item.Type == JTokenType.String)
             {
                 var requirementId = item.Value<string>()?.Trim();
                 if (string.IsNullOrEmpty(requirementId)) return null;
-                if (LegacyConverterConstants.CoreLegacyRequirements.Contains(requirementId)) return null;
+                if (filterReplacementCapabilities && LegacyConverterConstants.IsCoreLegacyRequirement(requirementId)) return null;
                 return new JObject { ["id"] = requirementId };
             }
 
@@ -56,7 +62,7 @@ namespace FUSE.Converter.Conversion
 
             var id = (obj.Value<string>("id") ?? obj.Value<string>("Id") ?? string.Empty).Trim();
             if (string.IsNullOrEmpty(id)) return null;
-            if (LegacyConverterConstants.CoreLegacyRequirements.Contains(id)) return null;
+            if (filterReplacementCapabilities && LegacyConverterConstants.IsCoreLegacyRequirement(id)) return null;
 
             var result = new JObject
             {
@@ -75,18 +81,51 @@ namespace FUSE.Converter.Conversion
         /// </summary>
         public static JArray ConvertRequirements(JToken value)
         {
+            return ConvertReferences(value, true);
+        }
+
+        private static JArray ConvertReferences(JToken value, bool filterReplacementCapabilities)
+        {
             var result = new JArray();
             if (!(value is JArray arr)) return result;
 
             foreach (var item in arr)
             {
-                var converted = ConvertRequirement(item);
+                var converted = ConvertReference(item, filterReplacementCapabilities);
                 if (converted != null)
                 {
                     result.Add(converted);
                 }
             }
             return result;
+        }
+
+        public static JArray LegacyConflictsWith(string modFolder)
+        {
+            var path = Path.Combine(modFolder ?? string.Empty, "Definition.json");
+            if (!File.Exists(path))
+            {
+                return new JArray();
+            }
+
+            try
+            {
+                var definition = LegacyJsonReader.ReadJson(path) as JObject;
+                var converted = ConvertReferences(
+                    definition?["conflictsWith"] ?? definition?["ConflictsWith"],
+                    false);
+                return new JArray(converted.OfType<JObject>().Select(reference =>
+                    JsonCleanHelper.CleanObject(new JObject
+                    {
+                        ["Id"] = reference["id"]?.DeepClone(),
+                        ["NotBefore"] = reference["notBefore"]?.DeepClone(),
+                        ["NotAfter"] = reference["notAfter"]?.DeepClone()
+                    })));
+            }
+            catch (Exception)
+            {
+                return new JArray();
+            }
         }
 
         /// <summary>
@@ -100,7 +139,7 @@ namespace FUSE.Converter.Conversion
         {
             var text = (requirementId ?? string.Empty).Trim();
             if (string.IsNullOrEmpty(text)) return null;
-            if (LegacyConverterConstants.CoreLegacyRequirements.Contains(text)) return null;
+            if (LegacyConverterConstants.IsCoreLegacyRequirement(text)) return null;
             if (text.EndsWith(".FUSE", StringComparison.OrdinalIgnoreCase)) return text;
             return text + ".FUSE";
         }
@@ -114,19 +153,33 @@ namespace FUSE.Converter.Conversion
         /// </summary>
         public static List<string> LegacyLoadAfter(string modFolder)
         {
-            var result = new List<string>();
+            var dependencies = LegacyDependencies(modFolder);
+            var result = new List<string>(dependencies.Requires);
+            result.AddRange(dependencies.LoadAfter);
+            return Deduplicate(result);
+        }
+
+        /// <summary>
+        /// Reads hard requirements separately from advisory ordering. The old
+        /// converter flattened both into LoadAfter, which made a missing required
+        /// package look optional to FUSE.
+        /// </summary>
+        public static (List<string> Requires, List<string> LoadAfter) LegacyDependencies(string modFolder)
+        {
+            var required = new List<string>();
+            var loadAfter = new List<string>();
             var path = Path.Combine(modFolder ?? string.Empty, "Definition.json");
-            if (!File.Exists(path)) return result;
+            if (!File.Exists(path)) return (required, loadAfter);
 
             JObject definition;
             try
             {
                 definition = LegacyJsonReader.ReadJson(path) as JObject;
-                if (definition == null) return result;
+                if (definition == null) return (required, loadAfter);
             }
             catch (Exception)
             {
-                return result;
+                return (required, loadAfter);
             }
 
             var requirements =
@@ -141,37 +194,97 @@ namespace FUSE.Converter.Conversion
                 var packageId = FusePackageId((requirement as JObject)?.Value<string>("id"));
                 if (!string.IsNullOrEmpty(packageId))
                 {
-                    result.Add(packageId);
+                    required.Add(packageId);
                 }
             }
 
             var loadAfterToken = definition["loadAfter"] ?? definition["LoadAfter"];
-            var loadAfterList = new List<string>();
             if (loadAfterToken is JArray la)
             {
                 foreach (var item in la)
                 {
-                    if (item.Type == JTokenType.String) loadAfterList.Add(item.Value<string>());
+                    var id = item.Type == JTokenType.String
+                        ? item.Value<string>()
+                        : (item as JObject)?.Value<string>("id") ?? (item as JObject)?.Value<string>("Id");
+                    var packageId = FusePackageId(id);
+                    if (!string.IsNullOrEmpty(packageId)) loadAfter.Add(packageId);
                 }
             }
             else if (loadAfterToken?.Type == JTokenType.String)
             {
-                loadAfterList.Add(loadAfterToken.Value<string>());
-            }
-
-            foreach (var item in loadAfterList)
-            {
-                var packageId = FusePackageId(item);
+                var packageId = FusePackageId(loadAfterToken.Value<string>());
                 if (!string.IsNullOrEmpty(packageId))
                 {
-                    result.Add(packageId);
+                    loadAfter.Add(packageId);
                 }
             }
 
-            // Dedup preserving first-seen order (case-insensitive).
+            foreach (var id in EnumerateMixintoRequirementIds(
+                         definition["mixintos"] ?? definition["Mixintos"]))
+            {
+                var packageId = FusePackageId(id);
+                if (!string.IsNullOrEmpty(packageId))
+                {
+                    loadAfter.Add(packageId);
+                }
+            }
+
+            return (Deduplicate(required), Deduplicate(loadAfter));
+        }
+
+        private static IEnumerable<string> EnumerateMixintoRequirementIds(JToken value)
+        {
+            if (value == null || value.Type == JTokenType.Null)
+            {
+                yield break;
+            }
+
+            if (value is JArray array)
+            {
+                foreach (var item in array)
+                {
+                    foreach (var id in EnumerateMixintoRequirementIds(item))
+                    {
+                        yield return id;
+                    }
+                }
+
+                yield break;
+            }
+
+            if (!(value is JObject obj))
+            {
+                yield break;
+            }
+
+            foreach (var requirement in ConvertRequirements(obj["requires"] ?? obj["Requires"]).OfType<JObject>())
+            {
+                var id = requirement.Value<string>("id");
+                if (!string.IsNullOrWhiteSpace(id))
+                {
+                    yield return id;
+                }
+            }
+
+            foreach (var property in obj.Properties())
+            {
+                if (string.Equals(property.Name, "requires", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                foreach (var id in EnumerateMixintoRequirementIds(property.Value))
+                {
+                    yield return id;
+                }
+            }
+        }
+
+        private static List<string> Deduplicate(IEnumerable<string> values)
+        {
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var ordered = new List<string>();
-            foreach (var item in result)
+            foreach (var item in values ?? Array.Empty<string>())
             {
                 if (seen.Add(item))
                 {
@@ -213,7 +326,7 @@ namespace FUSE.Converter.Conversion
                 return (metadata, orderedFiles);
             }
 
-            void Record(string target, string reference, JArray requirements)
+            void Record(string target, string reference, JArray requirements, JArray conflictsWith)
             {
                 var referencedFile = ExtractFileReference(reference);
                 if (string.IsNullOrEmpty(referencedFile)) return;
@@ -229,6 +342,7 @@ namespace FUSE.Converter.Conversion
                     ["target"] = (target ?? string.Empty).Trim(),
                     ["sourceFile"] = sourceFile,
                     ["requires"] = requirements ?? new JArray(),
+                    ["conflictsWith"] = conflictsWith ?? new JArray(),
                 });
             }
 
@@ -238,7 +352,7 @@ namespace FUSE.Converter.Conversion
 
                 if (value.Type == JTokenType.String)
                 {
-                    Record(target, value.Value<string>(), null);
+                    Record(target, value.Value<string>(), null, null);
                     return;
                 }
 
@@ -251,8 +365,9 @@ namespace FUSE.Converter.Conversion
                 if (!(value is JObject obj)) return;
 
                 var requirements = ConvertRequirements(obj["requires"] ?? obj["Requires"]);
+                var conflictsWith = ConvertReferences(obj["conflictsWith"] ?? obj["ConflictsWith"], false);
                 var reference = obj.Value<string>("mixinto") ?? obj.Value<string>("Mixinto");
-                Record(target, reference, requirements);
+                Record(target, reference, requirements, conflictsWith);
             }
 
             var mixintos = definition["mixintos"] as JObject ?? definition["Mixintos"] as JObject;

--- a/FUSE.Converter/Conversion/LegacyKindDetector.cs
+++ b/FUSE.Converter/Conversion/LegacyKindDetector.cs
@@ -30,6 +30,9 @@ namespace FUSE.Converter.Conversion
             public const string Route = "route";
             public const string Audio = "audio";
             public const string Asset = "asset";
+            public const string MapTile = "map_tile";
+            public const string Native = "native";
+            public const string Code = "code";
             public const string Archive = "archive";
             public const string Unknown = "unknown";
         }
@@ -74,14 +77,46 @@ namespace FUSE.Converter.Conversion
 
             if (!Directory.Exists(sourcePath)) return Kinds.Unknown;
 
+            if (ContainsNativeFuseFragment(sourcePath)) return Kinds.Native;
+            if (ContainsCompiledPlugin(sourcePath)
+                && !DetectsDirectRouteData(sourcePath)
+                && !DetectsDirectAudio(sourcePath))
+            {
+                return Kinds.Code;
+            }
             if (DetectsAudio(sourcePath) && !DetectsRouteData(sourcePath))
             {
                 return Kinds.Audio;
             }
             if (DetectsRouteData(sourcePath)) return Kinds.Route;
-            if (FindMapTileSources(sourcePath).Any()) return Kinds.Route;
-            if (FindAssetPackSources(sourcePath).Any()) return Kinds.Asset;
+            if (ContainsCompiledPlugin(sourcePath)) return Kinds.Code;
+            if (FindMapTileSources(sourcePath).Count > 0) return Kinds.MapTile;
+            if (FindAssetPackSources(sourcePath).Count > 0) return Kinds.Asset;
             return Kinds.Unknown;
+        }
+
+        private static bool ContainsNativeFuseFragment(string folder)
+        {
+            try
+            {
+                return Directory.EnumerateFiles(folder, "*.fuse.json", SearchOption.TopDirectoryOnly).Any();
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        private static bool ContainsCompiledPlugin(string folder)
+        {
+            try
+            {
+                return Directory.EnumerateFiles(folder, "*.dll", SearchOption.TopDirectoryOnly).Any();
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -104,6 +139,49 @@ namespace FUSE.Converter.Conversion
                 catch (Exception) { /* malformed JSON ignored — counted in conversion later */ }
             }
             return false;
+        }
+
+        private static bool DetectsDirectRouteData(string sourcePath)
+        {
+            IEnumerable<string> paths;
+            try
+            {
+                paths = Directory.EnumerateFiles(sourcePath, "*.json", SearchOption.TopDirectoryOnly);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            foreach (var path in paths)
+            {
+                if (JsonManifestNames.Contains(Path.GetFileName(path))) continue;
+                try
+                {
+                    var data = LegacyJsonReader.ReadJson(path) as JObject;
+                    if (data != null && data.Properties().Any(p => LegacyDataKeys.Contains(p.Name))) return true;
+                }
+                catch (Exception)
+                {
+                    // Malformed files are reported by conversion after the package kind is known.
+                    continue;
+                }
+            }
+            return false;
+        }
+
+        private static bool DetectsDirectAudio(string sourcePath)
+        {
+            try
+            {
+                return Directory.EnumerateFiles(sourcePath, "*.json", SearchOption.TopDirectoryOnly)
+                    .Where(path => !JsonManifestNames.Contains(Path.GetFileName(path)))
+                    .Any(DetectsAudioFile);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
 
         public static bool DetectsAudio(string sourcePath)

--- a/FUSE.Converter/Conversion/LegacyTrackConverter.cs
+++ b/FUSE.Converter/Conversion/LegacyTrackConverter.cs
@@ -31,6 +31,7 @@ namespace FUSE.Converter.Conversion
                 ["position"] = VectorHelper.Vector(obj?["position"] ?? obj?["localPosition"]),
                 ["rotation"] = VectorHelper.Vector(obj?["rotation"] ?? obj?["localRotation"]),
                 ["flipSwitchStand"] = obj?.Value<bool?>("flipSwitchStand") ?? false,
+                ["isDiamond"] = obj?.Value<bool?>("isDiamond") ?? obj?.Value<bool?>("IsDiamond") ?? false,
             };
         }
 
@@ -58,15 +59,20 @@ namespace FUSE.Converter.Conversion
             }
 
             var partial = string.IsNullOrEmpty(startNodeId) || string.IsNullOrEmpty(endNodeId);
+            var flags = FirstInt(obj, 0, "flags", "Flags");
+            var hasFlags = obj.ContainsKey("flags") || obj.ContainsKey("Flags");
+            var style = obj.Value<string>("Style") ?? obj.Value<string>("style");
 
             var result = new JObject
             {
-                ["style"] = obj.Value<string>("Style") ?? obj.Value<string>("style") ?? "standard",
+                ["style"] = style ?? StyleFromFlags(flags),
                 ["trackClass"] = obj.Value<string>("trackClass") ?? obj.Value<string>("TrackClass") ?? "main",
                 ["speedLimit"] = FirstInt(obj, 45, "speedLimit", "SpeedLimit"),
                 ["priority"] = obj.Value<int?>("priority") ?? 0,
                 ["groupId"] = groupId,
                 ["gauge"] = obj.Value<string>("gauge") ?? obj.Value<string>("Gauge"),
+                ["bridgeSupportsSteel"] = hasFlags && (flags & 4) != 0,
+                ["yard"] = hasFlags && (flags & 16) != 0,
             };
 
             if (!string.IsNullOrEmpty(startNodeId))
@@ -86,6 +92,8 @@ namespace FUSE.Converter.Conversion
                 // overwrite values the original author committed to.
                 result["partial"] = true;
                 result["preserveStyle"] = !obj.ContainsKey("Style") && !obj.ContainsKey("style");
+                result["preserveBridgeSupportsSteel"] = !hasFlags && string.IsNullOrEmpty(style);
+                result["preserveYard"] = !hasFlags && string.IsNullOrEmpty(style);
                 result["preserveTrackClass"] = !obj.ContainsKey("trackClass") && !obj.ContainsKey("TrackClass");
                 result["preserveSpeedLimit"] = !obj.ContainsKey("speedLimit") && !obj.ContainsKey("SpeedLimit");
                 result["preservePriority"] = !obj.ContainsKey("priority");
@@ -364,6 +372,14 @@ namespace FUSE.Converter.Conversion
                 }
             }
             return fallback;
+        }
+
+        private static string StyleFromFlags(int flags)
+        {
+            if ((flags & 8) != 0) return "tunnel";
+            if ((flags & 2) != 0) return "bridge";
+            if ((flags & 16) != 0) return "yard";
+            return "standard";
         }
     }
 }

--- a/FUSE.Converter/FuseLegacyConverter.cs
+++ b/FUSE.Converter/FuseLegacyConverter.cs
@@ -167,8 +167,16 @@ namespace FUSE.Converter
 
             EmitTrackGroupCoverageWarning(declaredInitialGroups, result.Report);
 
-            var legacyLoadAfter = LegacyDefinitionConverter.LegacyLoadAfter(modFolder);
-            WriteInfoJson(outputFolder, manifest, result.WrittenFragments, result.Report, legacyLoadAfter);
+            var legacyDependencies = LegacyDefinitionConverter.LegacyDependencies(modFolder);
+            var legacyConflictsWith = LegacyDefinitionConverter.LegacyConflictsWith(modFolder);
+            WriteInfoJson(
+                outputFolder,
+                manifest,
+                result.WrittenFragments,
+                result.Report,
+                legacyDependencies.Requires,
+                legacyDependencies.LoadAfter,
+                legacyConflictsWith);
 
             // Asset packs + map tiles are file-system payloads that
             // ride alongside the converted *.fuse.json fragments.
@@ -228,14 +236,10 @@ namespace FUSE.Converter
         }
 
         /// <summary>
-        /// Kind-aware dispatcher: routes to <see cref="ConvertMod"/>
-        /// for route packages,
-        /// <see cref="LegacyAudioConverter.ConvertAudioMod"/> for
-        /// audio packages, and produces an empty-success result with
-        /// a warning for asset / unknown kinds (the user can copy
-        /// asset packs verbatim — that's already what
-        /// <see cref="ConvertMod"/> does at the end of the route
-        /// path).
+        /// Kind-aware dispatcher. Only legacy JSON route and audio data
+        /// are conversion inputs. Native FUSE, compiled code, map-tile,
+        /// and asset-only packages are installed directly instead of
+        /// being copied into misleading zero-fragment conversions.
         /// </summary>
         public static FuseConversionResult ConvertPackage(string modFolder, string outputFolder, string requestedKind = "auto")
         {
@@ -245,68 +249,50 @@ namespace FUSE.Converter
                 case "audio":
                     return LegacyAudioConverter.ConvertAudioMod(modFolder, outputFolder);
                 case "asset":
-                    return ConvertAssetOnly(modFolder, outputFolder);
+                    return UnsupportedPackage(
+                        modFolder,
+                        outputFolder,
+                        "Asset-pack-only package detected. FUSE loads supported asset packs directly; install this package with the FUSE installer instead of converting it.");
+                case "map_tile":
+                    return UnsupportedPackage(
+                        modFolder,
+                        outputFolder,
+                        "Legacy map-tile package detected. FUSE's Alina compatibility loads supported tile data directly; install this package with the FUSE installer instead of converting it.");
+                case "native":
+                    return UnsupportedPackage(
+                        modFolder,
+                        outputFolder,
+                        "This package already contains FUSE-native *.fuse.json data. No conversion is needed; install the original package with the FUSE installer.");
+                case "code":
+                    return UnsupportedPackage(
+                        modFolder,
+                        outputFolder,
+                        "Compiled code mod detected. The converter only translates RailLoader JSON data and cannot reproduce DLL behavior; install a compatible code mod directly or ask its author for a FUSE-native version.");
                 case "route":
+                    return ConvertMod(modFolder, outputFolder);
                 case "unknown":
                 default:
-                    return ConvertMod(modFolder, outputFolder);
+                    return UnsupportedPackage(
+                        modFolder,
+                        outputFolder,
+                        "No convertible RailLoader JSON data was detected. Expected route, track, scenery, industry, progression, or supported audio JSON; code, assets, map tiles, and native FUSE packages are installed rather than converted.");
             }
         }
 
-        /// <summary>
-        /// Asset-only conversion: just copies asset-pack folders and
-        /// writes a FUSE Info.json. Used when the source has no
-        /// JSON-side data (no tracks/industries/etc.) but does ship
-        /// asset packs (Catalog.json + Definitions.json + bundle).
-        /// </summary>
-        private static FuseConversionResult ConvertAssetOnly(string modFolder, string outputFolder)
+        private static FuseConversionResult UnsupportedPackage(string modFolder, string outputFolder, string reason)
         {
             var result = new FuseConversionResult
             {
                 OutputFolderPath = outputFolder,
+                Success = false,
             };
-
-            if (LegacyAssetCopier.PathsOverlap(modFolder, outputFolder))
-            {
-                result.Success = false;
-                result.Report.Add(Error("Output folder overlaps the source folder; refusing to convert in place (it would overwrite the original mod).", modFolder));
-                return result;
-            }
 
             var manifest = LegacyManifestReader.Read(modFolder);
             result.ModId = manifest.Id;
             result.ModName = manifest.Name;
             result.ModVersion = manifest.Version;
             result.Author = manifest.Author;
-
-            try
-            {
-                Directory.CreateDirectory(outputFolder);
-                var assetRoots = LegacyKindDetector.FindAssetPackSources(modFolder);
-                if (assetRoots.Count > 0)
-                {
-                    LegacyAssetCopier.CopyAssetSources(modFolder, outputFolder, assetRoots, result);
-                }
-
-                var info = new JObject
-                {
-                    ["$schema"] = ".\\schemas\\umm-info.schema.json",
-                    ["Id"] = manifest.Id + ".FUSE",
-                    ["DisplayName"] = manifest.Name + " (FUSE)",
-                    ["Author"] = manifest.Author ?? string.Empty,
-                    ["Version"] = manifest.Version ?? "1.0.0",
-                    ["ManagerVersion"] = "0.27.10",
-                    ["Requirements"] = new JArray("FUSE"),
-                    ["LoadAfter"] = new JArray("FUSE"),
-                    ["FuseAssetPacks"] = JArray.FromObject(assetRoots.Count > 0 ? assetRoots : (System.Collections.Generic.IEnumerable<string>)new[] { "." }),
-                };
-                File.WriteAllText(Path.Combine(outputFolder, "Info.json"), info.ToString(Formatting.Indented));
-                result.Success = true;
-            }
-            catch (Exception ex)
-            {
-                result.Report.Add(Error("Asset-only conversion failed: " + ex.Message, modFolder));
-            }
+            result.Report.Add(Error(reason, modFolder));
             return result;
         }
 
@@ -397,19 +383,21 @@ namespace FUSE.Converter
 
         private static void WriteInfoJson(string outputFolder, LegacyManifestReader.LegacyManifest manifest,
                                           List<string> fragments, List<FuseConversionReportEntry> report,
-                                          List<string> legacyLoadAfter = null)
+                                          List<string> legacyRequires = null,
+                                          List<string> legacyLoadAfter = null,
+                                          JArray legacyConflictsWith = null)
         {
             try
             {
-                // LoadAfter starts with "FUSE" (the runtime), then
-                // every legacy requirement / loadAfter id remapped
-                // via LegacyDefinitionConverter.FusePackageId so we
-                // wait for any sibling-converted packages.
-                var loadAfter = new JArray("FUSE");
-                if (legacyLoadAfter != null)
-                {
-                    foreach (var id in legacyLoadAfter) loadAfter.Add(id);
-                }
+                // UMM only needs to start FUSE first. Data-package requirements
+                // and ordering belong to FUSE's own dependency graph; keeping
+                // them separate preserves hard-vs-advisory legacy semantics.
+                var fuseRequires = legacyRequires == null
+                    ? new JArray()
+                    : JArray.FromObject(legacyRequires);
+                var fuseLoadAfter = legacyLoadAfter == null
+                    ? new JArray()
+                    : JArray.FromObject(legacyLoadAfter);
 
                 var info = new JObject
                 {
@@ -420,7 +408,10 @@ namespace FUSE.Converter
                     ["Version"] = manifest.Version ?? "1.0.0",
                     ["ManagerVersion"] = "0.27.10",
                     ["Requirements"] = new JArray("FUSE"),
-                    ["LoadAfter"] = loadAfter,
+                    ["LoadAfter"] = new JArray("FUSE"),
+                    ["FuseRequires"] = fuseRequires,
+                    ["FuseLoadAfter"] = fuseLoadAfter,
+                    ["FuseConflictsWith"] = legacyConflictsWith ?? new JArray(),
                     ["FuseDataFiles"] = JArray.FromObject(fragments),
                 };
 

--- a/FUSE.ConverterCli/CliOptions.cs
+++ b/FUSE.ConverterCli/CliOptions.cs
@@ -18,7 +18,7 @@ internal sealed class CliOptions
     public bool Quiet { get; set; }
     public bool ShowHelp { get; set; }
 
-    private static readonly string[] Kinds = { "auto", "route", "audio", "asset" };
+    private static readonly string[] Kinds = { "auto", "route", "audio" };
     private static readonly string[] Formats = { "console", "json", "markdown", "all" };
 
     public bool WriteJsonReport => Format is "json" or "all";
@@ -53,13 +53,13 @@ internal sealed class CliOptions
                 case "--kind":
                     if (++index >= args.Length)
                     {
-                        error = "--kind requires a value (auto, route, audio, or asset).";
+                        error = "--kind requires a value (auto, route, or audio).";
                         return null;
                     }
 
                     if (!Kinds.Contains(args[index]))
                     {
-                        error = $"--kind: invalid value '{args[index]}'. Allowed: auto, route, audio, asset.";
+                        error = $"--kind: invalid value '{args[index]}'. Allowed: auto, route, audio.";
                         return null;
                     }
 
@@ -142,16 +142,18 @@ ARGUMENTS:
 OPTIONS:
   --out <dir>     Output root. Each mod converts into '<dir>\<ModFolder>.FUSE'.
                   Default: '.\FUSEConverted'.
-  --kind <kind>   Force a package kind: auto | route | audio | asset. Default: auto.
+  --kind <kind>   Force a JSON package kind: auto | route | audio. Default: auto.
   --clean         Replace an existing '.FUSE' output folder for each converted mod.
-  --batch         Treat each input as a container of mods and convert every
-                  recognized child folder.
+  --batch         Treat each input as a container of mods. JSON packages are
+                  converted; code/assets/tiles/native packages are reported
+                  with their correct install guidance.
   --validate      Validate converted fragments and print fix-hints (default: on).
   --no-validate   Skip validation.
   --strict        Exit with code 2 when validation produces warnings, not just errors.
   --format <fmt>  console (default) | json | markdown | all. json writes
                   conversion-report.json and markdown writes conversion-report.md
-                  into each mod's output folder; all writes both.
+                  into successful output packages. Failed/unsupported inputs
+                  write under '<out>\_conversion-reports'; all writes both.
   --quiet         Suppress per-diagnostic console output; print only summaries.
   -h, --help      Show this help.
 

--- a/FUSE.ConverterCli/Program.cs
+++ b/FUSE.ConverterCli/Program.cs
@@ -122,7 +122,7 @@ internal static class Program
             }
 
             var recognized = Directory.GetDirectories(input)
-                .Where(child => FuseLegacyConverter.DetectKind(child, options.Kind) != "unknown")
+                .Where(child => FuseLegacyConverter.DetectKind(child, options.Kind) != "unknown" || LooksLikeModFolder(child))
                 .OrderBy(child => child, StringComparer.OrdinalIgnoreCase)
                 .ToList();
             if (recognized.Count == 0)
@@ -135,6 +135,13 @@ internal static class Program
         }
 
         return folders;
+    }
+
+    private static bool LooksLikeModFolder(string folder)
+    {
+        return File.Exists(Path.Combine(folder, "Definition.json"))
+            || File.Exists(Path.Combine(folder, "Info.json"))
+            || Directory.EnumerateFiles(folder, "*.dll", SearchOption.TopDirectoryOnly).Any();
     }
 
     /// <summary>
@@ -204,8 +211,10 @@ internal static class Program
     }
 
     /// <summary>
-    /// Writes conversion-report.json / conversion-report.md (the legacy
-    /// Python converter's report file names) into the mod's output folder.
+    /// Writes conversion-report.json / conversion-report.md. Successful
+    /// conversions keep reports inside the package. Failed/unsupported
+    /// inputs use a sibling _conversion-reports folder so a report-only
+    /// directory cannot be mistaken for an installable .FUSE package.
     /// </summary>
     private static void WriteReports(
         CliOptions options,
@@ -218,9 +227,20 @@ internal static class Program
             return;
         }
 
-        if (!Directory.Exists(result.OutputFolderPath))
+        var reportFolder = result.Success
+            ? result.OutputFolderPath
+            : Path.Combine(
+                Path.GetDirectoryName(result.OutputFolderPath) ?? ".",
+                "_conversion-reports",
+                Path.GetFileName(result.OutputFolderPath));
+
+        try
         {
-            Console.Error.WriteLine($"fuse-convert: cannot write reports; output folder does not exist: {result.OutputFolderPath}");
+            Directory.CreateDirectory(reportFolder);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"fuse-convert: cannot create report folder '{reportFolder}': {ex.Message}");
             return;
         }
 
@@ -240,7 +260,7 @@ internal static class Program
             try
             {
                 File.WriteAllText(
-                    Path.Combine(result.OutputFolderPath, "conversion-report.json"),
+                    Path.Combine(reportFolder, "conversion-report.json"),
                     report.ToString(Formatting.Indented));
             }
             catch (Exception ex)
@@ -262,7 +282,7 @@ internal static class Program
                 (validationDiagnostics.Count > 0 ? FuseValidationRenderer.ToMarkdown(validationDiagnostics) : "No validation findings.\n");
             try
             {
-                File.WriteAllText(Path.Combine(result.OutputFolderPath, "conversion-report.md"), markdown);
+                File.WriteAllText(Path.Combine(reportFolder, "conversion-report.md"), markdown);
             }
             catch (Exception ex)
             {

--- a/FUSE.Core/Migrations/FuseMigration.cs
+++ b/FUSE.Core/Migrations/FuseMigration.cs
@@ -78,6 +78,7 @@ namespace Fuse.Core.Migrations
             definition.Audio = definition.Audio ?? new FuseAudioRoot();
             definition.Progression = definition.Progression ?? new FuseProgressionRoot();
             definition.Settings = definition.Settings ?? new Dictionary<string, FuseModSettingDefinition>();
+            definition.FeatureRules = definition.FeatureRules ?? new Dictionary<string, FuseFeatureRule>();
             definition.Extensions = definition.Extensions ?? new Dictionary<string, object>();
 
             foreach (var setting in definition.Settings.Values.Where(setting => setting != null))
@@ -86,6 +87,7 @@ namespace Fuse.Core.Migrations
                 setting.Scope = string.IsNullOrWhiteSpace(setting.Scope) ? "user" : setting.Scope.Trim();
                 setting.Values = setting.Values ?? Array.Empty<string>();
             }
+            NormalizeFeatureRules(definition.FeatureRules);
 
             definition.Tracks.Nodes = definition.Tracks.Nodes ?? new Dictionary<string, FuseNode>();
             definition.Tracks.Segments = definition.Tracks.Segments ?? new Dictionary<string, FuseSegment>();
@@ -105,6 +107,7 @@ namespace Fuse.Core.Migrations
             definition.World.Scenery = definition.World.Scenery ?? new Dictionary<string, FuseScenery>();
             definition.World.SpawnPoints = definition.World.SpawnPoints ?? Array.Empty<FuseSpawnPoint>();
             definition.World.Splineys = definition.World.Splineys ?? new Dictionary<string, FuseSpliney>();
+            definition.World.WaterSurfaces = definition.World.WaterSurfaces ?? new Dictionary<string, FuseWaterSurface>();
             definition.World.TelegraphPoles = definition.World.TelegraphPoles ?? new Dictionary<string, FuseTelegraphPoles>();
             definition.World.TelegraphPoleMovements = definition.World.TelegraphPoleMovements ?? Array.Empty<FuseTelegraphPoleMovement>();
             definition.World.MapLabels = definition.World.MapLabels ?? new Dictionary<string, FuseMapLabel>();
@@ -120,6 +123,7 @@ namespace Fuse.Core.Migrations
             definition.World.Removals = definition.World.Removals ?? new FuseWorldRemovals();
             definition.World.Removals.Scenery = definition.World.Removals.Scenery ?? Array.Empty<string>();
             definition.World.Removals.Splineys = definition.World.Removals.Splineys ?? Array.Empty<string>();
+            definition.World.Removals.WaterSurfaces = definition.World.Removals.WaterSurfaces ?? Array.Empty<string>();
             definition.World.Removals.TelegraphPoles = definition.World.Removals.TelegraphPoles ?? Array.Empty<string>();
             definition.World.Removals.MapLabels = definition.World.Removals.MapLabels ?? Array.Empty<string>();
             definition.World.Removals.MapMasks = definition.World.Removals.MapMasks ?? Array.Empty<string>();
@@ -303,7 +307,49 @@ namespace Fuse.Core.Migrations
             mixinto.Target = string.IsNullOrWhiteSpace(mixinto.Target) ? null : mixinto.Target.Trim();
             mixinto.SourceFile = string.IsNullOrWhiteSpace(mixinto.SourceFile) ? null : mixinto.SourceFile.Trim();
             mixinto.Requires = mixinto.Requires ?? Array.Empty<FuseModRequirement>();
-            foreach (var requirement in mixinto.Requires)
+            mixinto.ConflictsWith = mixinto.ConflictsWith ?? Array.Empty<FuseModRequirement>();
+            NormalizeModReferences(mixinto.Requires);
+            NormalizeModReferences(mixinto.ConflictsWith);
+        }
+
+        private static void NormalizeFeatureRules(IDictionary<string, FuseFeatureRule> rules)
+        {
+            if (rules == null)
+                return;
+            foreach (var rule in rules.Values.Where(rule => rule != null))
+            {
+                rule.Operator = string.IsNullOrWhiteSpace(rule.Operator) ? "equals" : rule.Operator.Trim();
+                rule.Targets = rule.Targets ?? new FuseFeatureTargets();
+                var targets = rule.Targets;
+                targets.TrackNodes = targets.TrackNodes ?? Array.Empty<string>();
+                targets.TrackSegments = targets.TrackSegments ?? Array.Empty<string>();
+                targets.TrackSpans = targets.TrackSpans ?? Array.Empty<string>();
+                targets.TrackAreas = targets.TrackAreas ?? Array.Empty<string>();
+                targets.Loads = targets.Loads ?? Array.Empty<string>();
+                targets.Industries = targets.Industries ?? Array.Empty<string>();
+                targets.IndustryComponents = targets.IndustryComponents ?? Array.Empty<string>();
+                targets.Loaders = targets.Loaders ?? Array.Empty<string>();
+                targets.Turntables = targets.Turntables ?? Array.Empty<string>();
+                targets.Stations = targets.Stations ?? Array.Empty<string>();
+                targets.Scenery = targets.Scenery ?? Array.Empty<string>();
+                targets.Splineys = targets.Splineys ?? Array.Empty<string>();
+                targets.WaterSurfaces = targets.WaterSurfaces ?? Array.Empty<string>();
+                targets.TelegraphPoles = targets.TelegraphPoles ?? Array.Empty<string>();
+                targets.MapLabels = targets.MapLabels ?? Array.Empty<string>();
+                targets.MapMasks = targets.MapMasks ?? Array.Empty<string>();
+                targets.MapTiles = targets.MapTiles ?? Array.Empty<string>();
+                targets.SceneClones = targets.SceneClones ?? Array.Empty<string>();
+                targets.Progressions = targets.Progressions ?? Array.Empty<string>();
+                targets.MapFeatures = targets.MapFeatures ?? Array.Empty<string>();
+                targets.Whistles = targets.Whistles ?? Array.Empty<string>();
+                targets.Horns = targets.Horns ?? Array.Empty<string>();
+                targets.Bells = targets.Bells ?? Array.Empty<string>();
+            }
+        }
+
+        private static void NormalizeModReferences(FuseModRequirement[] references)
+        {
+            foreach (var requirement in references ?? Array.Empty<FuseModRequirement>())
             {
                 if (requirement == null)
                 {

--- a/FUSE.Core/Model/FuseIndustryComponentTypes.cs
+++ b/FUSE.Core/Model/FuseIndustryComponentTypes.cs
@@ -99,6 +99,7 @@ namespace Fuse.Core.Model
                 { "pay-for-resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
                 { "confusingsupplements.pay4resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
                 { "confusingsupplements.industrycomponents.pay4resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
+                { "adrfdr.pay4resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
                 { "confusingsupplements.empty", "ConfusingSupplements.IndustryComponents.Empty" },
                 { "confusingsupplements.industrycomponents.empty", "ConfusingSupplements.IndustryComponents.Empty" }
             };

--- a/FUSE.Core/Model/FuseModDefinition.cs
+++ b/FUSE.Core/Model/FuseModDefinition.cs
@@ -26,6 +26,7 @@ namespace Fuse.Core.Model
         public FuseAudioRoot Audio { get; set; } = new FuseAudioRoot();
         public FuseProgressionRoot Progression { get; set; } = new FuseProgressionRoot();
         public Dictionary<string, FuseModSettingDefinition> Settings { get; set; } = new Dictionary<string, FuseModSettingDefinition>();
+        public Dictionary<string, FuseFeatureRule> FeatureRules { get; set; } = new Dictionary<string, FuseFeatureRule>();
         public FuseEditorState Editor { get; set; }
         public Dictionary<string, object> Extensions { get; set; } = new Dictionary<string, object>();
     }
@@ -50,6 +51,12 @@ namespace Fuse.Core.Model
         /// instead of treating it as a package fault.
         /// </summary>
         public FuseModRequirement[] Requires { get; set; }
+
+        /// <summary>
+        /// Optional legacy incompatibility references. If any matching package
+        /// is enabled, only this conditional fragment is skipped.
+        /// </summary>
+        public FuseModRequirement[] ConflictsWith { get; set; }
     }
 
     public sealed class FuseModRequirement

--- a/FUSE.Core/Model/FuseModSettingsDefinition.cs
+++ b/FUSE.Core/Model/FuseModSettingsDefinition.cs
@@ -20,4 +20,39 @@ namespace Fuse.Core.Model
         public bool Advanced { get; set; }
         public bool ReloadRequired { get; set; }
     }
+
+    public sealed class FuseFeatureRule
+    {
+        public string Setting { get; set; }
+        public string Operator { get; set; } = "equals";
+        public JToken Value { get; set; }
+        public FuseFeatureTargets Targets { get; set; } = new FuseFeatureTargets();
+    }
+
+    public sealed class FuseFeatureTargets
+    {
+        public string[] TrackNodes { get; set; } = Array.Empty<string>();
+        public string[] TrackSegments { get; set; } = Array.Empty<string>();
+        public string[] TrackSpans { get; set; } = Array.Empty<string>();
+        public string[] TrackAreas { get; set; } = Array.Empty<string>();
+        public string[] Loads { get; set; } = Array.Empty<string>();
+        public string[] Industries { get; set; } = Array.Empty<string>();
+        public string[] IndustryComponents { get; set; } = Array.Empty<string>();
+        public string[] Loaders { get; set; } = Array.Empty<string>();
+        public string[] Turntables { get; set; } = Array.Empty<string>();
+        public string[] Stations { get; set; } = Array.Empty<string>();
+        public string[] Scenery { get; set; } = Array.Empty<string>();
+        public string[] Splineys { get; set; } = Array.Empty<string>();
+        public string[] WaterSurfaces { get; set; } = Array.Empty<string>();
+        public string[] TelegraphPoles { get; set; } = Array.Empty<string>();
+        public string[] MapLabels { get; set; } = Array.Empty<string>();
+        public string[] MapMasks { get; set; } = Array.Empty<string>();
+        public string[] MapTiles { get; set; } = Array.Empty<string>();
+        public string[] SceneClones { get; set; } = Array.Empty<string>();
+        public string[] Progressions { get; set; } = Array.Empty<string>();
+        public string[] MapFeatures { get; set; } = Array.Empty<string>();
+        public string[] Whistles { get; set; } = Array.Empty<string>();
+        public string[] Horns { get; set; } = Array.Empty<string>();
+        public string[] Bells { get; set; } = Array.Empty<string>();
+    }
 }

--- a/FUSE.Core/Model/FuseRemovedTrackSnapshots.cs
+++ b/FUSE.Core/Model/FuseRemovedTrackSnapshots.cs
@@ -3,7 +3,7 @@ namespace Fuse.Core.Model
     /// <summary>
     /// Serializable node snapshot used to restore base-game track removed by a
     /// FUSE package. Preserved fields: id, transform, switch stand flip, thrown
-    /// state, and public CTC flags. Lossy fields: turntable links, private CTC
+    /// state, diamond-crossing state, and public CTC flags. Lossy fields: turntable links, private CTC
     /// display state, event delegates, and runtime cache state.
     /// </summary>
     public sealed class FuseRemovedNodeSnapshot
@@ -12,6 +12,7 @@ namespace Fuse.Core.Model
         public FuseVector3 Position { get; set; }
         public FuseVector3 Rotation { get; set; }
         public bool FlipSwitchStand { get; set; }
+        public bool IsDiamond { get; set; }
         public bool IsThrown { get; set; }
         public bool IsCtcSwitch { get; set; }
         public bool IsCtcSwitchUnlocked { get; set; }
@@ -19,7 +20,7 @@ namespace Fuse.Core.Model
 
     /// <summary>
     /// Serializable segment snapshot used to restore base-game track removed by a
-    /// FUSE package. Preserved fields: id, endpoints, style, class, group,
+    /// FUSE package. Preserved fields: id, endpoints, style/structure flags, class, group,
     /// priority, speed limit, availability flags, endpoint transforms, and
     /// measured length. Lossy fields: private Bezier caches, turntable links,
     /// editor gizmo state, and generated mesh state.
@@ -30,6 +31,7 @@ namespace Fuse.Core.Model
         public string StartNodeId { get; set; }
         public string EndNodeId { get; set; }
         public string Style { get; set; }
+        public int StructureFlags { get; set; }
         public string TrackClass { get; set; }
         public string GroupId { get; set; }
         public int Priority { get; set; }

--- a/FUSE.Core/Model/FuseTrackDefinition.cs
+++ b/FUSE.Core/Model/FuseTrackDefinition.cs
@@ -24,6 +24,7 @@ namespace Fuse.Core.Model
         public FuseVector3 Position { get; set; }
         public FuseVector3 Rotation { get; set; }
         public bool FlipSwitchStand { get; set; }
+        public bool IsDiamond { get; set; }
         public string GroupId { get; set; }
         public string[] Tags { get; set; }
     }
@@ -39,8 +40,12 @@ namespace Fuse.Core.Model
         public string GroupId { get; set; }
         public string[] Tags { get; set; }
         public string Gauge { get; set; }
+        public bool BridgeSupportsSteel { get; set; }
+        public bool Yard { get; set; }
         public bool Partial { get; set; }
         public bool PreserveStyle { get; set; }
+        public bool PreserveBridgeSupportsSteel { get; set; }
+        public bool PreserveYard { get; set; }
         public bool PreserveTrackClass { get; set; }
         public bool PreserveSpeedLimit { get; set; }
         public bool PreservePriority { get; set; }

--- a/FUSE.Core/Model/FuseWorldDefinition.cs
+++ b/FUSE.Core/Model/FuseWorldDefinition.cs
@@ -8,6 +8,7 @@ namespace Fuse.Core.Model
         public Dictionary<string, FuseScenery> Scenery { get; set; } = new Dictionary<string, FuseScenery>();
         public FuseSpawnPoint[] SpawnPoints { get; set; } = Array.Empty<FuseSpawnPoint>();
         public Dictionary<string, FuseSpliney> Splineys { get; set; } = new Dictionary<string, FuseSpliney>();
+        public Dictionary<string, FuseWaterSurface> WaterSurfaces { get; set; } = new Dictionary<string, FuseWaterSurface>();
         public Dictionary<string, FuseTelegraphPoles> TelegraphPoles { get; set; } = new Dictionary<string, FuseTelegraphPoles>();
         public FuseTelegraphPoleMovement[] TelegraphPoleMovements { get; set; } = Array.Empty<FuseTelegraphPoleMovement>();
         public Dictionary<string, FuseMapLabel> MapLabels { get; set; } = new Dictionary<string, FuseMapLabel>();
@@ -35,6 +36,7 @@ namespace Fuse.Core.Model
     {
         public string[] Scenery { get; set; } = Array.Empty<string>();
         public string[] Splineys { get; set; } = Array.Empty<string>();
+        public string[] WaterSurfaces { get; set; } = Array.Empty<string>();
         public string[] TelegraphPoles { get; set; } = Array.Empty<string>();
         public string[] MapLabels { get; set; } = Array.Empty<string>();
         public string[] MapMasks { get; set; } = Array.Empty<string>();
@@ -94,6 +96,17 @@ namespace Fuse.Core.Model
         public float OffsetY { get; set; }
         public string HeadStyle { get; set; }
         public string TailStyle { get; set; }
+        public string AssetIdentifier { get; set; }
+        public string Prefab { get; set; }
+        public float Spacing { get; set; } = 5f;
+        public FuseVector3 InstanceScale { get; set; } = FuseVector3.one;
+        public FuseVector3 RotationOffset { get; set; }
+        public float LateralOffset { get; set; }
+        public float VerticalOffset { get; set; }
+        public bool SnapToTerrain { get; set; }
+        public bool AlignToSlope { get; set; }
+        public bool PlaceAtEnd { get; set; } = true;
+        public int MaximumInstances { get; set; } = 1024;
         public FuseSplineyPoint[] Points { get; set; }
     }
 
@@ -102,6 +115,20 @@ namespace Fuse.Core.Model
         public FuseVector3 Position { get; set; }
         public FuseVector3 Rotation { get; set; }
         public float? Width { get; set; }
+    }
+
+    public sealed class FuseWaterSurface
+    {
+        public FuseVector3[] Points { get; set; } = Array.Empty<FuseVector3>();
+        public string SourceLakePath { get; set; }
+        public string MaterialName { get; set; }
+        public bool LockHeight { get; set; } = true;
+        public bool SnapToTerrain { get; set; }
+        public bool EnableCollider { get; set; } = true;
+        public float UvScale { get; set; } = 1f;
+        public float TriangleDensity { get; set; } = 0.2f;
+        public float MaximumTriangleArea { get; set; } = 50f;
+        public float YOffset { get; set; }
     }
 
     public sealed class FuseTelegraphPoles

--- a/FUSE.Core/Validation/FuseDefinitionValidator.cs
+++ b/FUSE.Core/Validation/FuseDefinitionValidator.cs
@@ -15,6 +15,13 @@ namespace Fuse.Core.Validation
     /// </summary>
     public sealed class FuseDefinitionValidator : IValidator<FuseModDefinition>
     {
+        private static readonly HashSet<string> ValidFeatureRuleOperators =
+            new HashSet<string>(new[]
+            {
+                "equals", "notEquals", "greaterThan", "greaterThanOrEqual",
+                "lessThan", "lessThanOrEqual"
+            }, StringComparer.OrdinalIgnoreCase);
+
         public ValidationResult Validate(FuseModDefinition value)
         {
             var result = new ValidationResult();
@@ -52,6 +59,7 @@ namespace Fuse.Core.Validation
             ValidateAudio(result, value.Audio);
             ValidateProgression(result, value.Progression);
             ValidateSettings(result, value.Settings);
+            ValidateFeatureRules(result, value);
             return result;
         }
 
@@ -100,20 +108,30 @@ namespace Fuse.Core.Validation
                 result.AddWarning("mixinto.sourceFile", "Mixinto sourceFile is blank; conversion provenance will be less clear.", "fuse.mixinto.sourceFile.blank");
             }
 
-            var requirements = mixinto.Requires ?? Array.Empty<FuseModRequirement>();
-            for (var index = 0; index < requirements.Length; index++)
+            ValidateMixintoReferences(result, mixinto.Requires, "requires", "requirement");
+            ValidateMixintoReferences(result, mixinto.ConflictsWith, "conflictsWith", "conflict");
+        }
+
+        private static void ValidateMixintoReferences(
+            ValidationResult result,
+            FuseModRequirement[] references,
+            string propertyName,
+            string kind)
+        {
+            var materialized = references ?? Array.Empty<FuseModRequirement>();
+            for (var index = 0; index < materialized.Length; index++)
             {
-                var requirement = requirements[index];
-                var path = $"mixinto.requires[{index}]";
+                var requirement = materialized[index];
+                var path = $"mixinto.{propertyName}[{index}]";
                 if (requirement == null)
                 {
-                    result.AddWarning(path, "Null mixinto requirement will be ignored.", "fuse.mixinto.requirement.null");
+                    result.AddWarning(path, $"Null mixinto {kind} will be ignored.", $"fuse.mixinto.{kind}.null");
                     continue;
                 }
 
                 if (string.IsNullOrWhiteSpace(requirement.Id))
                 {
-                    result.AddWarning($"{path}.id", "Mixinto requirement id is blank and will be ignored.", "fuse.mixinto.requirement.id.blank");
+                    result.AddWarning($"{path}.id", $"Mixinto {kind} id is blank and will be ignored.", $"fuse.mixinto.{kind}.id.blank");
                 }
             }
         }
@@ -163,6 +181,111 @@ namespace Fuse.Core.Validation
                     result.AddWarning(path, "Server-scoped reload-required settings should be documented for multiplayer profile sharing.", "fuse.settings.server.reloadRequired", pair.Key);
                 }
             }
+        }
+
+        private static void ValidateFeatureRules(ValidationResult result, FuseModDefinition definition)
+        {
+            var rules = definition.FeatureRules;
+            if (rules == null)
+                return;
+            foreach (var pair in rules)
+            {
+                var path = $"featureRules.{pair.Key}";
+                if (string.IsNullOrWhiteSpace(pair.Key))
+                {
+                    result.AddError("featureRules", "Feature rule IDs must not be blank.", "fuse.featureRule.id.blank");
+                    continue;
+                }
+                var rule = pair.Value;
+                if (rule == null)
+                {
+                    result.AddError(path, "Feature rule definition is required.", "fuse.featureRule.required");
+                    continue;
+                }
+                if (string.IsNullOrWhiteSpace(rule.Setting) ||
+                    !definition.Settings.TryGetValue(rule.Setting, out var setting) || setting == null)
+                {
+                    result.AddError($"{path}.setting", "Feature rule must reference a setting declared by this definition.", "fuse.featureRule.setting.missing", rule.Setting);
+                }
+                else
+                {
+                    var normalizedOperator = (rule.Operator ?? "equals").Trim();
+                    if ((normalizedOperator.Equals("greaterThan", StringComparison.OrdinalIgnoreCase) ||
+                         normalizedOperator.Equals("greaterThanOrEqual", StringComparison.OrdinalIgnoreCase) ||
+                         normalizedOperator.Equals("lessThan", StringComparison.OrdinalIgnoreCase) ||
+                         normalizedOperator.Equals("lessThanOrEqual", StringComparison.OrdinalIgnoreCase)) &&
+                        FuseSettingTypes.NormalizeType(setting.Type) != "number")
+                    {
+                        result.AddError($"{path}.operator", "Numeric feature-rule comparisons require a number setting.", "fuse.featureRule.operator.type", rule.Operator);
+                    }
+                    if (!setting.ReloadRequired)
+                    {
+                        result.AddWarning($"settings.{rule.Setting}.reloadRequired", "Settings used by feature rules take effect on map reload; set reloadRequired to true so players are told clearly.", "fuse.featureRule.setting.reloadRequired", rule.Setting);
+                    }
+                }
+                if (!ValidFeatureRuleOperators.Contains((rule.Operator ?? "equals").Trim()))
+                    result.AddError($"{path}.operator", "Feature rule operator is not supported.", "fuse.featureRule.operator", rule.Operator);
+                if (rule.Value == null)
+                    result.AddError($"{path}.value", "Feature rule comparison value is required.", "fuse.featureRule.value.required");
+                ValidateFeatureTargets(result, definition, path, rule.Targets);
+            }
+        }
+
+        private static void ValidateFeatureTargets(ValidationResult result, FuseModDefinition definition, string path, FuseFeatureTargets targets)
+        {
+            if (targets == null)
+            {
+                result.AddError($"{path}.targets", "Feature rule targets are required.", "fuse.featureRule.targets.required");
+                return;
+            }
+            var componentIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var industry in definition.Operations.Industries)
+                foreach (var component in industry.Value?.Components ?? new Dictionary<string, FuseIndustryComponent>())
+                    componentIds.Add(industry.Key + "/" + component.Key);
+            var count = 0;
+            count += ValidateFeatureTargetIds(result, path, "trackNodes", targets.TrackNodes, definition.Tracks.Nodes.Keys);
+            count += ValidateFeatureTargetIds(result, path, "trackSegments", targets.TrackSegments, definition.Tracks.Segments.Keys);
+            count += ValidateFeatureTargetIds(result, path, "trackSpans", targets.TrackSpans, definition.Tracks.Spans.Keys);
+            count += ValidateFeatureTargetIds(result, path, "trackAreas", targets.TrackAreas, definition.Tracks.Areas.Keys);
+            count += ValidateFeatureTargetIds(result, path, "loads", targets.Loads, definition.Operations.Loads.Keys);
+            count += ValidateFeatureTargetIds(result, path, "industries", targets.Industries, definition.Operations.Industries.Keys);
+            count += ValidateFeatureTargetIds(result, path, "industryComponents", targets.IndustryComponents, componentIds);
+            count += ValidateFeatureTargetIds(result, path, "loaders", targets.Loaders, definition.Operations.Loaders.Keys);
+            count += ValidateFeatureTargetIds(result, path, "turntables", targets.Turntables, definition.Operations.Turntables.Keys);
+            count += ValidateFeatureTargetIds(result, path, "stations", targets.Stations, definition.Operations.Stations.Keys);
+            count += ValidateFeatureTargetIds(result, path, "scenery", targets.Scenery, definition.World.Scenery.Keys);
+            count += ValidateFeatureTargetIds(result, path, "splineys", targets.Splineys, definition.World.Splineys.Keys);
+            count += ValidateFeatureTargetIds(result, path, "waterSurfaces", targets.WaterSurfaces, definition.World.WaterSurfaces.Keys);
+            count += ValidateFeatureTargetIds(result, path, "telegraphPoles", targets.TelegraphPoles, definition.World.TelegraphPoles.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapLabels", targets.MapLabels, definition.World.MapLabels.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapMasks", targets.MapMasks, definition.World.MapMasks.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapTiles", targets.MapTiles, definition.World.MapTiles.Keys);
+            count += ValidateFeatureTargetIds(result, path, "sceneClones", targets.SceneClones, definition.World.SceneClones.Keys);
+            count += ValidateFeatureTargetIds(result, path, "progressions", targets.Progressions, definition.Progression.Progressions.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapFeatures", targets.MapFeatures, definition.Progression.MapFeatures.Keys);
+            count += ValidateFeatureTargetIds(result, path, "whistles", targets.Whistles, definition.Audio.Whistles.Keys);
+            count += ValidateFeatureTargetIds(result, path, "horns", targets.Horns, definition.Audio.Horns.Keys);
+            count += ValidateFeatureTargetIds(result, path, "bells", targets.Bells, definition.Audio.Bells.Keys);
+            if (count == 0)
+                result.AddError($"{path}.targets", "Feature rule must target at least one authored object.", "fuse.featureRule.targets.empty");
+        }
+
+        private static int ValidateFeatureTargetIds(ValidationResult result, string path, string property, IEnumerable<string> values, IEnumerable<string> defined)
+        {
+            var ids = (values ?? Array.Empty<string>()).ToArray();
+            var known = new HashSet<string>(defined ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var index = 0; index < ids.Length; index++)
+            {
+                var id = ids[index];
+                if (string.IsNullOrWhiteSpace(id))
+                    result.AddError($"{path}.targets.{property}[{index}]", "Feature target ID must not be blank.", "fuse.featureRule.target.blank");
+                else if (!known.Contains(id))
+                    result.AddError($"{path}.targets.{property}[{index}]", "Feature target must name an object authored in this definition.", "fuse.featureRule.target.missing", id);
+                else if (!seen.Add(id))
+                    result.AddWarning($"{path}.targets.{property}[{index}]", "Feature target is listed more than once in this rule.", "fuse.featureRule.target.duplicate", id);
+            }
+            return ids.Length;
         }
 
         private static void ValidateTrack(ValidationResult result, FuseTrackDefinition tracks, FuseOperationsDefinition operations)
@@ -548,6 +671,7 @@ namespace Fuse.Core.Validation
             {
                 ValidateWorldRemovalTargets(result, "world.removals.scenery", world.Removals.Scenery, world.Scenery.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.splineys", world.Removals.Splineys, world.Splineys.Keys);
+                ValidateWorldRemovalTargets(result, "world.removals.waterSurfaces", world.Removals.WaterSurfaces, world.WaterSurfaces.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.telegraphPoles", world.Removals.TelegraphPoles, world.TelegraphPoles.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.mapLabels", world.Removals.MapLabels, world.MapLabels.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.mapMasks", world.Removals.MapMasks, world.MapMasks.Keys);
@@ -598,11 +722,52 @@ namespace Fuse.Core.Validation
 
             foreach (var spliney in world.Splineys)
             {
-                Required(result, $"world.splineys.{spliney.Key}.type", spliney.Value.Type);
-                if (spliney.Value.Points == null || spliney.Value.Points.Length < 2)
+                var path = $"world.splineys.{spliney.Key}";
+                var value = spliney.Value;
+                if (value == null)
                 {
-                    result.AddError($"world.splineys.{spliney.Key}.points", "Spliney objects require at least two points.", "fuse.spliney.points");
+                    result.AddError(path, "Spliney definition is required.", "fuse.spliney.required");
+                    continue;
                 }
+                Required(result, $"{path}.type", value.Type);
+                if (value.Points == null || value.Points.Length < 2)
+                {
+                    result.AddError($"{path}.points", "Spliney objects require at least two points.", "fuse.spliney.points");
+                }
+                if (IsObjectLine(value.Type))
+                {
+                    if (string.IsNullOrWhiteSpace(value.AssetIdentifier)
+                        == string.IsNullOrWhiteSpace(value.Prefab))
+                    {
+                        result.AddError(
+                            path,
+                            "Object-line splineys require exactly one of assetIdentifier or prefab.",
+                            "fuse.spliney.objectLine.source");
+                    }
+                    if (value.Spacing <= 0f)
+                        result.AddError($"{path}.spacing", "Object-line spacing must be greater than 0.", "fuse.spliney.objectLine.spacing", value.Spacing);
+                    if (value.MaximumInstances < 1 || value.MaximumInstances > 4096)
+                        result.AddError($"{path}.maximumInstances", "Object-line maximumInstances must be between 1 and 4096.", "fuse.spliney.objectLine.maximumInstances", value.MaximumInstances);
+                }
+            }
+
+            foreach (var waterSurface in world.WaterSurfaces)
+            {
+                var path = $"world.waterSurfaces.{waterSurface.Key}";
+                var value = waterSurface.Value;
+                if (value == null)
+                {
+                    result.AddError(path, "Water surface definition is required.", "fuse.waterSurface.required");
+                    continue;
+                }
+                if (value.Points == null || value.Points.Length < 3)
+                    result.AddError($"{path}.points", "Water surfaces require at least three boundary points.", "fuse.waterSurface.points");
+                if (value.TriangleDensity <= 0f || value.TriangleDensity > 1f)
+                    result.AddError($"{path}.triangleDensity", "Triangle density must be greater than 0 and at most 1.", "fuse.waterSurface.triangleDensity", value.TriangleDensity);
+                if (value.MaximumTriangleArea <= 0f)
+                    result.AddError($"{path}.maximumTriangleArea", "Maximum triangle area must be greater than 0.", "fuse.waterSurface.maximumTriangleArea", value.MaximumTriangleArea);
+                if (value.UvScale <= 0f)
+                    result.AddError($"{path}.uvScale", "UV scale must be greater than 0.", "fuse.waterSurface.uvScale", value.UvScale);
             }
 
             foreach (var telegraph in world.TelegraphPoles)
@@ -705,6 +870,14 @@ namespace Fuse.Core.Validation
 
                 Required(result, $"world.sceneClones.{sceneClone.Key}.targetPath", sceneClone.Value.TargetPath);
             }
+        }
+
+        private static bool IsObjectLine(string type)
+        {
+            return string.Equals(type, "objectLine", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(type, "object-line", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(type, "fence", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(type, "retainingWall", StringComparison.OrdinalIgnoreCase);
         }
 
         private static void ValidateWorldRemovalTargets(ValidationResult result, string path, IEnumerable<string> removals, IEnumerable<string> definitions)

--- a/FUSE.Core/Validation/Help/fuse-validation-help.json
+++ b/FUSE.Core/Validation/Help/fuse-validation-help.json
@@ -41,6 +41,78 @@
     "fix": "Make the top level of the file a JSON object, with at least id and name set.",
     "example": "{\"id\":\"my-mod\",\"name\":\"My Mod\"}"
   },
+  "fuse.featureRule.id.blank": {
+    "title": "Feature rule ID is blank",
+    "why": "A key under featureRules is empty or whitespace, so FUSE cannot identify the rule or report which player option controls it. This is an error and the definition does not pass validation.",
+    "fix": "Give every feature rule a non-empty, unique key that describes the option-controlled feature.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.operator": {
+    "title": "Feature rule operator is unsupported",
+    "why": "The operator is not one of equals, notEquals, greaterThan, greaterThanOrEqual, lessThan, or lessThanOrEqual, so FUSE cannot evaluate the rule deterministically.",
+    "fix": "Replace operator with one of the supported names; use equals for a normal on/off or choice setting.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.operator.type": {
+    "title": "Numeric feature comparison uses a non-number setting",
+    "why": "greaterThan, greaterThanOrEqual, lessThan, and lessThanOrEqual compare numbers, but the referenced setting is not type number. The comparison cannot have a reliable meaning.",
+    "fix": "Change the setting to type number, or use equals/notEquals for bool, enum, or text settings.",
+    "example": "{\"settings\":{\"yardSize\":{\"type\":\"number\",\"default\":1,\"reloadRequired\":true}},\"featureRules\":{\"large-yard\":{\"setting\":\"yardSize\",\"operator\":\"greaterThanOrEqual\",\"value\":2,\"targets\":{\"trackSegments\":[\"yard-2\"]}}}}"
+  },
+  "fuse.featureRule.required": {
+    "title": "Feature rule definition is null",
+    "why": "A key under featureRules maps to JSON null instead of a rule object, so it has no setting, comparison, or targets to evaluate.",
+    "fix": "Remove the null entry, or replace it with a rule object containing setting, operator, value, and targets.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.setting.missing": {
+    "title": "Feature rule references a missing setting",
+    "why": "The rule's setting is blank or does not name a setting declared in this same definition. Without that option FUSE has no player value to evaluate.",
+    "fix": "Add the setting under settings, or correct featureRules.<id>.setting to the exact declared setting ID.",
+    "example": "{\"settings\":{\"yardEnabled\":{\"type\":\"bool\",\"default\":true,\"reloadRequired\":true}},\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.setting.reloadRequired": {
+    "title": "Feature-controlled setting is not marked reload-required",
+    "why": "Feature rules change which authored objects are applied during map load. A setting used by a rule cannot safely rebuild that content immediately, so leaving reloadRequired false would mislead players about when the option takes effect.",
+    "fix": "Set reloadRequired to true on the referenced setting and mention the reload in its description.",
+    "example": "{\"settings\":{\"yardEnabled\":{\"type\":\"bool\",\"default\":true,\"reloadRequired\":true,\"description\":\"Reload the map after changing this option.\"}}}"
+  },
+  "fuse.featureRule.target.blank": {
+    "title": "Feature rule contains a blank target ID",
+    "why": "One of the rule's target arrays contains an empty or whitespace-only value. A blank value cannot name an authored object and would never control anything.",
+    "fix": "Remove the blank array entry, or replace it with the exact ID of an object authored in this definition.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.target.duplicate": {
+    "title": "Feature rule lists the same target more than once",
+    "why": "The same object ID appears repeatedly in one target array. FUSE can still evaluate the rule, but the duplicate adds noise and commonly indicates a copy/paste mistake.",
+    "fix": "Keep each target ID only once in that rule's target array.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\",\"yard-2\"]}}}}"
+  },
+  "fuse.featureRule.target.missing": {
+    "title": "Feature rule target does not exist",
+    "why": "A target ID does not name an object authored in this definition. Feature rules intentionally do not guess at dependency-owned or base-game objects, so the target could never be enabled or disabled by this package.",
+    "fix": "Correct the ID and target category, or author the referenced object in this definition before targeting it.",
+    "example": "{\"tracks\":{\"segments\":{\"yard-1\":{\"startNodeId\":\"n1\",\"endNodeId\":\"n2\"}}},\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.targets.empty": {
+    "title": "Feature rule has no targets",
+    "why": "The targets object exists but all of its arrays are empty, so changing the setting would not enable or disable any authored content.",
+    "fix": "Add at least one valid object ID to the appropriate target category, or remove the unused rule.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.targets.required": {
+    "title": "Feature rule targets are missing",
+    "why": "The rule's targets value is null, so the rule cannot identify which authored objects it controls.",
+    "fix": "Add a targets object with at least one supported category and authored object ID.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.value.required": {
+    "title": "Feature rule comparison value is missing",
+    "why": "The rule has no value to compare with the selected setting. FUSE cannot decide whether the rule is active without a bool, number, string, or enum value.",
+    "fix": "Set value to the setting value that should activate this rule, such as true, 2, or \"large\".",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
   "fuse.map.displayName.blank": {
     "title": "Map displayName is blank",
     "why": "The map declaration has no displayName, so wherever the map is offered for selection (console listings, menus) FUSE falls back to the package name. That usually reads worse than a purpose-written map title.",
@@ -88,18 +160,6 @@
     "why": "An entry under world.mapTiles maps to null instead of a tile source object, so FUSE has no directory or sourceFolder to load map tiles from. This is an error until the entry is a real object.",
     "fix": "Replace the null value with an object that sets directory and sourceFolder.",
     "example": "{\"world\":{\"mapTiles\":{\"newValley\":{\"directory\":\"mapTiles\",\"sourceFolder\":\"newValley\"}}}}"
-  },
-  "fuse.mixinto.requirement.id.blank": {
-    "title": "Mixinto requirement id is blank",
-    "why": "An entry in mixinto.requires has a blank or whitespace-only id, so FUSE ignores that requirement entirely. The fragment will not be gated on the mod you meant to require and may apply even when that mod is absent.",
-    "fix": "Set the requirement's id to the identifier of the mod this fragment depends on, or delete the entry if no dependency is intended.",
-    "example": "{\"mixinto\": {\"requires\": [{\"id\": \"ExampleMod\"}]}}"
-  },
-  "fuse.mixinto.requirement.null": {
-    "title": "Null mixinto requirement entry",
-    "why": "The mixinto.requires array contains a null entry, which FUSE skips at load. A null requirement cannot gate the fragment, so any conditional-loading intent behind it is silently lost.",
-    "fix": "Remove the null entry from the requires array, or replace it with a requirement object that has an id.",
-    "example": "{\"mixinto\": {\"requires\": [{\"id\": \"ExampleMod\"}]}}"
   },
   "fuse.mixinto.sourceFile.blank": {
     "title": "Mixinto sourceFile is blank",
@@ -413,11 +473,35 @@
     "fix": "Document the reload requirement in the setting's description so multiplayer users know a reload is needed. Alternatively drop reloadRequired or move the setting off server scope if either is unnecessary.",
     "example": "{\"settings\": {\"trackGauge\": {\"type\": \"number\", \"scope\": \"server\", \"reloadRequired\": true, \"description\": \"Synced to all players; requires a reload to apply.\"}}}"
   },
+  "fuse.spliney.objectLine.maximumInstances": {
+    "title": "Object line instance limit is out of range",
+    "why": "maximumInstances is below 1 or above 4096. A non-positive limit cannot place an object, while an unbounded repeated line can freeze or exhaust the game.",
+    "fix": "Set maximumInstances between 1 and 4096; use the smallest limit that safely covers the authored line.",
+    "example": "{\"world\":{\"splineys\":{\"yard-fence\":{\"type\":\"objectLine\",\"assetIdentifier\":\"FencePanel\",\"spacing\":3,\"maximumInstances\":500,\"points\":[{\"position\":{\"x\":0,\"y\":560,\"z\":0}},{\"position\":{\"x\":30,\"y\":560,\"z\":0}}]}}}}"
+  },
+  "fuse.spliney.objectLine.source": {
+    "title": "Object line needs exactly one model source",
+    "why": "An objectLine has neither assetIdentifier nor prefab, or it sets both. FUSE needs one unambiguous source for the repeated fence, wall, pipe, or other rigid module.",
+    "fix": "Set exactly one of assetIdentifier (PrefabStore asset) or prefab (loaded scene prefab path), and remove the other field.",
+    "example": "{\"world\":{\"splineys\":{\"yard-fence\":{\"type\":\"objectLine\",\"assetIdentifier\":\"FencePanel\",\"spacing\":3,\"points\":[{\"position\":{\"x\":0,\"y\":560,\"z\":0}},{\"position\":{\"x\":30,\"y\":560,\"z\":0}}]}}}}"
+  },
+  "fuse.spliney.objectLine.spacing": {
+    "title": "Object line spacing is not positive",
+    "why": "spacing is zero or negative, so FUSE cannot advance along the path while placing repeated modules.",
+    "fix": "Set spacing to a positive distance in metres that matches the module length or desired gap.",
+    "example": "{\"world\":{\"splineys\":{\"yard-fence\":{\"type\":\"objectLine\",\"assetIdentifier\":\"FencePanel\",\"spacing\":3,\"points\":[{\"position\":{\"x\":0,\"y\":560,\"z\":0}},{\"position\":{\"x\":30,\"y\":560,\"z\":0}}]}}}}"
+  },
   "fuse.spliney.points": {
     "title": "Spliney needs at least two points",
     "why": "The spliney's points array is missing or has fewer than two entries. Spliney objects require at least two points to define a path; this is an error and must be fixed.",
     "fix": "Add a points array with two or more point entries (each with a position) tracing the spliney's path.",
     "example": "{\"world\": {\"splineys\": {\"yardFence\": {\"type\": \"fence\", \"points\": [{\"position\": {\"x\": 0, \"y\": 560, \"z\": 0}}, {\"position\": {\"x\": 25, \"y\": 560, \"z\": 10}}]}}}}"
+  },
+  "fuse.spliney.required": {
+    "title": "Spliney definition is null",
+    "why": "A key under world.splineys maps to JSON null instead of a spline definition, so there is no type or path to build.",
+    "fix": "Remove the null entry, or replace it with a spliney object containing type and at least two points.",
+    "example": "{\"world\":{\"splineys\":{\"yard-road\":{\"type\":\"road\",\"points\":[{\"position\":{\"x\":0,\"y\":560,\"z\":0}},{\"position\":{\"x\":30,\"y\":560,\"z\":0}}]}}}}"
   },
   "fuse.telegraph.points": {
     "title": "Telegraph pole set needs two points",
@@ -598,6 +682,36 @@
     "why": "Error: the turntable's subdivisions value is below 4 or above 32, outside the range the validator allows. The document fails validation, so the turntable definition is rejected.",
     "fix": "Set subdivisions to a whole number between 4 and 32 (inclusive) under operations.turntables.<id>. The default is 16 if you have no specific need.",
     "example": "{\"operations\": {\"turntables\": {\"ewh-turntable\": {\"radius\": 12.5, \"subdivisions\": 16}}}}"
+  },
+  "fuse.waterSurface.maximumTriangleArea": {
+    "title": "Water surface maximum triangle area is not positive",
+    "why": "maximumTriangleArea is zero or negative, so the mesh generator has no valid upper bound for water-surface triangles.",
+    "fix": "Set maximumTriangleArea to a positive square-metre value; 50 is a practical starting point for a lake.",
+    "example": "{\"world\":{\"waterSurfaces\":{\"mill-pond\":{\"points\":[{\"x\":0,\"y\":550,\"z\":0},{\"x\":50,\"y\":550,\"z\":0},{\"x\":25,\"y\":550,\"z\":40}],\"maximumTriangleArea\":50}}}}"
+  },
+  "fuse.waterSurface.points": {
+    "title": "Water surface needs at least three boundary points",
+    "why": "The water surface has fewer than three points, so its boundary cannot form a polygon and no visible lake mesh can be generated.",
+    "fix": "Add at least three non-collinear world-space boundary points in perimeter order.",
+    "example": "{\"world\":{\"waterSurfaces\":{\"mill-pond\":{\"points\":[{\"x\":0,\"y\":550,\"z\":0},{\"x\":50,\"y\":550,\"z\":0},{\"x\":25,\"y\":550,\"z\":40}]}}}}"
+  },
+  "fuse.waterSurface.required": {
+    "title": "Water surface definition is null",
+    "why": "A key under world.waterSurfaces maps to JSON null instead of a water-surface object, so FUSE has no boundary or rendering profile to build.",
+    "fix": "Remove the null entry, or replace it with a water-surface object containing at least three points.",
+    "example": "{\"world\":{\"waterSurfaces\":{\"mill-pond\":{\"points\":[{\"x\":0,\"y\":550,\"z\":0},{\"x\":50,\"y\":550,\"z\":0},{\"x\":25,\"y\":550,\"z\":40}]}}}}"
+  },
+  "fuse.waterSurface.triangleDensity": {
+    "title": "Water surface triangle density is out of range",
+    "why": "triangleDensity must be greater than 0 and no more than 1. Values outside that range cannot produce the bounded tessellation FUSE expects.",
+    "fix": "Set triangleDensity within (0, 1]; 0.2 is the default and a useful starting point.",
+    "example": "{\"world\":{\"waterSurfaces\":{\"mill-pond\":{\"points\":[{\"x\":0,\"y\":550,\"z\":0},{\"x\":50,\"y\":550,\"z\":0},{\"x\":25,\"y\":550,\"z\":40}],\"triangleDensity\":0.2}}}}"
+  },
+  "fuse.waterSurface.uvScale": {
+    "title": "Water surface UV scale is not positive",
+    "why": "uvScale is zero or negative, so the lake material cannot receive a valid repeating texture coordinate scale.",
+    "fix": "Set uvScale to a positive number; 1 uses the source material's normal scale.",
+    "example": "{\"world\":{\"waterSurfaces\":{\"mill-pond\":{\"points\":[{\"x\":0,\"y\":550,\"z\":0},{\"x\":50,\"y\":550,\"z\":0},{\"x\":25,\"y\":550,\"z\":40}],\"uvScale\":1}}}}"
   },
   "fuse.world.removal.blank": {
     "title": "Blank world removal ID",

--- a/FUSE.ExternalEditor.UiTests/LegacyImportServiceTests.cs
+++ b/FUSE.ExternalEditor.UiTests/LegacyImportServiceTests.cs
@@ -21,7 +21,8 @@ public class LegacyImportServiceTests
         {
             File.WriteAllText(Path.Combine(src, "Definition.json"),
                 "{\"id\":\"my.legacy.mod\",\"name\":\"My Legacy Mod\",\"version\":\"1.2.3\",\"author\":\"me\"}");
-            File.WriteAllText(Path.Combine(src, "data.json"), "{}");
+            File.WriteAllText(Path.Combine(src, "data.json"),
+                "{\"tracks\":{\"nodes\":{\"n_legacy\":{\"position\":{\"x\":10,\"y\":20,\"z\":30},\"rotation\":{\"x\":0,\"y\":0,\"z\":0}}}}}");
 
             var result = new LegacyImportService().Convert(src, outDir);
 

--- a/FUSE.ExternalEditor.UiTests/TerrainGenerationServiceTests.cs
+++ b/FUSE.ExternalEditor.UiTests/TerrainGenerationServiceTests.cs
@@ -134,8 +134,7 @@ public class TerrainGenerationServiceTests
         // Progress<T> posts its callbacks asynchronously to the thread pool (no SynchronizationContext
         // in headless xUnit), so they can trail GenerateRegionAsync's completion. Await their delivery
         // with a bounded timeout instead of a fixed delay that a loaded CI runner can outrun.
-        var delivered = await Task.WhenAny(allReported.Task, Task.Delay(TimeSpan.FromSeconds(2)));
-        Assert.True(delivered == allReported.Task, "expected all 6 Progress<T> callbacks to be delivered");
+        await allReported.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
         lock (reports)
         {
             Assert.Equal(6, reports.Count);

--- a/FUSE.Tests/API/FuseLegacyPlaceholderIndustryComponentTests.cs
+++ b/FUSE.Tests/API/FuseLegacyPlaceholderIndustryComponentTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using System.Runtime.Serialization;
+using FUSE.Runtime.API;
+using Model.Ops;
+using Model.Ops.Definition;
+using Track;
+using Xunit;
+
+namespace FUSE.Tests.API
+{
+    public sealed class FuseLegacyPlaceholderIndustryComponentTests
+    {
+        [Fact]
+        public void ConfusingSupplementsEmpty_RemainsVisibleAndAcceptsEveryAutoDestinationKind()
+        {
+            var component = (FuseLegacyPlaceholderIndustryComponent)
+                FormatterServices.GetUninitializedObject(typeof(FuseLegacyPlaceholderIndustryComponent));
+            component.trackSpans = new TrackSpan[1];
+
+            Assert.True(component.IsVisible);
+            Assert.All(
+                Enum.GetValues(typeof(AutoDestinationType)).Cast<AutoDestinationType>(),
+                destinationType => Assert.True(component.WantsAutoDestination(destinationType)));
+        }
+    }
+}

--- a/FUSE.Tests/API/SceneryApiLegacyHelperTests.cs
+++ b/FUSE.Tests/API/SceneryApiLegacyHelperTests.cs
@@ -1,0 +1,30 @@
+using FUSE.Authoring.Data;
+using FUSE.Runtime.API;
+using Xunit;
+
+namespace FUSE.Tests.API
+{
+    public sealed class SceneryApiLegacyHelperTests
+    {
+        [Theory]
+        [InlineData("TurntableMeasurementTool")]
+        [InlineData("scenery://TurntableMeasurementTool")]
+        [InlineData("ALW_ModRes_TurntableMeasurementTool")]
+        public void Turntable_measurement_plate_is_editor_only(string identifier)
+        {
+            Assert.True(SceneryAPI.IsEditorOnlyLegacySceneryReference(new FuseScenery
+            {
+                AssetIdentifier = identifier
+            }));
+        }
+
+        [Fact]
+        public void Ordinary_turntable_scenery_is_not_editor_only()
+        {
+            Assert.False(SceneryAPI.IsEditorOnlyLegacySceneryReference(new FuseScenery
+            {
+                AssetIdentifier = "scenery://ALW_ModRes_plate50x250"
+            }));
+        }
+    }
+}

--- a/FUSE.Tests/API/TrackApiCompanionExtensionTests.cs
+++ b/FUSE.Tests/API/TrackApiCompanionExtensionTests.cs
@@ -36,8 +36,12 @@ namespace FUSE.Tests.API
                 StartNodeId = "a",
                 EndNodeId = "b",
                 Gauge = "DualGauge",
+                BridgeSupportsSteel = true,
+                Yard = true,
                 Partial = true,
                 PreserveStyle = true,
+                PreserveBridgeSupportsSteel = true,
+                PreserveYard = true,
                 PreserveTrackClass = true,
                 PreserveSpeedLimit = true,
                 PreservePriority = true,
@@ -52,8 +56,12 @@ namespace FUSE.Tests.API
             var clone = Assert.IsType<FuseSegment>(cloneMethod.Invoke(null, new object[] { source }));
 
             Assert.Equal("DualGauge", clone.Gauge);
+            Assert.True(clone.BridgeSupportsSteel);
+            Assert.True(clone.Yard);
             Assert.True(clone.Partial);
             Assert.True(clone.PreserveStyle);
+            Assert.True(clone.PreserveBridgeSupportsSteel);
+            Assert.True(clone.PreserveYard);
             Assert.True(clone.PreserveTrackClass);
             Assert.True(clone.PreserveSpeedLimit);
             Assert.True(clone.PreservePriority);

--- a/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
+++ b/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
@@ -1,0 +1,207 @@
+using System.Collections.Generic;
+using FUSE.Compatibility;
+using FUSE.Interface.Console;
+using KeyValue.Runtime;
+using Model.Definition.Data;
+using System.Linq;
+using System.Reflection;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Compatibility
+{
+    public sealed class FuseConfusingSupplementsCompatibilityTests
+    {
+        [Fact]
+        public void BodygroupsComponent_UsesLegacyWireKindWithFuseOwnedType()
+        {
+            var component = new FuseConfusingSupplementsBodygroupsComponent();
+
+            Assert.Equal("ConfusingSupplements.Bodygroups", component.Kind);
+            Assert.Empty(component.Groups);
+            Assert.Contains(component.Kind, FuseConfusingSupplementsCompatibility.ImplementedComponentKinds);
+        }
+
+        [Fact]
+        public void BodygroupsBuilder_EmptySavedValueSelectsFirstDeclaredOption()
+        {
+            var options = new List<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>>
+            {
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "pilot",
+                    new FuseConfusingSupplementsBodygroupOption { Name = "Pilot" }),
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "snowplow",
+                    new FuseConfusingSupplementsBodygroupOption { Name = "Snowplow" })
+            };
+
+            var selected = FuseConfusingSupplementsBodygroupsBuilder.ReadSelectedOption(
+                Value.Null(),
+                options);
+
+            Assert.Equal("pilot", selected);
+        }
+
+        [Fact]
+        public void BodygroupsBuilder_SavedValueWinsOverDefault()
+        {
+            var options = new List<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>>
+            {
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "pilot",
+                    new FuseConfusingSupplementsBodygroupOption()),
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "snowplow",
+                    new FuseConfusingSupplementsBodygroupOption())
+            };
+
+            var selected = FuseConfusingSupplementsBodygroupsBuilder.ReadSelectedOption(
+                Value.String("snowplow"),
+                options);
+
+            Assert.Equal("snowplow", selected);
+        }
+
+        [Fact]
+        public void ReplacementSurface_AccountsForEveryRegisteredRollingStockKind()
+        {
+            Assert.Equal(
+                new[]
+                {
+                    "ConfusingSupplements.Bodygroups",
+                    "ConfusingSupplements.DestinationSign",
+                    "ConfusingSupplements.LabelPrinter",
+                    "CS.LiverySwap",
+                    "ConfusingSupplements.Refiller"
+                },
+                FuseConfusingSupplementsCompatibility.ImplementedComponentKinds);
+        }
+
+        [Fact]
+        public void LabelPrinter_SavedPropertyIdUsesGroupThenNameFallback()
+        {
+            var grouped = new FuseConfusingSupplementsLabelPrinterComponent
+            {
+                Name = "Visible Name",
+                Group = "shared-label"
+            };
+            var ungrouped = new FuseConfusingSupplementsLabelPrinterComponent
+            {
+                Name = "road-name"
+            };
+
+            Assert.Equal("shared-label", grouped.SavedPropertyId);
+            Assert.Equal("road-name", ungrouped.SavedPropertyId);
+            Assert.Equal(string.Empty, FuseConfusingSupplementsLabelPrinterBuilder.ReadText(Value.Null()));
+        }
+
+        [Theory]
+        [InlineData(-1, 3, false, 0)]
+        [InlineData(2, 3, false, -1)]
+        [InlineData(-1, 3, true, 2)]
+        [InlineData(0, 3, true, -1)]
+        [InlineData(0, 0, false, -1)]
+        public void DestinationSign_CyclesThroughHiddenAndNamedStates(
+            int current,
+            int count,
+            bool previous,
+            int expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseConfusingSupplementsDestinationSignController.NextIndex(current, count, previous));
+        }
+
+        [Theory]
+        [InlineData("paint.PNG", true)]
+        [InlineData("paint.jpeg", true)]
+        [InlineData("paint.JPG", true)]
+        [InlineData("readme.txt", false)]
+        public void LiveryRegistry_AcceptsOnlySupportedTextureFiles(string path, bool expected)
+        {
+            Assert.Equal(expected, FuseConfusingSupplementsLiveryRegistry.IsTextureFile(path));
+        }
+
+        [Fact]
+        public void LiveryCompatibility_RegistersRefreshAndDiagnosticCommands()
+        {
+            var commands = FuseConsoleCommands.CreateAll();
+            var keywords = commands.Select(command => CustomAttributeData
+                    .GetCustomAttributes(command.GetType())
+                    .Single(attribute =>
+                        attribute.AttributeType.FullName ==
+                        "UI.Console.ConsoleCommandAttribute")
+                    .ConstructorArguments[0]
+                    .Value as string)
+                .ToArray();
+
+            Assert.Contains("/cs-livery-refresh", keywords);
+            Assert.Contains("/fuse.liveries", keywords);
+        }
+
+        [Fact]
+        public void RefillerCompatibility_MatchesLoadIdentifiersCaseInsensitively()
+        {
+            var source = new CarDefinition
+            {
+                LoadSlots = new List<LoadSlot>
+                {
+                    new LoadSlot { RequiredLoadIdentifier = "diesel" }
+                }
+            };
+            var target = new CarDefinition
+            {
+                LoadSlots = new List<LoadSlot>
+                {
+                    new LoadSlot { RequiredLoadIdentifier = "DIESEL" }
+                }
+            };
+
+            Assert.True(FuseConfusingSupplementsRefillerRuntime.CanReceiveFrom(source, target));
+        }
+
+        [Fact]
+        public void StrangeCustomsFileCache_NormalizesPathsAndTracksEntryState()
+        {
+            var relative = Path.Combine("fixtures", "audio.wav");
+            Assert.Equal(Path.GetFullPath(relative), StrangeCustoms.FileCache.NormalizePath(relative));
+
+            var entry = new StrangeCustoms.FileCache.CacheEntry<string>(relative);
+            string observed = null;
+            entry.Register(value => observed = value);
+            entry.Set("loaded");
+
+            Assert.True(entry.IsValid);
+            Assert.False(entry.IsLoading);
+            Assert.Equal("loaded", entry.Value);
+            Assert.Equal("loaded", observed);
+
+            entry.Invalidate();
+            Assert.False(entry.IsValid);
+            Assert.Null(entry.Value);
+        }
+
+        [Fact]
+        public void StrangeCustomsFlowyBuilder_AdaptsLegacyDataToNativeSpliney()
+        {
+            var definition = StrangeCustoms.FlowyThingBuilder.ConvertDefinition(
+                JObject.Parse(@"{
+                    'handler': 'StrangeCustoms.FlowyThingBuilder',
+                    'style': 'River',
+                    'profile': 'River profile',
+                    'points': [
+                        { 'position': { 'x': 1, 'y': 2, 'z': 3 }, 'width': 4 },
+                        { 'position': { 'x': 5, 'y': 6, 'z': 7 }, 'width': 8 }
+                    ]
+                }"));
+
+            Assert.Equal("river", definition.Type);
+            Assert.Equal("River profile", definition.Profile);
+            Assert.Equal(-0.1f, definition.OffsetY);
+            Assert.Equal(2, definition.Points.Length);
+            Assert.Equal(4f, definition.Points[0].Width);
+            Assert.Equal(7f, definition.Points[1].Position.z);
+        }
+    }
+}

--- a/FUSE.Tests/Compatibility/FuseLegacyDebugInformationTests.cs
+++ b/FUSE.Tests/Compatibility/FuseLegacyDebugInformationTests.cs
@@ -1,0 +1,51 @@
+using System;
+using FUSE.Compatibility;
+using GalaSoft.MvvmLight.Messaging;
+using Railloader.Events;
+using Xunit;
+
+namespace FUSE.Tests.Compatibility
+{
+    public sealed class FuseLegacyDebugInformationTests
+    {
+        [Fact]
+        public void Collect_DispatchesLegacyEventAndNormalizesMultilineContributions()
+        {
+            var recipient = new DebugRecipient();
+            var lines = FuseLegacyDebugInformation.Collect(recipient.Handle);
+
+            Assert.Contains("first", lines);
+            Assert.Contains("second", lines);
+            Assert.Contains("third", lines);
+        }
+
+        [Fact]
+        public void Collect_BoundsOversizedLegacyContributions()
+        {
+            var recipient = new OversizedDebugRecipient();
+            var lines = FuseLegacyDebugInformation.Collect(recipient.Handle);
+
+            Assert.True(lines.Count <= FuseLegacyDebugInformation.MaximumLines + 1);
+            Assert.Contains(lines, line => line.StartsWith("[FUSE truncated", StringComparison.Ordinal));
+        }
+
+        public sealed class DebugRecipient
+        {
+            public void Handle(WillCopyDebugInformation message)
+            {
+                message.AppendLine("first\r\nsecond\nthird");
+            }
+        }
+
+        public sealed class OversizedDebugRecipient
+        {
+            public void Handle(WillCopyDebugInformation message)
+            {
+                for (var index = 0; index <= FuseLegacyDebugInformation.MaximumLines; index++)
+                {
+                    message.AppendLine("line " + index);
+                }
+            }
+        }
+    }
+}

--- a/FUSE.Tests/Compatibility/FuseLegacyInstallDetectorTests.cs
+++ b/FUSE.Tests/Compatibility/FuseLegacyInstallDetectorTests.cs
@@ -1,0 +1,28 @@
+using FUSE.Compatibility;
+using Xunit;
+
+namespace FUSE.Tests.Compatibility
+{
+    public sealed class FuseLegacyInstallDetectorTests
+    {
+        [Theory]
+        [InlineData("Railloader")]
+        [InlineData("Railloader.Injector")]
+        [InlineData("Railloader.Interchange")]
+        [InlineData("StrangeCustoms")]
+        public void IsLegacyLoaderAssemblyName_RecognizesEveryReplacedAssembly(string assemblyName)
+        {
+            Assert.True(FuseLegacyInstallDetector.IsLegacyLoaderAssemblyName(assemblyName));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("FUSE")]
+        [InlineData("UnityModManager")]
+        public void IsLegacyLoaderAssemblyName_DoesNotFlagCurrentRuntimeAssemblies(string assemblyName)
+        {
+            Assert.False(FuseLegacyInstallDetector.IsLegacyLoaderAssemblyName(assemblyName));
+        }
+    }
+}

--- a/FUSE.Tests/Compatibility/FuseLegacyTypeRegistryTests.cs
+++ b/FUSE.Tests/Compatibility/FuseLegacyTypeRegistryTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Linq;
+using FUSE.Compatibility;
+using Xunit;
+
+namespace FUSE.Tests.Compatibility
+{
+    public sealed class FuseLegacyTypeRegistryTests
+    {
+        [Fact]
+        public void RegisterSubType_ReplacesSameIdentifierCaseInsensitively()
+        {
+            var identifier = "test-" + Guid.NewGuid().ToString("N");
+
+            FuseLegacyTypeRegistry.RegisterSubType(typeof(TestBase), identifier, typeof(FirstImplementation));
+            FuseLegacyTypeRegistry.RegisterSubType(typeof(TestBase), identifier.ToUpperInvariant(), typeof(SecondImplementation));
+
+            var registrations = FuseLegacyTypeRegistry.Snapshot(typeof(TestBase));
+            var registration = Assert.Single(registrations, pair =>
+                string.Equals(pair.Key, identifier, StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(typeof(SecondImplementation), registration.Value);
+        }
+
+        [Fact]
+        public void RegisterSubType_RejectsUnrelatedImplementation()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                FuseLegacyTypeRegistry.RegisterSubType(
+                    typeof(TestBase),
+                    "invalid-" + Guid.NewGuid().ToString("N"),
+                    typeof(string)));
+        }
+
+        private abstract class TestBase
+        {
+        }
+
+        private sealed class FirstImplementation : TestBase
+        {
+        }
+
+        private sealed class SecondImplementation : TestBase
+        {
+        }
+    }
+}

--- a/FUSE.Tests/Converter/FuseLegacyConverterTests.cs
+++ b/FUSE.Tests/Converter/FuseLegacyConverterTests.cs
@@ -75,6 +75,94 @@ namespace FUSE.Tests.Converter
         }
 
         [Fact]
+        public void ConvertMod_preserves_issue_240_hard_dependencies_and_object_load_after_ids()
+        {
+            var modFolder = Path.Combine(_workspace, "Katers.SylvaYardTurntable");
+            Directory.CreateDirectory(modFolder);
+
+            // Regression fixture reduced from issue #240. Both dependency lists use
+            // the Railloader object form, and the real package contains a trailing
+            // comma in loadAfter. Older converter builds stringified those objects
+            // into entries such as "{'id': 'Katers.SylvaInterchange'}.FUSE" and
+            // incorrectly treated every hard requirement as advisory ordering.
+            File.WriteAllText(Path.Combine(modFolder, "Definition.json"), @"{
+                ""manifestVersion"": 5,
+                ""id"": ""Katers.SylvaYardTurntable"",
+                ""name"": ""Katers Sylva Yard Turntable"",
+                ""version"": ""1.2.6"",
+                ""requires"": [
+                    { ""id"": ""railloader"", ""notBefore"": ""1.10.0.2"" },
+                    { ""id"": ""Zamu.StrangeCustoms"", ""notBefore"": ""1.10.25017.313"" },
+                    { ""id"": ""AlinaNova21.AlinasMapMod"", ""notBefore"": ""1.5.25131.608"" },
+                    { ""id"": ""C_L_B.ASSETS01"", ""notBefore"": ""2.5.4"" },
+                    { ""id"": ""Katers.SylvaInterchange"", ""notBefore"": ""3.0"" },
+                    { ""id"": ""C_L_B.DKW"", ""notBefore"": ""1.1"" }
+                ],
+                ""loadAfter"": [
+                    { ""id"": ""Katers.SylvaInterchange"", },
+                    { ""id"": ""Katers.SylvaYPassingext"" }
+                ]
+            }");
+            File.WriteAllText(Path.Combine(modFolder, "SylvaYardTurntable.json"),
+                "{ \"tracks\": { \"nodes\": { \"n\": { \"position\": { \"x\": 0, \"y\": 0, \"z\": 0 } } } } }");
+
+            var outputFolder = Path.Combine(_workspace, "Katers.SylvaYardTurntable.FUSE");
+            var result = FuseLegacyConverter.ConvertMod(modFolder, outputFolder);
+
+            Assert.True(result.Success);
+            var info = JObject.Parse(File.ReadAllText(Path.Combine(outputFolder, "Info.json")));
+            Assert.Equal(new[]
+            {
+                "C_L_B.ASSETS01.FUSE",
+                "Katers.SylvaInterchange.FUSE",
+                "C_L_B.DKW.FUSE"
+            }, info.Value<JArray>("FuseRequires").Values<string>());
+            Assert.Equal(new[]
+            {
+                "Katers.SylvaInterchange.FUSE",
+                "Katers.SylvaYPassingext.FUSE"
+            }, info.Value<JArray>("FuseLoadAfter").Values<string>());
+            Assert.DoesNotContain(
+                info.Value<JArray>("FuseLoadAfter").Values<string>(),
+                dependency => dependency.IndexOf("{'id'", StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        [Fact]
+        public void ConvertMod_preserves_top_level_and_conditional_conflictsWith()
+        {
+            var modFolder = Path.Combine(_workspace, "conflicting.mod");
+            Directory.CreateDirectory(modFolder);
+            File.WriteAllText(Path.Combine(modFolder, "Definition.json"), @"{
+                ""id"": ""Author.Conflict"",
+                ""name"": ""Conflict Fixture"",
+                ""version"": ""1.0"",
+                ""conflictsWith"": [ { ""id"": ""Other.Route"", ""notBefore"": ""2.0"" } ],
+                ""mixintos"": {
+                    ""game-graph"": {
+                        ""mixinto"": ""file(track.json)"",
+                        ""conflictsWith"": [ ""Conditional.Route"" ]
+                    }
+                }
+            }");
+            File.WriteAllText(
+                Path.Combine(modFolder, "track.json"),
+                "{ \"nodes\": { \"N1\": { \"position\": { \"x\": 0, \"y\": 0, \"z\": 0 } } } }");
+
+            var outputFolder = Path.Combine(_workspace, "conflicting.mod.FUSE");
+            var result = FuseLegacyConverter.ConvertMod(modFolder, outputFolder);
+
+            Assert.True(result.Success);
+            var info = JObject.Parse(File.ReadAllText(Path.Combine(outputFolder, "Info.json")));
+            var manifestConflict = Assert.Single((JArray)info["FuseConflictsWith"]);
+            Assert.Equal("Other.Route", manifestConflict.Value<string>("Id"));
+            Assert.Equal("2.0", manifestConflict.Value<string>("NotBefore"));
+
+            var fragment = JObject.Parse(File.ReadAllText(Path.Combine(outputFolder, "track.fuse.json")));
+            var conditionalConflict = Assert.Single((JArray)fragment["mixinto"]["conflictsWith"]);
+            Assert.Equal("Conditional.Route", conditionalConflict.Value<string>("id"));
+        }
+
+        [Fact]
         public void ConvertMod_refuses_when_output_overlaps_source()
         {
             var modFolder = Path.Combine(_workspace, "inplace.mod");
@@ -174,6 +262,46 @@ namespace FUSE.Tests.Converter
 
             Assert.False(result.Success);
             Assert.Contains(result.Report, r => r.Level == FuseConversionReportLevel.Error);
+        }
+
+        [Fact]
+        public void ConvertPackage_rejects_asset_only_package_with_install_guidance()
+        {
+            var modFolder = Path.Combine(_workspace, "asset.mod");
+            Directory.CreateDirectory(modFolder);
+            File.WriteAllText(Path.Combine(modFolder, "bundle"), "asset");
+            File.WriteAllText(Path.Combine(modFolder, "Catalog.json"), "{}");
+            File.WriteAllText(Path.Combine(modFolder, "Definitions.json"), "{}");
+            var outputFolder = Path.Combine(_workspace, "asset.mod.FUSE");
+
+            var result = FuseLegacyConverter.ConvertPackage(modFolder, outputFolder);
+
+            Assert.False(result.Success);
+            Assert.Empty(result.WrittenFragments);
+            Assert.False(Directory.Exists(outputFolder));
+            Assert.Contains(result.Report, entry =>
+                entry.Level == FuseConversionReportLevel.Error
+                && entry.Message.IndexOf("install this package", StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        [Fact]
+        public void ConvertPackage_rejects_compiled_code_instead_of_reporting_zero_fragment_success()
+        {
+            var modFolder = Path.Combine(_workspace, "code.mod");
+            Directory.CreateDirectory(modFolder);
+            File.WriteAllText(Path.Combine(modFolder, "Info.json"),
+                "{ \"Id\": \"code.mod\", \"DisplayName\": \"Code Mod\", \"AssemblyName\": \"Code.dll\" }");
+            File.WriteAllText(Path.Combine(modFolder, "Code.dll"), "not-a-real-assembly");
+            var outputFolder = Path.Combine(_workspace, "code.mod.FUSE");
+
+            var result = FuseLegacyConverter.ConvertPackage(modFolder, outputFolder);
+
+            Assert.False(result.Success);
+            Assert.Empty(result.WrittenFragments);
+            Assert.False(Directory.Exists(outputFolder));
+            Assert.Contains(result.Report, entry =>
+                entry.Level == FuseConversionReportLevel.Error
+                && entry.Message.IndexOf("cannot reproduce DLL behavior", StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         [Fact]

--- a/FUSE.Tests/Converter/LegacyDefinitionConverterTests.cs
+++ b/FUSE.Tests/Converter/LegacyDefinitionConverterTests.cs
@@ -50,7 +50,28 @@ namespace FUSE.Tests.Converter
         {
             Assert.Null(LegacyDefinitionConverter.ConvertRequirement(JToken.Parse("\"Railroader\"")));
             Assert.Null(LegacyDefinitionConverter.ConvertRequirement(JToken.Parse("\"StrangeCustoms\"")));
+            Assert.Null(LegacyDefinitionConverter.ConvertRequirement(JToken.Parse("\"AlinaNova21.AlinasMapMod\"")));
+            Assert.Null(LegacyDefinitionConverter.ConvertRequirement(JToken.Parse("\"Railloader.Interchange\"")));
+            Assert.Null(LegacyDefinitionConverter.ConvertRequirement(JToken.Parse("\"AssetLoader\"")));
             Assert.Null(LegacyDefinitionConverter.ConvertRequirement(JToken.Parse("\"FUSE\"")));
+        }
+
+        [Fact]
+        public void ConvertRequirement_keeps_alina_content_pack_as_real_dependency()
+        {
+            var converted = LegacyDefinitionConverter.ConvertRequirement(
+                JToken.Parse("\"AlinaNova21.AlinasMapExpansionSW\""));
+
+            Assert.Equal("AlinaNova21.AlinasMapExpansionSW", converted.Value<string>("id"));
+        }
+
+        [Fact]
+        public void ConvertRequirement_keeps_zamu_mod_without_native_parity_as_real_dependency()
+        {
+            var converted = LegacyDefinitionConverter.ConvertRequirement(
+                JToken.Parse("\"Zamu.SomeKindOfMadness\""));
+
+            Assert.Equal("Zamu.SomeKindOfMadness", converted.Value<string>("id"));
         }
 
         [Fact]
@@ -173,6 +194,84 @@ namespace FUSE.Tests.Converter
             }
         }
 
+        [Fact]
+        public void LegacyDependencies_preserves_hard_requirements_separately_from_ordering()
+        {
+            var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                Directory.CreateDirectory(temp);
+                File.WriteAllText(Path.Combine(temp, "Definition.json"), @"{
+                    ""requires"": [ { ""id"": ""RequiredMod"", ""notBefore"": ""2.0"" } ],
+                    ""loadAfter"": [ { ""id"": ""OptionalOrderingMod"" } ]
+                }");
+
+                var result = LegacyDefinitionConverter.LegacyDependencies(temp);
+
+                Assert.Equal(new[] { "RequiredMod.FUSE" }, result.Requires);
+                Assert.Equal(new[] { "OptionalOrderingMod.FUSE" }, result.LoadAfter);
+            }
+            finally
+            {
+                try { Directory.Delete(temp, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void LegacyDependencies_orders_after_conditional_mixinto_requirements_without_making_them_hard()
+        {
+            var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                Directory.CreateDirectory(temp);
+                File.WriteAllText(Path.Combine(temp, "Definition.json"), @"{
+                    ""mixintos"": {
+                        ""game-graph"": {
+                            ""mixinto"": ""file(optional-track.json)"",
+                            ""requires"": [ ""OptionalBase"" ]
+                        }
+                    }
+                }");
+
+                var result = LegacyDefinitionConverter.LegacyDependencies(temp);
+
+                Assert.Empty(result.Requires);
+                Assert.Equal(new[] { "OptionalBase.FUSE" }, result.LoadAfter);
+            }
+            finally
+            {
+                try { Directory.Delete(temp, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void LegacyConflictsWith_preserves_core_ids_and_version_bounds_for_manifest_enforcement()
+        {
+            var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                Directory.CreateDirectory(temp);
+                File.WriteAllText(Path.Combine(temp, "Definition.json"), @"{
+                    ""conflictsWith"": [
+                        { ""id"": ""Other.Route"", ""notBefore"": ""2.0"", ""notAfter"": ""3.0"" },
+                        ""Zamu.StrangeCustoms""
+                    ]
+                }");
+
+                var result = LegacyDefinitionConverter.LegacyConflictsWith(temp);
+
+                Assert.Equal(2, result.Count);
+                Assert.Equal("Other.Route", result[0].Value<string>("Id"));
+                Assert.Equal("2.0", result[0].Value<string>("NotBefore"));
+                Assert.Equal("3.0", result[0].Value<string>("NotAfter"));
+                Assert.Equal("Zamu.StrangeCustoms", result[1].Value<string>("Id"));
+            }
+            finally
+            {
+                try { Directory.Delete(temp, true); } catch { }
+            }
+        }
+
         // ------------------------------------------------------------------
         // MixintoMetadata
         // ------------------------------------------------------------------
@@ -241,6 +340,33 @@ namespace FUSE.Tests.Converter
                 Assert.NotNull(requires);
                 Assert.Single(requires);
                 Assert.Equal("DependencyMod", ((JObject)requires[0]).Value<string>("id"));
+            }
+            finally
+            {
+                try { Directory.Delete(temp, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void MixintoMetadata_preserves_conditional_conflictsWith()
+        {
+            var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                Directory.CreateDirectory(temp);
+                File.WriteAllText(Path.Combine(temp, "Definition.json"), @"{
+                    ""mixintos"": {
+                        ""game-graph"": {
+                            ""mixinto"": ""file(optional.json)"",
+                            ""conflictsWith"": [ { ""id"": ""Other.Route"", ""notBefore"": ""2.0"" } ]
+                        }
+                    }
+                }");
+
+                var (metadata, _) = LegacyDefinitionConverter.MixintoMetadata(temp);
+                var conflict = Assert.Single((JArray)metadata["optional.json"]["conflictsWith"]);
+                Assert.Equal("Other.Route", conflict.Value<string>("id"));
+                Assert.Equal("2.0", conflict.Value<string>("notBefore"));
             }
             finally
             {

--- a/FUSE.Tests/Converter/LegacyKindDetectorTests.cs
+++ b/FUSE.Tests/Converter/LegacyKindDetectorTests.cs
@@ -72,13 +72,48 @@ namespace FUSE.Tests.Converter
         }
 
         [Fact]
-        public void DetectKind_returns_route_for_map_tile_folder()
+        public void DetectKind_returns_map_tile_for_map_tile_folder()
         {
             var folder = Path.Combine(_workspace, "tiles");
             Directory.CreateDirectory(folder);
             File.WriteAllText(Path.Combine(folder, "tile-0-0.data"), "binary");
-            // map-tile folder reports as route (route covers tiles).
+            Assert.Equal("map_tile", LegacyKindDetector.DetectKind(folder, "auto"));
+        }
+
+        [Fact]
+        public void DetectKind_returns_code_for_compiled_plugin()
+        {
+            var folder = Path.Combine(_workspace, "plugin");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(Path.Combine(folder, "Plugin.dll"), "not-a-real-assembly");
+            var nested = Path.Combine(folder, "schemas");
+            Directory.CreateDirectory(nested);
+            File.WriteAllText(Path.Combine(nested, "example.json"),
+                "{ \"tracks\": { \"nodes\": {} } }");
+
+            Assert.Equal("code", LegacyKindDetector.DetectKind(folder, "auto"));
+        }
+
+        [Fact]
+        public void DetectKind_returns_route_for_mixed_code_and_convertible_json()
+        {
+            var folder = Path.Combine(_workspace, "mixed-plugin");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(Path.Combine(folder, "Plugin.dll"), "not-a-real-assembly");
+            File.WriteAllText(Path.Combine(folder, "track.json"),
+                "{ \"tracks\": { \"nodes\": {} } }");
+
             Assert.Equal("route", LegacyKindDetector.DetectKind(folder, "auto"));
+        }
+
+        [Fact]
+        public void DetectKind_returns_native_for_fuse_fragment()
+        {
+            var folder = Path.Combine(_workspace, "native");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(Path.Combine(folder, "track.fuse.json"), "{}");
+
+            Assert.Equal("native", LegacyKindDetector.DetectKind(folder, "auto"));
         }
 
         [Fact]

--- a/FUSE.Tests/Converter/LegacyTrackStructureConverterTests.cs
+++ b/FUSE.Tests/Converter/LegacyTrackStructureConverterTests.cs
@@ -1,0 +1,55 @@
+using FUSE.Converter.Conversion;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Converter
+{
+    public sealed class LegacyTrackStructureConverterTests
+    {
+        [Fact]
+        public void ConvertNode_PreservesDiamondCrossingMarker()
+        {
+            var converted = LegacyTrackConverter.ConvertNode(JObject.Parse(
+                "{ 'position': [1,2,3], 'rotation': [0,90,0], 'isDiamond': true }"));
+
+            Assert.True(converted.Value<bool>("isDiamond"));
+        }
+
+        [Theory]
+        [InlineData(0, "standard", false, false)]
+        [InlineData(2, "bridge", false, false)]
+        [InlineData(6, "bridge", true, false)]
+        [InlineData(8, "tunnel", false, false)]
+        [InlineData(18, "bridge", false, true)]
+        public void ConvertSegment_DecodesFlagsBasedTrackStructure(
+            int flags,
+            string expectedStyle,
+            bool expectedSteel,
+            bool expectedYard)
+        {
+            var legacy = new JObject
+            {
+                ["a"] = "node-a",
+                ["b"] = "node-b",
+                ["flags"] = flags
+            };
+
+            var converted = LegacyTrackConverter.ConvertSegment(legacy);
+
+            Assert.Equal(expectedStyle, converted.Value<string>("style"));
+            Assert.Equal(expectedSteel, converted.Value<bool>("bridgeSupportsSteel"));
+            Assert.Equal(expectedYard, converted.Value<bool>("yard"));
+        }
+
+        [Fact]
+        public void ConvertPartialSegment_PreservesUnspecifiedStructureFields()
+        {
+            var converted = LegacyTrackConverter.ConvertSegment(JObject.Parse("{ 'a': 'node-a' }"));
+
+            Assert.True(converted.Value<bool>("partial"));
+            Assert.True(converted.Value<bool>("preserveStyle"));
+            Assert.True(converted.Value<bool>("preserveBridgeSupportsSteel"));
+            Assert.True(converted.Value<bool>("preserveYard"));
+        }
+    }
+}

--- a/FUSE.Tests/Data/FuseIndustryComponentTypesTests.cs
+++ b/FUSE.Tests/Data/FuseIndustryComponentTypesTests.cs
@@ -32,6 +32,7 @@ namespace FUSE.Tests.Data
             [InlineData("passenger-stop", "passengerStop")]
             [InlineData("paxstationcomponent", "passengerStop")]
             [InlineData("alinasmapmod.paxstationcomponent", "passengerStop")]
+            [InlineData("ADRFDR.Pay4Resource", "ConfusingSupplements.IndustryComponents.Pay4Resource")]
             public void Known_Aliases_NormalizeToCanonical(string input, string expected)
             {
                 Assert.Equal(expected, FuseIndustryComponentTypes.Normalize(input));

--- a/FUSE.Tests/FUSE.Tests.csproj
+++ b/FUSE.Tests/FUSE.Tests.csproj
@@ -55,6 +55,9 @@
     <None Include="..\schemas\fuse-mod.example.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\schemas\fuse-mod.schema.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <!-- The main FUSE project references game-shipped assemblies with <Private>false</Private>
@@ -116,6 +119,14 @@
     </Reference>
     <Reference Include="AssetPack.Common" Condition="Exists('$(UnityManagedDir)\AssetPack.Common.dll')">
       <HintPath>$(UnityManagedDir)\AssetPack.Common.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+    <Reference Include="KeyValue.Runtime" Condition="Exists('$(UnityManagedDir)\KeyValue.Runtime.dll')">
+      <HintPath>$(UnityManagedDir)\KeyValue.Runtime.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+    <Reference Include="Unity.RenderPipelines.Universal.Runtime" Condition="Exists('$(UnityManagedDir)\Unity.RenderPipelines.Universal.Runtime.dll')">
+      <HintPath>$(UnityManagedDir)\Unity.RenderPipelines.Universal.Runtime.dll</HintPath>
       <Private>true</Private>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule" Condition="Exists('$(UnityManagedDir)\UnityEngine.AssetBundleModule.dll')">

--- a/FUSE.Tests/Infrastructure/FuseLiveLogBufferTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseLiveLogBufferTests.cs
@@ -1,0 +1,54 @@
+using System;
+using FUSE.Infrastructure;
+using Xunit;
+
+namespace FUSE.Tests.Infrastructure
+{
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class FuseLiveLogBufferTestCollection
+    {
+        public const string Name = "Fuse live log buffer tests";
+    }
+
+    [Collection(FuseLiveLogBufferTestCollection.Name)]
+    public class FuseLiveLogBufferTests
+    {
+        public FuseLiveLogBufferTests()
+        {
+            FuseLiveLogBuffer.ResetForTests();
+        }
+
+        [Fact]
+        public void Snapshot_FiltersBySeverityAndText()
+        {
+            var now = new DateTime(2026, 8, 19, 12, 0, 0, DateTimeKind.Local);
+            FuseLiveLogBuffer.Append(now, "INFO", "mounted track package");
+            FuseLiveLogBuffer.Append(now.AddSeconds(1), "WARN", "missing optional asset alias");
+            FuseLiveLogBuffer.Append(now.AddSeconds(2), "ERROR", "bad track json");
+
+            var warnings = FuseLiveLogBuffer.Snapshot("Warnings + Errors", string.Empty, 20);
+            Assert.Equal(2, warnings.Length);
+            Assert.Equal("WARN", warnings[0].Level);
+            Assert.Equal("ERROR", warnings[1].Level);
+
+            var json = FuseLiveLogBuffer.Snapshot("All", "json", 20);
+            Assert.Single(json);
+            Assert.Equal("bad track json", json[0].Message);
+        }
+
+        [Fact]
+        public void Buffer_IsBoundedAndSnapshotReturnsNewestEntriesInOrder()
+        {
+            var now = DateTime.Now;
+            for (var index = 0; index < FuseLiveLogBuffer.Capacity + 25; index++)
+            {
+                FuseLiveLogBuffer.Append(now.AddMilliseconds(index), "INFO", "line " + index);
+            }
+
+            Assert.Equal(FuseLiveLogBuffer.Capacity, FuseLiveLogBuffer.Count);
+            var latest = FuseLiveLogBuffer.Snapshot("All", string.Empty, 3);
+            Assert.Equal(new[] { "line 1022", "line 1023", "line 1024" },
+                new[] { latest[0].Message, latest[1].Message, latest[2].Message });
+        }
+    }
+}

--- a/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
@@ -34,6 +34,7 @@ namespace FUSE.Tests.Infrastructure
                 "rebillAutoConfigSuppressed=0 " +
                 "brssModMenuDeferred=0 " +
                 "timeSyncMainThread=0 " +
+                "passengerStopSpansSanitized=0 " +
                 "flares=0 switchRailsBackfilled=0 frameSpikes=0",
                 FuseRuntimeGuardCounters.FormatSummary());
         }
@@ -92,18 +93,20 @@ namespace FUSE.Tests.Infrastructure
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordBrssModMenuDeferred());
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordTimeSyncMainThreadMarshaled());
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordSwitchGeometryRailsBackfilled());
+            Assert.Equal(1, FuseRuntimeGuardCounters.RecordPassengerStopSpanSanitized());
 
             // Third-party containment must surface as guard activity: an
             // active suppression storm reading as "guards idle" would hide
             // the offender from every report surface.
             Assert.False(FuseRuntimeGuardCounters.AllIdle);
-            Assert.Equal(6, FuseRuntimeGuardCounters.GuardTotal);
+            Assert.Equal(7, FuseRuntimeGuardCounters.GuardTotal);
             var summary = FuseRuntimeGuardCounters.FormatSummary();
             Assert.Contains("mapEnhancerCullingGuarded=2", summary);
             Assert.Contains("rebillAutoConfigSuppressed=1", summary);
             Assert.Contains("brssModMenuDeferred=1", summary);
             Assert.Contains("timeSyncMainThread=1", summary);
             Assert.Contains("switchRailsBackfilled=1", summary);
+            Assert.Contains("passengerStopSpansSanitized=1", summary);
         }
     }
 }

--- a/FUSE.Tests/Interface/AssetsToolPageTests.cs
+++ b/FUSE.Tests/Interface/AssetsToolPageTests.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using FUSE.Interface.MenuWindow;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Interface
+{
+    public class AssetsToolPageTests
+    {
+        [Fact]
+        public void GroupDuplicateAssets_CollapsesKeysWithTheSameWinnerAndSources()
+        {
+            var groups = AssetsToolPage.GroupDuplicateAssets(new[]
+            {
+                Duplicate("mine", false, "RTM/primary", "RTM/nested"),
+                Duplicate("engine-house", false, "RTM/primary", "RTM/nested"),
+                Duplicate("sound-1", true, "Latoms", "lt-objects")
+            });
+
+            Assert.Equal(2, groups.Length);
+            var identical = Assert.Single(groups, group => !group.DefinitionsDiffer);
+            Assert.Equal(new[] { "mine", "engine-house" }, identical.Keys);
+            Assert.Equal(new[] { "RTM/primary", "RTM/nested" }, identical.Sources);
+
+            var different = Assert.Single(groups, group => group.DefinitionsDiffer);
+            Assert.Equal(new[] { "sound-1" }, different.Keys);
+        }
+
+        [Fact]
+        public void GroupDuplicateAssets_PreservesWinnerOrderAsPartOfTheGroupIdentity()
+        {
+            var groups = AssetsToolPage.GroupDuplicateAssets(new[]
+            {
+                Duplicate("a", false, "winner-a", "source-b"),
+                Duplicate("b", false, "source-b", "winner-a")
+            });
+
+            Assert.Equal(2, groups.Length);
+        }
+
+        [Fact]
+        public void BuildAssetSummary_ReportsGroupedImpactInsteadOfOnePreviewPerKey()
+        {
+            var diagnostics = new FuseAssetPackDiagnostics
+            {
+                UniqueAssetKeys = 10,
+                DuplicateKeys = new[]
+                {
+                    Duplicate("mine", false, "RTM/primary", "RTM/nested"),
+                    Duplicate("engine-house", false, "RTM/primary", "RTM/nested")
+                }
+            };
+
+            var summary = AssetsToolPage.BuildAssetSummary(diagnostics);
+
+            Assert.Contains("Overlapping asset keys: 2", summary);
+            Assert.Contains("Source overlap groups: 1", summary);
+            Assert.Contains("2 key(s)", summary);
+            Assert.Contains("identical copies; no behavior change", summary);
+            Assert.DoesNotContain("1 more duplicate key", summary);
+        }
+
+        private static FuseDuplicateAssetKey Duplicate(
+            string key,
+            bool definitionsDiffer,
+            params string[] sources)
+        {
+            return new FuseDuplicateAssetKey
+            {
+                Key = key,
+                DefinitionsDiffer = definitionsDiffer,
+                Sources = sources
+            };
+        }
+    }
+}

--- a/FUSE.Tests/Interface/AuditsToolPageTests.cs
+++ b/FUSE.Tests/Interface/AuditsToolPageTests.cs
@@ -1,0 +1,34 @@
+using FUSE.Interface.MenuWindow;
+using Xunit;
+
+namespace FUSE.Tests.Interface
+{
+    public sealed class AuditsToolPageTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Base_game_span_without_package_owner_is_not_audited(string owner)
+        {
+            Assert.False(AuditsToolPage.ShouldAuditTrackSpanOwner(owner));
+        }
+
+        [Fact]
+        public void Fuse_owned_span_remains_eligible_for_validation()
+        {
+            Assert.True(AuditsToolPage.ShouldAuditTrackSpanOwner("Katers.SylvaInterchange.FUSE"));
+        }
+
+        [Theory]
+        [InlineData("shared-extension", false)]
+        [InlineData("SHARED-EXTENSION", false)]
+        [InlineData("ownership-conflict", true)]
+        [InlineData("", true)]
+        [InlineData(null, true)]
+        public void Only_actionable_registry_records_are_audit_findings(string classification, bool expected)
+        {
+            Assert.Equal(expected, AuditsToolPage.ShouldAuditConflictRecord(classification));
+        }
+    }
+}

--- a/FUSE.Tests/Interface/FuseWorldLabelsOverlayTests.cs
+++ b/FUSE.Tests/Interface/FuseWorldLabelsOverlayTests.cs
@@ -1,0 +1,22 @@
+using FUSE.Interface;
+using Xunit;
+
+namespace FUSE.Tests.Interface
+{
+    public sealed class FuseWorldLabelsOverlayTests
+    {
+        [Theory]
+        [InlineData(false, false, false, false)]
+        [InlineData(true, true, false, false)]
+        [InlineData(true, false, true, false)]
+        [InlineData(true, false, false, true)]
+        public void ShouldRender_hides_labels_while_disabled_paused_or_a_game_window_is_open(
+            bool enabled,
+            bool paused,
+            bool shownWindow,
+            bool expected)
+        {
+            Assert.Equal(expected, FuseWorldLabelsOverlay.ShouldRender(enabled, paused, shownWindow));
+        }
+    }
+}

--- a/FUSE.Tests/Interface/MenuWindow/DependencyGraphPageTests.cs
+++ b/FUSE.Tests/Interface/MenuWindow/DependencyGraphPageTests.cs
@@ -55,6 +55,21 @@ namespace FUSE.Tests.Interface.MenuWindow
                 DependencyGraphPage.FormatDependencyEdge("c_l_b.assets01", Packages, PresentInModsRoot, advisory: true));
         }
 
+        [Theory]
+        [InlineData("Zamu.StrangeCustoms")]
+        [InlineData("AlinaNova21.AlinasMapMod.FUSE")]
+        [InlineData("AssetLoader")]
+        public void ReplacementCapability_IsIdentifiedAsProvidedByFuse(string dependencyId)
+        {
+            Assert.Contains(
+                "PROVIDED BY FUSE",
+                DependencyGraphPage.FormatDependencyEdge(
+                    dependencyId,
+                    Packages,
+                    PresentInModsRoot,
+                    advisory: false));
+        }
+
         [Fact]
         public void UnknownTarget_IsMissing_ForNativePackages_ButOptionalForLegacyHints()
         {

--- a/FUSE.Tests/Interface/MenuWindow/ModConflictsToolPageTests.cs
+++ b/FUSE.Tests/Interface/MenuWindow/ModConflictsToolPageTests.cs
@@ -1,0 +1,140 @@
+using FUSE.Interface.MenuWindow;
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using FUSE.Runtime.Registry;
+using Xunit;
+
+namespace FUSE.Tests.Interface.MenuWindow
+{
+    [Collection("FuseRegistry")]
+    public sealed class ModConflictsToolPageTests
+    {
+        public ModConflictsToolPageTests()
+        {
+            FuseRegistry.Reset();
+        }
+
+        [Fact]
+        public void BuildGroups_groups_reverse_ownership_records_under_one_package_pair()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Segment,
+                "segment-a",
+                "package-z",
+                "package-a",
+                "later package definition won");
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Node,
+                "node-b",
+                "package-a",
+                "package-z",
+                "later package removal won");
+
+            var group = Assert.Single(ModConflictsToolPage.BuildGroups(FuseRegistry.Conflicts));
+
+            Assert.Equal("package-a", group.FirstPackageId);
+            Assert.Equal("package-z", group.SecondPackageId);
+            Assert.Equal(2, group.Conflicts.Length);
+        }
+
+        [Fact]
+        public void BuildReport_identifies_spatial_overlap_and_lists_both_packages()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Segment,
+                "spatial-overlap:east-whittier",
+                "yard-revamp",
+                "crossover",
+                "spatial track overlap detected; both packages retained");
+
+            var report = ModConflictsToolPage.BuildReport(
+                ModConflictsToolPage.BuildGroups(FuseRegistry.Conflicts));
+
+            Assert.Contains("crossover  <->  yard-revamp", report);
+            Assert.Contains("Potential track-layout overlap", report);
+            Assert.Contains("spatial-overlap:east-whittier", report);
+        }
+
+        [Fact]
+        public void BuildGroups_collapses_definition_fragments_to_their_discovered_mod_ids()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Segment,
+                "segment-a",
+                "Author.RouteA.FUSE.graph",
+                "Author.RouteB.FUSE.track",
+                "later package definition won");
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Span,
+                "span-b",
+                "Author.RouteA.FUSE.operations",
+                "Author.RouteB.FUSE.spans",
+                "later package definition won");
+
+            var group = Assert.Single(ModConflictsToolPage.BuildGroups(
+                FuseRegistry.Conflicts,
+                new[] { "Author.RouteA.FUSE", "Author.RouteB.FUSE" }));
+
+            Assert.Equal("Author.RouteA.FUSE", group.FirstPackageId);
+            Assert.Equal("Author.RouteB.FUSE", group.SecondPackageId);
+            Assert.Equal(2, group.Conflicts.Length);
+        }
+
+        [Fact]
+        public void DeclaredConflicts_are_reported_separately_from_runtime_ownership()
+        {
+            var declaring = new FusePackageManifestSnapshot
+            {
+                Id = "Katers.Route.FUSE",
+                Version = "1.0",
+                ConflictsWith = new[]
+                {
+                    new FuseModRequirement { Id = "Other.Route", NotBefore = "2.0" }
+                }
+            };
+            var conflicting = new FusePackageManifestSnapshot
+            {
+                Id = "Other.Route.FUSE",
+                Version = "2.5"
+            };
+
+            var matches = ModConflictsToolPage.BuildDeclaredConflictMatches(new[] { declaring, conflicting });
+            var match = Assert.Single(matches);
+            var report = ModConflictsToolPage.BuildReport(
+                System.Linq.Enumerable.Empty<ModConflictsToolPage.ConflictGroup>(),
+                matches);
+
+            Assert.Equal("Katers.Route.FUSE", match.DeclaringPackage.Id);
+            Assert.Contains("Author-declared incompatibilities: 1", report);
+            Assert.Contains("DECLARED: Katers.Route.FUSE  X  Other.Route.FUSE", report);
+            Assert.DoesNotContain("Conflict records: 1", report);
+        }
+
+        [Fact]
+        public void Successful_shared_industry_merge_is_informational_not_actionable()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Industry,
+                "component:kirkland-mine.KirkOBSTrackLoad",
+                "CF.AndrewsCoalPower.FUSE.kirklandcoalpatchpower-migration",
+                "Katers.TuckasegeeSteelWorks.FUSE.kirklandcoal",
+                "shared industry destination overlap; definitions merged into the same runtime location");
+
+            var record = Assert.Single(FuseRegistry.Conflicts);
+            Assert.True(record.IsCooperativeMerge);
+
+            var sharedGroups = ModConflictsToolPage.BuildGroups(
+                new[] { record },
+                new[] { "CF.AndrewsCoalPower.FUSE", "Katers.TuckasegeeSteelWorks.FUSE" });
+            var report = ModConflictsToolPage.BuildReport(
+                System.Linq.Enumerable.Empty<ModConflictsToolPage.ConflictGroup>(),
+                System.Linq.Enumerable.Empty<ModConflictsToolPage.DeclaredConflictMatch>(),
+                sharedGroups);
+
+            Assert.Contains("Package pairs needing attention: 0", report);
+            Assert.Contains("Informational shared-extension records: 1", report);
+            Assert.Contains("SHARED: CF.AndrewsCoalPower.FUSE  +  Katers.TuckasegeeSteelWorks.FUSE", report);
+            Assert.Contains("no mod lost content", report);
+        }
+    }
+}

--- a/FUSE.Tests/Interface/MenuWindow/ModsPanelBuilderTests.cs
+++ b/FUSE.Tests/Interface/MenuWindow/ModsPanelBuilderTests.cs
@@ -107,5 +107,99 @@ namespace FUSE.Tests.Interface.MenuWindow
 
             Assert.Equal("NotEnoughRosters", Assert.Single(result).DisplayName);
         }
+
+        [Theory]
+        [InlineData("Package 'Example' requires 'Missing.Mod', but no matching package was discovered.", "Missing dependency")]
+        [InlineData("Package 'Example' conflictsWith 'Other.Mod'; matching package is enabled.", "Incompatible mod installed")]
+        [InlineData("manifest JSON: Unexpected character at line 12.", "Invalid package data")]
+        public void ClassifyPackageStatus_distinguishes_actionable_failure_types(string fault, string expected)
+        {
+            var snapshot = new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                Faults = new[] { fault }
+            };
+
+            var status = ModsPanelBuilder.ClassifyPackageStatus(snapshot);
+
+            Assert.Equal(expected, status.Label);
+            Assert.Equal("Mods Needing Attention", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_reports_successfully_applied_package()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                AppliedToRuntime = true
+            });
+
+            Assert.Equal("Applied", status.Label);
+            Assert.Equal("Applied Mods", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_keeps_optional_mixinto_skip_non_actionable()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                AppliedToRuntime = true,
+                SkipReason = "mixinto dependency missing 'Optional.Mod'"
+            });
+
+            Assert.Equal("Applied", status.Label);
+            Assert.Contains("Optional content is inactive", status.Detail);
+            Assert.Equal("Applied Mods", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_does_not_hide_actionable_skip_behind_optional_fragment()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                AppliedToRuntime = true,
+                SkipReasons = new[]
+                {
+                    "mixinto dependency missing id='Optional.Mod'",
+                    "runtime apply exception"
+                }
+            });
+
+            Assert.Equal("Partially applied", status.Label);
+            Assert.Contains("runtime apply exception", status.Detail);
+            Assert.Equal("Mods Needing Attention", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_reports_partial_apply_without_calling_whole_package_failed()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                AppliedToRuntime = true,
+                RuntimeFaults = new[] { "runtime apply: one definition failed" }
+            });
+
+            Assert.Equal("Partially applied", status.Label);
+            Assert.Equal("Mods Needing Attention", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_reports_disabled_package_separately()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                Disabled = true,
+                DisabledReason = "disabled in the active profile"
+            });
+
+            Assert.Equal("Disabled", status.Label);
+            Assert.Equal("disabled in the active profile", status.Detail);
+            Assert.Equal("Disabled Mods", status.ListGroup);
+        }
     }
 }

--- a/FUSE.Tests/Loading/FuseAssetLoaderDefinitionOverrideTests.cs
+++ b/FUSE.Tests/Loading/FuseAssetLoaderDefinitionOverrideTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.IO;
+using System.Linq;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseAssetLoaderDefinitionOverrideTests : IDisposable
+    {
+        private readonly string _root;
+
+        public FuseAssetLoaderDefinitionOverrideTests()
+        {
+            _root = Path.Combine(
+                Path.GetTempPath(),
+                "FuseAssetLoaderDefinitionOverrideTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(_root))
+                {
+                    Directory.Delete(_root, recursive: true);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Best-effort temporary fixture cleanup.
+                System.Diagnostics.Debug.WriteLine(ex);
+            }
+        }
+
+        [Fact]
+        public void Implicit_discovery_matches_AssetLoader_immediate_child_convention()
+        {
+            var package = CreatePackage("RollingStock", "RollingStock.Mod", null);
+            var definitionsOnly = CreateDefinitions(package, @"fm-flatcar03\Definitions.json");
+            var catalogChild = CreateDefinitions(package, @"catalog-store\Definitions.json");
+            File.WriteAllText(Path.Combine(Path.GetDirectoryName(catalogChild), "Catalog.json"), "{}");
+            CreateDefinitions(package, @"nested\ignored-store\Definitions.json");
+
+            var candidates = FuseAssetPackRegistry.DiscoverDefinitionOverrideCandidatesForPackage(
+                package,
+                out var issues);
+
+            var candidate = Assert.Single(candidates);
+            Assert.Equal("fm-flatcar03", candidate.StoreIdentifier);
+            Assert.Equal(Path.GetFullPath(definitionsOnly), candidate.DefinitionsPath);
+            Assert.False(candidate.Explicit);
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Explicit_manifest_entry_supports_nested_definition_file_and_target()
+        {
+            const string info = @"{
+  ""Id"": ""Native.Override.Mod"",
+  ""FuseDefinitionOverrides"": [
+    {
+      ""StoreIdentifier"": ""ne-caboose03"",
+      ""Path"": ""overrides/caboose/Definitions.json""
+    }
+  ]
+}";
+            var package = CreatePackage("NativeOverride", "Native.Override.Mod", info);
+            var definitions = CreateDefinitions(package, @"overrides\caboose\Definitions.json");
+
+            var candidates = FuseAssetPackRegistry.DiscoverDefinitionOverrideCandidatesForPackage(
+                package,
+                out var issues);
+
+            var candidate = Assert.Single(candidates);
+            Assert.Equal("ne-caboose03", candidate.StoreIdentifier);
+            Assert.Equal(Path.GetFullPath(definitions), candidate.DefinitionsPath);
+            Assert.True(candidate.Explicit);
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Explicit_manifest_entry_cannot_escape_package_folder()
+        {
+            const string info = @"{
+  ""Id"": ""Unsafe.Override.Mod"",
+  ""FuseDefinitionOverrides"": {
+    ""StoreIdentifier"": ""shared"",
+    ""Path"": ""../outside/Definitions.json""
+  }
+}";
+            var package = CreatePackage("UnsafeOverride", "Unsafe.Override.Mod", info);
+
+            var candidates = FuseAssetPackRegistry.DiscoverDefinitionOverrideCandidatesForPackage(
+                package,
+                out var issues);
+
+            Assert.Empty(candidates);
+            Assert.Contains(issues, issue => issue.Contains("escapes the package folder"));
+        }
+
+        [Fact]
+        public void Explicit_candidate_wins_duplicate_target_deterministically()
+        {
+            var legacy = new FuseLegacyDefinitionOverrideRegistration
+            {
+                StoreIdentifier = "fm-flatcar03",
+                DefinitionsPath = @"C:\Mods\Legacy\fm-flatcar03\Definitions.json",
+                PackageId = "Legacy",
+                PackagePath = @"C:\Mods\Legacy",
+                Explicit = false
+            };
+            var explicitCandidate = new FuseLegacyDefinitionOverrideRegistration
+            {
+                StoreIdentifier = "fm-flatcar03",
+                DefinitionsPath = @"C:\Mods\Native\overrides\Definitions.json",
+                PackageId = "Native",
+                PackagePath = @"C:\Mods\Native",
+                Explicit = true
+            };
+
+            var winners = FuseAssetPackRegistry.SelectLegacyDefinitionOverrides(
+                new[] { legacy, explicitCandidate },
+                out var issues);
+
+            Assert.Same(explicitCandidate, winners["fm-flatcar03"]);
+            Assert.Single(issues);
+            Assert.Contains("selected", issues[0]);
+            Assert.Contains("ignored", issues[0]);
+        }
+
+        [Fact]
+        public void Target_store_identifiers_remain_case_sensitive_like_PrefabStore()
+        {
+            var upper = Candidate("Store", @"C:\Mods\A\Definitions.json", "A");
+            var lower = Candidate("store", @"C:\Mods\B\Definitions.json", "B");
+
+            var winners = FuseAssetPackRegistry.SelectLegacyDefinitionOverrides(
+                new[] { upper, lower },
+                out var issues);
+
+            Assert.Equal(2, winners.Count);
+            Assert.Empty(issues);
+        }
+
+        private string CreatePackage(string folderName, string id, string infoText)
+        {
+            var package = Path.Combine(_root, folderName);
+            Directory.CreateDirectory(package);
+            File.WriteAllText(
+                Path.Combine(package, "Info.json"),
+                infoText ?? "{\"Id\":\"" + id + "\"}");
+            return package;
+        }
+
+        private static string CreateDefinitions(string package, string relativePath)
+        {
+            var path = Path.Combine(package, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllText(path, "{\"objects\":[]}");
+            return path;
+        }
+
+        private static FuseLegacyDefinitionOverrideRegistration Candidate(
+            string storeIdentifier,
+            string definitionsPath,
+            string packageId)
+        {
+            return new FuseLegacyDefinitionOverrideRegistration
+            {
+                StoreIdentifier = storeIdentifier,
+                DefinitionsPath = definitionsPath,
+                PackageId = packageId,
+                PackagePath = Path.GetDirectoryName(definitionsPath),
+                Explicit = false
+            };
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseAssetPackDiscoveryOrderTests.cs
+++ b/FUSE.Tests/Loading/FuseAssetPackDiscoveryOrderTests.cs
@@ -74,6 +74,15 @@ namespace FUSE.Tests.Loading
             return full;
         }
 
+        private string CreateCatalogOnlyPackFolder(string relative)
+        {
+            var full = Path.Combine(_modsRoot, relative);
+            Directory.CreateDirectory(full);
+            File.WriteAllText(Path.Combine(full, "Catalog.json"), "{}");
+            File.WriteAllText(Path.Combine(full, "Definitions.json"), "{}");
+            return full;
+        }
+
         [Fact]
         public void Discovery_yields_root_packs_before_SCAssetPacks_packs()
         {
@@ -137,6 +146,24 @@ namespace FUSE.Tests.Loading
         }
 
         [Fact]
+        public void Discovery_yields_package_root_catalog_store_before_child_stores()
+        {
+            var modFolder = Path.Combine(_modsRoot, "RootCatalogMod");
+            Directory.CreateDirectory(modFolder);
+            File.WriteAllText(Path.Combine(modFolder, "Catalog.json"), "{}");
+            File.WriteAllText(Path.Combine(modFolder, "Definitions.json"), "{}");
+            var child = CreatePackFolder(@"RootCatalogMod\child-store");
+
+            var folders = FuseAssetPackRegistry
+                .EnumerateFallbackAssetPackFolders(modFolder)
+                .Select(Path.GetFullPath)
+                .ToArray();
+
+            Assert.Equal(Path.GetFullPath(modFolder), folders[0]);
+            Assert.Contains(Path.GetFullPath(child), folders);
+        }
+
+        [Fact]
         public void Discovery_yields_model_only_packs_without_definitions()
         {
             var modFolder = Path.Combine(_modsRoot, "WhistleModels");
@@ -150,6 +177,23 @@ namespace FUSE.Tests.Loading
                 .ToArray();
 
             Assert.Contains(Path.GetFullPath(modelPack), folders);
+        }
+
+        [Fact]
+        public void Discovery_yields_catalog_stores_without_a_local_bundle()
+        {
+            var modFolder = Path.Combine(_modsRoot, "DefinitionsOnlyCatalogMod");
+            Directory.CreateDirectory(modFolder);
+
+            var catalogStore = CreateCatalogOnlyPackFolder(
+                @"DefinitionsOnlyCatalogMod\player-coal-load");
+
+            var folders = FuseAssetPackRegistry
+                .EnumerateFallbackAssetPackFolders(modFolder)
+                .Select(Path.GetFullPath)
+                .ToArray();
+
+            Assert.Contains(Path.GetFullPath(catalogStore), folders);
         }
 
         [Fact]

--- a/FUSE.Tests/Loading/FuseDeclaredPackageRelationshipTests.cs
+++ b/FUSE.Tests/Loading/FuseDeclaredPackageRelationshipTests.cs
@@ -1,0 +1,81 @@
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseDeclaredPackageRelationshipTests
+    {
+        [Fact]
+        public void Requires_marks_later_override_as_expected_when_resolved_order_agrees()
+        {
+            var existing = Snapshot(1, "Katers.SylvaInterchange.FUSE");
+            var later = Snapshot(2, "Katers.SylvaInterchangeHYSpans.FUSE");
+            later.RequiredPackageIds = new[] { "Katers.SylvaInterchange" };
+
+            Assert.True(FuseDeclaredPackageRelationship.IsExpectedLaterOverride(existing, later));
+        }
+
+        [Fact]
+        public void LoadAfter_object_id_alias_marks_later_override_as_expected()
+        {
+            var existing = Snapshot(3, "Katers.SylvaInterchange.FUSE");
+            var later = Snapshot(4, "Katers.SylvaInterchangeHYSpans.FUSE");
+            later.LoadAfter = new[] { "Katers.SylvaInterchange.FUSE" };
+
+            Assert.True(FuseDeclaredPackageRelationship.IsExpectedLaterOverride(existing, later));
+        }
+
+        [Fact]
+        public void LoadBefore_on_base_marks_later_override_as_expected()
+        {
+            var existing = Snapshot(1, "base.route");
+            var later = Snapshot(2, "extension.route");
+            existing.LoadBefore = new[] { "extension.route" };
+
+            Assert.True(FuseDeclaredPackageRelationship.IsExpectedLaterOverride(existing, later));
+        }
+
+        [Fact]
+        public void Conditional_mixinto_requirement_marks_later_override_as_expected()
+        {
+            var existing = Snapshot(1, "base.route");
+            var later = Snapshot(2, "extension.route");
+            var definition = new FuseModDefinition
+            {
+                Mixinto = new FuseMixintoDefinition
+                {
+                    Requires = new[] { new FuseModRequirement { Id = "base.route" } }
+                }
+            };
+
+            Assert.True(FuseDeclaredPackageRelationship.IsExpectedLaterOverride(
+                existing,
+                later,
+                laterDefinition: definition));
+        }
+
+        [Fact]
+        public void Declaration_does_not_hide_conflict_when_resolved_order_contradicts_it()
+        {
+            var existing = Snapshot(4, "base.route");
+            var later = Snapshot(2, "extension.route");
+            later.LoadAfter = new[] { "base.route" };
+
+            Assert.False(FuseDeclaredPackageRelationship.IsExpectedLaterOverride(existing, later));
+        }
+
+        [Fact]
+        public void Unrelated_packages_remain_conflicts()
+        {
+            Assert.False(FuseDeclaredPackageRelationship.IsExpectedLaterOverride(
+                Snapshot(1, "yard-a"),
+                Snapshot(2, "yard-b")));
+        }
+
+        private static FusePackageManifestSnapshot Snapshot(int order, string id)
+        {
+            return new FusePackageManifestSnapshot { Order = order, Id = id };
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseDefinitionFileDiscoveryTests.cs
+++ b/FUSE.Tests/Loading/FuseDefinitionFileDiscoveryTests.cs
@@ -115,5 +115,17 @@ namespace FUSE.Tests.Loading
 
             Assert.Empty(FuseDataPackageDiscovery.DiscoverPackageFolders(_root));
         }
+
+        [Fact]
+        public void NativePackageWithMalformedInfo_IsStillDiscoveredForFaultReporting()
+        {
+            var folder = CreateModFolder("BrokenNativePackage");
+            File.WriteAllText(Path.Combine(folder, "Info.json"), "{ \"Id\": \"BrokenNativePackage\", ");
+            File.WriteAllText(Path.Combine(folder, "track.fuse.json"), "{}");
+
+            var discovered = FuseDataPackageDiscovery.DiscoverPackageFolders(_root);
+
+            Assert.Equal(new[] { folder }, discovered);
+        }
     }
 }

--- a/FUSE.Tests/Loading/FuseFeatureRuleEvaluatorTests.cs
+++ b/FUSE.Tests/Loading/FuseFeatureRuleEvaluatorTests.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseFeatureRuleEvaluatorTests
+    {
+        [Fact]
+        public void FalseBooleanRule_RemovesEveryNamedTargetAndKeepsUntargetedObjects()
+        {
+            var definition = DefinitionWithOptionalObjects();
+
+            var result = FuseFeatureRuleEvaluator.Apply(
+                definition,
+                (_, __) => new JValue(false));
+
+            Assert.Equal(1, result.DisabledRuleCount);
+            Assert.Equal(4, result.RemovedObjectCount);
+            Assert.DoesNotContain("optional-node", definition.Tracks.Nodes.Keys);
+            Assert.DoesNotContain("optional-segment", definition.Tracks.Segments.Keys);
+            Assert.DoesNotContain("optional-scenery", definition.World.Scenery.Keys);
+            Assert.DoesNotContain("optional-component", definition.Operations.Industries["yard"].Components.Keys);
+            Assert.Contains("always-scenery", definition.World.Scenery.Keys);
+        }
+
+        [Fact]
+        public void TrueBooleanRule_KeepsTargets()
+        {
+            var definition = DefinitionWithOptionalObjects();
+
+            var result = FuseFeatureRuleEvaluator.Apply(
+                definition,
+                (_, __) => new JValue(true));
+
+            Assert.Equal(1, result.EnabledRuleCount);
+            Assert.Equal(0, result.RemovedObjectCount);
+            Assert.Contains("optional-node", definition.Tracks.Nodes.Keys);
+            Assert.Contains("optional-scenery", definition.World.Scenery.Keys);
+        }
+
+        [Theory]
+        [InlineData("high", "equals", "high", true)]
+        [InlineData("low", "notEquals", "high", true)]
+        [InlineData(4, "greaterThanOrEqual", 4, true)]
+        [InlineData(3, "lessThan", 4, true)]
+        [InlineData(5, "lessThanOrEqual", 4, false)]
+        public void Matches_SupportsChoiceAndNumericOperators(object current, string operation, object expected, bool matches)
+        {
+            Assert.Equal(matches, FuseFeatureRuleEvaluator.Matches(JToken.FromObject(current), operation, JToken.FromObject(expected)));
+        }
+
+        [Fact]
+        public void MultipleFalseRules_TargetingSameObject_CountRemovalOnce()
+        {
+            var definition = DefinitionWithOptionalObjects();
+            definition.FeatureRules["second"] = new FuseFeatureRule
+            {
+                Setting = "enabled",
+                Value = new JValue(true),
+                Targets = new FuseFeatureTargets { Scenery = new[] { "optional-scenery" } }
+            };
+
+            var result = FuseFeatureRuleEvaluator.Apply(
+                definition,
+                (_, __) => new JValue(false));
+
+            Assert.Equal(2, result.DisabledRuleCount);
+            Assert.Equal(4, result.RemovedObjectCount);
+        }
+
+        private static FuseModDefinition DefinitionWithOptionalObjects()
+        {
+            var definition = new FuseModDefinition
+            {
+                Id = "feature-test",
+                Name = "Feature Test"
+            };
+            definition.Settings["enabled"] = new FuseModSettingDefinition
+            {
+                Type = "bool",
+                Default = new JValue(true),
+                ReloadRequired = true
+            };
+            definition.Tracks.Nodes["optional-node"] = new FuseNode();
+            definition.Tracks.Segments["optional-segment"] = new FuseSegment();
+            definition.World.Scenery["optional-scenery"] = new FuseScenery();
+            definition.World.Scenery["always-scenery"] = new FuseScenery();
+            definition.Operations.Industries["yard"] = new FuseIndustry
+            {
+                Components = new Dictionary<string, FuseIndustryComponent>
+                {
+                    ["optional-component"] = new FuseIndustryComponent()
+                }
+            };
+            definition.FeatureRules["optional"] = new FuseFeatureRule
+            {
+                Setting = "enabled",
+                Value = new JValue(true),
+                Targets = new FuseFeatureTargets
+                {
+                    TrackNodes = new[] { "optional-node" },
+                    TrackSegments = new[] { "optional-segment" },
+                    Scenery = new[] { "optional-scenery" },
+                    IndustryComponents = new[] { "yard/optional-component" }
+                }
+            };
+            return definition;
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseIndustryComponentOwnershipTests.cs
+++ b/FUSE.Tests/Loading/FuseIndustryComponentOwnershipTests.cs
@@ -1,0 +1,53 @@
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseIndustryComponentOwnershipTests
+    {
+        [Fact]
+        public void ClaimId_MatchesEquivalentDestinationsAcrossDifferentIndustryIds()
+        {
+            var first = new FuseIndustryComponent
+            {
+                Type = "consumer",
+                Name = "Whittier Saw Mill MP1",
+                TrackSpanIds = new[] { "R3", "R2" }
+            };
+            var second = new FuseIndustryComponent
+            {
+                Type = "consumer",
+                Name = "Whittier Saw Mill MP1",
+                TrackSpanPatch = new FuseStringListPatch
+                {
+                    Replace = new[] { "r2", "r3" }
+                }
+            };
+
+            var firstId = FuseModLoader.BuildIndustryComponentClaimId(
+                "bjorn-sawmill",
+                "mp1",
+                first);
+            var secondId = FuseModLoader.BuildIndustryComponentClaimId(
+                "appy-sawmill",
+                "main-product-one",
+                second);
+
+            Assert.Equal(firstId, secondId, ignoreCase: true);
+            Assert.Contains("Whittier Saw Mill MP1", firstId);
+            Assert.Contains("spans=R2,R3", firstId);
+        }
+
+        [Fact]
+        public void ClaimId_FallsBackToExactComponentForPartialPatchWithoutSemanticData()
+        {
+            var id = FuseModLoader.BuildIndustryComponentClaimId(
+                "sylva-paperboard",
+                "R2-R3",
+                new FuseIndustryComponent { Partial = true });
+
+            Assert.Equal("component:sylva-paperboard.R2-R3", id);
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseLegacyAssemblyOrderingTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyAssemblyOrderingTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using FUSE.Loading;
+using Railloader;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseLegacyAssemblyOrderingTests
+    {
+        [Fact]
+        public void LoadAfter_orders_hosted_plugin_after_referenced_package()
+        {
+            var extension = Manifest("Extension.Mod", "A-Extension");
+            extension.LoadAfter = new[] { new ModReference { Id = "Base.Mod" } };
+            var @base = Manifest("Base.Mod", "Z-Base");
+
+            var ordered = FuseLegacyAssemblyHost.OrderLegacyManifestsForHosting(new[] { extension, @base });
+
+            Assert.Equal(new[] { "Base.Mod", "Extension.Mod" }, ordered.Select(item => item.Id));
+        }
+
+        [Fact]
+        public void LoadBefore_orders_hosted_plugin_before_referenced_package_alias()
+        {
+            var extension = Manifest("Extension.Mod.FUSE", "A-Extension");
+            var @base = Manifest("Base.Mod", "Z-Base");
+            @base.LoadBefore = new[] { "Extension.Mod" };
+
+            var ordered = FuseLegacyAssemblyHost.OrderLegacyManifestsForHosting(new[] { extension, @base });
+
+            Assert.Equal(new[] { "Base.Mod", "Extension.Mod.FUSE" }, ordered.Select(item => item.Id));
+        }
+
+        [Fact]
+        public void Required_reference_also_orders_dependency_before_hosted_plugin()
+        {
+            var extension = Manifest("Extension.Mod", "A-Extension");
+            extension.RequiredReferences = new[] { new ModReference { Id = "Base.Mod" } };
+            var @base = Manifest("Base.Mod", "Z-Base");
+
+            var ordered = FuseLegacyAssemblyHost.OrderLegacyManifestsForHosting(new[] { extension, @base });
+
+            Assert.Equal(new[] { "Base.Mod", "Extension.Mod" }, ordered.Select(item => item.Id));
+        }
+
+        [Fact]
+        public void Missing_advisory_reference_does_not_drop_package()
+        {
+            var package = Manifest("Only.Mod", "Only");
+            package.LoadAfter = new[] { new ModReference { Id = "Not.Installed" } };
+
+            Assert.Same(package, Assert.Single(FuseLegacyAssemblyHost.OrderLegacyManifestsForHosting(new[] { package })));
+        }
+
+        [Fact]
+        public void Load_order_cycle_keeps_every_package_in_deterministic_folder_order()
+        {
+            var first = Manifest("First.Mod", "A-First");
+            var second = Manifest("Second.Mod", "B-Second");
+            first.LoadAfter = new[] { new ModReference { Id = second.Id } };
+            second.LoadAfter = new[] { new ModReference { Id = first.Id } };
+
+            var ordered = FuseLegacyAssemblyHost.OrderLegacyManifestsForHosting(new[] { second, first });
+
+            Assert.Equal(new[] { "First.Mod", "Second.Mod" }, ordered.Select(item => item.Id));
+        }
+
+        private static FuseLegacyAssemblyManifest Manifest(string id, string folder)
+        {
+            return new FuseLegacyAssemblyManifest
+            {
+                Id = id,
+                Name = id,
+                Version = "1.0",
+                FolderPath = "C:\\Railroader\\Mods\\" + folder,
+                Assemblies = Array.Empty<string>()
+            };
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseLegacyCapabilityActivationTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyCapabilityActivationTests.cs
@@ -1,0 +1,47 @@
+using System;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseLegacyCapabilityActivationTests
+    {
+        [Fact]
+        public void BuildRequestedIds_includes_enabled_package_and_dependency_ids()
+        {
+            var requested = FuseLegacyCapabilityActivation.BuildRequestedIds(new[]
+            {
+                new FusePackageManifestSnapshot
+                {
+                    Id = "Consumer.FUSE",
+                    RequiredPackageIds = new[] { "Zamu.SomeKindOfMadness.FUSE" },
+                },
+            });
+
+            Assert.Contains("Consumer", requested);
+            Assert.Contains("Zamu.SomeKindOfMadness", requested);
+        }
+
+        [Fact]
+        public void BuildRequestedIds_excludes_disabled_packages_and_their_dependencies()
+        {
+            var requested = FuseLegacyCapabilityActivation.BuildRequestedIds(new[]
+            {
+                new FusePackageManifestSnapshot
+                {
+                    Id = "Disabled.Consumer",
+                    Disabled = true,
+                    RequiredPackageIds = new[] { "Zamu.AbsoluteMadness" },
+                },
+            });
+
+            Assert.Empty(requested);
+        }
+
+        [Fact]
+        public void BuildRequestedIds_accepts_a_null_snapshot_sequence()
+        {
+            Assert.Empty(FuseLegacyCapabilityActivation.BuildRequestedIds(null));
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseLegacyEditorHelperSceneryTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyEditorHelperSceneryTests.cs
@@ -1,0 +1,76 @@
+using FUSE.Loading;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public class FuseLegacyEditorHelperSceneryTests
+    {
+        [Theory]
+        [InlineData("TurntableMeasurementTool", true)]
+        [InlineData("scenery://TurntableMeasurementTool", true)]
+        [InlineData("SCENERY://turntablemeasurementtool", true)]
+        [InlineData("30m Turntable", false)]
+        [InlineData("TurntableMeasurementTool Shed", false)]
+        [InlineData(null, false)]
+        public void EditorHelperDetection_IsExact(string assetIdentifier, bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseLegacyDataConverter.IsLegacyEditorOnlySceneryAsset(assetIdentifier));
+        }
+
+        [Fact]
+        public void StrykerBrysonMeasurementOverlay_IsNotMaterializedBesideRealTurntable()
+        {
+            var source = new JObject
+            {
+                ["scenery"] = new JObject
+                {
+                    ["TTPlaceholder"] = new JObject
+                    {
+                        ["modelIdentifier"] = "TurntableMeasurementTool",
+                        ["position"] = new JObject
+                        {
+                            ["x"] = 4278.08,
+                            ["y"] = 529.0,
+                            ["z"] = 5371.88
+                        }
+                    },
+                    ["RealBuilding"] = new JObject
+                    {
+                        ["modelIdentifier"] = "ALWHouses_CabooseHouse"
+                    }
+                },
+                ["splineys"] = new JObject
+                {
+                    ["Bryson_new_TT"] = new JObject
+                    {
+                        ["handler"] = "AlinasMapMod.Turntable.TurntableBuilder",
+                        ["position"] = new JObject
+                        {
+                            ["x"] = 4278.08,
+                            ["y"] = 529.0,
+                            ["z"] = 5371.88
+                        },
+                        ["rotation"] = new JObject { ["y"] = 2.5 }
+                    }
+                }
+            };
+            var manifest = new FuseLegacyPackageManifest
+            {
+                PackageId = "StrykerBryson.FUSE",
+                DisplayName = "Stryker's Bryson",
+                Version = "1.1"
+            };
+            var root = FuseLegacyDataConverter.CreateSkeleton(manifest, "brysonttplaceholder");
+
+            FuseLegacyDataConverter.ConvertSource(source, root, manifest);
+
+            var scenery = (JObject)root["world"]["scenery"];
+            Assert.Null(scenery["TTPlaceholder"]);
+            Assert.NotNull(scenery["RealBuilding"]);
+            Assert.NotNull(root["operations"]["turntables"]["Bryson_new_TT"]);
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs
@@ -42,6 +42,135 @@ namespace FUSE.Tests.Loading
         public class TopLevelPartialPatch
         {
             [Fact]
+            public void AreaUsedOnlyAsIndustryNamespace_DoesNotEmitBaseAreaMutation()
+            {
+                // ARC Whittier and KWIX use areas.whittier only to reach the
+                // industry dictionary. It must not become an area definition at
+                // position zero, which moves the base Whittier operations root.
+                var source = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["whittier"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["whittier-sawmill"] = new JObject
+                                {
+                                    ["components"] = new JObject
+                                    {
+                                        ["logs"] = new JObject
+                                        {
+                                            ["trackSpans"] = new JObject
+                                            {
+                                                ["$replace"] = new JArray("R1", "R2", "R3")
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+
+                Assert.Null(root["tracks"]?["areas"]?["whittier"]);
+                Assert.Equal("whittier", (string)industries["whittier-sawmill"]?["areaId"]);
+                Assert.Equal(
+                    new[] { "R1", "R2", "R3" },
+                    industries["whittier-sawmill"]?["components"]?["logs"]?
+                        ["trackSpanPatch"]?["replace"]?.Values<string>());
+            }
+
+            [Fact]
+            public void ExplicitAreaMetadata_StillEmitsAreaWithoutInventingMissingFields()
+            {
+                var source = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["new-yard"] = new JObject
+                        {
+                            ["position"] = new JObject
+                            {
+                                ["x"] = 12f,
+                                ["y"] = 3f,
+                                ["z"] = -8f
+                            },
+                            ["radius"] = 250f
+                        }
+                    }
+                };
+
+                var (root, _) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var area = root["tracks"]?["areas"]?["new-yard"];
+
+                Assert.NotNull(area);
+                Assert.False(((JObject)area).TryGetValue("name", out _), area.ToString());
+                Assert.Equal(12f, area["position"].Value<float>("x"));
+                Assert.Equal(250f, area.Value<float>("radius"));
+            }
+
+            [Fact]
+            public void RootLevelSpansAndAreas_ConvertTogether_ForKwixStyleFragments()
+            {
+                // Regression for issue #210. KWIX keeps each industry's spans at
+                // the document root beside the area/industry patch. Dropping the
+                // root-level spans leaves a valid-looking loader whose runtime
+                // TrackSpans array is empty, which later breaks EOD processing.
+                var source = new JObject
+                {
+                    ["spans"] = new JObject
+                    {
+                        ["KWIX_Bottling_GB-A"] = new JObject
+                        {
+                            ["upper"] = new JObject
+                            {
+                                ["segmentId"] = "SKWIX_IND_vm6e",
+                                ["distance"] = 0,
+                                ["end"] = "Start"
+                            },
+                            ["lower"] = new JObject
+                            {
+                                ["segmentId"] = "SKWIX_IND_vm6e",
+                                ["distance"] = 0,
+                                ["end"] = "End"
+                            }
+                        }
+                    },
+                    ["areas"] = new JObject
+                    {
+                        ["whittier"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["kwix-bottling"] = new JObject
+                                {
+                                    ["components"] = new JObject
+                                    {
+                                        ["kwix-bottling_GB-A"] = new JObject
+                                        {
+                                            ["type"] = "Model.Ops.IndustryLoader",
+                                            ["trackSpans"] = new JArray("KWIX_Bottling_GB-A"),
+                                            ["loadId"] = "glass-bottles"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+
+                Assert.NotNull(root["tracks"]?["spans"]?["KWIX_Bottling_GB-A"]);
+                Assert.Equal(
+                    "KWIX_Bottling_GB-A",
+                    (string)industries["kwix-bottling"]?["components"]?["kwix-bottling_GB-A"]?["trackSpanIds"]?[0]);
+            }
+
+            [Fact]
             public void NoAreaIdNoPositionNoRotation_ConverterOmitsTransformDirectives()
             {
                 var source = new JObject
@@ -332,6 +461,162 @@ namespace FUSE.Tests.Loading
 
         public class ReplaceDirectives
         {
+            [Fact]
+            public void Dw5WhittierSawmill_MultipleAdds_PreserveBaseUnloaderAndAllAddedTracks()
+            {
+                // Issue #236's DW5 Whittier Saw Mill package patches the existing
+                // `logs` unloader with three one-value $add instructions. Treating
+                // this array as a replacement leaves only one unloading area.
+                var patch = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["whittier"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["whittier-sawmill"] = new JObject
+                                {
+                                    ["components"] = new JObject
+                                    {
+                                        ["logs"] = new JObject
+                                        {
+                                            ["name"] = "Whittier Saw Mill R1/R2/R3",
+                                            ["trackSpans"] = new JArray(
+                                                new JObject { ["$add"] = "R2" },
+                                                new JObject { ["$add"] = "R3" },
+                                                new JObject { ["$add"] = "R4" }),
+                                            ["maxStorage"] = 220.0
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+                var state = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["whittier"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["whittier-sawmill"] = new JObject
+                                {
+                                    ["components"] = new JObject
+                                    {
+                                        ["logs"] = new JObject
+                                        {
+                                            ["type"] = "Model.Ops.IndustryUnloader",
+                                            ["trackSpans"] = new JArray("R1"),
+                                            ["loadId"] = "logs"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                FuseLegacyJsonPatch.Apply(state, patch, "DW5SawMill.json");
+                var expandedSlice = FuseLegacyGameGraphCompatibility.BuildPatchSlice(state, patch);
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(expandedSlice);
+                var converted = industries["whittier-sawmill"]?["components"]?["logs"];
+
+                Assert.True(converted.Value<bool>("partial"));
+                Assert.Null(converted["type"]);
+                Assert.Equal(
+                    new[] { "R2", "R3", "R4" },
+                    converted["trackSpanPatch"]?["append"]?.Values<string>());
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                var component = definition.Operations.Industries["whittier-sawmill"].Components["logs"];
+                Assert.True(component.Partial);
+                Assert.Equal(new[] { "R2", "R3", "R4" }, component.TrackSpanPatch.Append);
+                Assert.Null(component.TrackSpanPatch.Replace);
+            }
+
+            [Fact]
+            public void SylvaIndustriesBoosted_ArrayWrappedAdd_PreservesBaseSpanAndAddsR3()
+            {
+                // Sylva Industries Boosted 0.9 uses the Strange Customs form
+                //   "trackSpans": [ { "$add": "Piei" } ]
+                // for both lime and salt. This is a patch program: retain the
+                // vanilla P3z2 span (R2) and append the re-authored Piei span
+                // (R3). Flattening it to a one-item replacement makes only one
+                // track highlight and prevents cars on the other track from
+                // being accepted at EOD.
+                var patch = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["sylva"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["sylva-paperboard"] = new JObject
+                                {
+                                    ["components"] = new JObject
+                                    {
+                                        ["lime"] = new JObject
+                                        {
+                                            ["type"] = "Model.Ops.IndustryUnloader",
+                                            ["name"] = "Sylva Paperboard R2 & R3",
+                                            ["trackSpans"] = new JArray(
+                                                new JObject { ["$add"] = "Piei" }),
+                                            ["loadId"] = "lime"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+                var state = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["sylva"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["sylva-paperboard"] = new JObject
+                                {
+                                    ["components"] = new JObject
+                                    {
+                                        ["lime"] = new JObject
+                                        {
+                                            ["type"] = "Model.Ops.IndustryUnloader",
+                                            ["trackSpans"] = new JArray("P3z2"),
+                                            ["loadId"] = "lime"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                FuseLegacyJsonPatch.Apply(state, patch, "SylvaIndustriesBoosted.json");
+                var expandedSlice = FuseLegacyGameGraphCompatibility.BuildPatchSlice(state, patch);
+                var preservedDirective = expandedSlice["areas"]?["sylva"]?["industries"]?
+                    ["sylva-paperboard"]?["components"]?["lime"]?["trackSpans"]?[0];
+                Assert.Equal("Piei", (string)preservedDirective?["$add"]);
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(expandedSlice);
+                var converted = industries["sylva-paperboard"]?["components"]?["lime"];
+                Assert.True(converted.Value<bool>("partial"));
+                Assert.Null(converted["type"]);
+                Assert.Equal(new[] { "Piei" }, converted["trackSpanPatch"]?["append"]?.Values<string>());
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                var component = definition.Operations.Industries["sylva-paperboard"].Components["lime"];
+                Assert.True(component.Partial);
+                Assert.Equal(new[] { "Piei" }, component.TrackSpanPatch.Append);
+                Assert.Null(component.TrackSpanPatch.Replace);
+            }
+
             [Fact]
             public void TrackSpanReplace_RoundTripsAsReplacementPatch()
             {

--- a/FUSE.Tests/Loading/FuseLegacyManifestSourceDetectionTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyManifestSourceDetectionTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using FUSE.Loading;
+using FUSE.Authoring.Data;
 using Xunit;
 
 namespace FUSE.Tests.Loading
@@ -64,6 +65,60 @@ namespace FUSE.Tests.Loading
             var found = FuseLegacyDataConverter.TryReadLegacyManifest(folder, out _);
 
             Assert.False(found);
+        }
+
+        [Fact]
+        public void ConditionalMixintoRequirement_IsAdvisoryLoadAfter_NotHardRequirement()
+        {
+            var folder = Path.Combine(_root, "Conditional.Mixinto");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(
+                Path.Combine(folder, "Definition.json"),
+                "{\"id\":\"Conditional.Mixinto\",\"mixintos\":{\"game-graph\":{" +
+                "\"mixinto\":\"file(optional.json)\",\"requires\":[\"Optional.Base\"]}}}");
+            File.WriteAllText(
+                Path.Combine(folder, "optional.json"),
+                "{\"nodes\":{\"N1\":{\"position\":{\"x\":1,\"y\":2,\"z\":3}}}}");
+
+            var found = FuseLegacyDataConverter.TryReadLegacyManifest(folder, out var manifest);
+
+            Assert.True(found);
+            Assert.Empty(manifest.RequiredPackageIds);
+            Assert.Contains("Optional.Base.FUSE", manifest.LoadAfter);
+        }
+
+        [Fact]
+        public void LegacyConflictsWith_PreservesVersionBounds()
+        {
+            var folder = Path.Combine(_root, "Legacy.Conflict");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(
+                Path.Combine(folder, "Definition.json"),
+                "{\"id\":\"Legacy.Conflict\",\"conflictsWith\":[{" +
+                "\"id\":\"Other.Route\",\"notBefore\":\"2.0\",\"notAfter\":\"3.0\"}]}");
+            File.WriteAllText(
+                Path.Combine(folder, "game-graph.json"),
+                "{\"nodes\":{\"N1\":{\"position\":{\"x\":1,\"y\":2,\"z\":3}}}}");
+
+            Assert.True(FuseLegacyDataConverter.TryReadLegacyManifest(folder, out var manifest));
+
+            var conflict = Assert.Single(manifest.ConflictsWith);
+            Assert.Equal("Other.Route", conflict.Id);
+            Assert.Equal("2.0", conflict.NotBefore);
+            Assert.Equal("3.0", conflict.NotAfter);
+        }
+
+        [Fact]
+        public void SyntheticMapTileDefinition_IsNotTreatedAsGameGraphPatch()
+        {
+            var definition = new FuseModDefinition
+            {
+                Id = "Legacy.MapTiles",
+                Tags = new[] { "legacy-converted" }
+            };
+            var loaded = new FuseLoadedMod(_root, "legacy://map-tiles", definition);
+
+            Assert.False(FuseLegacyGameGraphCompatibility.ShouldExpand(loaded));
         }
 
         private string CreatePackage(string id, string graphJson)

--- a/FUSE.Tests/Loading/FuseLoadReportModExceptionsTests.cs
+++ b/FUSE.Tests/Loading/FuseLoadReportModExceptionsTests.cs
@@ -12,10 +12,9 @@ namespace FUSE.Tests.Loading
 {
     /// <summary>
     /// Pins the report surfaces for the third-party exception registry: the
-    /// summary's <c>modErrors</c> segment sits between <c>orphans</c> and the
-    /// <c>/fuse.report</c> suffix, the details section names each mod, the
-    /// JSON block rides beside <c>runtimeGuards</c>, and HasProblems only
-    /// flips for repeated faults (episodes >= 3 or count >= 10 per mod).
+    /// exception counts stay out of the readiness summary while the details
+    /// and structured JSON retain the complete diagnostic evidence. Runtime
+    /// exception observations never change package readiness.
     /// Uses the internal Build*ForTests seams against a hand-built snapshot
     /// so no live capture registries are touched. The exception registry is
     /// static session-cumulative state shared with
@@ -77,11 +76,12 @@ namespace FUSE.Tests.Loading
         }
 
         [Fact]
-        public void Summary_CarriesModErrorsSegment_BetweenOrphansAndReportSuffix_EvenWhenIdle()
+        public void Summary_OmitsRuntimeExceptionNoise()
         {
             var summary = FuseLoadReport.BuildSummaryForTests(CreateEmptySnapshot());
 
-            Assert.Contains("orphans 0 | modErrors 0 | /fuse.report", summary);
+            Assert.Contains("orphans 0 | /fuse.report", summary);
+            Assert.DoesNotContain("modErrors", summary);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace FUSE.Tests.Loading
             var snapshot = CreateEmptySnapshot();
 
             var summary = FuseLoadReport.BuildSummaryForTests(snapshot);
-            Assert.Contains($"modErrors {FuseModExceptionRegistry.GrandTotal} | /fuse.report", summary);
+            Assert.DoesNotContain("modErrors", summary);
 
             var details = FuseLoadReport.BuildDetailsForTests(snapshot);
             Assert.Contains("Third-party mod exceptions observed this session:", details);
@@ -146,7 +146,7 @@ namespace FUSE.Tests.Loading
         }
 
         [Fact]
-        public void HasProblems_IgnoresOneOffException_ButTripsOnRepeats()
+        public void HasProblems_IgnoresOneOffAndRepeatingRuntimeExceptions()
         {
             RecordMapEnhancerStyleException();
             Assert.False(CreateEmptySnapshot().HasProblems);
@@ -158,7 +158,8 @@ namespace FUSE.Tests.Loading
                 RecordMapEnhancerStyleException();
             }
 
-            Assert.True(CreateEmptySnapshot().HasProblems);
+            Assert.False(CreateEmptySnapshot().HasProblems);
+            Assert.True(CreateEmptySnapshot().HasModExceptionProblem);
         }
 
         [Fact]
@@ -199,6 +200,91 @@ namespace FUSE.Tests.Loading
             var json = JObject.Parse(FuseLoadReport.BuildJsonForTests(snapshot));
             Assert.True((bool)json["hasProblems"]);
             Assert.Equal(1, (int)json["counts"]["blockingNotices"]);
+        }
+
+        [Fact]
+        public void PackageFaultLocation_RendersInHumanAndStructuredReports()
+        {
+            var snapshot = CreateEmptySnapshot();
+            snapshot.Faults = new[]
+            {
+                new FusePackageFault(
+                    "Broken.Track",
+                    "schema validation",
+                    "Segment is missing an endpoint.",
+                    "validator details",
+                    @"C:\Railroader\Mods\Broken.Track",
+                    @"C:\Railroader\Mods\Broken.Track\track.fuse.json",
+                    "track.segments.bad.a",
+                    42,
+                    17,
+                    "Add endpoint node a.")
+            };
+
+            var details = FuseLoadReport.BuildDetailsForTests(snapshot);
+            Assert.Contains(@"file: C:\Railroader\Mods\Broken.Track\track.fuse.json", details);
+            Assert.Contains("relative file: track.fuse.json", details);
+            Assert.Contains("JSON location: track.segments.bad.a line 42, position 17", details);
+            Assert.Contains("action: Add endpoint node a.", details);
+
+            var json = JObject.Parse(FuseLoadReport.BuildJsonForTests(snapshot));
+            var fault = (JObject)json["packages"]["faults"][0];
+            Assert.Equal(@"C:\Railroader\Mods\Broken.Track\track.fuse.json", (string)fault["sourceFile"]);
+            Assert.Equal("track.fuse.json", (string)fault["relativeSourceFile"]);
+            Assert.Equal("Broken.Track", (string)fault["packageName"]);
+            Assert.Equal("track.segments.bad.a", (string)fault["jsonPath"]);
+            Assert.Equal(42, (int)fault["lineNumber"]);
+            Assert.Equal("validator details", (string)fault["details"]);
+        }
+
+        [Fact]
+        public void Shared_extension_merge_does_not_inflate_conflicts_or_health()
+        {
+            var snapshot = CreateEmptySnapshot();
+            snapshot.Conflicts = new[]
+            {
+                new FuseRegistryConflict
+                {
+                    Kind = FuseClaimKind.Industry,
+                    Id = "destination:type=teleportLoading,name=Kirkland Valley Coal",
+                    OwnerPackageId = "CF.AndrewsCoalPower.FUSE.patch",
+                    AttemptedPackageId = "Katers.TuckasegeeSteelWorks.FUSE.kirklandcoal",
+                    Resolution = "shared industry destination overlap; definitions merged into the same runtime location"
+                }
+            };
+
+            Assert.Equal(0, snapshot.ActionableConflictCount);
+            Assert.Equal(1, snapshot.CooperativeConflictCount);
+            Assert.False(snapshot.HasProblems);
+
+            var details = FuseLoadReport.BuildDetailsForTests(snapshot);
+            Assert.Contains("Ownership conflicts requiring attention: 0", details);
+            Assert.Contains("shared extension targets merged successfully: 1", details);
+
+            var json = JObject.Parse(FuseLoadReport.BuildJsonForTests(snapshot));
+            Assert.Equal(0, (int)json["counts"]["conflicts"]);
+            Assert.Equal(1, (int)json["counts"]["sharedExtensionOverlaps"]);
+            Assert.Equal("shared-extension", (string)json["conflicts"][0]["classification"]);
+        }
+
+        [Fact]
+        public void Optional_mixinto_skips_are_reported_as_inactive_fragments()
+        {
+            var snapshot = CreateEmptySnapshot();
+            snapshot.AppliedPackageIds = new[] { "Author.Package.base" };
+            snapshot.SkippedPackages = new Dictionary<string, string>
+            {
+                ["Author.Package.optional"] = "mixinto dependency missing id='Optional.Companion'"
+            };
+
+            Assert.False(snapshot.HasProblems);
+            Assert.Empty(snapshot.ActionableSkippedPackages);
+            Assert.Single(snapshot.OptionalSkippedPackages);
+
+            var details = FuseLoadReport.BuildDetailsForTests(snapshot);
+            Assert.Contains("Runtime definitions: resident=0; applied=1; actionable skips=0; optional fragments inactive=1.", details);
+            Assert.Contains("Optional conditional fragments inactive:", details);
+            Assert.DoesNotContain("Skipped packages:", details);
         }
     }
 }

--- a/FUSE.Tests/Loading/FuseModRequirementResolverTests.cs
+++ b/FUSE.Tests/Loading/FuseModRequirementResolverTests.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using FUSE.Authoring.Data;
 using FUSE.Loading;
 using Xunit;
@@ -7,6 +10,212 @@ namespace FUSE.Tests.Loading
 {
     public class FuseModRequirementResolverTests
     {
+        [Fact]
+        public void MissingMixintoDependency_IdentifiesPackageFolderFileAndAction()
+        {
+            var dependencyId = "missing." + Guid.NewGuid().ToString("N");
+            var folder = Path.Combine(Path.GetTempPath(), "fuse-requirement-source");
+            var definitionPath = Path.Combine(folder, "track.fuse.json");
+            var loaded = new FuseLoadedMod(
+                folder,
+                definitionPath,
+                new FuseModDefinition
+                {
+                    Id = "author.sample",
+                    Mixinto = new FuseMixintoDefinition
+                    {
+                        Target = "railroader",
+                        Requires = new[] { new FuseModRequirement { Id = dependencyId } }
+                    }
+                });
+
+            var shouldApply = FuseModRequirementResolver.ShouldApply(loaded, out var reason);
+
+            Assert.False(shouldApply);
+            Assert.Contains("package='author.sample'", reason);
+            Assert.Contains($"id='{dependencyId}'", reason);
+            Assert.Contains($"folder='{folder}'", reason);
+            Assert.Contains($"sourceFile='{definitionPath}'", reason);
+            Assert.Contains("action='Install and enable", reason);
+        }
+
+        [Theory]
+        [InlineData("Zamu.StrangeCustoms", "99.0.0")]
+        [InlineData("AlinaNova21.AlinasMapMod", "99.0.0")]
+        [InlineData("AssetLoader", "99.0.0")]
+        public void Replacement_capability_satisfies_mixinto_requirement_without_legacy_version_comparison(
+            string dependencyId,
+            string legacyMinimumVersion)
+        {
+            var loaded = new FuseLoadedMod(
+                "C:\\Mods\\Extension",
+                "C:\\Mods\\Extension\\track.fuse.json",
+                new FuseModDefinition
+                {
+                    Id = "author.extension",
+                    Mixinto = new FuseMixintoDefinition
+                    {
+                        Target = "game-graph",
+                        Requires = new[]
+                        {
+                            new FuseModRequirement { Id = dependencyId, NotBefore = legacyMinimumVersion }
+                        }
+                    }
+                });
+
+            Assert.True(FuseModRequirementResolver.ShouldApply(loaded, out var reason));
+            Assert.Contains("requirements satisfied", reason);
+        }
+
+        [Fact]
+        public void Mixinto_conflictsWith_replacement_capability_skips_only_the_fragment()
+        {
+            var loaded = new FuseLoadedMod(
+                "C:\\Mods\\Conditional",
+                "C:\\Mods\\Conditional\\track.fuse.json",
+                new FuseModDefinition
+                {
+                    Id = "author.conditional",
+                    Mixinto = new FuseMixintoDefinition
+                    {
+                        Target = "game-graph",
+                        ConflictsWith = new[]
+                        {
+                            new FuseModRequirement { Id = "Zamu.StrangeCustoms", NotBefore = "99.0.0" }
+                        }
+                    }
+                });
+
+            Assert.False(FuseModRequirementResolver.ShouldApply(loaded, out var reason));
+            Assert.Contains("mixinto conflict matched", reason);
+            Assert.Contains("intentionally inactive", reason);
+        }
+
+        [Theory]
+        [InlineData("Route.Base", "Route.Base.FUSE", "1.5", "1.0", "2.0", false, true)]
+        [InlineData("Route.Base", "Route.Base.FUSE", "3.0", "1.0", "2.0", false, false)]
+        [InlineData("Route.Base", "Route.Other.FUSE", "1.5", null, null, false, false)]
+        [InlineData("Route.Base", "Route.Base.FUSE", "1.5", null, null, true, false)]
+        public void Declared_package_conflict_matches_alias_version_and_enabled_state(
+            string conflictId,
+            string targetId,
+            string targetVersion,
+            string notBefore,
+            string notAfter,
+            bool disabled,
+            bool expected)
+        {
+            var reference = new FuseModRequirement
+            {
+                Id = conflictId,
+                NotBefore = notBefore,
+                NotAfter = notAfter
+            };
+
+            Assert.Equal(expected, FuseDataPackageDiscovery.IsDeclaredConflictMatch(
+                reference,
+                targetId,
+                targetVersion,
+                disabled));
+        }
+
+        [Theory]
+        [InlineData("1.5", "1.0", "2.0", false, true)]
+        [InlineData("3.0", "1.0", "2.0", false, false)]
+        [InlineData("0.0", "99.0", null, true, true)]
+        public void Top_level_declared_conflict_matches_code_or_asset_package_inventory(
+            string installedVersion,
+            string notBefore,
+            string notAfter,
+            bool replacementCapability,
+            bool expected)
+        {
+            var installed = new FuseModRequirementResolver.InstalledMod
+            {
+                Id = "External.CodeMod",
+                Version = installedVersion,
+                Source = replacementCapability ? "FUSE replacement capability" : "Info.json",
+                IsReplacementCapability = replacementCapability,
+                FolderPath = "C:\\Railroader\\Mods\\ExternalCodeMod"
+            };
+            var inventory = new Dictionary<string, FuseModRequirementResolver.InstalledMod>(StringComparer.OrdinalIgnoreCase)
+            {
+                [installed.Id] = installed
+            };
+
+            var matched = FuseDataPackageDiscovery.TryMatchInstalledConflict(
+                "Author.Package",
+                "C:\\Railroader\\Mods\\AuthorPackage",
+                new FuseModRequirement
+                {
+                    Id = installed.Id,
+                    NotBefore = notBefore,
+                    NotAfter = notAfter
+                },
+                inventory,
+                out var result);
+
+            Assert.Equal(expected, matched);
+            Assert.Equal(expected ? installed : null, result);
+        }
+
+        [Fact]
+        public void Top_level_declared_conflict_does_not_match_declaring_folder_alias()
+        {
+            var installed = new FuseModRequirementResolver.InstalledMod
+            {
+                Id = "Author.Package.Alias",
+                Version = "1.0",
+                Source = "Info.json",
+                FolderPath = "C:\\Railroader\\Mods\\AuthorPackage"
+            };
+            var inventory = new Dictionary<string, FuseModRequirementResolver.InstalledMod>(StringComparer.OrdinalIgnoreCase)
+            {
+                [installed.Id] = installed
+            };
+
+            Assert.False(FuseDataPackageDiscovery.TryMatchInstalledConflict(
+                "Author.Package",
+                "C:\\Railroader\\Mods\\AuthorPackage\\",
+                new FuseModRequirement { Id = installed.Id },
+                inventory,
+                out _));
+        }
+
+        [Fact]
+        public void LegacyContextMods_IncludesInstalledManifestAndFuseReplacementCapabilities()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "fuse-legacy-mods-" + Guid.NewGuid().ToString("N"));
+            var package = Path.Combine(root, "Some Hosted Package");
+            var companion = Path.Combine(root, "Some Kind Of Madness");
+            Directory.CreateDirectory(package);
+            Directory.CreateDirectory(companion);
+            try
+            {
+                File.WriteAllText(
+                    Path.Combine(package, "Definition.json"),
+                    "{ \"id\": \"Joo.Sample\", \"name\": \"Sample\", \"version\": \"2.1\" }");
+                File.WriteAllText(
+                    Path.Combine(companion, "Definition.json"),
+                    "{ \"id\": \"Zamu.SomeKindOfMadness\", \"name\": \"Some Kind Of Madness\", \"version\": \"1.0\" }");
+
+                var mods = FuseLegacyAssemblyHost.EnumerateInstalledMods(root, (_, __) => true);
+
+                Assert.Contains(mods, mod => mod.Id == "Joo.Sample" && mod.IsEnabled && mod.IsLoaded);
+                Assert.Contains(mods, mod => mod.Id == "Zamu.SomeKindOfMadness" && mod.IsEnabled && mod.IsLoaded);
+                Assert.Contains(mods, mod => mod.Id == "Zamu.StrangeCustoms" && mod.IsEnabled && mod.IsLoaded);
+                Assert.Contains(mods, mod => mod.Id == "FUSE" && mod.IsEnabled && mod.IsLoaded);
+                Assert.Equal(mods.Count, mods.Select(mod => mod.Id).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, true);
+                }
+            }
+        }
+
         public class TryParseVersionTests
         {
             [Theory]

--- a/FUSE.Tests/Loading/FusePackageFaultRegistryTests.cs
+++ b/FUSE.Tests/Loading/FusePackageFaultRegistryTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using FUSE.Loading;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace FUSE.Tests.Loading
@@ -97,6 +98,62 @@ namespace FUSE.Tests.Loading
 
             var fault = Assert.Single(FusePackageFaultRegistry.GetFaults());
             Assert.Contains("inner-detail", fault.Details);
+        }
+
+        [Fact]
+        public void RecordFault_ExtractsJsonLocationAndSourceFile()
+        {
+            Exception exception = null;
+            try
+            {
+                JObject.Parse("{\"track\": [ }");
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            var source = @"C:\Railroader\Mods\BrokenTrack\track.fuse.json";
+            FusePackageFaultRegistry.RecordFault(
+                "BrokenTrack",
+                "JSON deserialization",
+                "Invalid JSON",
+                exception,
+                @"C:\Railroader\Mods\BrokenTrack",
+                source);
+
+            var fault = Assert.Single(FusePackageFaultRegistry.GetFaults());
+            Assert.Equal(source, fault.SourceFile);
+            Assert.Equal("BrokenTrack", fault.PackageName);
+            Assert.Equal("track.fuse.json", fault.RelativeSourceFile);
+            Assert.Equal("track", fault.JsonPath);
+            Assert.True(fault.LineNumber > 0);
+            Assert.Contains("Valid JSON", fault.ExpectedShape);
+            Assert.Contains("Unexpected character", fault.ReceivedValue);
+            Assert.Contains("Correct the JSON", fault.SuggestedAction);
+        }
+
+        [Fact]
+        public void RecordFault_PreservesSchemaExpectationCodeAndReceivedValue()
+        {
+            FusePackageFaultRegistry.RecordFault(
+                "pkg",
+                "schema validation",
+                "Number expected.",
+                folderPath: @"C:\Railroader\Mods\Pretty Folder",
+                sourceFile: @"C:\Railroader\Mods\Pretty Folder\map.fuse.json",
+                jsonPath: "operations.loaders.loader.rate",
+                packageName: "Pretty Package",
+                validationCode: "fuse.number",
+                expectedShape: "A finite number greater than zero.",
+                receivedValue: "fast");
+
+            var fault = Assert.Single(FusePackageFaultRegistry.GetFaults());
+            Assert.Equal("Pretty Package", fault.PackageName);
+            Assert.Equal("map.fuse.json", fault.RelativeSourceFile);
+            Assert.Equal("fuse.number", fault.ValidationCode);
+            Assert.Equal("A finite number greater than zero.", fault.ExpectedShape);
+            Assert.Equal("fast", fault.ReceivedValue);
         }
 
         [Fact]

--- a/FUSE.Tests/Loading/FuseReplacementCapabilityCatalogTests.cs
+++ b/FUSE.Tests/Loading/FuseReplacementCapabilityCatalogTests.cs
@@ -1,0 +1,41 @@
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseReplacementCapabilityCatalogTests
+    {
+        [Theory]
+        [InlineData("Zamu.StrangeCustoms")]
+        [InlineData("Zamu.ConfusingSupplements.FUSE")]
+        [InlineData("Zamu.C1CD")]
+        [InlineData("C1CD.FUSE")]
+        [InlineData("Zamu.FallFromGrace")]
+        [InlineData("FallFromGrace.FUSE")]
+        [InlineData("Zamu.AbsoluteMadness")]
+        [InlineData("AbsoluteMadness.FUSE")]
+        [InlineData("Zamu.SomeKindOfMadness")]
+        [InlineData("SomeKindOfMadness.FUSE")]
+        [InlineData("Zamu.Interchange2Interchange")]
+        [InlineData("Interchange2Interchange.FUSE")]
+        [InlineData("AlinaNova21.AlinasMapMod")]
+        [InlineData("AssetLoader")]
+        [InlineData("Railloader.Injector")]
+        [InlineData("Railloader.Interchange.FUSE")]
+        public void IsProvided_accepts_only_declared_replacement_families(string packageId)
+        {
+            Assert.True(FuseReplacementCapabilityCatalog.IsProvided(packageId));
+        }
+
+        [Theory]
+        [InlineData("AlinaNova21.AlinasMapExpansionSW")]
+        [InlineData("Joo.SignalsEverywhere")]
+        [InlineData("C_L_B.DKW")]
+        [InlineData("Embedded.BuildingBlocks")]
+        [InlineData("Zamu.SerialTrafficControl")]
+        public void IsProvided_does_not_waive_real_content_dependencies(string packageId)
+        {
+            Assert.False(FuseReplacementCapabilityCatalog.IsProvided(packageId));
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseRmroc451CompatibilityTests.cs
+++ b/FUSE.Tests/Loading/FuseRmroc451CompatibilityTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection;
+using FUSE.Compatibility;
+using FUSE.Loading;
+using HarmonyLib;
+using Railloader;
+using Xunit;
+
+#pragma warning disable CS0618 // This test intentionally exercises the legacy shim.
+
+namespace FUSE.Tests.Loading
+{
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class FuseRmroc451CompatibilityCollection
+    {
+        public const string Name = "RMROC451 real legacy assembly compatibility";
+    }
+
+    /// <summary>
+    /// Opt-in field harness for issue #198. This loads the real third-party
+    /// assembly, resolves its Railloader.Interchange reference through FUSE,
+    /// constructs the plugin with FUSE's independent context, and resolves the
+    /// plugin's real Harmony targets against the installed Railroader API. The
+    /// test host does not patch Unity ECall methods because they require Unity's
+    /// native runtime; successful target resolution is the safe compatibility
+    /// gate available under the net48 xUnit runner.
+    /// </summary>
+    [Collection(FuseRmroc451CompatibilityCollection.Name)]
+    public sealed class FuseRmroc451CompatibilityTests
+    {
+        [Rmroc451RealAssemblyFact]
+        public void Real_plugin_resolves_hosts_and_patches_with_fuse_shim()
+        {
+            var archivePath = Environment.GetEnvironmentVariable("FUSE_TEST_RMROC451_ZIP");
+            var gameDirectory = Environment.GetEnvironmentVariable("FUSE_TEST_GAME_DIR");
+            var managedDirectory = Path.Combine(gameDirectory, "Railroader_Data", "Managed");
+            var extractionRoot = Path.Combine(
+                Path.GetTempPath(),
+                "fuse-rmroc451-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(extractionRoot);
+
+            PluginBase plugin = null;
+            ResolveEventHandler gameAssemblyResolver = (_, args) =>
+            {
+                var requested = new AssemblyName(args.Name).Name;
+                var candidate = Path.Combine(managedDirectory, requested + ".dll");
+                return File.Exists(candidate) ? Assembly.LoadFrom(candidate) : null;
+            };
+            FuseLegacySupportAssemblyShim.Initialize();
+            AppDomain.CurrentDomain.AssemblyResolve += gameAssemblyResolver;
+            try
+            {
+                ZipFile.ExtractToDirectory(archivePath, extractionRoot);
+                var assemblyPath = Directory.GetFiles(
+                        extractionRoot,
+                        "RMROC451.TweaksAndThings.dll",
+                        SearchOption.AllDirectories)
+                    .Single();
+                var packageFolder = Path.GetDirectoryName(assemblyPath);
+                var modsRoot = Directory.GetParent(packageFolder)?.FullName
+                               ?? extractionRoot;
+                var manifest = new FuseLegacyAssemblyManifest
+                {
+                    Id = "RMROC451.TweaksAndThings",
+                    Name = "RMROC451's Tweaks and Things",
+                    Version = "2.1.7",
+                    FolderPath = packageFolder,
+                    Assemblies = new[] { "RMROC451.TweaksAndThings" }
+                };
+                var definition = new FuseLegacyModDefinition(manifest);
+                var context = new FuseLegacyModdingContext(modsRoot);
+                var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+                var pluginType = assembly.GetType(
+                    "RMROC451.TweaksAndThings.TweaksAndThingsPlugin",
+                    throwOnError: true);
+
+                Assert.True(typeof(PluginBase).IsAssignableFrom(pluginType));
+                Assert.True(typeof(IUpdateHandler).IsAssignableFrom(pluginType));
+                Assert.True(typeof(IModTabHandler).IsAssignableFrom(pluginType));
+
+                plugin = (PluginBase)Activator.CreateInstance(
+                    pluginType,
+                    context,
+                    definition);
+                AssertHarmonyTargetsResolve(
+                    assembly,
+                    "RMROC451TweaksAndThings");
+            }
+            finally
+            {
+                AppDomain.CurrentDomain.AssemblyResolve -= gameAssemblyResolver;
+                FuseLegacySupportAssemblyShim.Shutdown();
+                try
+                {
+                    Directory.Delete(extractionRoot, recursive: true);
+                }
+                catch (IOException ex)
+                {
+                    // Assembly.Load(byte[]) normally leaves the extraction
+                    // unlocked. If an old CLR probes a sidecar from this folder,
+                    // the operating system will reclaim the temp folder later.
+                    System.Diagnostics.Trace.TraceWarning(
+                        $"RMROC451 compatibility harness could not remove temporary folder '{extractionRoot}': {ex.Message}");
+                }
+            }
+        }
+
+        private static void AssertHarmonyTargetsResolve(
+            Assembly assembly,
+            string category)
+        {
+            var harmony = new Harmony("FUSE.Tests.RMROC451.TargetAudit");
+            var processorType = typeof(PatchClassProcessor);
+            var getBulkMethods = processorType.GetMethod(
+                "GetBulkMethods",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            var patchMethodsField = processorType.GetField(
+                "patchMethods",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            var getOriginalMethod = typeof(Harmony).Assembly
+                .GetType("HarmonyLib.PatchTools", throwOnError: false)?
+                .GetMethod(
+                    "GetOriginalMethod",
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
+                    null,
+                    new[] { typeof(HarmonyMethod) },
+                    null);
+            Assert.NotNull(getBulkMethods);
+            Assert.NotNull(patchMethodsField);
+            Assert.NotNull(getOriginalMethod);
+
+            var patchClassCount = 0;
+            var resolvedTargetCount = 0;
+            foreach (var type in assembly.GetTypes())
+            {
+                var processor = new PatchClassProcessor(harmony, type);
+                if (!string.Equals(
+                        processor.Category,
+                        category,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                patchClassCount++;
+                var bulkMethods = (System.Collections.IEnumerable)
+                    getBulkMethods.Invoke(processor, null);
+                var bulkCount = 0;
+                foreach (var target in bulkMethods)
+                {
+                    Assert.NotNull(target);
+                    bulkCount++;
+                    resolvedTargetCount++;
+                }
+                if (bulkCount > 0)
+                {
+                    continue;
+                }
+
+                var patchMethods = (System.Collections.IEnumerable)
+                    patchMethodsField.GetValue(processor);
+                foreach (var patch in patchMethods)
+                {
+                    var info = (HarmonyMethod)patch.GetType()
+                        .GetField("info", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                        .GetValue(patch);
+                    Assert.NotNull(info.method);
+                    Assert.NotNull(getOriginalMethod.Invoke(null, new object[] { info }));
+                    resolvedTargetCount++;
+                }
+            }
+
+            Assert.True(patchClassCount > 0, "No RMROC451 Harmony patch classes were discovered.");
+            Assert.True(resolvedTargetCount > 0, "No RMROC451 Harmony targets resolved against the installed game.");
+        }
+    }
+
+    internal sealed class Rmroc451RealAssemblyFactAttribute : FactAttribute
+    {
+        public Rmroc451RealAssemblyFactAttribute()
+        {
+            var archivePath = Environment.GetEnvironmentVariable("FUSE_TEST_RMROC451_ZIP");
+            if (string.IsNullOrWhiteSpace(archivePath) || !File.Exists(archivePath))
+            {
+                Skip = "Opt-in real RMROC451 harness: set FUSE_TEST_RMROC451_ZIP to RMROC451.TweaksAndThings.zip.";
+                return;
+            }
+
+            var gameDirectory = Environment.GetEnvironmentVariable("FUSE_TEST_GAME_DIR");
+            if (string.IsNullOrWhiteSpace(gameDirectory) ||
+                !File.Exists(Path.Combine(gameDirectory, "Railroader_Data", "Managed", "Serilog.dll")))
+            {
+                Skip = "Opt-in real RMROC451 harness: set FUSE_TEST_GAME_DIR to a Railroader installation.";
+            }
+        }
+    }
+}
+
+#pragma warning restore CS0618

--- a/FUSE.Tests/Loading/FuseSpatialTrackConflictDetectorTests.cs
+++ b/FUSE.Tests/Loading/FuseSpatialTrackConflictDetectorTests.cs
@@ -1,0 +1,92 @@
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using System.Collections.Generic;
+using UnityEngine;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseSpatialTrackConflictDetectorTests
+    {
+        [Fact]
+        public void Detect_reports_two_independent_track_layouts_with_multiple_nearby_nodes()
+        {
+            var conflicts = FuseSpatialTrackConflictDetector.Detect(new[]
+            {
+                Package("yard-a", "C:\\Mods\\YardA", ("a1", 100f, 200f), ("a2", 130f, 230f)),
+                Package("yard-b", "C:\\Mods\\YardB", ("b1", 105f, 203f), ("b2", 138f, 235f))
+            });
+
+            var conflict = Assert.Single(conflicts);
+            Assert.StartsWith("spatial-overlap:", conflict.Id);
+            Assert.Contains("both packages retained", conflict.Resolution);
+            Assert.Equal("yard-a", conflict.OwnerPackageId);
+            Assert.Equal("yard-b", conflict.AttemptedPackageId);
+        }
+
+        [Fact]
+        public void Detect_ignores_a_single_shared_connection_point()
+        {
+            var conflicts = FuseSpatialTrackConflictDetector.Detect(new[]
+            {
+                Package("extension-a", "C:\\Mods\\A", ("a1", 100f, 200f), ("a2", 130f, 230f)),
+                Package("extension-b", "C:\\Mods\\B", ("b1", 105f, 203f), ("b2", 500f, 600f))
+            });
+
+            Assert.Empty(conflicts);
+        }
+
+        [Fact]
+        public void Detect_ignores_definition_fragments_from_the_same_package_folder()
+        {
+            var conflicts = FuseSpatialTrackConflictDetector.Detect(new[]
+            {
+                Package("package.track", "C:\\Mods\\OnePackage", ("a1", 100f, 200f), ("a2", 130f, 230f)),
+                Package("package.spans", "C:\\Mods\\OnePackage", ("b1", 105f, 203f), ("b2", 138f, 235f))
+            });
+
+            Assert.Empty(conflicts);
+        }
+
+        [Fact]
+        public void Detect_ignores_declared_base_and_extension_layering()
+        {
+            var basePackage = Package(
+                "Katers.SylvaInterchange.FUSE",
+                "C:\\Mods\\SylvaBase",
+                ("a1", 100f, 200f),
+                ("a2", 130f, 230f));
+            var extension = Package(
+                "Katers.SylvaInterchangeHYSpans.FUSE",
+                "C:\\Mods\\SylvaHYSpans",
+                ("b1", 105f, 203f),
+                ("b2", 138f, 235f));
+            extension.RequiredPackageIds = new[] { "Katers.SylvaInterchange" };
+
+            var conflicts = FuseSpatialTrackConflictDetector.Detect(new[] { basePackage, extension });
+
+            Assert.Empty(conflicts);
+        }
+
+        private static FuseSpatialTrackPackage Package(
+            string id,
+            string folder,
+            params (string id, float x, float z)[] nodes)
+        {
+            var tracks = new FuseTrackDefinition();
+            foreach (var node in nodes)
+            {
+                tracks.Nodes[node.id] = new FuseNode { Position = new Vector3(node.x, 500f, node.z) };
+            }
+
+            tracks.Segments["segment-1"] = new FuseSegment();
+            tracks.Segments["segment-2"] = new FuseSegment();
+            return new FuseSpatialTrackPackage
+            {
+                PackageId = id,
+                FolderPath = folder,
+                TrackDefinitions = new[] { tracks }
+            };
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseAlinasUtilitiesCompatibilityTests.cs
+++ b/FUSE.Tests/Patches/FuseAlinasUtilitiesCompatibilityTests.cs
@@ -1,0 +1,70 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public class FuseAlinasUtilitiesCompatibilityTests
+    {
+        [Theory]
+        [InlineData("AlinasUtils", true)]
+        [InlineData("AlinasUtils1", true)]
+        [InlineData("alinasutils-recovered", true)]
+        [InlineData("Utilities", false)]
+        [InlineData("AlinasMapMod", false)]
+        [InlineData(null, false)]
+        public void AssemblyMatch_AcceptsRecoveredAlinasUtilitiesIdentities(
+            string assemblyName,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseAlinasUtilitiesCompatibility.IsTargetAssemblyName(assemblyName));
+        }
+
+        [Fact]
+        public void SettingsResolution_PreservesCurrentInstance()
+        {
+            var current = new object();
+            var umm = new object();
+
+            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettingsForTests(
+                current,
+                umm,
+                () => new object());
+
+            Assert.Same(current, resolved);
+        }
+
+        [Fact]
+        public void SettingsResolution_UsesUmmSettingsBeforeDefault()
+        {
+            var umm = new object();
+            var created = false;
+
+            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettingsForTests(
+                null,
+                umm,
+                () =>
+                {
+                    created = true;
+                    return new object();
+                });
+
+            Assert.Same(umm, resolved);
+            Assert.False(created);
+        }
+
+        [Fact]
+        public void SettingsResolution_CreatesDefaultAsLastResort()
+        {
+            var fallback = new object();
+
+            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettingsForTests(
+                null,
+                null,
+                () => fallback);
+
+            Assert.Same(fallback, resolved);
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseAssetLoaderReplacementCompatibilityTests.cs
+++ b/FUSE.Tests/Patches/FuseAssetLoaderReplacementCompatibilityTests.cs
@@ -1,0 +1,20 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public class FuseAssetLoaderReplacementCompatibilityTests
+    {
+        [Theory]
+        [InlineData("AssetLoader", true)]
+        [InlineData("assetloader", true)]
+        [InlineData("FUSE", false)]
+        [InlineData("SomeAssetPack", false)]
+        [InlineData(null, false)]
+        public void AssemblyMatch_IsExactAndCaseInsensitive(string assemblyName, bool expected)
+        {
+            Assert.Equal(expected,
+                FuseAssetLoaderReplacementCompatibility.IsTargetAssemblyName(assemblyName));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseC1CdCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseC1CdCompatibilityPatchTests.cs
@@ -1,0 +1,58 @@
+using FUSE.Patches;
+using Game;
+using HarmonyLib;
+using Model.Ops;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseC1CdCompatibilityPatchTests
+    {
+        [Theory]
+        [InlineData(0, 8f, 150, 0f, 24f, 0, 10.5f)]
+        [InlineData(0, 4f, 30, 6f, 18f, 0, 6f)]
+        [InlineData(0, 17f, 120, 6f, 18f, 1, 6f)]
+        [InlineData(0, 12f, 30, 22f, 6f, 0, 22f)]
+        [InlineData(0, 23f, 30, 22f, 6f, 0, 23.5f)]
+        public void Schedule_policy_respects_interval_and_service_window(
+            int day,
+            float hour,
+            int interval,
+            float notBefore,
+            float notAfter,
+            int expectedDay,
+            float expectedHour)
+        {
+            var actual = FuseC1CdSchedulePolicy.CalculateNextServiceTime(
+                new GameDateTime(day, hour),
+                interval,
+                notBefore,
+                notAfter);
+
+            Assert.Equal(expectedDay, actual.Day);
+            Assert.Equal(expectedHour, actual.Hours, 3);
+        }
+
+        [Fact]
+        public void Schedule_policy_rejects_non_positive_interval_without_hanging()
+        {
+            var actual = FuseC1CdSchedulePolicy.CalculateNextServiceTime(
+                new GameDateTime(2, 8f),
+                0,
+                0f,
+                24f);
+
+            Assert.Equal(2, actual.Day);
+            Assert.Equal(10.5f, actual.Hours, 3);
+        }
+
+        [Fact]
+        public void Patch_targets_current_static_service_method()
+        {
+            Assert.NotNull(AccessTools.Method(
+                typeof(Interchange),
+                nameof(Interchange.NextAvailableServiceTime),
+                new[] { typeof(GameDateTime) }));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseCompanyStarterPlacementPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseCompanyStarterPlacementPatchTests.cs
@@ -1,0 +1,63 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseCompanyStarterPlacementPatchTests
+    {
+        [Fact]
+        public void StarterPool_RequiresAppalachianWhittierStartDefinition()
+        {
+            Assert.False(
+                FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
+                    "ewh-company",
+                    new[] { "FUSE", "Some.Other.Mod" }));
+            Assert.True(
+                FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
+                    "ewh-company",
+                    new[]
+                    {
+                        "FUSE",
+                        "KingG.Appalachian-Railway.start-whit",
+                    }));
+        }
+
+        [Fact]
+        public void StarterPool_DoesNotAffectOtherCompanyStarts()
+        {
+            var loaded = new[]
+            {
+                "KingG.Appalachian-Railway.start-whit",
+            };
+
+            Assert.False(
+                FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
+                    "ela-company",
+                    loaded));
+            Assert.False(
+                FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
+                    "",
+                    loaded));
+        }
+
+        [Theory]
+        [InlineData(false, 3, 0, false)]
+        [InlineData(true, 3, 0, false)]
+        [InlineData(true, 3, 2, false)]
+        [InlineData(true, 3, 3, true)]
+        [InlineData(true, 0, 0, false)]
+        public void StarterPool_ConsumesCutOnlyAfterConfirmedCompletePlacement(
+            bool callbackReportedPlaced,
+            int expectedCarCount,
+            int placedCarCount,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseCompanyStarterPlacementPatch.WasPlacementCommitted(
+                    callbackReportedPlaced,
+                    expectedCarCount,
+                    placedCarCount));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseCustomIndustryTitlePatchTests.cs
+++ b/FUSE.Tests/Patches/FuseCustomIndustryTitlePatchTests.cs
@@ -1,0 +1,43 @@
+using System.Runtime.Serialization;
+using FUSE.Patches;
+using Model.Ops;
+using StrangeCustoms.Tracks.Industries;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseCustomIndustryTitlePatchTests
+    {
+        [Fact]
+        public void TargetMethod_ResolvesCurrentGamePickerTitleMethod()
+        {
+            Assert.NotNull(FuseCustomIndustryTitlePatch.TargetMethod());
+        }
+
+        [Fact]
+        public void Prefix_UsesLegacyCustomIndustryTitleContract()
+        {
+            var component = (FakeTitledComponent)FormatterServices
+                .GetUninitializedObject(typeof(FakeTitledComponent));
+            var result = string.Empty;
+
+            var runOriginal = FuseCustomIndustryTitlePatch.Prefix(component, ref result);
+
+            Assert.False(runOriginal);
+            Assert.Equal("Acquire coal at test depot", result);
+        }
+
+        private sealed class FakeTitledComponent : IndustryComponent, ICustomIndustryTitle
+        {
+            public string Title => "Acquire coal at test depot";
+
+            public override void OrderCars(IIndustryContext ctx)
+            {
+            }
+
+            public override void Service(IIndustryContext ctx)
+            {
+            }
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseFallFromGraceCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseFallFromGraceCompatibilityPatchTests.cs
@@ -1,0 +1,52 @@
+using FUSE.Patches;
+using HarmonyLib;
+using Model.Ops;
+using Track;
+using UI.Builder;
+using UI.CarInspector;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseFallFromGraceCompatibilityPatchTests
+    {
+        [Theory]
+        [InlineData(0, 0, 1, 0, 0)]
+        [InlineData(2, 0, 2, 1, 5)]
+        [InlineData(0, 3, 1, 0, 3)]
+        [InlineData(2, 0, int.MaxValue, int.MaxValue, int.MaxValue)]
+        public void Grace_adjustment_is_identity_configurable_and_overflow_safe(
+            int baseDays,
+            int minimum,
+            int multiplier,
+            int added,
+            int expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseFallFromGraceCalculationPatch.AdjustGraceDays(baseDays, minimum, multiplier, added));
+        }
+
+        [Fact]
+        public void Grace_patch_targets_the_location_overload()
+        {
+            var target = AccessTools.Method(
+                typeof(OpsController),
+                "CalculateGraceDays",
+                new[] { typeof(Location), typeof(Location) });
+
+            Assert.NotNull(target);
+        }
+
+        [Fact]
+        public void Inspector_patch_targets_the_waybill_panel_overload()
+        {
+            var target = AccessTools.Method(
+                typeof(CarInspector),
+                "PopulateWaybillPanel",
+                new[] { typeof(UIPanelBuilder), typeof(Waybill) });
+
+            Assert.NotNull(target);
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseForYourConvenienceCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseForYourConvenienceCompatibilityPatchTests.cs
@@ -1,0 +1,64 @@
+using FUSE.Patches;
+using HarmonyLib;
+using Model;
+using UI.Map;
+using UI.Tags;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseForYourConvenienceCompatibilityPatchTests
+    {
+        [Theory]
+        [InlineData(0f, "0.0 MPH")]
+        [InlineData(10f, "22.4 MPH")]
+        [InlineData(-10f, "22.4 MPH")]
+        public void Speed_is_displayed_as_absolute_mph(float metersPerSecond, string expected)
+        {
+            Assert.Equal(expected, FuseForYourConveniencePolicy.FormatSpeed(metersPerSecond));
+        }
+
+        [Theory]
+        [InlineData(5f, 10f, "Coal", "50% Coal")]
+        [InlineData(50f, 10f, "Coal", "100% Coal")]
+        [InlineData(5f, 0f, null, "0% Unknown load")]
+        public void Load_summary_is_bounded_and_handles_bad_capacity(
+            float quantity,
+            float capacity,
+            string description,
+            string expected)
+        {
+            Assert.Equal(expected,
+                FuseForYourConveniencePolicy.FormatLoad(quantity, capacity, description));
+        }
+
+        [Theory]
+        [InlineData("Whittier", "whittier", null, true)]
+        [InlineData("Whittier Station", "WHITTIER_AREA", null, true)]
+        [InlineData("Bryson Depot", null, "bryson-depot", true)]
+        [InlineData("Whittier Saw Mill", "whittier", null, false)]
+        [InlineData("Whittier Saw Mill", "bryson", "bryson-depot", false)]
+        [InlineData("R1", "r1", null, false)]
+        public void Station_actions_require_a_matching_named_icon(
+            string iconIdentity,
+            string areaId,
+            string passengerStopId,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseForYourConvenienceStationMapPatch.IsStationIdentityMatch(
+                    iconIdentity,
+                    areaId,
+                    passengerStopId));
+        }
+
+        [Fact]
+        public void Harmony_targets_match_the_installed_game_contract()
+        {
+            Assert.NotNull(AccessTools.Method(typeof(Car), nameof(Car.Setup)));
+            Assert.NotNull(AccessTools.Method(typeof(TagController), "UpdateTag"));
+            Assert.NotNull(AccessTools.Method(typeof(MapBuilder), nameof(MapBuilder.Rebuild)));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseInterchangeToInterchangeCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseInterchangeToInterchangeCompatibilityPatchTests.cs
@@ -1,0 +1,43 @@
+using FUSE.Infrastructure;
+using FUSE.Patches;
+using HarmonyLib;
+using Model.Ops;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseInterchangeToInterchangeCompatibilityPatchTests
+    {
+        [Theory]
+        [InlineData(30, 1f, 30)]
+        [InlineData(30, 0.5f, 15)]
+        [InlineData(30, 2f, 60)]
+        [InlineData(30, 0f, 0)]
+        [InlineData(-1, 1f, 0)]
+        [InlineData(200, 2f, 200)]
+        public void Maximum_cut_policy_is_bounded(
+            int configured,
+            float multiplier,
+            int expected)
+        {
+            Assert.Equal(expected,
+                FuseInterchangeToInterchangePolicy.ScaleMaximumCars(configured, multiplier));
+        }
+
+        [Theory]
+        [InlineData(-1, 0)]
+        [InlineData(30, 30)]
+        [InlineData(999, 200)]
+        public void User_setting_is_bounded(int value, int expected)
+        {
+            Assert.Equal(expected, FuseSettings.ClampInterchangeToInterchangeMaximumCars(value));
+        }
+
+        [Fact]
+        public void Harmony_targets_match_the_installed_game_contract()
+        {
+            Assert.NotNull(AccessTools.Method(typeof(Interchange), nameof(Interchange.OrderCars)));
+            Assert.NotNull(AccessTools.Method(typeof(OpsController), "RebuildCollections"));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseLocationPickerDeduplicationPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseLocationPickerDeduplicationPatchTests.cs
@@ -1,0 +1,62 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseLocationPickerDeduplicationPatchTests
+    {
+        [Fact]
+        public void DeduplicateByKey_CollapsesEquivalentKeysAndPreservesOrder()
+        {
+            var source = new[] { "sawmill-mp1", "SAWMILL-MP1", "sawmill-mp2" };
+
+            var removed = FuseLocationPickerDeduplicationPatch.DeduplicateByKey(
+                source,
+                value => value,
+                out var result);
+
+            Assert.Equal(1, removed);
+            Assert.Equal(new[] { "sawmill-mp1", "sawmill-mp2" }, result);
+        }
+
+        [Fact]
+        public void DeduplicateByKey_PreservesRowsWhoseIdentityCannotBeResolved()
+        {
+            var source = new[] { "broken-one", "broken-two" };
+
+            var removed = FuseLocationPickerDeduplicationPatch.DeduplicateByKey(
+                source,
+                _ => null,
+                out var result);
+
+            Assert.Equal(0, removed);
+            Assert.Equal(source, result);
+        }
+
+        [Fact]
+        public void ResolveCanonicalByKey_ReturnsRetainedEquivalentInstance()
+        {
+            var retained = new Item("sawmill-mp1", 1);
+            var duplicate = new Item("SAWMILL-MP1", 2);
+
+            var selected = FuseLocationPickerDeduplicationPatch.ResolveCanonicalByKey(
+                duplicate,
+                new[] { retained },
+                item => item.Id);
+
+            Assert.Same(retained, selected);
+        }
+
+        private sealed class Item
+        {
+            internal Item(string id, int instance)
+            {
+                Id = id;
+                Instance = instance;
+            }
+
+            internal string Id { get; }
+            internal int Instance { get; }
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseMessengerIsolationPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseMessengerIsolationPatchTests.cs
@@ -6,6 +6,7 @@ using FUSE.Patches;
 using GalaSoft.MvvmLight.Helpers;
 using Game.Events;
 using HarmonyLib;
+using Railloader.Events;
 using Xunit;
 
 namespace FUSE.Tests.Patches
@@ -64,9 +65,10 @@ namespace FUSE.Tests.Patches
         }
 
         [Fact]
-        public void TargetMethods_CoverAllFourLifecycleEvents_WithBothDispatchEntries()
+        public void TargetMethods_CoverLifecycleAndLegacyDebugEvents_WithBothDispatchEntries()
         {
-            // Full expected surface: four lifecycle structs, two dispatch
+            // Full expected surface: four lifecycle structs plus the legacy
+            // debug-report contribution event, two dispatch
             // entries each. Compile-time typeofs again so any single
             // event going missing or changing shape raises an alarm here
             // instead of a runtime "stays unguarded" warning nobody reads.
@@ -75,7 +77,8 @@ namespace FUSE.Tests.Patches
                 typeof(MapWillLoadEvent),
                 typeof(MapDidLoadEvent),
                 typeof(MapWillUnloadEvent),
-                typeof(MapDidUnloadEvent)
+                typeof(MapDidUnloadEvent),
+                typeof(WillCopyDebugInformation)
             };
 
             var expected = new HashSet<MethodBase>();

--- a/FUSE.Tests/Patches/FuseOutboundIndustryRoutingPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseOutboundIndustryRoutingPatchTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Infrastructure;
+using FUSE.Patches;
+using HarmonyLib;
+using Model.Ops;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseOutboundIndustryRoutingPatchTests
+    {
+        [Theory]
+        [InlineData(false, false, false, 0)]
+        [InlineData(false, true, false, 1)]
+        [InlineData(false, false, true, 2)]
+        [InlineData(false, true, true, 2)]
+        [InlineData(true, false, false, 2)]
+        public void ResolveMode_preserves_opt_in_and_legacy_precedence(
+            bool explicitOptIn,
+            bool absolute,
+            bool configurable,
+            int expected)
+        {
+            Assert.Equal(expected, (int)FuseOutboundIndustryRoutingPatch.ResolveMode(
+                explicitOptIn,
+                absolute,
+                configurable));
+        }
+
+        [Theory]
+        [InlineData(0f, 0)]
+        [InlineData(0.24f, 0)]
+        [InlineData(0.25f, 0)]
+        [InlineData(0.26f, 1)]
+        [InlineData(0.99f, 1)]
+        public void Weighted_selection_uses_remaining_capacity(float sample, int expected)
+        {
+            Assert.Equal(expected, FuseOutboundIndustryRoutingPatch.SelectWeightedIndex(
+                new[] { 1f, 3f },
+                sample));
+        }
+
+        [Fact]
+        public void Weighted_selection_handles_empty_and_zero_weight_sets()
+        {
+            Assert.Equal(-1, FuseOutboundIndustryRoutingPatch.SelectWeightedIndex(Array.Empty<float>(), 0.5f));
+            Assert.Equal(1, FuseOutboundIndustryRoutingPatch.SelectWeightedIndex(new[] { 0f, 0f }, 0.75f));
+        }
+
+        [Fact]
+        public void Shuffle_is_deterministic_with_a_supplied_random_source()
+        {
+            var first = new List<int> { 1, 2, 3, 4, 5 };
+            var second = new List<int> { 1, 2, 3, 4, 5 };
+
+            FuseOutboundIndustryBlockingPatch.Shuffle(first, new Random(19));
+            FuseOutboundIndustryBlockingPatch.Shuffle(second, new Random(19));
+
+            Assert.Equal(first, second);
+            Assert.NotEqual(new[] { 1, 2, 3, 4, 5 }, first);
+        }
+
+        [Fact]
+        public void Settings_clamp_untrusted_routing_values()
+        {
+            Assert.Equal(0.1f, FuseSettings.ClampOutboundIndustryFillFactor(-5f));
+            Assert.Equal(3f, FuseSettings.ClampOutboundIndustryFillFactor(99f));
+            Assert.Equal(FuseSettings.DefaultOutboundIndustryFillFactor,
+                FuseSettings.ClampOutboundIndustryFillFactor(float.NaN));
+            Assert.Equal(0f, FuseSettings.ClampOutboundIndustryPaymentMultiplier(-5f));
+            Assert.Equal(10f, FuseSettings.ClampOutboundIndustryPaymentMultiplier(99f));
+        }
+
+        [Fact]
+        public void Harmony_targets_match_the_installed_game_contract()
+        {
+            Assert.NotNull(AccessTools.Method(typeof(OpsController), nameof(OpsController.AddOrderForOutboundEmptyCar)));
+            Assert.NotNull(AccessTools.Method(typeof(OpsController), nameof(OpsController.AddOrderForOutboundLoadedCar)));
+            Assert.NotNull(AccessTools.Method(typeof(IndustryContext), "AddOrderedCars"));
+        }
+    }
+}

--- a/FUSE.Tests/Registry/FuseRegistryTests.cs
+++ b/FUSE.Tests/Registry/FuseRegistryTests.cs
@@ -63,6 +63,44 @@ namespace FUSE.Tests.Registry
             Assert.Empty(FuseRegistry.Conflicts);
         }
 
+        [Fact]
+        public void RecordPlannedConflict_ReportsDeleteVersusDefinitionWithoutCreatingAClaim()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Node,
+                "node-removed",
+                "route-a.graph",
+                "route-b.patch",
+                "later package removal won; earlier package definition suppressed");
+
+            var conflict = Assert.Single(FuseRegistry.Conflicts);
+            Assert.Equal(FuseClaimKind.Node, conflict.Kind);
+            Assert.Equal("node-removed", conflict.Id);
+            Assert.Equal("route-a.graph", conflict.OwnerPackageId);
+            Assert.Equal("route-b.patch", conflict.AttemptedPackageId);
+            Assert.Contains("removal won", conflict.Resolution);
+            Assert.Equal(0, FuseRegistry.ExclusiveClaimCount);
+        }
+
+        [Fact]
+        public void RecordPlannedConflict_DeduplicatesTheSamePackagePairAcrossReapplyOrder()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Industry,
+                "destination:type=consumer;name=MP1;spans=R2,R3",
+                "pkg-a",
+                "pkg-b",
+                "shared industry destination overlap");
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Industry,
+                "destination:type=consumer;name=MP1;spans=R2,R3",
+                "pkg-b",
+                "pkg-a",
+                "shared industry destination overlap");
+
+            Assert.Single(FuseRegistry.Conflicts);
+        }
+
         [Theory]
         [InlineData(null, "pkg")]
         [InlineData("", "pkg")]

--- a/FUSE.Tests/Runtime/API/FuseObjectLineLayoutTests.cs
+++ b/FUSE.Tests/Runtime/API/FuseObjectLineLayoutTests.cs
@@ -1,0 +1,98 @@
+using System;
+using FUSE.Authoring.Data;
+using FUSE.Runtime.API;
+using UnityEngine;
+using Xunit;
+
+namespace FUSE.Tests.Runtime.API
+{
+    public sealed class FuseObjectLineLayoutTests
+    {
+        [Fact]
+        public void UniformSpacingIncludesFinalEndpointWhenRequested()
+        {
+            var placements = FuseObjectLineLayout.Build(
+                new[]
+                {
+                    Point(0f, 0f),
+                    Point(10f, 0f),
+                },
+                4f,
+                true,
+                10);
+
+            Assert.Collection(
+                placements,
+                placement => Assert.Equal(0f, placement.Position.x, 3),
+                placement => Assert.Equal(4f, placement.Position.x, 3),
+                placement => Assert.Equal(8f, placement.Position.x, 3),
+                placement => Assert.Equal(10f, placement.Position.x, 3));
+            Assert.All(placements, placement => Assert.Equal(Vector3.right, placement.Forward));
+        }
+
+        [Fact]
+        public void SpacingContinuesAcrossPolylineCorners()
+        {
+            var placements = FuseObjectLineLayout.Build(
+                new[]
+                {
+                    Point(0f, 0f),
+                    Point(5f, 0f),
+                    Point(5f, 5f),
+                },
+                4f,
+                true,
+                10);
+
+            Assert.Equal(4, placements.Count);
+            Assert.Equal(new Vector3(0f, 0f, 0f), placements[0].Position);
+            Assert.Equal(new Vector3(4f, 0f, 0f), placements[1].Position);
+            Assert.Equal(new Vector3(5f, 0f, 3f), placements[2].Position);
+            Assert.Equal(new Vector3(5f, 0f, 5f), placements[3].Position);
+            Assert.Equal(Vector3.forward, placements[2].Forward);
+        }
+
+        [Fact]
+        public void SafetyLimitRejectsAccidentalInstanceExplosion()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                FuseObjectLineLayout.Build(
+                    new[]
+                    {
+                        Point(0f, 0f),
+                        Point(100f, 0f),
+                    },
+                    1f,
+                    true,
+                    20));
+
+            Assert.Contains("20 instance safety limit", exception.Message);
+            Assert.Contains("Increase spacing", exception.Message);
+        }
+
+        [Fact]
+        public void DuplicateOnlyPathIsRejected()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                FuseObjectLineLayout.Build(
+                    new[]
+                    {
+                        Point(2f, 3f),
+                        Point(2f, 3f),
+                    },
+                    5f,
+                    true,
+                    20));
+
+            Assert.Contains("non-zero path", exception.Message);
+        }
+
+        private static FuseSplineyPoint Point(float x, float z)
+        {
+            return new FuseSplineyPoint
+            {
+                Position = new Vector3(x, 0f, z),
+            };
+        }
+    }
+}

--- a/FUSE.Tests/Runtime/API/FuseRuntimeDefinitionCacheTests.cs
+++ b/FUSE.Tests/Runtime/API/FuseRuntimeDefinitionCacheTests.cs
@@ -1,0 +1,62 @@
+using System;
+using FUSE.Authoring.Data;
+using FUSE.Authoring.Data.Common;
+using FUSE.Runtime.API;
+using UnityEngine;
+using Xunit;
+
+namespace FUSE.Tests.Runtime.API
+{
+    public sealed class FuseRuntimeDefinitionCacheTests
+    {
+        [Fact]
+        public void Span_reads_are_deep_clones_and_cannot_erase_cached_endpoints()
+        {
+            var id = "span-cache-test-" + Guid.NewGuid().ToString("N");
+            var source = new FuseSpan
+            {
+                Upper = new FuseTrackLocation { SegmentId = "upper-segment", Normalized = 0.25f },
+                Lower = new FuseTrackLocation { SegmentId = "lower-segment", Distance = 12.5f },
+                Normalize = false,
+                GroupId = "test-group",
+            };
+
+            FuseRuntimeDefinitionCache.Store(FuseDefinitionKind.TrackSpan, id, source);
+            Assert.True(FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.TrackSpan, id, out FuseSpan first));
+
+            first.Upper.SegmentId = "mutated";
+            first.Lower = null;
+            first.GroupId = "mutated-group";
+
+            Assert.True(FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.TrackSpan, id, out FuseSpan second));
+            Assert.Equal("upper-segment", second.Upper.SegmentId);
+            Assert.Equal(0.25f, second.Upper.Normalized);
+            Assert.Equal("lower-segment", second.Lower.SegmentId);
+            Assert.Equal(12.5f, second.Lower.Distance);
+            Assert.False(second.Normalize);
+            Assert.Equal("test-group", second.GroupId);
+
+            FuseRuntimeDefinitionCache.Remove(FuseDefinitionKind.TrackSpan, id);
+        }
+
+        [Fact]
+        public void Water_surface_reads_clone_boundary_points()
+        {
+            var id = "water-cache-test-" + Guid.NewGuid().ToString("N");
+            var source = new FuseWaterSurface
+            {
+                Points = new[] { Vector3.zero, Vector3.right, Vector3.forward },
+                MaterialName = "Stock Water",
+            };
+
+            FuseRuntimeDefinitionCache.Store(FuseDefinitionKind.WaterSurface, id, source);
+            Assert.True(FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.WaterSurface, id, out FuseWaterSurface first));
+            first.Points[0] = Vector3.one;
+
+            Assert.True(FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.WaterSurface, id, out FuseWaterSurface second));
+            Assert.Equal(Vector3.zero, second.Points[0]);
+            Assert.Equal("Stock Water", second.MaterialName);
+            FuseRuntimeDefinitionCache.Remove(FuseDefinitionKind.WaterSurface, id);
+        }
+    }
+}

--- a/FUSE.Tests/Runtime/API/WaterSurfaceApiProfileTests.cs
+++ b/FUSE.Tests/Runtime/API/WaterSurfaceApiProfileTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using FUSE.Runtime.API;
+using UnityEngine;
+using UnityEngine.Rendering;
+using Xunit;
+
+namespace FUSE.Tests.Runtime.API
+{
+    public sealed class WaterSurfaceApiProfileTests
+    {
+        [Fact]
+        public void SourceLakeProfileCopiesRenderingFlowAndTerrainSnapControls()
+        {
+            var source = UninitializedLake();
+            source.distSmooth = 7.5f;
+            source.terrainSmoothMultiplier = 2.5f;
+            source.overrideLakeRender = true;
+            source.receiveShadows = true;
+            source.shadowCastingMode = ShadowCastingMode.TwoSided;
+            source.automaticFlowMapScale = 0.65f;
+            source.noiseflowMap = true;
+            source.noiseMultiplierflowMap = 1.7f;
+            source.noiseSizeXflowMap = 0.15f;
+            source.noiseSizeZflowMap = 0.35f;
+            source.floatSpeed = 12f;
+            source.flowSpeed = 3f;
+            source.flowDirection = 42f;
+            source.normalFromRaycast = true;
+            source.snapMask = 123;
+
+            var target = UninitializedLake();
+            InvokeApplySourceProfile(source, target);
+
+            Assert.Equal(source.distSmooth, target.distSmooth);
+            Assert.Equal(source.terrainSmoothMultiplier, target.terrainSmoothMultiplier);
+            Assert.Equal(source.overrideLakeRender, target.overrideLakeRender);
+            Assert.Equal(source.receiveShadows, target.receiveShadows);
+            Assert.Equal(source.shadowCastingMode, target.shadowCastingMode);
+            Assert.Equal(source.automaticFlowMapScale, target.automaticFlowMapScale);
+            Assert.Equal(source.noiseflowMap, target.noiseflowMap);
+            Assert.Equal(source.noiseMultiplierflowMap, target.noiseMultiplierflowMap);
+            Assert.Equal(source.noiseSizeXflowMap, target.noiseSizeXflowMap);
+            Assert.Equal(source.noiseSizeZflowMap, target.noiseSizeZflowMap);
+            Assert.Equal(source.floatSpeed, target.floatSpeed);
+            Assert.Equal(source.flowSpeed, target.flowSpeed);
+            Assert.Equal(source.flowDirection, target.flowDirection);
+            Assert.Equal(source.normalFromRaycast, target.normalFromRaycast);
+            Assert.Equal(source.snapMask.value, target.snapMask.value);
+        }
+
+        [Fact]
+        public void MissingSourceUsesNonShadowedSafeDefaults()
+        {
+            var target = UninitializedLake();
+            target.receiveShadows = true;
+            target.shadowCastingMode = ShadowCastingMode.TwoSided;
+
+            InvokeApplySourceProfile(null, target);
+
+            Assert.Null(target.currentProfile);
+            Assert.False(target.receiveShadows);
+            Assert.Equal(ShadowCastingMode.Off, target.shadowCastingMode);
+        }
+
+        private static LakePolygon UninitializedLake()
+        {
+#pragma warning disable SYSLIB0050
+            return (LakePolygon)FormatterServices.GetUninitializedObject(typeof(LakePolygon));
+#pragma warning restore SYSLIB0050
+        }
+
+        private static void InvokeApplySourceProfile(LakePolygon source, LakePolygon target)
+        {
+            var method = typeof(WaterSurfaceAPI).GetMethod(
+                "ApplySourceLakeProfile",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var exception = Record.Exception(() => method.Invoke(null, new object[] { source, target }));
+            if (exception is TargetInvocationException invocation && invocation.InnerException != null)
+                throw invocation.InnerException;
+            Assert.Null(exception);
+        }
+    }
+}

--- a/FUSE.Tests/Serialization/FuseJsonSchemaContractTests.cs
+++ b/FUSE.Tests/Serialization/FuseJsonSchemaContractTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Serialization
+{
+    public sealed class FuseJsonSchemaContractTests
+    {
+        [Fact]
+        public void Gauge_IsSegmentMetadata_WithAllEditorAuthoredValues()
+        {
+            var schemaPath = Path.Combine(
+                AppContext.BaseDirectory,
+                "fuse-mod.schema.json");
+            var schema = JObject.Parse(File.ReadAllText(schemaPath));
+            var definitions = Assert.IsType<JObject>(schema["$defs"]);
+            var node = Assert.IsType<JObject>(definitions["trackNode"]);
+            var segment = Assert.IsType<JObject>(definitions["trackSegment"]);
+            var nodeProperties = Assert.IsType<JObject>(node["properties"]);
+            var segmentProperties = Assert.IsType<JObject>(
+                segment["properties"]);
+
+            Assert.Null(nodeProperties["gauge"]);
+            var gauge = Assert.IsType<JObject>(segmentProperties["gauge"]);
+            var values = Assert.IsType<JArray>(gauge["enum"])
+                .Values<string>()
+                .ToArray();
+
+            Assert.Contains("Standard", values);
+            Assert.Contains("Narrow", values);
+            Assert.Contains("DualGauge", values);
+            Assert.Contains("DualGauge_L", values);
+            Assert.Contains("DualGauge_R", values);
+            Assert.Contains("DualGauge_T", values);
+        }
+
+        [Fact]
+        public void TrackStructureContract_IncludesDiamondAndFlagsEraMetadata()
+        {
+            var schemaPath = Path.Combine(AppContext.BaseDirectory, "fuse-mod.schema.json");
+            var schema = JObject.Parse(File.ReadAllText(schemaPath));
+            var definitions = Assert.IsType<JObject>(schema["$defs"]);
+            var nodeProperties = Assert.IsType<JObject>(definitions["trackNode"]?["properties"]);
+            var segmentProperties = Assert.IsType<JObject>(definitions["trackSegment"]?["properties"]);
+
+            Assert.Equal("boolean", nodeProperties["isDiamond"]?["type"]?.Value<string>());
+            Assert.Equal("boolean", segmentProperties["bridgeSupportsSteel"]?["type"]?.Value<string>());
+            Assert.Equal("boolean", segmentProperties["yard"]?["type"]?.Value<string>());
+            Assert.NotNull(segmentProperties["preserveBridgeSupportsSteel"]);
+            Assert.NotNull(segmentProperties["preserveYard"]);
+        }
+
+        [Fact]
+        public void UriContract_IncludesDocumentedFuseScheme()
+        {
+            var schemaPath = Path.Combine(
+                AppContext.BaseDirectory,
+                "fuse-mod.schema.json");
+            var schema = JObject.Parse(File.ReadAllText(schemaPath));
+            var definitions = Assert.IsType<JObject>(schema["$defs"]);
+            var uri = Assert.IsType<JObject>(definitions["uri"]);
+            var pattern = Assert.IsType<JValue>(uri["pattern"])
+                .Value<string>();
+
+            Assert.Contains("fuse", pattern, StringComparison.Ordinal);
+        }
+    }
+}

--- a/FUSE.Tests/Validation/FuseDefinitionValidatorDeeperTests.World.cs
+++ b/FUSE.Tests/Validation/FuseDefinitionValidatorDeeperTests.World.cs
@@ -107,6 +107,45 @@ namespace FUSE.Tests.Validation
         public class WorldSplineyAndTelegraphRules
         {
             [Fact]
+            public void WaterSurface_WithInvalidGeometry_EmitsActionableErrors()
+            {
+                var definition = MinimalValid();
+                definition.World.WaterSurfaces["lake"] = new FuseWaterSurface
+                {
+                    Points = new[] { Vector3.zero, Vector3.one },
+                    TriangleDensity = 0f,
+                    MaximumTriangleArea = 0f,
+                    UvScale = 0f,
+                };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.Contains(result.Errors, e => e.Code == "fuse.waterSurface.points");
+                Assert.Contains(result.Errors, e => e.Code == "fuse.waterSurface.triangleDensity");
+                Assert.Contains(result.Errors, e => e.Code == "fuse.waterSurface.maximumTriangleArea");
+                Assert.Contains(result.Errors, e => e.Code == "fuse.waterSurface.uvScale");
+            }
+
+            [Fact]
+            public void WaterSurface_WithThreePointsAndSafeTessellation_IsAccepted()
+            {
+                var definition = MinimalValid();
+                definition.World.WaterSurfaces["lake"] = new FuseWaterSurface
+                {
+                    Points = new[]
+                    {
+                        Vector3.zero,
+                        new Vector3(20f, 0f, 0f),
+                        new Vector3(0f, 0f, 20f),
+                    },
+                };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.DoesNotContain(result.Errors, e => e.Field.StartsWith("world.waterSurfaces.lake", StringComparison.Ordinal));
+            }
+
+            [Fact]
             public void Spliney_WithFewerThanTwoPoints_EmitsError()
             {
                 var definition = MinimalValid();
@@ -134,6 +173,57 @@ namespace FUSE.Tests.Validation
                 var result = NewValidator().Validate(definition);
 
                 Assert.Contains(result.Errors, e => e.Field == "world.splineys.wires.type" && e.Code == "fuse.required");
+            }
+
+            [Fact]
+            public void ObjectLine_RequiresOneSourceAndSafeLayoutLimits()
+            {
+                var definition = MinimalValid();
+                definition.World.Splineys["fence"] = new FuseSpliney
+                {
+                    Type = "objectLine",
+                    AssetIdentifier = "fence-panel",
+                    Prefab = "path://scene/World/Fence",
+                    Spacing = 0f,
+                    MaximumInstances = 5000,
+                    Points = new[]
+                    {
+                        new FuseSplineyPoint { Position = Vector3.zero },
+                        new FuseSplineyPoint { Position = Vector3.right },
+                    },
+                };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.Contains(result.Errors, error => error.Code == "fuse.spliney.objectLine.source");
+                Assert.Contains(result.Errors, error => error.Code == "fuse.spliney.objectLine.spacing");
+                Assert.Contains(result.Errors, error => error.Code == "fuse.spliney.objectLine.maximumInstances");
+            }
+
+            [Fact]
+            public void ObjectLine_WithOneAssetSourceAndSafeLimits_IsAccepted()
+            {
+                var definition = MinimalValid();
+                definition.World.Splineys["fence"] = new FuseSpliney
+                {
+                    Type = "objectLine",
+                    AssetIdentifier = "fence-panel",
+                    Spacing = 3f,
+                    MaximumInstances = 200,
+                    Points = new[]
+                    {
+                        new FuseSplineyPoint { Position = Vector3.zero },
+                        new FuseSplineyPoint { Position = Vector3.right * 20f },
+                    },
+                };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.DoesNotContain(
+                    result.Errors,
+                    error => error.Field.StartsWith(
+                        "world.splineys.fence",
+                        StringComparison.Ordinal));
             }
 
             [Fact]
@@ -363,6 +453,21 @@ namespace FUSE.Tests.Validation
                 var result = NewValidator().Validate(definition);
 
                 Assert.Contains(result.Errors, e => e.Code == "fuse.world.removal.conflict");
+            }
+
+            [Fact]
+            public void WaterSurfaceRemoval_AlsoDefined_EmitsConflictError()
+            {
+                var definition = MinimalValid();
+                definition.World.WaterSurfaces["lake"] = new FuseWaterSurface
+                {
+                    Points = new[] { Vector3.zero, Vector3.right, Vector3.forward },
+                };
+                definition.World.Removals.WaterSurfaces = new[] { "lake" };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.Contains(result.Errors, e => e.Field == "world.removals.waterSurfaces[0]" && e.Code == "fuse.world.removal.conflict");
             }
 
             [Fact]

--- a/FUSE.Tests/Validation/FuseDefinitionValidatorTests.cs
+++ b/FUSE.Tests/Validation/FuseDefinitionValidatorTests.cs
@@ -173,6 +173,24 @@ namespace FUSE.Tests.Validation
 
                 Assert.Contains(result.Warnings, w => w.Field == "mixinto.requires[0].id" && w.Code == "fuse.mixinto.requirement.id.blank");
             }
+
+            [Fact]
+            public void BlankConflictId_EmitsWarning()
+            {
+                var definition = MinimalValid();
+                definition.Mixinto = new FuseMixintoDefinition
+                {
+                    Target = "game-graph",
+                    SourceFile = "src.json",
+                    ConflictsWith = new[] { new FuseModRequirement { Id = "   " } }
+                };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.Contains(result.Warnings, warning =>
+                    warning.Field == "mixinto.conflictsWith[0].id" &&
+                    warning.Code == "fuse.mixinto.conflict.id.blank");
+            }
         }
 
         public class SettingsRules

--- a/FUSE.Tests/Validation/FuseFeatureRuleValidationTests.cs
+++ b/FUSE.Tests/Validation/FuseFeatureRuleValidationTests.cs
@@ -1,0 +1,87 @@
+using FUSE.Authoring.Data;
+using FUSE.Authoring.Validation;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Validation
+{
+    public sealed class FuseFeatureRuleValidationTests
+    {
+        [Fact]
+        public void ValidRule_PassesValidation()
+        {
+            var definition = ValidDefinition();
+
+            var result = new FuseDefinitionValidator().Validate(definition);
+
+            Assert.DoesNotContain(result.Errors, error => error.Field.StartsWith("featureRules."));
+        }
+
+        [Fact]
+        public void MissingSetting_IsActionableError()
+        {
+            var definition = ValidDefinition();
+            definition.FeatureRules["optional"].Setting = "missing";
+
+            var result = new FuseDefinitionValidator().Validate(definition);
+
+            Assert.Contains(result.Errors, error => error.Code == "fuse.featureRule.setting.missing");
+        }
+
+        [Fact]
+        public void UnknownTarget_IsActionableError()
+        {
+            var definition = ValidDefinition();
+            definition.FeatureRules["optional"].Targets.Scenery = new[] { "not-authored-here" };
+
+            var result = new FuseDefinitionValidator().Validate(definition);
+
+            Assert.Contains(result.Errors, error => error.Code == "fuse.featureRule.target.missing" && error.Field.Contains("scenery"));
+        }
+
+        [Fact]
+        public void NumericOperator_OnBooleanSetting_IsRejected()
+        {
+            var definition = ValidDefinition();
+            definition.FeatureRules["optional"].Operator = "greaterThan";
+
+            var result = new FuseDefinitionValidator().Validate(definition);
+
+            Assert.Contains(result.Errors, error => error.Code == "fuse.featureRule.operator.type");
+        }
+
+        [Fact]
+        public void EmptyTargets_AreRejected()
+        {
+            var definition = ValidDefinition();
+            definition.FeatureRules["optional"].Targets = new FuseFeatureTargets();
+
+            var result = new FuseDefinitionValidator().Validate(definition);
+
+            Assert.Contains(result.Errors, error => error.Code == "fuse.featureRule.targets.empty");
+        }
+
+        private static FuseModDefinition ValidDefinition()
+        {
+            var definition = new FuseModDefinition
+            {
+                Id = "feature-test",
+                Name = "Feature Test"
+            };
+            definition.Settings["enabled"] = new FuseModSettingDefinition
+            {
+                Type = "bool",
+                Default = new JValue(true),
+                ReloadRequired = true
+            };
+            definition.World.Scenery["optional-scenery"] = new FuseScenery();
+            definition.FeatureRules["optional"] = new FuseFeatureRule
+            {
+                Setting = "enabled",
+                Value = new JValue(true),
+                Targets = new FuseFeatureTargets { Scenery = new[] { "optional-scenery" } }
+            };
+            return definition;
+        }
+    }
+}

--- a/FUSE/Authoring/Data/FuseModDefinition.cs
+++ b/FUSE/Authoring/Data/FuseModDefinition.cs
@@ -26,6 +26,7 @@ namespace FUSE.Authoring.Data
         public FuseAudioRoot Audio { get; set; } = new FuseAudioRoot();
         public FuseProgressionRoot Progression { get; set; } = new FuseProgressionRoot();
         public Dictionary<string, FuseModSettingDefinition> Settings { get; set; } = new Dictionary<string, FuseModSettingDefinition>();
+        public Dictionary<string, FuseFeatureRule> FeatureRules { get; set; } = new Dictionary<string, FuseFeatureRule>();
         public FuseEditorState Editor { get; set; }
         public Dictionary<string, object> Extensions { get; set; } = new Dictionary<string, object>();
     }
@@ -50,6 +51,12 @@ namespace FUSE.Authoring.Data
         /// instead of treating it as a package fault.
         /// </summary>
         public FuseModRequirement[] Requires { get; set; }
+
+        /// <summary>
+        /// Optional legacy incompatibility references. If any matching package
+        /// is enabled, only this conditional fragment is skipped.
+        /// </summary>
+        public FuseModRequirement[] ConflictsWith { get; set; }
     }
 
     public sealed class FuseModRequirement

--- a/FUSE/Authoring/Data/FuseModSettingsDefinition.cs
+++ b/FUSE/Authoring/Data/FuseModSettingsDefinition.cs
@@ -20,4 +20,45 @@ namespace FUSE.Authoring.Data
         public bool Advanced { get; set; }
         public bool ReloadRequired { get; set; }
     }
+
+    /// <summary>
+    /// Conditionally includes a named set of authored objects based on one
+    /// package setting. Rules are evaluated after schema validation and before
+    /// the definition becomes resident; changing the setting therefore takes
+    /// effect on the next map/package reload.
+    /// </summary>
+    public sealed class FuseFeatureRule
+    {
+        public string Setting { get; set; }
+        public string Operator { get; set; } = "equals";
+        public JToken Value { get; set; }
+        public FuseFeatureTargets Targets { get; set; } = new FuseFeatureTargets();
+    }
+
+    public sealed class FuseFeatureTargets
+    {
+        public string[] TrackNodes { get; set; } = Array.Empty<string>();
+        public string[] TrackSegments { get; set; } = Array.Empty<string>();
+        public string[] TrackSpans { get; set; } = Array.Empty<string>();
+        public string[] TrackAreas { get; set; } = Array.Empty<string>();
+        public string[] Loads { get; set; } = Array.Empty<string>();
+        public string[] Industries { get; set; } = Array.Empty<string>();
+        public string[] IndustryComponents { get; set; } = Array.Empty<string>();
+        public string[] Loaders { get; set; } = Array.Empty<string>();
+        public string[] Turntables { get; set; } = Array.Empty<string>();
+        public string[] Stations { get; set; } = Array.Empty<string>();
+        public string[] Scenery { get; set; } = Array.Empty<string>();
+        public string[] Splineys { get; set; } = Array.Empty<string>();
+        public string[] WaterSurfaces { get; set; } = Array.Empty<string>();
+        public string[] TelegraphPoles { get; set; } = Array.Empty<string>();
+        public string[] MapLabels { get; set; } = Array.Empty<string>();
+        public string[] MapMasks { get; set; } = Array.Empty<string>();
+        public string[] MapTiles { get; set; } = Array.Empty<string>();
+        public string[] SceneClones { get; set; } = Array.Empty<string>();
+        public string[] Progressions { get; set; } = Array.Empty<string>();
+        public string[] MapFeatures { get; set; } = Array.Empty<string>();
+        public string[] Whistles { get; set; } = Array.Empty<string>();
+        public string[] Horns { get; set; } = Array.Empty<string>();
+        public string[] Bells { get; set; } = Array.Empty<string>();
+    }
 }

--- a/FUSE/Authoring/Data/Operations/FuseIndustryComponentTypes.cs
+++ b/FUSE/Authoring/Data/Operations/FuseIndustryComponentTypes.cs
@@ -99,6 +99,7 @@ namespace FUSE.Authoring.Data
                 { "pay-for-resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
                 { "confusingsupplements.pay4resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
                 { "confusingsupplements.industrycomponents.pay4resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
+                { "adrfdr.pay4resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
                 { "confusingsupplements.empty", "ConfusingSupplements.IndustryComponents.Empty" },
                 { "confusingsupplements.industrycomponents.empty", "ConfusingSupplements.IndustryComponents.Empty" }
             };

--- a/FUSE/Authoring/Data/Tracks/FuseRemovedTrackSnapshots.cs
+++ b/FUSE/Authoring/Data/Tracks/FuseRemovedTrackSnapshots.cs
@@ -6,7 +6,7 @@ namespace FUSE.Authoring.Data
     /// <summary>
     /// Serializable node snapshot used to restore base-game track removed by a
     /// FUSE package. Preserved fields: id, transform, switch stand flip, thrown
-    /// state, and public CTC flags. Lossy fields: turntable links, private CTC
+    /// state, diamond-crossing state, and public CTC flags. Lossy fields: turntable links, private CTC
     /// display state, event delegates, and runtime cache state.
     /// </summary>
     public sealed class FuseRemovedNodeSnapshot
@@ -15,6 +15,7 @@ namespace FUSE.Authoring.Data
         public Vector3 Position { get; set; }
         public Vector3 Rotation { get; set; }
         public bool FlipSwitchStand { get; set; }
+        public bool IsDiamond { get; set; }
         public bool IsThrown { get; set; }
         public bool IsCtcSwitch { get; set; }
         public bool IsCtcSwitchUnlocked { get; set; }
@@ -22,7 +23,7 @@ namespace FUSE.Authoring.Data
 
     /// <summary>
     /// Serializable segment snapshot used to restore base-game track removed by a
-    /// FUSE package. Preserved fields: id, endpoints, style, class, group,
+    /// FUSE package. Preserved fields: id, endpoints, style/structure flags, class, group,
     /// priority, speed limit, availability flags, endpoint transforms, and
     /// measured length. Lossy fields: private Bezier caches, turntable links,
     /// editor gizmo state, and generated mesh state.
@@ -33,6 +34,7 @@ namespace FUSE.Authoring.Data
         public string StartNodeId { get; set; }
         public string EndNodeId { get; set; }
         public string Style { get; set; }
+        public int StructureFlags { get; set; }
         public string TrackClass { get; set; }
         public string GroupId { get; set; }
         public int Priority { get; set; }

--- a/FUSE/Authoring/Data/Tracks/FuseTrackDefinition.cs
+++ b/FUSE/Authoring/Data/Tracks/FuseTrackDefinition.cs
@@ -26,6 +26,7 @@ namespace FUSE.Authoring.Data
         public Vector3 Position { get; set; }
         public Vector3 Rotation { get; set; }
         public bool FlipSwitchStand { get; set; }
+        public bool IsDiamond { get; set; }
         public string GroupId { get; set; }
         public string[] Tags { get; set; }
     }
@@ -41,8 +42,12 @@ namespace FUSE.Authoring.Data
         public string GroupId { get; set; }
         public string[] Tags { get; set; }
         public string Gauge { get; set; }
+        public bool BridgeSupportsSteel { get; set; }
+        public bool Yard { get; set; }
         public bool Partial { get; set; }
         public bool PreserveStyle { get; set; }
+        public bool PreserveBridgeSupportsSteel { get; set; }
+        public bool PreserveYard { get; set; }
         public bool PreserveTrackClass { get; set; }
         public bool PreserveSpeedLimit { get; set; }
         public bool PreservePriority { get; set; }

--- a/FUSE/Authoring/Data/World/FuseWorldDefinition.cs
+++ b/FUSE/Authoring/Data/World/FuseWorldDefinition.cs
@@ -9,6 +9,7 @@ namespace FUSE.Authoring.Data
         public Dictionary<string, FuseScenery> Scenery { get; set; } = new Dictionary<string, FuseScenery>();
         public FuseSpawnPoint[] SpawnPoints { get; set; } = Array.Empty<FuseSpawnPoint>();
         public Dictionary<string, FuseSpliney> Splineys { get; set; } = new Dictionary<string, FuseSpliney>();
+        public Dictionary<string, FuseWaterSurface> WaterSurfaces { get; set; } = new Dictionary<string, FuseWaterSurface>();
         public Dictionary<string, FuseTelegraphPoles> TelegraphPoles { get; set; } = new Dictionary<string, FuseTelegraphPoles>();
         public FuseTelegraphPoleMovement[] TelegraphPoleMovements { get; set; } = Array.Empty<FuseTelegraphPoleMovement>();
         public Dictionary<string, FuseMapLabel> MapLabels { get; set; } = new Dictionary<string, FuseMapLabel>();
@@ -36,6 +37,7 @@ namespace FUSE.Authoring.Data
     {
         public string[] Scenery { get; set; } = Array.Empty<string>();
         public string[] Splineys { get; set; } = Array.Empty<string>();
+        public string[] WaterSurfaces { get; set; } = Array.Empty<string>();
         public string[] TelegraphPoles { get; set; } = Array.Empty<string>();
         public string[] MapLabels { get; set; } = Array.Empty<string>();
         public string[] MapMasks { get; set; } = Array.Empty<string>();
@@ -95,6 +97,17 @@ namespace FUSE.Authoring.Data
         public float OffsetY { get; set; }
         public string HeadStyle { get; set; }
         public string TailStyle { get; set; }
+        public string AssetIdentifier { get; set; }
+        public string Prefab { get; set; }
+        public float Spacing { get; set; } = 5f;
+        public Vector3 InstanceScale { get; set; } = Vector3.one;
+        public Vector3 RotationOffset { get; set; }
+        public float LateralOffset { get; set; }
+        public float VerticalOffset { get; set; }
+        public bool SnapToTerrain { get; set; }
+        public bool AlignToSlope { get; set; }
+        public bool PlaceAtEnd { get; set; } = true;
+        public int MaximumInstances { get; set; } = 1024;
         public FuseSplineyPoint[] Points { get; set; }
     }
 
@@ -103,6 +116,25 @@ namespace FUSE.Authoring.Data
         public Vector3 Position { get; set; }
         public Vector3 Rotation { get; set; }
         public float? Width { get; set; }
+    }
+
+    /// <summary>
+    /// A flat or terrain-following lake polygon. Points are authored in world
+    /// coordinates. FUSE reuses a loaded Railroader water material/profile so
+    /// native map packages do not need to copy game assets.
+    /// </summary>
+    public sealed class FuseWaterSurface
+    {
+        public Vector3[] Points { get; set; } = Array.Empty<Vector3>();
+        public string SourceLakePath { get; set; }
+        public string MaterialName { get; set; }
+        public bool LockHeight { get; set; } = true;
+        public bool SnapToTerrain { get; set; }
+        public bool EnableCollider { get; set; } = true;
+        public float UvScale { get; set; } = 1f;
+        public float TriangleDensity { get; set; } = 0.2f;
+        public float MaximumTriangleArea { get; set; } = 50f;
+        public float YOffset { get; set; }
     }
 
     public sealed class FuseTelegraphPoles

--- a/FUSE/Authoring/Entities/FuseSceneryEntity.cs
+++ b/FUSE/Authoring/Entities/FuseSceneryEntity.cs
@@ -34,6 +34,9 @@ namespace FUSE.Authoring.Entities
         [FuseHidden]
         public SceneryAssetInstance RuntimeScenery { get; private set; }
 
+        [FuseHidden]
+        public bool AllowUnverifiedLegacyAsset { get; set; }
+
         [FuseEditable("Anchor Spans", Group = "Scenery", Order = 12)]
         public string[] AnchorSpanIds { get; set; } = System.Array.Empty<string>();
 
@@ -108,11 +111,15 @@ namespace FUSE.Authoring.Entities
                 // recompute had no readers, and the per-item
                 // GetComponentsInChildren scan sat inside the post-load
                 // activation wave for nothing.
-                RuntimeScenery = SceneryAPI.AddScenery(Id, definition);
+                RuntimeScenery = SceneryAPI.AddScenery(
+                    Id,
+                    definition,
+                    onDeferredActivated: null,
+                    allowUnverifiedLegacyAsset: AllowUnverifiedLegacyAsset);
             }
             else
             {
-                SceneryAPI.UpdateScenery(Id, definition);
+                SceneryAPI.UpdateScenery(Id, definition, AllowUnverifiedLegacyAsset);
                 RuntimeScenery = SceneryAPI.GetScenery(Id);
             }
 

--- a/FUSE/Authoring/Migrations/FuseMigration.cs
+++ b/FUSE/Authoring/Migrations/FuseMigration.cs
@@ -70,6 +70,7 @@ namespace FUSE.Authoring.Migrations
             definition.Audio = definition.Audio ?? new FuseAudioRoot();
             definition.Progression = definition.Progression ?? new FuseProgressionRoot();
             definition.Settings = definition.Settings ?? new Dictionary<string, FuseModSettingDefinition>();
+            definition.FeatureRules = definition.FeatureRules ?? new Dictionary<string, FuseFeatureRule>();
             definition.Extensions = definition.Extensions ?? new Dictionary<string, object>();
 
             foreach (var setting in definition.Settings.Values.Where(setting => setting != null))
@@ -78,6 +79,7 @@ namespace FUSE.Authoring.Migrations
                 setting.Scope = string.IsNullOrWhiteSpace(setting.Scope) ? "user" : setting.Scope.Trim();
                 setting.Values = setting.Values ?? Array.Empty<string>();
             }
+            NormalizeFeatureRules(definition.FeatureRules);
 
             definition.Tracks.Nodes = definition.Tracks.Nodes ?? new Dictionary<string, FuseNode>();
             definition.Tracks.Segments = definition.Tracks.Segments ?? new Dictionary<string, FuseSegment>();
@@ -301,7 +303,49 @@ namespace FUSE.Authoring.Migrations
             mixinto.Target = string.IsNullOrWhiteSpace(mixinto.Target) ? null : mixinto.Target.Trim();
             mixinto.SourceFile = string.IsNullOrWhiteSpace(mixinto.SourceFile) ? null : mixinto.SourceFile.Trim();
             mixinto.Requires = mixinto.Requires ?? Array.Empty<FuseModRequirement>();
-            foreach (var requirement in mixinto.Requires)
+            mixinto.ConflictsWith = mixinto.ConflictsWith ?? Array.Empty<FuseModRequirement>();
+            NormalizeModReferences(mixinto.Requires);
+            NormalizeModReferences(mixinto.ConflictsWith);
+        }
+
+        private static void NormalizeFeatureRules(IDictionary<string, FuseFeatureRule> rules)
+        {
+            if (rules == null)
+                return;
+            foreach (var rule in rules.Values.Where(rule => rule != null))
+            {
+                rule.Operator = string.IsNullOrWhiteSpace(rule.Operator) ? "equals" : rule.Operator.Trim();
+                rule.Targets = rule.Targets ?? new FuseFeatureTargets();
+                var targets = rule.Targets;
+                targets.TrackNodes = targets.TrackNodes ?? Array.Empty<string>();
+                targets.TrackSegments = targets.TrackSegments ?? Array.Empty<string>();
+                targets.TrackSpans = targets.TrackSpans ?? Array.Empty<string>();
+                targets.TrackAreas = targets.TrackAreas ?? Array.Empty<string>();
+                targets.Loads = targets.Loads ?? Array.Empty<string>();
+                targets.Industries = targets.Industries ?? Array.Empty<string>();
+                targets.IndustryComponents = targets.IndustryComponents ?? Array.Empty<string>();
+                targets.Loaders = targets.Loaders ?? Array.Empty<string>();
+                targets.Turntables = targets.Turntables ?? Array.Empty<string>();
+                targets.Stations = targets.Stations ?? Array.Empty<string>();
+                targets.Scenery = targets.Scenery ?? Array.Empty<string>();
+                targets.Splineys = targets.Splineys ?? Array.Empty<string>();
+                targets.WaterSurfaces = targets.WaterSurfaces ?? Array.Empty<string>();
+                targets.TelegraphPoles = targets.TelegraphPoles ?? Array.Empty<string>();
+                targets.MapLabels = targets.MapLabels ?? Array.Empty<string>();
+                targets.MapMasks = targets.MapMasks ?? Array.Empty<string>();
+                targets.MapTiles = targets.MapTiles ?? Array.Empty<string>();
+                targets.SceneClones = targets.SceneClones ?? Array.Empty<string>();
+                targets.Progressions = targets.Progressions ?? Array.Empty<string>();
+                targets.MapFeatures = targets.MapFeatures ?? Array.Empty<string>();
+                targets.Whistles = targets.Whistles ?? Array.Empty<string>();
+                targets.Horns = targets.Horns ?? Array.Empty<string>();
+                targets.Bells = targets.Bells ?? Array.Empty<string>();
+            }
+        }
+
+        private static void NormalizeModReferences(FuseModRequirement[] references)
+        {
+            foreach (var requirement in references ?? Array.Empty<FuseModRequirement>())
             {
                 if (requirement == null)
                 {

--- a/FUSE/Authoring/Validation/FuseDefinitionValidator.cs
+++ b/FUSE/Authoring/Validation/FuseDefinitionValidator.cs
@@ -12,6 +12,13 @@ namespace FUSE.Authoring.Validation
 {
     public sealed class FuseDefinitionValidator : IValidator<FuseModDefinition>
     {
+        private static readonly HashSet<string> ValidFeatureRuleOperators =
+            new HashSet<string>(new[]
+            {
+                "equals", "notEquals", "greaterThan", "greaterThanOrEqual",
+                "lessThan", "lessThanOrEqual"
+            }, StringComparer.OrdinalIgnoreCase);
+
         public ValidationResult Validate(FuseModDefinition value)
         {
             var result = new ValidationResult();
@@ -49,6 +56,7 @@ namespace FUSE.Authoring.Validation
             ValidateAudio(result, value.Audio);
             ValidateProgression(result, value.Progression);
             ValidateSettings(result, value.Settings);
+            ValidateFeatureRules(result, value);
             return result;
         }
 
@@ -97,20 +105,30 @@ namespace FUSE.Authoring.Validation
                 result.AddWarning("mixinto.sourceFile", "Mixinto sourceFile is blank; conversion provenance will be less clear.", "fuse.mixinto.sourceFile.blank");
             }
 
-            var requirements = mixinto.Requires ?? Array.Empty<FuseModRequirement>();
-            for (var index = 0; index < requirements.Length; index++)
+            ValidateMixintoReferences(result, mixinto.Requires, "requires", "requirement");
+            ValidateMixintoReferences(result, mixinto.ConflictsWith, "conflictsWith", "conflict");
+        }
+
+        private static void ValidateMixintoReferences(
+            ValidationResult result,
+            FuseModRequirement[] references,
+            string propertyName,
+            string kind)
+        {
+            var materialized = references ?? Array.Empty<FuseModRequirement>();
+            for (var index = 0; index < materialized.Length; index++)
             {
-                var requirement = requirements[index];
-                var path = $"mixinto.requires[{index}]";
+                var requirement = materialized[index];
+                var path = $"mixinto.{propertyName}[{index}]";
                 if (requirement == null)
                 {
-                    result.AddWarning(path, "Null mixinto requirement will be ignored.", "fuse.mixinto.requirement.null");
+                    result.AddWarning(path, $"Null mixinto {kind} will be ignored.", $"fuse.mixinto.{kind}.null");
                     continue;
                 }
 
                 if (string.IsNullOrWhiteSpace(requirement.Id))
                 {
-                    result.AddWarning($"{path}.id", "Mixinto requirement id is blank and will be ignored.", "fuse.mixinto.requirement.id.blank");
+                    result.AddWarning($"{path}.id", $"Mixinto {kind} id is blank and will be ignored.", $"fuse.mixinto.{kind}.id.blank");
                 }
             }
         }
@@ -160,6 +178,111 @@ namespace FUSE.Authoring.Validation
                     result.AddWarning(path, "Server-scoped reload-required settings should be documented for multiplayer profile sharing.", "fuse.settings.server.reloadRequired", pair.Key);
                 }
             }
+        }
+
+        private static void ValidateFeatureRules(ValidationResult result, FuseModDefinition definition)
+        {
+            var rules = definition.FeatureRules;
+            if (rules == null)
+                return;
+            foreach (var pair in rules)
+            {
+                var path = $"featureRules.{pair.Key}";
+                if (string.IsNullOrWhiteSpace(pair.Key))
+                {
+                    result.AddError("featureRules", "Feature rule IDs must not be blank.", "fuse.featureRule.id.blank");
+                    continue;
+                }
+                var rule = pair.Value;
+                if (rule == null)
+                {
+                    result.AddError(path, "Feature rule definition is required.", "fuse.featureRule.required");
+                    continue;
+                }
+                if (string.IsNullOrWhiteSpace(rule.Setting) ||
+                    !definition.Settings.TryGetValue(rule.Setting, out var setting) || setting == null)
+                {
+                    result.AddError($"{path}.setting", "Feature rule must reference a setting declared by this definition.", "fuse.featureRule.setting.missing", rule.Setting);
+                }
+                else
+                {
+                    var normalizedOperator = (rule.Operator ?? "equals").Trim();
+                    if ((normalizedOperator.Equals("greaterThan", StringComparison.OrdinalIgnoreCase) ||
+                         normalizedOperator.Equals("greaterThanOrEqual", StringComparison.OrdinalIgnoreCase) ||
+                         normalizedOperator.Equals("lessThan", StringComparison.OrdinalIgnoreCase) ||
+                         normalizedOperator.Equals("lessThanOrEqual", StringComparison.OrdinalIgnoreCase)) &&
+                        FuseModSettingsStore.NormalizeType(setting.Type) != "number")
+                    {
+                        result.AddError($"{path}.operator", "Numeric feature-rule comparisons require a number setting.", "fuse.featureRule.operator.type", rule.Operator);
+                    }
+                    if (!setting.ReloadRequired)
+                    {
+                        result.AddWarning($"settings.{rule.Setting}.reloadRequired", "Settings used by feature rules take effect on map reload; set reloadRequired to true so players are told clearly.", "fuse.featureRule.setting.reloadRequired", rule.Setting);
+                    }
+                }
+                if (!ValidFeatureRuleOperators.Contains((rule.Operator ?? "equals").Trim()))
+                    result.AddError($"{path}.operator", "Feature rule operator is not supported.", "fuse.featureRule.operator", rule.Operator);
+                if (rule.Value == null)
+                    result.AddError($"{path}.value", "Feature rule comparison value is required.", "fuse.featureRule.value.required");
+                ValidateFeatureTargets(result, definition, path, rule.Targets);
+            }
+        }
+
+        private static void ValidateFeatureTargets(ValidationResult result, FuseModDefinition definition, string path, FuseFeatureTargets targets)
+        {
+            if (targets == null)
+            {
+                result.AddError($"{path}.targets", "Feature rule targets are required.", "fuse.featureRule.targets.required");
+                return;
+            }
+            var componentIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var industry in definition.Operations.Industries)
+                foreach (var component in industry.Value?.Components ?? new Dictionary<string, FuseIndustryComponent>())
+                    componentIds.Add(industry.Key + "/" + component.Key);
+            var count = 0;
+            count += ValidateFeatureTargetIds(result, path, "trackNodes", targets.TrackNodes, definition.Tracks.Nodes.Keys);
+            count += ValidateFeatureTargetIds(result, path, "trackSegments", targets.TrackSegments, definition.Tracks.Segments.Keys);
+            count += ValidateFeatureTargetIds(result, path, "trackSpans", targets.TrackSpans, definition.Tracks.Spans.Keys);
+            count += ValidateFeatureTargetIds(result, path, "trackAreas", targets.TrackAreas, definition.Tracks.Areas.Keys);
+            count += ValidateFeatureTargetIds(result, path, "loads", targets.Loads, definition.Operations.Loads.Keys);
+            count += ValidateFeatureTargetIds(result, path, "industries", targets.Industries, definition.Operations.Industries.Keys);
+            count += ValidateFeatureTargetIds(result, path, "industryComponents", targets.IndustryComponents, componentIds);
+            count += ValidateFeatureTargetIds(result, path, "loaders", targets.Loaders, definition.Operations.Loaders.Keys);
+            count += ValidateFeatureTargetIds(result, path, "turntables", targets.Turntables, definition.Operations.Turntables.Keys);
+            count += ValidateFeatureTargetIds(result, path, "stations", targets.Stations, definition.Operations.Stations.Keys);
+            count += ValidateFeatureTargetIds(result, path, "scenery", targets.Scenery, definition.World.Scenery.Keys);
+            count += ValidateFeatureTargetIds(result, path, "splineys", targets.Splineys, definition.World.Splineys.Keys);
+            count += ValidateFeatureTargetIds(result, path, "waterSurfaces", targets.WaterSurfaces, definition.World.WaterSurfaces.Keys);
+            count += ValidateFeatureTargetIds(result, path, "telegraphPoles", targets.TelegraphPoles, definition.World.TelegraphPoles.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapLabels", targets.MapLabels, definition.World.MapLabels.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapMasks", targets.MapMasks, definition.World.MapMasks.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapTiles", targets.MapTiles, definition.World.MapTiles.Keys);
+            count += ValidateFeatureTargetIds(result, path, "sceneClones", targets.SceneClones, definition.World.SceneClones.Keys);
+            count += ValidateFeatureTargetIds(result, path, "progressions", targets.Progressions, definition.Progression.Progressions.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapFeatures", targets.MapFeatures, definition.Progression.MapFeatures.Keys);
+            count += ValidateFeatureTargetIds(result, path, "whistles", targets.Whistles, definition.Audio.Whistles.Keys);
+            count += ValidateFeatureTargetIds(result, path, "horns", targets.Horns, definition.Audio.Horns.Keys);
+            count += ValidateFeatureTargetIds(result, path, "bells", targets.Bells, definition.Audio.Bells.Keys);
+            if (count == 0)
+                result.AddError($"{path}.targets", "Feature rule must target at least one authored object.", "fuse.featureRule.targets.empty");
+        }
+
+        private static int ValidateFeatureTargetIds(ValidationResult result, string path, string property, IEnumerable<string> values, IEnumerable<string> defined)
+        {
+            var ids = (values ?? Array.Empty<string>()).ToArray();
+            var known = new HashSet<string>(defined ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var index = 0; index < ids.Length; index++)
+            {
+                var id = ids[index];
+                if (string.IsNullOrWhiteSpace(id))
+                    result.AddError($"{path}.targets.{property}[{index}]", "Feature target ID must not be blank.", "fuse.featureRule.target.blank");
+                else if (!known.Contains(id))
+                    result.AddError($"{path}.targets.{property}[{index}]", "Feature target must name an object authored in this definition.", "fuse.featureRule.target.missing", id);
+                else if (!seen.Add(id))
+                    result.AddWarning($"{path}.targets.{property}[{index}]", "Feature target is listed more than once in this rule.", "fuse.featureRule.target.duplicate", id);
+            }
+            return ids.Length;
         }
 
         private static void ValidateTrack(ValidationResult result, FuseTrackDefinition tracks, FuseOperationsDefinition operations)
@@ -546,6 +669,7 @@ namespace FUSE.Authoring.Validation
             {
                 ValidateWorldRemovalTargets(result, "world.removals.scenery", world.Removals.Scenery, world.Scenery.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.splineys", world.Removals.Splineys, world.Splineys.Keys);
+                ValidateWorldRemovalTargets(result, "world.removals.waterSurfaces", world.Removals.WaterSurfaces, world.WaterSurfaces.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.telegraphPoles", world.Removals.TelegraphPoles, world.TelegraphPoles.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.mapLabels", world.Removals.MapLabels, world.MapLabels.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.mapMasks", world.Removals.MapMasks, world.MapMasks.Keys);
@@ -596,11 +720,52 @@ namespace FUSE.Authoring.Validation
 
             foreach (var spliney in world.Splineys)
             {
-                Required(result, $"world.splineys.{spliney.Key}.type", spliney.Value.Type);
-                if (spliney.Value.Points == null || spliney.Value.Points.Length < 2)
+                var path = $"world.splineys.{spliney.Key}";
+                var value = spliney.Value;
+                if (value == null)
                 {
-                    result.AddError($"world.splineys.{spliney.Key}.points", "Spliney objects require at least two points.", "fuse.spliney.points");
+                    result.AddError(path, "Spliney definition is required.", "fuse.spliney.required");
+                    continue;
                 }
+                Required(result, $"{path}.type", value.Type);
+                if (value.Points == null || value.Points.Length < 2)
+                {
+                    result.AddError($"{path}.points", "Spliney objects require at least two points.", "fuse.spliney.points");
+                }
+                if (IsObjectLine(value.Type))
+                {
+                    if (string.IsNullOrWhiteSpace(value.AssetIdentifier)
+                        == string.IsNullOrWhiteSpace(value.Prefab))
+                    {
+                        result.AddError(
+                            path,
+                            "Object-line splineys require exactly one of assetIdentifier or prefab.",
+                            "fuse.spliney.objectLine.source");
+                    }
+                    if (value.Spacing <= 0f)
+                        result.AddError($"{path}.spacing", "Object-line spacing must be greater than 0.", "fuse.spliney.objectLine.spacing", value.Spacing);
+                    if (value.MaximumInstances < 1 || value.MaximumInstances > 4096)
+                        result.AddError($"{path}.maximumInstances", "Object-line maximumInstances must be between 1 and 4096.", "fuse.spliney.objectLine.maximumInstances", value.MaximumInstances);
+                }
+            }
+
+            foreach (var waterSurface in world.WaterSurfaces)
+            {
+                var path = $"world.waterSurfaces.{waterSurface.Key}";
+                var value = waterSurface.Value;
+                if (value == null)
+                {
+                    result.AddError(path, "Water surface definition is required.", "fuse.waterSurface.required");
+                    continue;
+                }
+                if (value.Points == null || value.Points.Length < 3)
+                    result.AddError($"{path}.points", "Water surfaces require at least three boundary points.", "fuse.waterSurface.points");
+                if (value.TriangleDensity <= 0f || value.TriangleDensity > 1f)
+                    result.AddError($"{path}.triangleDensity", "Triangle density must be greater than 0 and at most 1.", "fuse.waterSurface.triangleDensity", value.TriangleDensity);
+                if (value.MaximumTriangleArea <= 0f)
+                    result.AddError($"{path}.maximumTriangleArea", "Maximum triangle area must be greater than 0.", "fuse.waterSurface.maximumTriangleArea", value.MaximumTriangleArea);
+                if (value.UvScale <= 0f)
+                    result.AddError($"{path}.uvScale", "UV scale must be greater than 0.", "fuse.waterSurface.uvScale", value.UvScale);
             }
 
             foreach (var telegraph in world.TelegraphPoles)
@@ -703,6 +868,14 @@ namespace FUSE.Authoring.Validation
 
                 Required(result, $"world.sceneClones.{sceneClone.Key}.targetPath", sceneClone.Value.TargetPath);
             }
+        }
+
+        private static bool IsObjectLine(string type)
+        {
+            return string.Equals(type, "objectLine", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(type, "object-line", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(type, "fence", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(type, "retainingWall", StringComparison.OrdinalIgnoreCase);
         }
 
         private static void ValidateWorldRemovalTargets(ValidationResult result, string path, IEnumerable<string> removals, IEnumerable<string> definitions)

--- a/FUSE/Compatibility/FuseConfusingSupplementsBodygroups.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsBodygroups.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Infrastructure;
+using Game.Messages;
+using Game.State;
+using HarmonyLib;
+using KeyValue.Runtime;
+using Model;
+using Model.Definition;
+using Model.Definition.Data;
+using Railloader.Extensions;
+using UI.Builder;
+using UnityEngine;
+
+namespace FUSE.Compatibility
+{
+    /// <summary>
+    /// FUSE-owned implementation of the rolling-stock body-group component used by
+    /// legacy Confusing Supplements asset packs. The implementation deliberately
+    /// lives in FUSE's namespace: FUSE reproduces the data contract and behavior
+    /// without loading or redistributing the retired library assembly.
+    /// </summary>
+    internal sealed class FuseConfusingSupplementsBodygroupsComponent : Model.Definition.Component
+    {
+        internal const string ComponentKind = "ConfusingSupplements.Bodygroups";
+
+        public override string Kind => ComponentKind;
+
+        public Dictionary<string, FuseConfusingSupplementsBodygroup> Groups { get; set; } =
+            new Dictionary<string, FuseConfusingSupplementsBodygroup>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal sealed class FuseConfusingSupplementsBodygroup
+    {
+        public string Name { get; set; }
+
+        public Dictionary<string, FuseConfusingSupplementsBodygroupOption> Options { get; set; } =
+            new Dictionary<string, FuseConfusingSupplementsBodygroupOption>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal sealed class FuseConfusingSupplementsBodygroupOption
+    {
+        public string Name { get; set; }
+
+        public string[] Path { get; set; }
+    }
+
+    internal sealed class FuseConfusingSupplementsBodygroupsBuilder : ComponentBuilder<FuseConfusingSupplementsBodygroupsComponent>
+    {
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsBodygroupsComponent component)
+        {
+            var car = context.GameObject?.GetComponentInParent<Car>();
+            var modelRoot = car?.BodyTransform;
+            if (car == null || modelRoot == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not attach legacy bodygroups to '{context.ObjectName ?? "<unknown car>"}' " +
+                    "because its car body was unavailable.");
+                return;
+            }
+
+            foreach (var groupEntry in component?.Groups ??
+                         Enumerable.Empty<KeyValuePair<string, FuseConfusingSupplementsBodygroup>>())
+            {
+                var groupId = groupEntry.Key?.Trim();
+                var group = groupEntry.Value;
+                if (string.IsNullOrWhiteSpace(groupId) || group?.Options == null || group.Options.Count == 0)
+                {
+                    FuseLog.Warning(
+                        $"FUSE ignored an empty legacy bodygroup on '{context.ObjectName ?? "<unknown car>"}'.");
+                    continue;
+                }
+
+                var propertyKey = "cs.bodygroups." + groupId;
+                var options = group.Options.ToArray();
+                context.ObserveProperty(propertyKey, value => ApplySelection(
+                    context.ObjectName,
+                    modelRoot,
+                    groupId,
+                    options,
+                    ReadSelectedOption(value, options)));
+            }
+        }
+
+        internal static string ReadSelectedOption(
+            Value value,
+            IReadOnlyList<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>> options)
+        {
+            var selected = value.StringValue;
+            return string.IsNullOrWhiteSpace(selected) && options != null && options.Count > 0
+                ? options[0].Key
+                : selected;
+        }
+
+        private static void ApplySelection(
+            string objectName,
+            Transform modelRoot,
+            string groupId,
+            IEnumerable<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>> options,
+            string selectedId)
+        {
+            foreach (var optionEntry in options)
+            {
+                var path = optionEntry.Value?.Path;
+                if (path == null || path.Length == 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var target = modelRoot.ResolveTransform(
+                        new TransformReference { Path = path },
+                        defaultReturnsReceiver: false);
+                    if (target == null)
+                    {
+                        FuseLog.Warning(
+                            $"FUSE legacy bodygroup '{groupId}' on '{objectName ?? "<unknown car>"}' " +
+                            $"could not resolve option '{optionEntry.Key}' path '{string.Join("/", path)}'.");
+                        continue;
+                    }
+
+                    target.gameObject.SetActive(
+                        string.Equals(optionEntry.Key, selectedId, StringComparison.OrdinalIgnoreCase));
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE contained a malformed legacy bodygroup path for '{objectName ?? "<unknown car>"}', " +
+                        $"group '{groupId}', option '{optionEntry.Key}': {ex.GetBaseException().Message}");
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(UI.CarCustomizeWindow.CarCustomizeWindow), "BuildColorTab")]
+    internal static class FuseConfusingSupplementsBodygroupsCustomizePatch
+    {
+        private static void Postfix(UIPanelBuilder builder, Car ____car)
+        {
+            if (____car?.Definition?.Components == null)
+            {
+                return;
+            }
+
+            var components = ____car.Definition.Components
+                .OfType<FuseConfusingSupplementsBodygroupsComponent>()
+                .Where(component => component.Groups != null && component.Groups.Count > 0)
+                .ToArray();
+            if (components.Length == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                builder.AddSection("Bodygroups", section =>
+                {
+                    foreach (var component in components)
+                    {
+                        AddGroups(section, ____car, component);
+                    }
+                }, 0f);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a legacy bodygroup Customize-window error; " +
+                    $"the rest of the window remains usable: {ex.GetBaseException().Message}");
+            }
+        }
+
+        private static void AddGroups(
+            UIPanelBuilder builder,
+            Car car,
+            FuseConfusingSupplementsBodygroupsComponent component)
+        {
+            foreach (var groupEntry in component.Groups)
+            {
+                var groupId = groupEntry.Key?.Trim();
+                var group = groupEntry.Value;
+                if (string.IsNullOrWhiteSpace(groupId) || group?.Options == null || group.Options.Count == 0)
+                {
+                    continue;
+                }
+
+                var optionEntries = group.Options.ToArray();
+                var optionIds = optionEntries.Select(entry => entry.Key).ToArray();
+                var optionNames = optionEntries
+                    .Select(entry => string.IsNullOrWhiteSpace(entry.Value?.Name) ? entry.Key : entry.Value.Name)
+                    .ToList();
+                var propertyKey = "cs.bodygroups." + groupId;
+                var current = car.KeyValueObject == null
+                    ? null
+                    : car.KeyValueObject[propertyKey].StringValue;
+                var selectedIndex = Array.FindIndex(
+                    optionIds,
+                    optionId => string.Equals(optionId, current, StringComparison.OrdinalIgnoreCase));
+                if (selectedIndex < 0)
+                {
+                    selectedIndex = 0;
+                }
+
+                var fieldName = string.IsNullOrWhiteSpace(group.Name) ? groupId : group.Name;
+                builder.AddField(fieldName, builder.AddDropdown(optionNames, selectedIndex, index =>
+                {
+                    if (index < 0 || index >= optionIds.Length)
+                    {
+                        return;
+                    }
+
+                    StateManager.ApplyLocal(new PropertyChange(
+                        car.id,
+                        propertyKey,
+                        new StringPropertyValue(optionIds[index])));
+                }));
+            }
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsCompatibility.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsCompatibility.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FUSE.Infrastructure;
+using Model;
+
+namespace FUSE.Compatibility
+{
+    /// <summary>
+    /// Owns the legacy component discriminator and saved-property contracts that
+    /// FUSE replaces when the retired Confusing Supplements package is suppressed.
+    /// </summary>
+    internal static class FuseConfusingSupplementsCompatibility
+    {
+        private static readonly object Gate = new object();
+        private static bool _initialized;
+
+        internal static IReadOnlyList<string> ImplementedComponentKinds { get; } = new[]
+        {
+            FuseConfusingSupplementsBodygroupsComponent.ComponentKind,
+            FuseConfusingSupplementsDestinationSignComponent.ComponentKind,
+            FuseConfusingSupplementsLabelPrinterComponent.ComponentKind,
+            FuseConfusingSupplementsLiveryComponent.ComponentKind,
+            FuseConfusingSupplementsRefillerComponent.ComponentKind
+        };
+
+        internal static void Initialize()
+        {
+            lock (Gate)
+            {
+                if (_initialized)
+                {
+                    return;
+                }
+
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsBodygroupsComponent),
+                    typeof(FuseConfusingSupplementsBodygroupsBuilder),
+                    FuseConfusingSupplementsBodygroupsComponent.ComponentKind);
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsDestinationSignComponent),
+                    typeof(FuseConfusingSupplementsDestinationSignBuilder),
+                    FuseConfusingSupplementsDestinationSignComponent.ComponentKind);
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsLabelPrinterComponent),
+                    typeof(FuseConfusingSupplementsLabelPrinterBuilder),
+                    FuseConfusingSupplementsLabelPrinterComponent.ComponentKind);
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsLiveryComponent),
+                    typeof(FuseConfusingSupplementsLiveryBuilder),
+                    FuseConfusingSupplementsLiveryComponent.ComponentKind);
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsRefillerComponent),
+                    typeof(FuseConfusingSupplementsRefillerBuilder),
+                    FuseConfusingSupplementsRefillerComponent.ComponentKind);
+                AppendTrainmasterPrefixes("cs.bodygroups.", "cs.labelprinter.", "cs.livery");
+                _initialized = true;
+            }
+        }
+
+        private static void RegisterComponent(Type componentType, Type builderType, string kind)
+        {
+            try
+            {
+                FuseLegacyTypeRegistry.RegisterComponent(componentType, builderType, kind);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not register its replacement for legacy component '{kind}': " +
+                    $"{ex.GetBaseException().GetType().Name}: {ex.GetBaseException().Message}");
+            }
+        }
+
+        private static void AppendTrainmasterPrefixes(params string[] requiredPrefixes)
+        {
+            try
+            {
+                var field = typeof(Car).GetField(
+                    "TrainmasterPrefixes",
+                    BindingFlags.Static | BindingFlags.NonPublic);
+                var current = field?.GetValue(null) as string[];
+                if (field == null || current == null)
+                {
+                    FuseLog.Warning(
+                        "FUSE could not extend the car property access list for legacy Confusing Supplements customization.");
+                    return;
+                }
+
+                var merged = current
+                    .Concat(requiredPrefixes ?? Array.Empty<string>())
+                    .Where(prefix => !string.IsNullOrWhiteSpace(prefix))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                if (merged.Length != current.Length)
+                {
+                    field.SetValue(null, merged);
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not extend the car property access list for legacy Confusing Supplements " +
+                    $"customization: {ex.GetBaseException().Message}");
+            }
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsDestinationSign.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsDestinationSign.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AssetPack.Runtime;
+using Effects.Decals;
+using FUSE.Infrastructure;
+using Helpers;
+using Helpers.Culling;
+using Model;
+using Model.Definition.Data;
+using Railloader.Extensions;
+using UnityEngine;
+using UnityEngine.Rendering.Universal;
+
+namespace FUSE.Compatibility
+{
+    internal sealed class FuseConfusingSupplementsDestinationSignComponent : Model.Definition.Component
+    {
+        internal const string ComponentKind = "ConfusingSupplements.DestinationSign";
+
+        public override string Kind => ComponentKind;
+
+        public AssetReference Model { get; set; } = new AssetReference();
+
+        public Vector3 Size { get; set; } = Vector3.one;
+
+        public List<string> Destinations { get; set; } = new List<string>();
+    }
+
+    internal sealed class FuseConfusingSupplementsDestinationSignBuilder : ComponentBuilder<FuseConfusingSupplementsDestinationSignComponent>
+    {
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsDestinationSignComponent component)
+        {
+            if (context.GameObject == null || component == null)
+            {
+                return;
+            }
+
+            var controller = context.GameObject.AddComponent<FuseConfusingSupplementsDestinationSignController>();
+            controller.Configure(component);
+        }
+    }
+
+    internal sealed class FuseConfusingSupplementsDestinationSignController : MonoBehaviour,
+        IPickable,
+        CullingManager.ICullingEventHandler
+    {
+        private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
+        private LoadedAssetReference<GameObject> _loadedModel;
+        private CullingManager.Token _cullingToken;
+        private DecalProjectorHelper _decal;
+        private GameObject _modelInstance;
+        private GameObject _sign;
+        private string[] _destinations = Array.Empty<string>();
+        private int _selectedIndex = -1;
+
+        public float MaxPickDistance => _sign == null ? 0f : 5f;
+
+        public int Priority => 0;
+
+        public TooltipInfo TooltipInfo => new TooltipInfo("Change destination sign", "Primary: next; secondary: previous");
+
+        public PickableActivationFilter ActivationFilter => PickableActivationFilter.Any;
+
+        internal async void Configure(FuseConfusingSupplementsDestinationSignComponent component)
+        {
+            await ConfigureAsync(component);
+        }
+
+        private async Task ConfigureAsync(FuseConfusingSupplementsDestinationSignComponent component)
+        {
+            try
+            {
+                if (component?.Model == null || component.Model.IsEmpty)
+                {
+                    throw new ArgumentException("Destination-sign model reference is empty.");
+                }
+
+                _destinations = (component.Destinations ?? new List<string>())
+                    .Where(destination => !string.IsNullOrWhiteSpace(destination))
+                    .ToArray();
+                _loadedModel = await TrainController.Shared.PrefabStore.LoadAssetAsync<GameObject>(
+                    component.Model.AssetPackIdentifier,
+                    component.Model.AssetIdentifier,
+                    _cancellation.Token);
+                _cancellation.Token.ThrowIfCancellationRequested();
+
+                if (_loadedModel?.Asset == null)
+                {
+                    throw new InvalidOperationException($"Destination-sign model '{component.Model.AssetIdentifier}' did not load.");
+                }
+
+                _modelInstance = UnityEngine.Object.Instantiate(_loadedModel.Asset, transform, false);
+                _modelInstance.name = "FUSE Destination Sign";
+                _modelInstance.transform.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
+                _sign = _modelInstance.GetComponentsInChildren<Transform>(true)
+                    .FirstOrDefault(child => string.Equals(child.name, "Sign", StringComparison.OrdinalIgnoreCase))
+                    ?.gameObject;
+                if (_sign == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Destination-sign model '{component.Model.AssetIdentifier}' has no child named 'Sign'.");
+                }
+
+                var projectorObject = new GameObject("FUSE Destination Text");
+                projectorObject.SetActive(false);
+                projectorObject.transform.SetParent(_sign.transform, false);
+                projectorObject.transform.SetLocalPositionAndRotation(
+                    Vector3.forward * 0.1f,
+                    Quaternion.Euler(0f, 180f, 0f));
+
+                var projector = projectorObject.AddComponent<DecalProjector>();
+                projector.size = component.Size;
+                projector.pivot = Vector3.zero;
+                projector.drawDistance = Mathf.Max(
+                    600f,
+                    Mathf.Max(component.Size.x, component.Size.y) * 100f);
+
+                _decal = projectorObject.AddComponent<DecalProjectorHelper>();
+                _decal.decalRenderer = CanvasDecalRenderer.Shared;
+                _decal.templateName = "Tender";
+                _decal.text = string.Empty;
+                _decal.ForceColor(Color.black);
+                _decal.RenderDecal();
+                projectorObject.SetActive(true);
+
+                _cullingToken = CullingManager.Scenery?.AddSphere(transform, 10f, this);
+                _cullingToken?.RegisterFixedUpdate(transform);
+                RefreshSign();
+            }
+            catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not build a legacy destination sign: " +
+                    $"{ex.GetBaseException().GetType().Name}: {ex.GetBaseException().Message}");
+                CleanupRuntimeObjects();
+            }
+        }
+
+        public void Activate(PickableActivateEvent evt)
+        {
+            _selectedIndex = NextIndex(
+                _selectedIndex,
+                _destinations.Length,
+                evt.Activation == PickableActivation.Secondary);
+            RefreshSign();
+        }
+
+        public void Deactivate()
+        {
+        }
+
+        internal static int NextIndex(int current, int count, bool previous)
+        {
+            if (count <= 0)
+            {
+                return -1;
+            }
+
+            if (previous)
+            {
+                return current <= -1 ? count - 1 : current - 1;
+            }
+
+            return current >= count - 1 ? -1 : current + 1;
+        }
+
+        private void RefreshSign()
+        {
+            if (_sign == null)
+            {
+                return;
+            }
+
+            if (_selectedIndex < 0 || _selectedIndex >= _destinations.Length || _decal == null)
+            {
+                _sign.SetActive(false);
+                return;
+            }
+
+            _decal.text = _destinations[_selectedIndex];
+            _decal.RenderDecal();
+            _sign.SetActive(true);
+        }
+
+        public void CullingSphereStateChanged(bool isVisible, int distanceBand)
+        {
+            if (_modelInstance != null)
+            {
+                _modelInstance.SetActive(isVisible && distanceBand < 1);
+            }
+        }
+
+        public void RequestUpdateCullingPosition()
+        {
+            _cullingToken?.UpdatePosition(transform);
+        }
+
+        private void OnDestroy()
+        {
+            _cancellation.Cancel();
+            _cancellation.Dispose();
+            CleanupRuntimeObjects();
+        }
+
+        private void CleanupRuntimeObjects()
+        {
+            _cullingToken?.Dispose();
+            _cullingToken = null;
+            _loadedModel?.Dispose();
+            _loadedModel = null;
+            if (_modelInstance != null)
+            {
+                UnityEngine.Object.Destroy(_modelInstance);
+                _modelInstance = null;
+            }
+
+            _sign = null;
+            _decal = null;
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Effects.Decals;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Helpers;
+using KeyValue.Runtime;
+using Model;
+using Model.Definition;
+using Model.Definition.Components;
+using Newtonsoft.Json;
+using Railloader.Extensions;
+using UI.Builder;
+using UnityEngine;
+using UnityEngine.Rendering.Universal;
+
+namespace FUSE.Compatibility
+{
+    internal sealed class FuseConfusingSupplementsLabelPrinterComponent : DecalComponent
+    {
+        internal const string ComponentKind = "ConfusingSupplements.LabelPrinter";
+
+        public override string Kind => ComponentKind;
+
+        public string Group { get; set; }
+
+        [JsonIgnore]
+        [DefinitionProperty(Hidden = true)]
+        public string SavedPropertyId => string.IsNullOrWhiteSpace(Group) ? Name : Group;
+    }
+
+    internal sealed class FuseConfusingSupplementsLabelPrinterBuilder : ComponentBuilder<FuseConfusingSupplementsLabelPrinterComponent>
+    {
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsLabelPrinterComponent component)
+        {
+            if (context.GameObject == null || component == null)
+            {
+                return;
+            }
+
+            var savedPropertyId = component.SavedPropertyId?.Trim();
+            if (string.IsNullOrWhiteSpace(savedPropertyId))
+            {
+                FuseLog.Warning(
+                    $"FUSE ignored a legacy label-printer component on '{context.ObjectName ?? "<unknown car>"}' " +
+                    "because both name and group are empty.");
+                return;
+            }
+
+            var projector = context.GameObject.AddComponent<DecalProjector>();
+            projector.size = component.Size;
+            projector.pivot = Vector3.zero;
+            projector.drawDistance = Mathf.Max(
+                600f,
+                Mathf.Max(component.Size.x, component.Size.y) * 100f);
+
+            var helper = context.GameObject.AddComponent<DecalProjectorHelper>();
+            helper.decalRenderer = CanvasDecalRenderer.Shared;
+            helper.templateName = TemplateName(component.Content);
+            if (!string.IsNullOrWhiteSpace(component.ForceColor))
+            {
+                var color = ColorHelper.ColorFromHex(component.ForceColor);
+                if (color.HasValue)
+                {
+                    helper.ForceColor(color.Value);
+                }
+            }
+
+            context.ObserveProperty("cs.labelprinter." + savedPropertyId, value =>
+            {
+                helper.text = ReadText(value);
+                helper.RenderDecal();
+            });
+        }
+
+        internal static string ReadText(Value value)
+        {
+            var values = value.DictionaryValue;
+            return values != null && values.TryGetValue("text", out var text)
+                ? text.StringValue ?? string.Empty
+                : string.Empty;
+        }
+
+        private static string TemplateName(DecalContent content)
+        {
+            switch (content)
+            {
+                case DecalContent.RoadNumber:
+                    return "Number";
+                case DecalContent.Lettering:
+                    return "Tender";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(content), content, "Unsupported label-printer content type.");
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(UI.CarCustomizeWindow.CarCustomizeWindow), "BuildColorTab")]
+    internal static class FuseConfusingSupplementsLabelPrinterCustomizePatch
+    {
+        private static void Postfix(UIPanelBuilder builder, Car ____car)
+        {
+            if (____car?.Definition?.Components == null)
+            {
+                return;
+            }
+
+            var labels = ____car.Definition.Components
+                .OfType<FuseConfusingSupplementsLabelPrinterComponent>()
+                .Where(component => !string.IsNullOrWhiteSpace(component.SavedPropertyId))
+                .GroupBy(component => component.SavedPropertyId, StringComparer.OrdinalIgnoreCase)
+                .Select(group => new
+                {
+                    Id = group.Key,
+                    Name = group.Select(component => component.Name)
+                        .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name)) ?? group.Key
+                })
+                .OrderBy(label => label.Name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (labels.Length == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                builder.AddSection("Labels", section =>
+                {
+                    foreach (var label in labels)
+                    {
+                        section.AddField(
+                            label.Name,
+                            section.AddInputField(
+                                GetText(____car, label.Id),
+                                text => SetText(____car, label.Id, text),
+                                null,
+                                100));
+                    }
+                }, 0f);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a legacy label-printer Customize-window error; " +
+                    $"the rest of the window remains usable: {ex.GetBaseException().Message}");
+            }
+        }
+
+        internal static string GetText(Car car, string savedPropertyId)
+        {
+            if (car?.KeyValueObject == null || string.IsNullOrWhiteSpace(savedPropertyId))
+            {
+                return string.Empty;
+            }
+
+            return FuseConfusingSupplementsLabelPrinterBuilder.ReadText(
+                car.KeyValueObject["cs.labelprinter." + savedPropertyId]);
+        }
+
+        private static void SetText(Car car, string savedPropertyId, string text)
+        {
+            if (car?.KeyValueObject == null || string.IsNullOrWhiteSpace(savedPropertyId))
+            {
+                return;
+            }
+
+            car.KeyValueObject["cs.labelprinter." + savedPropertyId] = Value.Dictionary(
+                new Dictionary<string, Value>
+                {
+                    ["text"] = Value.String(text ?? string.Empty)
+                });
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsLivery.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsLivery.cs
@@ -1,0 +1,515 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using HarmonyLib;
+using KeyValue.Runtime;
+using Model;
+using Railloader.Extensions;
+using UI.Builder;
+using UnityEngine;
+
+namespace FUSE.Compatibility
+{
+    internal sealed class FuseConfusingSupplementsLiveryComponent : Model.Definition.Component
+    {
+        internal const string ComponentKind = "CS.LiverySwap";
+
+        public override string Kind => ComponentKind;
+    }
+
+    internal sealed class FuseConfusingSupplementsLiveryBuilder : ComponentBuilder<FuseConfusingSupplementsLiveryComponent>
+    {
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsLiveryComponent component)
+        {
+            var car = context.GameObject?.GetComponentInParent<Car>();
+            if (car == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not attach legacy livery support to '{context.ObjectName ?? "<unknown car>"}' " +
+                    "because its car object was unavailable.");
+                return;
+            }
+
+            var controller = car.GetComponent<FuseConfusingSupplementsLiveryController>() ??
+                             car.gameObject.AddComponent<FuseConfusingSupplementsLiveryController>();
+            controller.Configure(car);
+            context.ObserveProperty("cs.livery", controller.ApplySavedSelection);
+        }
+    }
+
+    internal sealed class FuseConfusingSupplementsLiveryController : MonoBehaviour
+    {
+        private readonly List<MaterialSnapshot> _materials = new List<MaterialSnapshot>();
+        private Car _car;
+        private string _carIdentifier;
+        private bool _configured;
+
+        internal void Configure(Car car)
+        {
+            if (_configured || car == null)
+            {
+                return;
+            }
+
+            _car = car;
+            _carIdentifier = car.DefinitionInfo.Identifier;
+            CaptureMaterials(car);
+            _configured = true;
+        }
+
+        internal void ApplySavedSelection(Value value)
+        {
+            if (!_configured)
+            {
+                return;
+            }
+
+            var selected = value.StringValue;
+            RestoreOriginalTextures();
+            if (string.IsNullOrWhiteSpace(selected))
+            {
+                return;
+            }
+
+            var choice = FuseConfusingSupplementsLiveryRegistry.GetChoices(_carIdentifier)
+                .FirstOrDefault(candidate => string.Equals(candidate.Id, selected, StringComparison.OrdinalIgnoreCase));
+            if (choice == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not find legacy livery '{selected}' for rolling stock '{_carIdentifier}'. " +
+                    "The standard textures remain active.");
+                return;
+            }
+
+            ApplyDirectory(choice.DirectoryPath);
+        }
+
+        internal string CarIdentifier => _carIdentifier ?? string.Empty;
+
+        internal string SelectedLiveryId
+        {
+            get
+            {
+                if (!_configured || _car?.KeyValueObject == null)
+                {
+                    return string.Empty;
+                }
+
+                return _car.KeyValueObject["cs.livery"].StringValue ?? string.Empty;
+            }
+        }
+
+        internal void RefreshFromSavedSelection()
+        {
+            if (!_configured)
+            {
+                return;
+            }
+
+            ApplySavedSelection(
+                _car?.KeyValueObject == null
+                    ? Value.Null()
+                    : _car.KeyValueObject["cs.livery"]);
+        }
+
+        private void CaptureMaterials(Car car)
+        {
+            var propertyIds = new List<int>();
+            foreach (var renderer in car.GetComponentsInChildren<Renderer>(true))
+            {
+                Material[] materials;
+                try
+                {
+                    // Renderer.materials creates per-renderer instances. This keeps a
+                    // livery chosen on one car from repainting every car that shares
+                    // the asset pack's source material.
+                    materials = renderer.materials;
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not isolate livery materials on '{_carIdentifier}': {ex.GetBaseException().Message}");
+                    continue;
+                }
+
+                foreach (var material in materials.Where(material => material != null))
+                {
+                    propertyIds.Clear();
+                    material.GetTexturePropertyNameIDs(propertyIds);
+                    foreach (var propertyId in propertyIds)
+                    {
+                        var texture = material.GetTexture(propertyId);
+                        if (texture == null)
+                        {
+                            continue;
+                        }
+
+                        _materials.Add(new MaterialSnapshot(
+                            material,
+                            propertyId,
+                            texture,
+                            texture.name ?? string.Empty));
+                    }
+                }
+            }
+        }
+
+        private void RestoreOriginalTextures()
+        {
+            foreach (var snapshot in _materials)
+            {
+                if (snapshot.Material != null)
+                {
+                    snapshot.Material.SetTexture(snapshot.PropertyId, snapshot.OriginalTexture);
+                }
+            }
+        }
+
+        private void ApplyDirectory(string directoryPath)
+        {
+            var files = FuseConfusingSupplementsLiveryRegistry.IndexTextureFiles(directoryPath);
+            if (files.Count == 0)
+            {
+                FuseLog.Warning(
+                    $"FUSE legacy livery folder '{directoryPath}' has no PNG or JPEG texture files.");
+                return;
+            }
+
+            var replacements = 0;
+            foreach (var snapshot in _materials)
+            {
+                if (snapshot.Material == null || string.IsNullOrWhiteSpace(snapshot.OriginalTextureName) ||
+                    !files.TryGetValue(snapshot.OriginalTextureName, out var texturePath))
+                {
+                    continue;
+                }
+
+                var texture = FuseConfusingSupplementsLiveryRegistry.LoadTexture(texturePath);
+                if (texture == null)
+                {
+                    continue;
+                }
+
+                snapshot.Material.SetTexture(snapshot.PropertyId, texture);
+                replacements++;
+            }
+
+            if (replacements == 0)
+            {
+                FuseLog.Warning(
+                    $"FUSE legacy livery folder '{directoryPath}' did not match any source texture names on " +
+                    $"rolling stock '{_carIdentifier}'.");
+            }
+        }
+
+        private sealed class MaterialSnapshot
+        {
+            internal MaterialSnapshot(
+                Material material,
+                int propertyId,
+                Texture originalTexture,
+                string originalTextureName)
+            {
+                Material = material;
+                PropertyId = propertyId;
+                OriginalTexture = originalTexture;
+                OriginalTextureName = originalTextureName;
+            }
+
+            internal Material Material { get; }
+            internal int PropertyId { get; }
+            internal Texture OriginalTexture { get; }
+            internal string OriginalTextureName { get; }
+        }
+    }
+
+    internal static class FuseConfusingSupplementsLiveryRegistry
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<string, Texture2D> Textures =
+            new Dictionary<string, Texture2D>(StringComparer.OrdinalIgnoreCase);
+
+        internal static int CachedTextureCount
+        {
+            get
+            {
+                lock (Gate)
+                {
+                    return Textures.Count(pair => pair.Value != null);
+                }
+            }
+        }
+
+        internal static int RefreshLiveCars()
+        {
+            ClearTextureCache();
+
+            var controllers = Resources
+                .FindObjectsOfTypeAll<FuseConfusingSupplementsLiveryController>()
+                .Where(IsLiveController)
+                .ToArray();
+            foreach (var controller in controllers)
+            {
+                try
+                {
+                    controller.RefreshFromSavedSelection();
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not refresh the legacy livery on '{controller.CarIdentifier}': " +
+                        ex.GetBaseException().Message);
+                }
+            }
+
+            return controllers.Length;
+        }
+
+        internal static string BuildDiagnosticReport()
+        {
+            var controllers = Resources
+                .FindObjectsOfTypeAll<FuseConfusingSupplementsLiveryController>()
+                .Where(IsLiveController)
+                .OrderBy(controller => controller.CarIdentifier, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(controller => controller.GetInstanceID())
+                .ToArray();
+            var report = new StringBuilder();
+            report.Append("FUSE livery diagnostics: cars=")
+                .Append(controllers.Length)
+                .Append(" cachedTextures=")
+                .Append(CachedTextureCount);
+
+            foreach (var controller in controllers)
+            {
+                var choices = GetChoices(controller.CarIdentifier);
+                report.AppendLine()
+                    .Append("- car=")
+                    .Append(string.IsNullOrWhiteSpace(controller.CarIdentifier)
+                        ? "<unknown>"
+                        : controller.CarIdentifier)
+                    .Append(" selected=")
+                    .Append(string.IsNullOrWhiteSpace(controller.SelectedLiveryId)
+                        ? "<standard>"
+                        : controller.SelectedLiveryId)
+                    .Append(" choices=")
+                    .Append(choices.Count);
+                if (choices.Count > 0)
+                {
+                    report.Append(" [")
+                        .Append(string.Join(", ", choices.Select(choice => choice.Id)))
+                        .Append(']');
+                }
+            }
+
+            return report.ToString();
+        }
+
+        private static void ClearTextureCache()
+        {
+            lock (Gate)
+            {
+                foreach (var texture in Textures.Values.Where(texture => texture != null))
+                {
+                    UnityEngine.Object.Destroy(texture);
+                }
+
+                Textures.Clear();
+            }
+        }
+
+        private static bool IsLiveController(
+            FuseConfusingSupplementsLiveryController controller)
+        {
+            return controller != null
+                   && controller.gameObject != null
+                   && controller.gameObject.scene.IsValid();
+        }
+
+        internal static IReadOnlyList<FuseConfusingSupplementsLiveryChoice> GetChoices(string carIdentifier)
+        {
+            if (string.IsNullOrWhiteSpace(carIdentifier))
+            {
+                return Array.Empty<FuseConfusingSupplementsLiveryChoice>();
+            }
+
+            var choices = new Dictionary<string, FuseConfusingSupplementsLiveryChoice>(StringComparer.OrdinalIgnoreCase);
+            foreach (var mixinto in FuseLegacyAssemblyHost.EnumerateMixintos("livery:" + carIdentifier))
+            {
+                var path = mixinto.Mixinto;
+                if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+                {
+                    FuseLog.Warning(
+                        $"FUSE ignored legacy livery entry '{path ?? "<empty>"}' for '{carIdentifier}' " +
+                        "because it is not an existing directory.");
+                    continue;
+                }
+
+                var id = Path.GetFileName(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    continue;
+                }
+
+                if (choices.ContainsKey(id))
+                {
+                    FuseLog.Warning(
+                        $"FUSE found more than one legacy livery named '{id}' for '{carIdentifier}'. " +
+                        $"The first folder wins; ignored '{path}'.");
+                    continue;
+                }
+
+                choices[id] = new FuseConfusingSupplementsLiveryChoice(id, path);
+            }
+
+            return choices.Values.OrderBy(choice => choice.Id, StringComparer.OrdinalIgnoreCase).ToArray();
+        }
+
+        internal static Dictionary<string, string> IndexTextureFiles(string directoryPath)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(directoryPath) || !Directory.Exists(directoryPath))
+            {
+                return result;
+            }
+
+            foreach (var path in Directory.EnumerateFiles(directoryPath))
+            {
+                if (!IsTextureFile(path))
+                {
+                    continue;
+                }
+
+                result[Path.GetFileNameWithoutExtension(path)] = path;
+            }
+
+            return result;
+        }
+
+        internal static bool IsTextureFile(string path)
+        {
+            var extension = Path.GetExtension(path);
+            return string.Equals(extension, ".png", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(extension, ".jpg", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(extension, ".jpeg", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static Texture2D LoadTexture(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                return null;
+            }
+
+            lock (Gate)
+            {
+                if (Textures.TryGetValue(path, out var cached) && cached != null)
+                {
+                    return cached;
+                }
+
+                try
+                {
+                    var texture = new Texture2D(2, 2, TextureFormat.RGBA32, true)
+                    {
+                        name = Path.GetFileNameWithoutExtension(path)
+                    };
+                    if (!ImageConversion.LoadImage(texture, File.ReadAllBytes(path)))
+                    {
+                        UnityEngine.Object.Destroy(texture);
+                        return null;
+                    }
+
+                    Textures[path] = texture;
+                    return texture;
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not load legacy livery texture '{path}': {ex.GetBaseException().Message}");
+                    return null;
+                }
+            }
+        }
+    }
+
+    internal sealed class FuseConfusingSupplementsLiveryChoice
+    {
+        internal FuseConfusingSupplementsLiveryChoice(string id, string directoryPath)
+        {
+            Id = id;
+            DirectoryPath = directoryPath;
+        }
+
+        internal string Id { get; }
+        internal string DirectoryPath { get; }
+    }
+
+    [HarmonyPatch(typeof(UI.CarCustomizeWindow.CarCustomizeWindow), "BuildColorTab")]
+    internal static class FuseConfusingSupplementsLiveryCustomizePatch
+    {
+        private static readonly string[] StandardLiveryIds = { string.Empty };
+        private static readonly string[] StandardLiveryNames = { "Standard" };
+
+        private static void Postfix(UIPanelBuilder builder, Car ____car)
+        {
+            if (____car?.Definition?.Components == null ||
+                !____car.Definition.Components.OfType<FuseConfusingSupplementsLiveryComponent>().Any())
+            {
+                return;
+            }
+
+            try
+            {
+                var choices = FuseConfusingSupplementsLiveryRegistry
+                    .GetChoices(____car.DefinitionInfo.Identifier)
+                    .ToArray();
+                builder.AddSection("Livery", section =>
+                {
+                    if (choices.Length == 0)
+                    {
+                        section.AddLabel(
+                            $"No compatible liveries found for {____car.DefinitionInfo.Identifier}.");
+                        return;
+                    }
+
+                    var ids = StandardLiveryIds.Concat(choices.Select(choice => choice.Id)).ToArray();
+                    var names = StandardLiveryNames.Concat(choices.Select(choice => choice.Id)).ToList();
+                    var current = ____car.KeyValueObject == null
+                        ? null
+                        : ____car.KeyValueObject["cs.livery"].StringValue;
+                    var selected = Array.FindIndex(
+                        ids,
+                        id => string.Equals(id, current, StringComparison.OrdinalIgnoreCase));
+                    if (selected < 0)
+                    {
+                        selected = 0;
+                    }
+
+                    section.AddField("Livery", section.AddDropdown(names, selected, index =>
+                    {
+                        if (____car.KeyValueObject == null || index < 0 || index >= ids.Length)
+                        {
+                            return;
+                        }
+
+                        ____car.KeyValueObject["cs.livery"] = string.IsNullOrWhiteSpace(ids[index])
+                            ? Value.Null()
+                            : Value.String(ids[index]);
+                    }));
+                }, 0f);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a legacy livery Customize-window error; " +
+                    $"the rest of the window remains usable: {ex.GetBaseException().Message}");
+            }
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsRefiller.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsRefiller.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Linq;
+using FUSE.Infrastructure;
+using Game.State;
+using Model;
+using Model.Definition;
+using Model.Definition.Data;
+using Model.Ops;
+using Model.Physics;
+using Railloader.Extensions;
+using UnityEngine;
+
+namespace FUSE.Compatibility
+{
+    internal sealed class FuseConfusingSupplementsRefillerComponent : Model.Definition.Component
+    {
+        internal const string ComponentKind = "ConfusingSupplements.Refiller";
+
+        public override string Kind => ComponentKind;
+
+        public int TransferRate { get; set; } = 36000;
+    }
+
+    internal sealed class FuseConfusingSupplementsRefillerBuilder : ComponentBuilder<FuseConfusingSupplementsRefillerComponent>
+    {
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsRefillerComponent component)
+        {
+            var car = context.GameObject?.GetComponentInParent<Car>();
+            if (car == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not attach a legacy refiller to '{context.ObjectName ?? "<unknown car>"}' " +
+                    "because its car object was unavailable.");
+                return;
+            }
+
+            var runtime = car.GetComponent<FuseConfusingSupplementsRefillerRuntime>() ??
+                          car.gameObject.AddComponent<FuseConfusingSupplementsRefillerRuntime>();
+            runtime.TransferPerSecond = Mathf.Max(0f, (component?.TransferRate ?? 0) / 3600f);
+        }
+    }
+
+    internal sealed class FuseConfusingSupplementsRefillerRuntime : MonoBehaviour
+    {
+        internal float TransferPerSecond { get; set; }
+
+        private Car _source;
+        private float _nextUpdate;
+
+        private void Awake()
+        {
+            _source = GetComponent<Car>();
+        }
+
+        private void Update()
+        {
+            if (!StateManager.IsHost || _source == null || Time.time < _nextUpdate)
+            {
+                return;
+            }
+
+            _nextUpdate = Time.time + 1f;
+            try
+            {
+                var target = FindNearestCompatibleCar(_source, Car.LogicalEnd.A) ??
+                             FindNearestCompatibleCar(_source, Car.LogicalEnd.B);
+                if (target != null)
+                {
+                    TransferLoads(_source, target, TransferPerSecond);
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE contained a rolling-stock refiller error on '{_source.DisplayName ?? _source.id}': " +
+                    ex.GetBaseException().Message);
+            }
+        }
+
+        internal static bool CanReceiveFrom(CarDefinition source, CarDefinition target)
+        {
+            if (source?.LoadSlots == null || target?.LoadSlots == null)
+            {
+                return false;
+            }
+
+            return target.LoadSlots.Any(targetSlot =>
+                !string.IsNullOrWhiteSpace(targetSlot?.RequiredLoadIdentifier) &&
+                source.LoadSlots.Any(sourceSlot => string.Equals(
+                    sourceSlot?.RequiredLoadIdentifier,
+                    targetSlot.RequiredLoadIdentifier,
+                    StringComparison.OrdinalIgnoreCase)));
+        }
+
+        private static Car FindNearestCompatibleCar(Car source, Car.LogicalEnd end)
+        {
+            var set = source.set;
+            var index = set?.IndexOfCar(source);
+            if (!index.HasValue)
+            {
+                return null;
+            }
+
+            var cursor = index.Value;
+            var stop = false;
+            while (!stop)
+            {
+                var candidate = set.NextCarConnected(
+                    ref cursor,
+                    end,
+                    IntegrationSet.EnumerationCondition.AirConnected,
+                    out stop);
+                if (candidate == null)
+                {
+                    break;
+                }
+
+                if (candidate == source)
+                {
+                    continue;
+                }
+
+                if (IsSupportedTarget(candidate) && CanReceiveFrom(source.Definition, candidate.Definition))
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsSupportedTarget(Car car)
+        {
+            return car != null &&
+                   (car.Archetype == CarArchetype.LocomotiveDiesel ||
+                    car.Archetype == CarArchetype.LocomotiveSteam ||
+                    car.Archetype == CarArchetype.Tender);
+        }
+
+        private static void TransferLoads(Car source, Car target, float maximumTransfer)
+        {
+            if (maximumTransfer <= 0f || source?.Definition?.LoadSlots == null || target?.Definition?.LoadSlots == null)
+            {
+                return;
+            }
+
+            for (var targetIndex = 0; targetIndex < target.Definition.LoadSlots.Count; targetIndex++)
+            {
+                var targetSlot = target.Definition.LoadSlots[targetIndex];
+                var loadId = targetSlot?.RequiredLoadIdentifier;
+                if (string.IsNullOrWhiteSpace(loadId))
+                {
+                    continue;
+                }
+
+                var sourceIndex = source.Definition.LoadSlots.FindIndex(slot => string.Equals(
+                    slot?.RequiredLoadIdentifier,
+                    loadId,
+                    StringComparison.OrdinalIgnoreCase));
+                if (sourceIndex < 0)
+                {
+                    continue;
+                }
+
+                var sourceLoad = source.GetLoadInfo(sourceIndex);
+                if (!sourceLoad.HasValue || sourceLoad.Value.Quantity <= 0f)
+                {
+                    continue;
+                }
+
+                var targetLoad = target.GetLoadInfo(targetIndex);
+                var targetQuantity = targetLoad?.Quantity ?? 0f;
+                var availableCapacity = Mathf.Max(0f, targetSlot.MaximumCapacity - targetQuantity);
+                var quantity = Mathf.Min(maximumTransfer, Mathf.Min(availableCapacity, sourceLoad.Value.Quantity));
+                if (quantity <= 0f)
+                {
+                    continue;
+                }
+
+                var remainingSource = sourceLoad.Value;
+                remainingSource.Quantity -= quantity;
+                target.SetLoadInfo(targetIndex, new CarLoadInfo(loadId, targetQuantity + quantity));
+                source.SetLoadInfo(sourceIndex, remainingSource);
+            }
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseLegacyDebugInformation.cs
+++ b/FUSE/Compatibility/FuseLegacyDebugInformation.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using FUSE.Infrastructure;
+using GalaSoft.MvvmLight.Messaging;
+using Railloader.Events;
+
+namespace FUSE.Compatibility
+{
+    internal static class FuseLegacyDebugInformation
+    {
+        internal const int MaximumLines = 1000;
+        internal const int MaximumCharacters = 131072;
+        private const int MaximumLineCharacters = 4096;
+        private static readonly char[] NewLineSeparator = { '\n' };
+
+        internal static IReadOnlyList<string> Collect()
+        {
+            return Collect(Messenger.Default);
+        }
+
+        internal static IReadOnlyList<string> Collect(IMessenger messenger)
+        {
+            return Collect(message => messenger?.Send(message));
+        }
+
+        internal static IReadOnlyList<string> Collect(
+            Action<WillCopyDebugInformation> dispatch)
+        {
+            var lines = new List<string>();
+            var characterCount = 0;
+            var truncated = false;
+
+            void AppendLine(string value)
+            {
+                if (truncated || value == null)
+                {
+                    return;
+                }
+
+                var normalized = value.Replace("\r\n", "\n").Replace('\r', '\n');
+                foreach (var candidate in normalized.Split(NewLineSeparator, StringSplitOptions.None))
+                {
+                    var line = candidate.Length > MaximumLineCharacters
+                        ? candidate.Substring(0, MaximumLineCharacters) + " …"
+                        : candidate;
+                    if (lines.Count >= MaximumLines
+                        || characterCount + line.Length > MaximumCharacters)
+                    {
+                        truncated = true;
+                        break;
+                    }
+
+                    lines.Add(line);
+                    characterCount += line.Length;
+                }
+            }
+
+            try
+            {
+                dispatch?.Invoke(new WillCopyDebugInformation(AppendLine));
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a legacy debug-report listener failure: " +
+                    ex.GetBaseException().Message);
+            }
+
+            if (truncated)
+            {
+                lines.Add(
+                    $"[FUSE truncated legacy debug information at {MaximumLines} lines or " +
+                    $"{MaximumCharacters} characters.]");
+            }
+
+            return lines;
+        }
+
+        internal static string AppendToReport(string report)
+        {
+            var lines = Collect();
+            if (lines.Count == 0)
+            {
+                return report ?? string.Empty;
+            }
+
+            var builder = new StringBuilder(report ?? string.Empty);
+            if (builder.Length > 0 && builder[builder.Length - 1] != '\n')
+            {
+                builder.AppendLine();
+            }
+
+            builder.AppendLine("Legacy mod diagnostic contributions:");
+            foreach (var line in lines)
+            {
+                builder.Append("  ").AppendLine(line);
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseLegacyInstallDetector.cs
+++ b/FUSE/Compatibility/FuseLegacyInstallDetector.cs
@@ -8,7 +8,8 @@ using UnityEngine;
 namespace FUSE.Compatibility
 {
     // Detects when the legacy Railloader install is left in place alongside
-    // FUSE. The bad state is Railloader.dll and/or Railloader.Interchange.dll
+    // FUSE. The bad state is Railloader.dll, Railloader.Injector.dll, and/or
+    // Railloader.Interchange.dll
     // sitting in Railroader_Data\Managed\: Unity's assembly loader resolves
     // them before FuseLegacySupportAssemblyShim's AssemblyResolve hook fires,
     // so legacy mod IL binds to the real old-loader types instead of FUSE's
@@ -17,7 +18,9 @@ namespace FUSE.Compatibility
     internal static class FuseLegacyInstallDetector
     {
         private const string LegacyRailloaderDll = "Railloader.dll";
+        private const string LegacyInjectorDll = "Railloader.Injector.dll";
         private const string LegacyInterchangeDll = "Railloader.Interchange.dll";
+        private const string LegacyStrangeCustomsDll = "StrangeCustoms.dll";
 
         internal static IReadOnlyList<string> DetectConflictingFiles()
         {
@@ -39,7 +42,9 @@ namespace FUSE.Compatibility
 
                 var managedDir = Path.Combine(dataPath, "Managed");
                 AddIfFileExists(results, Path.Combine(managedDir, LegacyRailloaderDll));
+                AddIfFileExists(results, Path.Combine(managedDir, LegacyInjectorDll));
                 AddIfFileExists(results, Path.Combine(managedDir, LegacyInterchangeDll));
+                AddIfFileExists(results, Path.Combine(managedDir, LegacyStrangeCustomsDll));
             }
             catch (Exception ex)
             {
@@ -120,17 +125,9 @@ namespace FUSE.Compatibility
             }
         }
 
-        private static bool IsLegacyLoaderAssemblyName(string assemblyName)
+        internal static bool IsLegacyLoaderAssemblyName(string assemblyName)
         {
             if (string.IsNullOrWhiteSpace(assemblyName))
-            {
-                return false;
-            }
-
-            // Railloader.Injector is the Doorstop-style native-side hook that
-            // ships with the standard FUSE-compatible install — it is NOT the
-            // legacy managed loader API and must not be flagged as a conflict.
-            if (assemblyName.Equals("Railloader.Injector", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/FUSE/Compatibility/FuseLegacyTypeRegistry.cs
+++ b/FUSE/Compatibility/FuseLegacyTypeRegistry.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model;
+
+namespace FUSE.Compatibility
+{
+    /// <summary>
+    /// Runtime registry used by the RailLoader compatibility context. Legacy library
+    /// mods register JSON discriminator values and component builders during startup;
+    /// FUSE forwards those registrations into the live game instead of merely allowing
+    /// the plugin assembly to load.
+    /// </summary>
+    internal static class FuseLegacyTypeRegistry
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<Type, Dictionary<string, Type>> Registrations =
+            new Dictionary<Type, Dictionary<string, Type>>();
+
+        internal static void RegisterSubType(Type baseType, string identifier, Type implementationType)
+        {
+            if (baseType == null)
+            {
+                throw new ArgumentNullException(nameof(baseType));
+            }
+
+            if (string.IsNullOrWhiteSpace(identifier))
+            {
+                throw new ArgumentException("A legacy subtype identifier is required.", nameof(identifier));
+            }
+
+            if (implementationType == null)
+            {
+                throw new ArgumentNullException(nameof(implementationType));
+            }
+
+            if (!baseType.IsAssignableFrom(implementationType))
+            {
+                throw new ArgumentException(
+                    $"Legacy subtype '{implementationType.FullName}' is not assignable to '{baseType.FullName}'.",
+                    nameof(implementationType));
+            }
+
+            Type replaced = null;
+            lock (Gate)
+            {
+                if (!Registrations.TryGetValue(baseType, out var byIdentifier))
+                {
+                    byIdentifier = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+                    Registrations[baseType] = byIdentifier;
+                }
+
+                byIdentifier.TryGetValue(identifier.Trim(), out replaced);
+                byIdentifier[identifier.Trim()] = implementationType;
+            }
+
+            if (replaced != null && replaced != implementationType)
+            {
+                FuseLog.Warning(
+                    $"FUSE legacy subtype '{identifier}' for '{baseType.FullName}' was re-registered from " +
+                    $"'{replaced.FullName}' to '{implementationType.FullName}'. The latest registration will be used.");
+            }
+            else
+            {
+                FuseLog.Info(
+                    $"FUSE registered legacy subtype '{identifier}' for '{baseType.FullName}' as " +
+                    $"'{implementationType.FullName}'.");
+            }
+        }
+
+        internal static void RegisterComponent(Type componentType, Type builderType, string kind)
+        {
+            if (componentType == null)
+            {
+                throw new ArgumentNullException(nameof(componentType));
+            }
+
+            if (!typeof(Model.Definition.Component).IsAssignableFrom(componentType))
+            {
+                throw new ArgumentException(
+                    $"Legacy component '{componentType.FullName}' does not derive from Model.Definition.Component.",
+                    nameof(componentType));
+            }
+
+            if (builderType == null)
+            {
+                throw new ArgumentNullException(nameof(builderType));
+            }
+
+            if (!typeof(IComponentBuilder).IsAssignableFrom(builderType))
+            {
+                throw new ArgumentException(
+                    $"Legacy component builder '{builderType.FullName}' does not implement Model.IComponentBuilder.",
+                    nameof(builderType));
+            }
+
+            var builder = Activator.CreateInstance(builderType);
+            if (!(builder is IComponentBuilder typedBuilder))
+            {
+                throw new InvalidOperationException(
+                    $"Legacy component builder '{builderType.FullName}' could not be created as Model.IComponentBuilder.");
+            }
+
+            var prepare = AccessTools.Method(typeof(ComponentFactory), "PrepareBuildersIfNeeded");
+            var buildersField = AccessTools.Field(typeof(ComponentFactory), "_builders");
+            if (prepare == null || buildersField == null)
+            {
+                throw new MissingMemberException(
+                    typeof(ComponentFactory).FullName,
+                    "PrepareBuildersIfNeeded/_builders");
+            }
+
+            prepare.Invoke(null, null);
+            var builders = buildersField.GetValue(null) as IDictionary;
+            if (builders == null)
+            {
+                throw new InvalidOperationException("The game's component-builder registry was unavailable after initialization.");
+            }
+
+            builders[componentType] = typedBuilder;
+            RegisterSubType(typeof(Model.Definition.Component), kind, componentType);
+            Loading.FuseAssetPackRegistry.OnLegacyComponentKindRegistered(kind);
+            FuseLog.Info(
+                $"FUSE registered legacy component kind '{kind}' with builder '{builderType.FullName}'.");
+        }
+
+        internal static IReadOnlyList<KeyValuePair<string, Type>> Snapshot(Type baseType)
+        {
+            if (baseType == null)
+            {
+                return Array.Empty<KeyValuePair<string, Type>>();
+            }
+
+            lock (Gate)
+            {
+                if (!Registrations.TryGetValue(baseType, out var byIdentifier))
+                {
+                    return Array.Empty<KeyValuePair<string, Type>>();
+                }
+
+                return byIdentifier.ToArray();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds compatibility registrations to JsonSubTypes at lookup time. Keeping the
+    /// dynamic entries outside JsonSubTypes' private cache means registrations made by
+    /// a late-starting hosted plugin become visible immediately.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FuseLegacyJsonSubtypeRegistryPatch
+    {
+        private static Type _knownSubTypeAttributeType;
+        private static ConstructorInfo _knownSubTypeConstructor;
+
+        private static MethodInfo TargetMethod()
+        {
+            var jsonSubtypes =
+                AccessTools.TypeByName("JsonSubTypes.JsonSubtypes") ??
+                Type.GetType("JsonSubTypes.JsonSubtypes, JsonSubTypes", throwOnError: false);
+            if (jsonSubtypes == null)
+            {
+                return null;
+            }
+
+            _knownSubTypeAttributeType = jsonSubtypes.GetNestedType(
+                "KnownSubTypeAttribute",
+                BindingFlags.Public | BindingFlags.NonPublic);
+            _knownSubTypeConstructor = _knownSubTypeAttributeType?.GetConstructor(new[] { typeof(Type), typeof(object) });
+            // JsonSubTypes exposes both GetAttributes(Type) and
+            // GetAttributes<T>(Type). AccessTools.Method sees the identical
+            // parameter lists as ambiguous, so select the non-generic method
+            // explicitly. An ambiguous target makes Harmony detach the patch
+            // even though the runtime DLL is otherwise compatible.
+            return jsonSubtypes
+                .GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)
+                .SingleOrDefault(method =>
+                    string.Equals(method.Name, "GetAttributes", StringComparison.Ordinal) &&
+                    !method.IsGenericMethodDefinition &&
+                    method.GetParameters().Length == 1 &&
+                    method.GetParameters()[0].ParameterType == typeof(Type));
+        }
+
+        private static void Postfix(Type typeInfo, ref IEnumerable<object> __result)
+        {
+            var registrations = FuseLegacyTypeRegistry.Snapshot(typeInfo);
+            if (registrations.Count == 0 || _knownSubTypeConstructor == null)
+            {
+                return;
+            }
+
+            var replacementIds = new HashSet<string>(
+                registrations.Select(pair => pair.Key),
+                StringComparer.OrdinalIgnoreCase);
+            var combined = (__result ?? Enumerable.Empty<object>())
+                .Where(attribute => !IsReplacedKnownSubType(attribute, replacementIds))
+                .ToList();
+
+            foreach (var registration in registrations)
+            {
+                combined.Add(_knownSubTypeConstructor.Invoke(new object[]
+                {
+                    registration.Value,
+                    registration.Key
+                }));
+            }
+
+            __result = combined;
+        }
+
+        private static bool IsReplacedKnownSubType(object attribute, HashSet<string> replacementIds)
+        {
+            if (attribute == null || _knownSubTypeAttributeType == null ||
+                !_knownSubTypeAttributeType.IsInstanceOfType(attribute))
+            {
+                return false;
+            }
+
+            var associatedValue = _knownSubTypeAttributeType
+                .GetProperty("AssociatedValue", BindingFlags.Instance | BindingFlags.Public)
+                ?.GetValue(attribute, null) as string;
+            return associatedValue != null && replacementIds.Contains(associatedValue);
+        }
+    }
+}

--- a/FUSE/Compatibility/RailloaderLegacySupport.cs
+++ b/FUSE/Compatibility/RailloaderLegacySupport.cs
@@ -6,6 +6,9 @@ using UI.Builder;
 using UI.Common;
 using UI.Console;
 using UnityEngine;
+using LegacyComponent = Model.Definition.Component;
+using LegacyComponentBuilderContext = Model.ComponentBuilderContext;
+using LegacyComponentBuilder = Model.IComponentBuilder;
 
 // Legacy support surface for assemblies compiled against the previous loader API.
 // This file reproduces the public surface of the legacy Railloader.Interchange API
@@ -112,8 +115,8 @@ namespace Railloader
         /// Preserves the legacy component-builder registration contract so plugin types can load under FUSE.
         /// </summary>
         void RegisterComponent<TComponent, TComponentBuilder>(string kind)
-            where TComponent : Component
-            where TComponentBuilder : IComponentBuilder;
+            where TComponent : LegacyComponent
+            where TComponentBuilder : LegacyComponentBuilder;
     }
 
     [Obsolete(LegacyShim.Message)]
@@ -383,14 +386,14 @@ namespace Railloader
 namespace Railloader.Extensions
 {
     [Obsolete(LegacyShim.Message)]
-    public abstract class ComponentBuilder<T> : IComponentBuilder where T : Component
+    public abstract class ComponentBuilder<T> : LegacyComponentBuilder where T : LegacyComponent
     {
         public System.Type ComponentType => typeof(T);
 
         /// <summary>
         /// Preserves the legacy non-generic dispatch entry point and forwards it to the typed builder contract.
         /// </summary>
-        public void Build(ComponentBuilderContext ctx, Component component)
+        public void Build(LegacyComponentBuilderContext ctx, LegacyComponent component)
         {
             Build(ctx, (T)(object)component);
         }
@@ -398,7 +401,7 @@ namespace Railloader.Extensions
         /// <summary>
         /// Preserves the typed legacy component-build override implemented by existing plugin binaries.
         /// </summary>
-        protected abstract void Build(ComponentBuilderContext ctx, T component);
+        protected abstract void Build(LegacyComponentBuilderContext ctx, T component);
     }
 }
 

--- a/FUSE/Compatibility/RailroaderTrackContract.cs
+++ b/FUSE/Compatibility/RailroaderTrackContract.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Reflection;
+using Track;
+
+namespace FUSE.Compatibility
+{
+    /// <summary>
+    /// Bridges the released TrackSegment.Style representation and the newer
+    /// flags-based graph contract without taking a compile-time dependency on
+    /// fields that are absent from either game generation.
+    /// </summary>
+    internal static class RailroaderTrackContract
+    {
+        private const int BridgeFlag = 2;
+        private const int BridgeSupportsSteelFlag = 4;
+        private const int TunnelFlag = 8;
+        private const int YardFlag = 16;
+
+        private static readonly FieldInfo SegmentStyleField =
+            typeof(TrackSegment).GetField("style", BindingFlags.Instance | BindingFlags.Public);
+        private static readonly FieldInfo SegmentFlagsField =
+            typeof(TrackSegment).GetField("flags", BindingFlags.Instance | BindingFlags.Public);
+        private static readonly PropertyInfo NodeDiamondProperty =
+            typeof(TrackNode).GetProperty("IsDiamond", BindingFlags.Instance | BindingFlags.Public);
+        private static readonly FieldInfo NodeDiamondField =
+            typeof(TrackNode).GetField("isDiamond", BindingFlags.Instance | BindingFlags.Public);
+        private static readonly MethodInfo GraphSetNodeIsDiamondMethod =
+            typeof(Graph).GetMethod(
+                "SetNodeIsDiamond",
+                BindingFlags.Instance | BindingFlags.Public,
+                null,
+                new[] { typeof(TrackNode), typeof(bool) },
+                null);
+
+        internal static bool GetNodeIsDiamond(TrackNode node)
+        {
+            if (node == null)
+            {
+                return false;
+            }
+
+            if (NodeDiamondProperty?.CanRead == true)
+            {
+                return Convert.ToBoolean(NodeDiamondProperty.GetValue(node, null));
+            }
+
+            return NodeDiamondField != null && Convert.ToBoolean(NodeDiamondField.GetValue(node));
+        }
+
+        internal static void SetNodeIsDiamond(TrackNode node, bool value)
+        {
+            if (node == null)
+            {
+                return;
+            }
+
+            if (GraphSetNodeIsDiamondMethod != null && Graph.Shared != null)
+            {
+                GraphSetNodeIsDiamondMethod.Invoke(Graph.Shared, new object[] { node, value });
+            }
+            else if (NodeDiamondProperty?.CanWrite == true)
+            {
+                NodeDiamondProperty.SetValue(node, value, null);
+            }
+            else
+            {
+                NodeDiamondField?.SetValue(node, value);
+            }
+        }
+
+        internal static int GetStructureFlags(TrackSegment segment)
+        {
+            if (segment == null)
+            {
+                return 0;
+            }
+
+            if (SegmentFlagsField != null)
+            {
+                return Convert.ToInt32(SegmentFlagsField.GetValue(segment));
+            }
+
+            return StyleNameToFlags(SegmentStyleField?.GetValue(segment)?.ToString());
+        }
+
+        internal static string GetStyleName(TrackSegment segment)
+        {
+            if (segment == null)
+            {
+                return "Standard";
+            }
+
+            if (SegmentStyleField != null)
+            {
+                return SegmentStyleField.GetValue(segment)?.ToString() ?? "Standard";
+            }
+
+            var flags = GetStructureFlags(segment);
+            if ((flags & TunnelFlag) != 0)
+            {
+                return "Tunnel";
+            }
+
+            if ((flags & BridgeFlag) != 0)
+            {
+                return "Bridge";
+            }
+
+            if ((flags & YardFlag) != 0)
+            {
+                return "Yard";
+            }
+
+            return "Standard";
+        }
+
+        internal static bool GetBridgeSupportsSteel(TrackSegment segment)
+        {
+            return (GetStructureFlags(segment) & BridgeSupportsSteelFlag) != 0;
+        }
+
+        internal static bool GetYard(TrackSegment segment)
+        {
+            return (GetStructureFlags(segment) & YardFlag) != 0;
+        }
+
+        internal static void ApplyStructure(
+            TrackSegment segment,
+            string style,
+            bool bridgeSupportsSteel,
+            bool yard)
+        {
+            if (segment == null)
+            {
+                return;
+            }
+
+            if (SegmentFlagsField != null)
+            {
+                var flags = StyleNameToFlags(style);
+                if (bridgeSupportsSteel)
+                {
+                    flags |= BridgeFlag | BridgeSupportsSteelFlag;
+                }
+
+                if (yard)
+                {
+                    flags |= YardFlag;
+                }
+
+                SegmentFlagsField.SetValue(segment, Enum.ToObject(SegmentFlagsField.FieldType, flags));
+                return;
+            }
+
+            if (SegmentStyleField == null)
+            {
+                return;
+            }
+
+            var releasedStyle = style;
+            if (yard && string.Equals(releasedStyle, "standard", StringComparison.OrdinalIgnoreCase))
+            {
+                releasedStyle = "Yard";
+            }
+
+            SegmentStyleField.SetValue(
+                segment,
+                Enum.Parse(SegmentStyleField.FieldType, releasedStyle ?? "Standard", true));
+        }
+
+        internal static int StyleNameToFlags(string style)
+        {
+            if (string.Equals(style, "bridge", StringComparison.OrdinalIgnoreCase))
+            {
+                return BridgeFlag;
+            }
+
+            if (string.Equals(style, "tunnel", StringComparison.OrdinalIgnoreCase))
+            {
+                return TunnelFlag;
+            }
+
+            if (string.Equals(style, "yard", StringComparison.OrdinalIgnoreCase))
+            {
+                return YardFlag;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/FUSE/Compatibility/StrangeCustomsLegacySupport.cs
+++ b/FUSE/Compatibility/StrangeCustomsLegacySupport.cs
@@ -1,7 +1,12 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
+using FUSE.Infrastructure;
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using FUSE.Runtime.API;
 using Helpers;
 using Model;
 using Model.Definition.Data;
@@ -14,6 +19,7 @@ using Track;
 using UI.Builder;
 using UI.Console;
 using UnityEngine;
+using UnityEngine.Networking;
 
 // Interop declarations matching the StrangeCustoms public-API shape that the
 // old-loader plugin ecosystem (DKW, ModularScenery, Alina's Map Mod, etc.) was
@@ -69,10 +75,10 @@ namespace StrangeCustoms
     }
 
     /// <summary>
-    /// File-cache shape that legacy plugins use to fetch external assets at
-    /// runtime. The shim declares the surface so plugin IL JITs cleanly;
-    /// FUSE's asset pipeline does not populate <see cref="Instance"/>, so any
-    /// runtime call goes through the no-op bodies below.
+    /// FUSE-owned implementation of the loose-file cache used by legacy
+    /// Strange Customs consumers. It preserves the public ABI while keeping
+    /// cache ownership, loading, invalidation, and callback containment inside
+    /// FUSE.
     /// </summary>
     [Obsolete(LegacyShim.Message)]
     public class FileCache : MonoBehaviour
@@ -97,7 +103,8 @@ namespace StrangeCustoms
                 {
                     try
                     {
-                        return File.GetLastWriteTime(FileName) >= LastUpdate;
+                        return !File.Exists(FileName)
+                               || File.GetLastWriteTimeUtc(FileName) > LastUpdate;
                     }
                     catch
                     {
@@ -135,12 +142,31 @@ namespace StrangeCustoms
             public void Set(T value)
             {
                 Value = value;
-                LastUpdate = DateTime.UtcNow;
+                LastUpdate = File.Exists(FileName)
+                    ? File.GetLastWriteTimeUtc(FileName)
+                    : DateTime.UtcNow;
                 IsValid = true;
                 IsLoading = false;
                 var handler = Loaded;
                 Loaded = null;
-                handler?.Invoke(value);
+                if (handler == null)
+                {
+                    return;
+                }
+
+                foreach (Action<T> callback in handler.GetInvocationList())
+                {
+                    try
+                    {
+                        callback(value);
+                    }
+                    catch (Exception ex)
+                    {
+                        FuseLog.Warning(
+                            $"FUSE contained a Strange Customs file-cache callback error for '{FileName}': " +
+                            ex.GetBaseException().Message);
+                    }
+                }
             }
 
             /// <summary>
@@ -192,31 +218,294 @@ namespace StrangeCustoms
 
         public static FileCache Instance { get; private set; }
 
-        /// <summary>
-        /// Retains the legacy audio-load signature so plugin IL resolves; FUSE does not run that cache pipeline.
-        /// </summary>
-        public void LoadAudioClip(string fileName, Action<AudioClip> callback)
+        private readonly Dictionary<string, CacheEntry> _entries =
+            new Dictionary<string, CacheEntry>(StringComparer.OrdinalIgnoreCase);
+
+        internal static void EnsureInstance()
         {
-            // FUSE does not run the legacy file-cache pipeline. The callback is
-            // never invoked under FUSE; the method exists for interop only.
+            if (Instance != null)
+            {
+                return;
+            }
+
+            var host = new GameObject("FUSE Strange Customs File Cache");
+            UnityEngine.Object.DontDestroyOnLoad(host);
+            Instance = host.AddComponent<FileCache>();
+        }
+
+        internal static void Shutdown()
+        {
+            if (Instance == null)
+            {
+                return;
+            }
+
+            var host = Instance.gameObject;
+            Instance.Clear();
+            Instance = null;
+            if (host != null)
+            {
+                UnityEngine.Object.Destroy(host);
+            }
+        }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                UnityEngine.Object.Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+            {
+                Clear();
+                Instance = null;
+            }
         }
 
         /// <summary>
-        /// Retains the legacy texture-load signature and reports an uncached miss because FUSE does not service it.
+        /// Loads a loose audio file asynchronously and invokes every waiting
+        /// callback exactly once, including failures (with a null clip).
+        /// </summary>
+        public void LoadAudioClip(string fileName, Action<AudioClip> callback)
+        {
+            var fullPath = NormalizePath(fileName);
+            if (fullPath.Length == 0)
+            {
+                InvokeSafely(callback, null, fileName);
+                return;
+            }
+
+            if (_entries.TryGetValue(fullPath, out var rawEntry)
+                && rawEntry is CacheEntry<AudioClip> cached)
+            {
+                if (cached.IsValid && !cached.IsExpired && cached.Value != null)
+                {
+                    InvokeSafely(callback, cached.Value, fullPath);
+                    return;
+                }
+
+                cached.Register(callback);
+                if (cached.IsLoading)
+                {
+                    return;
+                }
+
+                DestroyCachedObject(cached.Value);
+                cached.Invalidate();
+                cached.IsLoading = true;
+                StartCoroutine(LoadAudioClipCoroutine(fullPath, cached));
+                return;
+            }
+
+            var entry = new CacheEntry<AudioClip>(fullPath)
+            {
+                IsLoading = true
+            };
+            entry.Register(callback);
+            _entries[fullPath] = entry;
+            StartCoroutine(LoadAudioClipCoroutine(fullPath, entry));
+        }
+
+        /// <summary>
+        /// Loads a PNG/JPEG texture immediately, reusing it until the source
+        /// file changes.
         /// </summary>
         public Texture2D LoadTexture(string fileName, out bool wasCached)
         {
             wasCached = false;
-            return null;
+            var fullPath = NormalizePath(fileName);
+            if (fullPath.Length == 0)
+            {
+                return null;
+            }
+
+            CacheEntry<Texture2D> cached = null;
+            if (_entries.TryGetValue(fullPath, out var rawEntry)
+                && (cached = rawEntry as CacheEntry<Texture2D>) != null)
+            {
+                if (cached.IsValid && !cached.IsExpired && cached.Value != null)
+                {
+                    wasCached = true;
+                    return cached.Value;
+                }
+
+                DestroyCachedObject(cached.Value);
+                cached.Invalidate();
+            }
+
+            if (!File.Exists(fullPath))
+            {
+                FuseLog.Warning(
+                    $"FUSE Strange Customs file cache could not find texture '{fullPath}'.");
+                return null;
+            }
+
+            try
+            {
+                var texture = new Texture2D(2, 2, TextureFormat.RGBA32, true)
+                {
+                    name = Path.GetFileNameWithoutExtension(fullPath)
+                };
+                if (!ImageConversion.LoadImage(texture, File.ReadAllBytes(fullPath)))
+                {
+                    UnityEngine.Object.Destroy(texture);
+                    FuseLog.Warning(
+                        $"FUSE Strange Customs file cache could not decode texture '{fullPath}'.");
+                    return null;
+                }
+
+                var entry = cached ?? new CacheEntry<Texture2D>(fullPath);
+                entry.Set(texture);
+                _entries[fullPath] = entry;
+                return texture;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE Strange Customs file cache could not load texture '{fullPath}': " +
+                    ex.GetBaseException().Message);
+                return null;
+            }
         }
 
         /// <summary>
-        /// Retains the legacy cache-lookup signature and reports a miss because FUSE does not populate this cache.
+        /// Returns the typed cache entry when one exists. Callers can inspect
+        /// validity/loading state or register for an in-flight completion.
         /// </summary>
         public bool TryGetValue<T>(string fileName, out CacheEntry<T> value)
         {
+            var fullPath = NormalizePath(fileName);
+            if (fullPath.Length > 0
+                && _entries.TryGetValue(fullPath, out var entry)
+                && entry is CacheEntry<T> typed)
+            {
+                value = typed;
+                return true;
+            }
+
             value = null;
             return false;
+        }
+
+        private IEnumerator LoadAudioClipCoroutine(
+            string fullPath,
+            CacheEntry<AudioClip> entry)
+        {
+            AudioClip clip = null;
+            if (!File.Exists(fullPath))
+            {
+                FuseLog.Warning(
+                    $"FUSE Strange Customs file cache could not find audio '{fullPath}'.");
+            }
+            else
+            {
+                var uri = new Uri(fullPath).AbsoluteUri;
+                using (var request = UnityWebRequestMultimedia.GetAudioClip(
+                           uri,
+                           AudioTypeForPath(fullPath)))
+                {
+                    yield return request.SendWebRequest();
+                    if (request.isNetworkError || request.isHttpError)
+                    {
+                        FuseLog.Warning(
+                            $"FUSE Strange Customs file cache could not load audio '{fullPath}': " +
+                            request.error);
+                    }
+                    else
+                    {
+                        clip = DownloadHandlerAudioClip.GetContent(request);
+                        if (clip != null)
+                        {
+                            clip.name = Path.GetFileNameWithoutExtension(fullPath);
+                        }
+                    }
+                }
+            }
+
+            entry.Set(clip);
+            if (clip == null)
+            {
+                entry.Invalidate();
+            }
+        }
+
+        private static AudioType AudioTypeForPath(string path)
+        {
+            switch ((Path.GetExtension(path) ?? string.Empty).ToLowerInvariant())
+            {
+                case ".mp3": return AudioType.MPEG;
+                case ".ogg": return AudioType.OGGVORBIS;
+                case ".wav": return AudioType.WAV;
+                case ".aif":
+                case ".aiff": return AudioType.AIFF;
+                default: return AudioType.UNKNOWN;
+            }
+        }
+
+        internal static string NormalizePath(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                return Path.GetFullPath(fileName.Trim());
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static void InvokeSafely<T>(
+            Action<T> callback,
+            T value,
+            string fileName)
+        {
+            if (callback == null)
+            {
+                return;
+            }
+
+            try
+            {
+                callback(value);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE contained a Strange Customs file-cache callback error for '{fileName}': " +
+                    ex.GetBaseException().Message);
+            }
+        }
+
+        private void Clear()
+        {
+            foreach (var entry in _entries.Values)
+            {
+                var valueProperty = entry?.GetType().GetProperty("Value");
+                DestroyCachedObject(valueProperty?.GetValue(entry, null) as UnityEngine.Object);
+                entry?.Invalidate();
+            }
+
+            _entries.Clear();
+        }
+
+        private static void DestroyCachedObject(UnityEngine.Object value)
+        {
+            if (value != null)
+            {
+                UnityEngine.Object.Destroy(value);
+            }
         }
     }
 
@@ -242,9 +531,8 @@ namespace StrangeCustoms
     }
 
     /// <summary>
-    /// Default spliney builder for "flowy" splines. FUSE does not own the
-    /// rendering, so the build method returns null; the type exists so plugin
-    /// IL that references it JITs.
+    /// Default legacy flowy-spline builder backed by FUSE's native spliney
+    /// conversion and runtime API.
     /// </summary>
     [Obsolete(LegacyShim.Message)]
     public class FlowyThingBuilder : ISplineyBuilder
@@ -254,7 +542,50 @@ namespace StrangeCustoms
         /// </summary>
         public GameObject BuildSpliney(string id, Transform parentTransform, JObject data)
         {
-            return null;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("A spliney id is required.", nameof(id));
+            }
+
+            var definition = ConvertDefinition(data);
+            GameObject root;
+            if (SplineyAPI.GetSpliney(id) == null)
+            {
+                root = SplineyAPI.AddSpliney(id, definition);
+            }
+            else
+            {
+                SplineyAPI.UpdateSpliney(id, definition);
+                root = SplineyAPI.GetSpliney(id);
+            }
+
+            if (root != null
+                && parentTransform != null
+                && root.transform.parent != parentTransform)
+            {
+                root.transform.SetParent(parentTransform, true);
+            }
+
+            return root;
+        }
+
+        internal static FuseSpliney ConvertDefinition(JObject data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            var converted = FuseLegacyDataConverter
+                .ConvertSplineyForCompatibility(data);
+            var definition = converted.ToObject<FuseSpliney>();
+            if (definition == null)
+            {
+                throw new InvalidOperationException(
+                    "The legacy flowy-spline definition could not be converted.");
+            }
+
+            return definition;
         }
     }
 
@@ -585,12 +916,18 @@ namespace StrangeCustoms.Tracks
 
             var upper = trackSpan.upper;
             var lower = trackSpan.lower;
-            Upper = upper.HasValue
+            Upper = upper.HasValue && upper.Value.IsValid
                 ? new SerializedLocation(upper.Value.Serializable())
                 : null;
-            Lower = lower.HasValue
+            Lower = lower.HasValue && lower.Value.IsValid
                 ? new SerializedLocation(lower.Value.Serializable())
                 : null;
+            if (Upper == null || Lower == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE omitted invalid endpoint data while projecting legacy track span " +
+                    $"'{trackSpan.id ?? "<unknown>"}'. A conflicting package removed one of its segments.");
+            }
         }
 
         /// <summary>

--- a/FUSE/FUSE.csproj
+++ b/FUSE/FUSE.csproj
@@ -158,6 +158,10 @@
       <HintPath>$(UnityManagedDir)\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="Unity.RenderPipelines.Universal.Runtime" Condition="Exists('$(UnityManagedDir)\Unity.RenderPipelines.Universal.Runtime.dll')">
+      <HintPath>$(UnityManagedDir)\Unity.RenderPipelines.Universal.Runtime.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
     <Reference Include="UnityEngine.UI" Condition="Exists('$(UnityManagedDir)\UnityEngine.UI.dll')">
       <HintPath>$(UnityManagedDir)\UnityEngine.UI.dll</HintPath>
       <Private>false</Private>

--- a/FUSE/FusePlugin.cs
+++ b/FUSE/FusePlugin.cs
@@ -65,7 +65,6 @@ namespace FUSE
             try
             {
                 FuseLegacySupportAssemblyShim.Initialize();
-                FuseLegacyUmmRecovery.RecoverFailedEntries();
                 WarnIfLegacyRailloaderInstallPresent();
                 LogStartupVersions(modEntry);
                 FuseSettings.Load(modEntry);
@@ -75,6 +74,8 @@ namespace FUSE
 
                 _harmony = new Harmony(HarmonyId);
                 FusePatchResilience.ApplyAll(_harmony, Assembly.GetExecutingAssembly());
+                FuseConfusingSupplementsCompatibility.Initialize();
+                StrangeCustoms.FileCache.EnsureInstance();
                 FuseNarrowGaugePerformanceCompatibility.Initialize(_harmony);
                 FuseEarlyLoader.SetPatchAvailable(FusePatchResilience.Applied.Any(patch =>
                     string.Equals(patch.TypeName, "FUSE.Patches.FuseEarlyLoaderSceneManagerPatch", StringComparison.Ordinal)));
@@ -258,6 +259,7 @@ namespace FUSE
             FuseSceneryLoadFailurePatch.Shutdown();
             FuseModExceptionLogHook.Shutdown();
             FuseLegacyAssemblyHost.Shutdown();
+            StrangeCustoms.FileCache.Shutdown();
             FuseLegacySupportAssemblyShim.Shutdown();
             FuseLegacyUmmRecovery.Reset();
             FuseRuntimeRebindService.Shutdown();

--- a/FUSE/Info.json
+++ b/FUSE/Info.json
@@ -23,6 +23,24 @@
     "FrameSpikeThresholdMs": 100,
     "ForceConstrainedVramMode": false,
     "EnableNativeLeakStackTraces": false,
-    "EnableUpdateCheck": true
+    "EnableUpdateCheck": true,
+    "GraceMinimumDays": 0,
+    "GraceMultiplier": 1,
+    "GraceAddedDays": 0,
+    "InterchangeServiceIntervalMinutes": 150,
+    "InterchangeContinuousService": false,
+    "InterchangeNotBeforeHour": 0,
+    "InterchangeNotAfterHour": 24,
+    "EnableOutboundIndustryRerouting": false,
+    "OutboundIndustryRerouteChance": 0.25,
+    "OutboundIndustryFillFactor": 1,
+    "OutboundIndustryPaymentMultiplier": 1,
+    "OutboundIndustryAllowShortTrips": false,
+    "OutboundIndustryIgnoreOrigin": false,
+    "OutboundIndustryPreventBlocking": false,
+    "InterchangeToInterchangeMaximumCars": 30,
+    "ForYourConvenienceShowCabooseIcons": false,
+    "ForYourConvenienceShowCarTagMph": false,
+    "ForYourConvenienceShowCarTagLoads": false
   }
 }

--- a/FUSE/Infrastructure/FuseLiveConsole.cs
+++ b/FUSE/Infrastructure/FuseLiveConsole.cs
@@ -1,0 +1,222 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace FUSE.Infrastructure
+{
+    /// <summary>
+    /// Optional Windows console mirror for authors who want a RailLoader-style
+    /// live FUSE log on another screen. FUSE detaches only a console it allocated
+    /// itself; an existing --console/parent console is never freed.
+    /// </summary>
+    internal static class FuseLiveConsole
+    {
+        private const string Kernel32 = "kernel32.dll";
+        private const string User32 = "user32.dll";
+        private const uint ScClose = 0xF060;
+        private const uint MfByCommand = 0x00000000;
+        private static readonly object Gate = new object();
+
+        private static bool _enabled;
+        private static bool _allocatedByFuse;
+        private static TextWriter _previousOut;
+        private static TextWriter _consoleWriter;
+
+        internal static bool IsEnabled
+        {
+            get
+            {
+                lock (Gate)
+                {
+                    return _enabled;
+                }
+            }
+        }
+
+        internal static string Enable()
+        {
+            lock (Gate)
+            {
+                if (_enabled)
+                {
+                    return "The FUSE live console is already open.";
+                }
+
+                if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+                {
+                    return "The separate live console is available on Windows only. Use the in-game log viewer on this platform.";
+                }
+
+                try
+                {
+                    _allocatedByFuse = GetConsoleOutputCP() == 0;
+                    if (_allocatedByFuse && !AllocConsole())
+                    {
+                        _allocatedByFuse = false;
+                        return "Windows could not open a console for FUSE.";
+                    }
+
+                    SetConsoleTitleW("FUSE Live Diagnostics");
+                    if (_allocatedByFuse)
+                    {
+                        DisableWindowCloseCommand();
+                    }
+                    _previousOut = System.Console.Out;
+                    var stream = System.Console.OpenStandardOutput();
+                    _consoleWriter = new StreamWriter(stream) { AutoFlush = true };
+                    System.Console.SetOut(_consoleWriter);
+                    _enabled = true;
+
+                    System.Console.WriteLine("FUSE live diagnostics console");
+                    System.Console.WriteLine("This mirrors FUSE.log. Close it from FUSE > Tools > Live Diagnostics.");
+                    foreach (var entry in FuseLiveLogBuffer.Snapshot("All", string.Empty, 120))
+                    {
+                        System.Console.WriteLine(entry.FormatLine());
+                    }
+
+                    return _allocatedByFuse
+                        ? "Opened the FUSE live diagnostics console."
+                        : "FUSE is now mirroring to the existing console.";
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is InvalidOperationException)
+                {
+                    RestoreConsoleOutput();
+                    if (_allocatedByFuse)
+                    {
+                        FreeConsole();
+                        _allocatedByFuse = false;
+                    }
+
+                    return "FUSE could not open the live console: " + ex.GetBaseException().Message;
+                }
+            }
+        }
+
+        internal static string Disable()
+        {
+            lock (Gate)
+            {
+                if (!_enabled)
+                {
+                    return "The FUSE live console is not open.";
+                }
+
+                var detached = _allocatedByFuse;
+                RestoreConsoleOutput();
+                if (_allocatedByFuse)
+                {
+                    FreeConsole();
+                }
+
+                _allocatedByFuse = false;
+                return detached
+                    ? "Closed the FUSE live diagnostics console."
+                    : "Stopped mirroring FUSE logs to the existing console.";
+            }
+        }
+
+        internal static void WriteLine(string line)
+        {
+            lock (Gate)
+            {
+                if (!_enabled)
+                {
+                    return;
+                }
+
+                try
+                {
+                    System.Console.WriteLine(line ?? string.Empty);
+                }
+                catch (Exception ex) when (ex is IOException || ex is ObjectDisposedException || ex is InvalidOperationException)
+                {
+                    var detachOwnedConsole = _allocatedByFuse;
+                    RestoreConsoleOutput();
+                    if (detachOwnedConsole)
+                    {
+                        FreeConsole();
+                    }
+
+                    _allocatedByFuse = false;
+                }
+            }
+        }
+
+        private static void DisableWindowCloseCommand()
+        {
+            // Closing an AllocConsole window through its title-bar X can deliver
+            // CTRL_CLOSE_EVENT to the game process. Keep this optional diagnostics
+            // surface non-destructive; the Tools page owns the explicit detach.
+            var consoleWindow = GetConsoleWindow();
+            if (consoleWindow == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var systemMenu = GetSystemMenu(consoleWindow, false);
+            if (systemMenu == IntPtr.Zero)
+            {
+                return;
+            }
+
+            if (DeleteMenu(systemMenu, ScClose, MfByCommand))
+            {
+                DrawMenuBar(consoleWindow);
+            }
+        }
+
+        private static void RestoreConsoleOutput()
+        {
+            _enabled = false;
+            if (_previousOut != null)
+            {
+                System.Console.SetOut(_previousOut);
+            }
+
+            try
+            {
+                _consoleWriter?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                // Do not route this through FuseLog: this cleanup can itself be
+                // running because the console-backed FuseLog mirror failed, and
+                // logging there would recurse into the same broken stream.
+                System.Diagnostics.Debug.WriteLine(
+                    "FUSE could not release its optional diagnostics console: " + ex.Message);
+            }
+
+            _consoleWriter = null;
+            _previousOut = null;
+        }
+
+        [DllImport(Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool AllocConsole();
+
+        [DllImport(Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool FreeConsole();
+
+        [DllImport(Kernel32)]
+        private static extern uint GetConsoleOutputCP();
+
+        [DllImport(Kernel32)]
+        private static extern IntPtr GetConsoleWindow();
+
+        [DllImport(Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetConsoleTitleW([MarshalAs(UnmanagedType.LPWStr)] string title);
+
+        [DllImport(User32, SetLastError = true)]
+        private static extern IntPtr GetSystemMenu(IntPtr window, [MarshalAs(UnmanagedType.Bool)] bool revert);
+
+        [DllImport(User32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool DeleteMenu(IntPtr menu, uint position, uint flags);
+
+        [DllImport(User32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool DrawMenuBar(IntPtr window);
+    }
+}

--- a/FUSE/Infrastructure/FuseLiveLogBuffer.cs
+++ b/FUSE/Infrastructure/FuseLiveLogBuffer.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FUSE.Infrastructure
+{
+    internal sealed class FuseLiveLogEntry
+    {
+        public long Sequence { get; set; }
+        public DateTime Timestamp { get; set; }
+        public string Level { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+
+        public string FormatLine() =>
+            $"[{Timestamp:HH:mm:ss.fff}] [{Level}] {Message}";
+    }
+
+    /// <summary>
+    /// A bounded, thread-safe copy of the current session's FUSE log. The disk
+    /// writer remains the durable source; this buffer exists so the Tools page
+    /// and optional live console never need to repeatedly reread FUSE.log.
+    /// </summary>
+    internal static class FuseLiveLogBuffer
+    {
+        internal const int Capacity = 1000;
+
+        private static readonly object Gate = new object();
+        private static readonly Queue<FuseLiveLogEntry> Entries =
+            new Queue<FuseLiveLogEntry>(Capacity);
+
+        private static long _nextSequence;
+
+        internal static void Append(DateTime timestamp, string level, string message)
+        {
+            lock (Gate)
+            {
+                while (Entries.Count >= Capacity)
+                {
+                    Entries.Dequeue();
+                }
+
+                Entries.Enqueue(new FuseLiveLogEntry
+                {
+                    Sequence = ++_nextSequence,
+                    Timestamp = timestamp,
+                    Level = NormalizeLevel(level),
+                    Message = message ?? string.Empty
+                });
+            }
+        }
+
+        internal static FuseLiveLogEntry[] Snapshot(string levelFilter, string search, int maximum)
+        {
+            maximum = Math.Max(1, maximum);
+            var normalizedLevel = (levelFilter ?? string.Empty).Trim();
+            var normalizedSearch = (search ?? string.Empty).Trim();
+
+            lock (Gate)
+            {
+                return Entries
+                    .Where(entry => MatchesLevel(entry.Level, normalizedLevel))
+                    .Where(entry => string.IsNullOrEmpty(normalizedSearch) ||
+                                    entry.Message.IndexOf(normalizedSearch, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                                    entry.Level.IndexOf(normalizedSearch, StringComparison.OrdinalIgnoreCase) >= 0)
+                    .Reverse()
+                    .Take(maximum)
+                    .Reverse()
+                    .Select(Clone)
+                    .ToArray();
+            }
+        }
+
+        internal static int Count
+        {
+            get
+            {
+                lock (Gate)
+                {
+                    return Entries.Count;
+                }
+            }
+        }
+
+        private static FuseLiveLogEntry Clone(FuseLiveLogEntry entry) =>
+            new FuseLiveLogEntry
+            {
+                Sequence = entry.Sequence,
+                Timestamp = entry.Timestamp,
+                Level = entry.Level,
+                Message = entry.Message
+            };
+
+        private static bool MatchesLevel(string actual, string filter)
+        {
+            if (string.IsNullOrEmpty(filter) || string.Equals(filter, "All", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (string.Equals(filter, "Warnings + Errors", StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Equals(actual, "WARN", StringComparison.OrdinalIgnoreCase) ||
+                       string.Equals(actual, "ERROR", StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (string.Equals(filter, "Errors", StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Equals(actual, "ERROR", StringComparison.OrdinalIgnoreCase);
+            }
+
+            return string.Equals(actual, filter, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string NormalizeLevel(string level)
+        {
+            var value = (level ?? string.Empty).Trim().ToUpperInvariant();
+            return string.IsNullOrEmpty(value) ? "INFO" : value;
+        }
+
+        internal static void ResetForTests()
+        {
+            lock (Gate)
+            {
+                Entries.Clear();
+                _nextSequence = 0;
+            }
+        }
+    }
+}

--- a/FUSE/Infrastructure/FuseLog.cs
+++ b/FUSE/Infrastructure/FuseLog.cs
@@ -215,6 +215,12 @@ namespace FUSE.Infrastructure
 
         private static void WriteFile(string level, string message)
         {
+            var timestamp = DateTime.Now;
+            var normalizedMessage = message ?? string.Empty;
+            var line = $"[{timestamp:HH:mm:ss.fff}] [{level}] {normalizedMessage}";
+            FuseLiveLogBuffer.Append(timestamp, level, normalizedMessage);
+            FuseLiveConsole.WriteLine(line);
+
             if (!_fileLoggingAvailable)
             {
                 return;
@@ -232,7 +238,7 @@ namespace FUSE.Infrastructure
             // no file I/O runs on the caller.
             try
             {
-                queue.Add($"[{DateTime.Now:HH:mm:ss.fff}] [{level}] {message ?? string.Empty}");
+                queue.Add(line);
             }
             catch (InvalidOperationException)
             {

--- a/FUSE/Infrastructure/FuseRuntimeGuardCounters.cs
+++ b/FUSE/Infrastructure/FuseRuntimeGuardCounters.cs
@@ -35,6 +35,7 @@ namespace FUSE.Infrastructure
         internal static long RebillAutoConfigSuppressed { get; private set; }
         internal static long BrssModMenuDeferred { get; private set; }
         internal static long TimeSyncMainThreadMarshaled { get; private set; }
+        internal static long PassengerStopSpansSanitized { get; private set; }
 
         internal static long FrameSpikes { get; private set; }
         internal static float FrameSpikeWorstMs { get; private set; }
@@ -66,7 +67,8 @@ namespace FUSE.Infrastructure
             MapEnhancerCullingGuarded +
             RebillAutoConfigSuppressed +
             BrssModMenuDeferred +
-            TimeSyncMainThreadMarshaled;
+            TimeSyncMainThreadMarshaled +
+            PassengerStopSpansSanitized;
 
         internal static bool AllIdle => GuardTotal == 0;
 
@@ -99,6 +101,8 @@ namespace FUSE.Infrastructure
         internal static long RecordBrssModMenuDeferred() => ++BrssModMenuDeferred;
 
         internal static long RecordTimeSyncMainThreadMarshaled() => ++TimeSyncMainThreadMarshaled;
+
+        internal static long RecordPassengerStopSpanSanitized() => ++PassengerStopSpansSanitized;
 
         internal static long RecordFrameSpike(float frameMs)
         {
@@ -133,6 +137,7 @@ namespace FUSE.Infrastructure
                 $"rebillAutoConfigSuppressed={RebillAutoConfigSuppressed} " +
                 $"brssModMenuDeferred={BrssModMenuDeferred} " +
                 $"timeSyncMainThread={TimeSyncMainThreadMarshaled} " +
+                $"passengerStopSpansSanitized={PassengerStopSpansSanitized} " +
                 $"flares={FlareSuppressed} switchRailsBackfilled={SwitchGeometryRailsBackfilled} " +
                 spikes;
         }
@@ -155,6 +160,7 @@ namespace FUSE.Infrastructure
             RebillAutoConfigSuppressed = 0;
             BrssModMenuDeferred = 0;
             TimeSyncMainThreadMarshaled = 0;
+            PassengerStopSpansSanitized = 0;
             FrameSpikes = 0;
             FrameSpikeWorstMs = 0f;
             SceneryLoadWatchAttached = 0;

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -68,6 +68,27 @@ namespace FUSE.Infrastructure
         // a newer stable FUSE release exists and, if so, surfaces a non-blocking
         // notice. On by default; one switch turns off all network access for it.
         public const bool DefaultEnableUpdateCheck = true;
+        // Native replacement for ZAMU FallFromGrace. The defaults preserve the
+        // base game's grace calculation exactly (minimum 0, x1, +0) while still
+        // enabling the useful due-date row in the car inspector.
+        public const int DefaultGraceMinimumDays = 0;
+        public const int DefaultGraceMultiplier = 1;
+        public const int DefaultGraceAddedDays = 0;
+        public const int DefaultInterchangeServiceIntervalMinutes = 150;
+        public const bool DefaultInterchangeContinuousService = false;
+        public const float DefaultInterchangeNotBeforeHour = 0f;
+        public const float DefaultInterchangeNotAfterHour = 24f;
+        public const bool DefaultEnableOutboundIndustryRerouting = false;
+        public const float DefaultOutboundIndustryRerouteChance = 0.25f;
+        public const float DefaultOutboundIndustryFillFactor = 1f;
+        public const float DefaultOutboundIndustryPaymentMultiplier = 1f;
+        public const bool DefaultOutboundIndustryAllowShortTrips = false;
+        public const bool DefaultOutboundIndustryIgnoreOrigin = false;
+        public const bool DefaultOutboundIndustryPreventBlocking = false;
+        public const int DefaultInterchangeToInterchangeMaximumCars = 30;
+        public const bool DefaultForYourConvenienceShowCabooseIcons = false;
+        public const bool DefaultForYourConvenienceShowCarTagMph = false;
+        public const bool DefaultForYourConvenienceShowCarTagLoads = false;
         // The cold load of a direct (fuseasset://) asset pack goes through the
         // game's public ContainerSerialization.Deserialize so old-loader
         // Harmony postfixes (LegosLibraryOfStuff clone/edit injection) apply
@@ -143,6 +164,57 @@ namespace FUSE.Infrastructure
 
         public static bool EnableUpdateCheck { get; private set; } = DefaultEnableUpdateCheck;
 
+        public static int GraceMinimumDays { get; private set; } = DefaultGraceMinimumDays;
+
+        public static int GraceMultiplier { get; private set; } = DefaultGraceMultiplier;
+
+        public static int GraceAddedDays { get; private set; } = DefaultGraceAddedDays;
+
+        public static int InterchangeServiceIntervalMinutes { get; private set; } =
+            DefaultInterchangeServiceIntervalMinutes;
+
+        public static bool InterchangeContinuousService { get; private set; } =
+            DefaultInterchangeContinuousService;
+
+        public static float InterchangeNotBeforeHour { get; private set; } =
+            DefaultInterchangeNotBeforeHour;
+
+        public static float InterchangeNotAfterHour { get; private set; } =
+            DefaultInterchangeNotAfterHour;
+
+        public static bool EnableOutboundIndustryRerouting { get; private set; } =
+            DefaultEnableOutboundIndustryRerouting;
+
+        public static float OutboundIndustryRerouteChance { get; private set; } =
+            DefaultOutboundIndustryRerouteChance;
+
+        public static float OutboundIndustryFillFactor { get; private set; } =
+            DefaultOutboundIndustryFillFactor;
+
+        public static float OutboundIndustryPaymentMultiplier { get; private set; } =
+            DefaultOutboundIndustryPaymentMultiplier;
+
+        public static bool OutboundIndustryAllowShortTrips { get; private set; } =
+            DefaultOutboundIndustryAllowShortTrips;
+
+        public static bool OutboundIndustryIgnoreOrigin { get; private set; } =
+            DefaultOutboundIndustryIgnoreOrigin;
+
+        public static bool OutboundIndustryPreventBlocking { get; private set; } =
+            DefaultOutboundIndustryPreventBlocking;
+
+        public static int InterchangeToInterchangeMaximumCars { get; private set; } =
+            DefaultInterchangeToInterchangeMaximumCars;
+
+        public static bool ForYourConvenienceShowCabooseIcons { get; private set; } =
+            DefaultForYourConvenienceShowCabooseIcons;
+
+        public static bool ForYourConvenienceShowCarTagMph { get; private set; } =
+            DefaultForYourConvenienceShowCarTagMph;
+
+        public static bool ForYourConvenienceShowCarTagLoads { get; private set; } =
+            DefaultForYourConvenienceShowCarTagLoads;
+
         public static bool DirectStoreNativeDeserialize { get; private set; } = DefaultDirectStoreNativeDeserialize;
 
         public static void Load(UnityModManager.ModEntry modEntry)
@@ -176,6 +248,24 @@ namespace FUSE.Infrastructure
             ForceConstrainedVramMode = DefaultForceConstrainedVramMode;
             EnableNativeLeakStackTraces = DefaultEnableNativeLeakStackTraces;
             EnableUpdateCheck = DefaultEnableUpdateCheck;
+            GraceMinimumDays = DefaultGraceMinimumDays;
+            GraceMultiplier = DefaultGraceMultiplier;
+            GraceAddedDays = DefaultGraceAddedDays;
+            InterchangeServiceIntervalMinutes = DefaultInterchangeServiceIntervalMinutes;
+            InterchangeContinuousService = DefaultInterchangeContinuousService;
+            InterchangeNotBeforeHour = DefaultInterchangeNotBeforeHour;
+            InterchangeNotAfterHour = DefaultInterchangeNotAfterHour;
+            EnableOutboundIndustryRerouting = DefaultEnableOutboundIndustryRerouting;
+            OutboundIndustryRerouteChance = DefaultOutboundIndustryRerouteChance;
+            OutboundIndustryFillFactor = DefaultOutboundIndustryFillFactor;
+            OutboundIndustryPaymentMultiplier = DefaultOutboundIndustryPaymentMultiplier;
+            OutboundIndustryAllowShortTrips = DefaultOutboundIndustryAllowShortTrips;
+            OutboundIndustryIgnoreOrigin = DefaultOutboundIndustryIgnoreOrigin;
+            OutboundIndustryPreventBlocking = DefaultOutboundIndustryPreventBlocking;
+            InterchangeToInterchangeMaximumCars = DefaultInterchangeToInterchangeMaximumCars;
+            ForYourConvenienceShowCabooseIcons = DefaultForYourConvenienceShowCabooseIcons;
+            ForYourConvenienceShowCarTagMph = DefaultForYourConvenienceShowCarTagMph;
+            ForYourConvenienceShowCarTagLoads = DefaultForYourConvenienceShowCarTagLoads;
             DirectStoreNativeDeserialize = DefaultDirectStoreNativeDeserialize;
             FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
 
@@ -248,6 +338,51 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, "EnableNativeLeakStackTraces", DefaultEnableNativeLeakStackTraces);
                 EnableUpdateCheck =
                     ReadBool(settings, "EnableUpdateCheck", DefaultEnableUpdateCheck);
+                GraceMinimumDays =
+                    ReadInt(settings, "GraceMinimumDays", DefaultGraceMinimumDays);
+                GraceMultiplier =
+                    ReadInt(settings, "GraceMultiplier", DefaultGraceMultiplier);
+                GraceAddedDays =
+                    ReadInt(settings, "GraceAddedDays", DefaultGraceAddedDays);
+                InterchangeServiceIntervalMinutes = NormalizeInterchangeServiceIntervalMinutes(
+                    ReadInt(settings, "InterchangeServiceIntervalMinutes", DefaultInterchangeServiceIntervalMinutes));
+                InterchangeContinuousService =
+                    ReadBool(settings, "InterchangeContinuousService", DefaultInterchangeContinuousService);
+                InterchangeNotBeforeHour = ClampInterchangeServiceHour(
+                    ReadFloat(settings, "InterchangeNotBeforeHour", DefaultInterchangeNotBeforeHour));
+                InterchangeNotAfterHour = ClampInterchangeServiceHour(
+                    ReadFloat(settings, "InterchangeNotAfterHour", DefaultInterchangeNotAfterHour));
+                EnableOutboundIndustryRerouting =
+                    ReadBool(settings, "EnableOutboundIndustryRerouting", DefaultEnableOutboundIndustryRerouting);
+                OutboundIndustryRerouteChance = Mathf.Clamp01(
+                    ReadFloat(settings, "OutboundIndustryRerouteChance", DefaultOutboundIndustryRerouteChance));
+                OutboundIndustryFillFactor = ClampOutboundIndustryFillFactor(
+                    ReadFloat(settings, "OutboundIndustryFillFactor", DefaultOutboundIndustryFillFactor));
+                OutboundIndustryPaymentMultiplier = ClampOutboundIndustryPaymentMultiplier(
+                    ReadFloat(settings, "OutboundIndustryPaymentMultiplier", DefaultOutboundIndustryPaymentMultiplier));
+                OutboundIndustryAllowShortTrips =
+                    ReadBool(settings, "OutboundIndustryAllowShortTrips", DefaultOutboundIndustryAllowShortTrips);
+                OutboundIndustryIgnoreOrigin =
+                    ReadBool(settings, "OutboundIndustryIgnoreOrigin", DefaultOutboundIndustryIgnoreOrigin);
+                OutboundIndustryPreventBlocking =
+                    ReadBool(settings, "OutboundIndustryPreventBlocking", DefaultOutboundIndustryPreventBlocking);
+                InterchangeToInterchangeMaximumCars = ClampInterchangeToInterchangeMaximumCars(
+                    ReadInt(
+                        settings,
+                        "InterchangeToInterchangeMaximumCars",
+                        DefaultInterchangeToInterchangeMaximumCars));
+                ForYourConvenienceShowCabooseIcons = ReadBool(
+                    settings,
+                    "ForYourConvenienceShowCabooseIcons",
+                    DefaultForYourConvenienceShowCabooseIcons);
+                ForYourConvenienceShowCarTagMph = ReadBool(
+                    settings,
+                    "ForYourConvenienceShowCarTagMph",
+                    DefaultForYourConvenienceShowCarTagMph);
+                ForYourConvenienceShowCarTagLoads = ReadBool(
+                    settings,
+                    "ForYourConvenienceShowCarTagLoads",
+                    DefaultForYourConvenienceShowCarTagLoads);
                 DirectStoreNativeDeserialize =
                     ReadBool(settings, "DirectStoreNativeDeserialize", DefaultDirectStoreNativeDeserialize);
                 ApplyUserOverrides();
@@ -284,6 +419,24 @@ namespace FUSE.Infrastructure
                     $"ForceConstrainedVramMode={ForceConstrainedVramMode} " +
                     $"EnableNativeLeakStackTraces={EnableNativeLeakStackTraces} " +
                     $"EnableUpdateCheck={EnableUpdateCheck} " +
+                    $"GraceMinimumDays={GraceMinimumDays} " +
+                    $"GraceMultiplier={GraceMultiplier} " +
+                    $"GraceAddedDays={GraceAddedDays} " +
+                    $"InterchangeServiceIntervalMinutes={InterchangeServiceIntervalMinutes} " +
+                    $"InterchangeContinuousService={InterchangeContinuousService} " +
+                    $"InterchangeNotBeforeHour={InterchangeNotBeforeHour} " +
+                    $"InterchangeNotAfterHour={InterchangeNotAfterHour} " +
+                    $"EnableOutboundIndustryRerouting={EnableOutboundIndustryRerouting} " +
+                    $"OutboundIndustryRerouteChance={OutboundIndustryRerouteChance} " +
+                    $"OutboundIndustryFillFactor={OutboundIndustryFillFactor} " +
+                    $"OutboundIndustryPaymentMultiplier={OutboundIndustryPaymentMultiplier} " +
+                    $"OutboundIndustryAllowShortTrips={OutboundIndustryAllowShortTrips} " +
+                    $"OutboundIndustryIgnoreOrigin={OutboundIndustryIgnoreOrigin} " +
+                    $"OutboundIndustryPreventBlocking={OutboundIndustryPreventBlocking} " +
+                    $"InterchangeToInterchangeMaximumCars={InterchangeToInterchangeMaximumCars} " +
+                    $"ForYourConvenienceShowCabooseIcons={ForYourConvenienceShowCabooseIcons} " +
+                    $"ForYourConvenienceShowCarTagMph={ForYourConvenienceShowCarTagMph} " +
+                    $"ForYourConvenienceShowCarTagLoads={ForYourConvenienceShowCarTagLoads} " +
                     $"DirectStoreNativeDeserialize={DirectStoreNativeDeserialize} " +
                     $"timeoutSeconds={ExperimentalEarlyScenePathSuppressionTimeoutSeconds}.");
             }
@@ -318,6 +471,24 @@ namespace FUSE.Infrastructure
                 ForceConstrainedVramMode = DefaultForceConstrainedVramMode;
                 EnableNativeLeakStackTraces = DefaultEnableNativeLeakStackTraces;
                 EnableUpdateCheck = DefaultEnableUpdateCheck;
+                GraceMinimumDays = DefaultGraceMinimumDays;
+                GraceMultiplier = DefaultGraceMultiplier;
+                GraceAddedDays = DefaultGraceAddedDays;
+                InterchangeServiceIntervalMinutes = DefaultInterchangeServiceIntervalMinutes;
+                InterchangeContinuousService = DefaultInterchangeContinuousService;
+                InterchangeNotBeforeHour = DefaultInterchangeNotBeforeHour;
+                InterchangeNotAfterHour = DefaultInterchangeNotAfterHour;
+                EnableOutboundIndustryRerouting = DefaultEnableOutboundIndustryRerouting;
+                OutboundIndustryRerouteChance = DefaultOutboundIndustryRerouteChance;
+                OutboundIndustryFillFactor = DefaultOutboundIndustryFillFactor;
+                OutboundIndustryPaymentMultiplier = DefaultOutboundIndustryPaymentMultiplier;
+                OutboundIndustryAllowShortTrips = DefaultOutboundIndustryAllowShortTrips;
+                OutboundIndustryIgnoreOrigin = DefaultOutboundIndustryIgnoreOrigin;
+                OutboundIndustryPreventBlocking = DefaultOutboundIndustryPreventBlocking;
+                InterchangeToInterchangeMaximumCars = DefaultInterchangeToInterchangeMaximumCars;
+                ForYourConvenienceShowCabooseIcons = DefaultForYourConvenienceShowCabooseIcons;
+                ForYourConvenienceShowCarTagMph = DefaultForYourConvenienceShowCarTagMph;
+                ForYourConvenienceShowCarTagLoads = DefaultForYourConvenienceShowCarTagLoads;
                 DirectStoreNativeDeserialize = DefaultDirectStoreNativeDeserialize;
                 FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
                 FuseLog.Exception($"FUSE failed to parse Info.json settings; experimental early scene-path suppression remains disabled", ex);
@@ -562,6 +733,158 @@ namespace FUSE.Infrastructure
                 "Takes effect on the next game start.");
         }
 
+        public static void SetGraceMinimumDays(int value)
+        {
+            GraceMinimumDays = value;
+            SaveUserOverride(nameof(GraceMinimumDays), value);
+            FuseLog.Info($"FUSE legacy gameplay setting changed: {nameof(GraceMinimumDays)}={value}.");
+        }
+
+        public static void SetGraceMultiplier(int value)
+        {
+            GraceMultiplier = value;
+            SaveUserOverride(nameof(GraceMultiplier), value);
+            FuseLog.Info($"FUSE legacy gameplay setting changed: {nameof(GraceMultiplier)}={value}.");
+        }
+
+        public static void SetGraceAddedDays(int value)
+        {
+            GraceAddedDays = value;
+            SaveUserOverride(nameof(GraceAddedDays), value);
+            FuseLog.Info($"FUSE legacy gameplay setting changed: {nameof(GraceAddedDays)}={value}.");
+        }
+
+        public static void SetInterchangeServiceIntervalMinutes(int value)
+        {
+            InterchangeServiceIntervalMinutes = NormalizeInterchangeServiceIntervalMinutes(value);
+            SaveUserOverride(nameof(InterchangeServiceIntervalMinutes), InterchangeServiceIntervalMinutes);
+            FuseLog.Info(
+                $"FUSE legacy gameplay setting changed: {nameof(InterchangeServiceIntervalMinutes)}=" +
+                $"{InterchangeServiceIntervalMinutes}.");
+        }
+
+        public static void SetInterchangeContinuousService(bool enabled)
+        {
+            InterchangeContinuousService = enabled;
+            SaveUserOverride(nameof(InterchangeContinuousService), enabled);
+            FuseLog.Info(
+                $"FUSE legacy gameplay setting changed: {nameof(InterchangeContinuousService)}={enabled}.");
+        }
+
+        public static void SetInterchangeNotBeforeHour(float value)
+        {
+            InterchangeNotBeforeHour = ClampInterchangeServiceHour(value);
+            SaveUserOverride(nameof(InterchangeNotBeforeHour), InterchangeNotBeforeHour);
+            FuseLog.Info(
+                $"FUSE legacy gameplay setting changed: {nameof(InterchangeNotBeforeHour)}=" +
+                $"{InterchangeNotBeforeHour:F2}.");
+        }
+
+        public static void SetInterchangeNotAfterHour(float value)
+        {
+            InterchangeNotAfterHour = ClampInterchangeServiceHour(value);
+            SaveUserOverride(nameof(InterchangeNotAfterHour), InterchangeNotAfterHour);
+            FuseLog.Info(
+                $"FUSE legacy gameplay setting changed: {nameof(InterchangeNotAfterHour)}=" +
+                $"{InterchangeNotAfterHour:F2}.");
+        }
+
+        internal static int NormalizeInterchangeServiceIntervalMinutes(int value)
+        {
+            return value <= 0 ? DefaultInterchangeServiceIntervalMinutes : Math.Min(value, 7 * 24 * 60);
+        }
+
+        internal static float ClampInterchangeServiceHour(float value)
+        {
+            if (float.IsNaN(value))
+            {
+                return 0f;
+            }
+
+            return Mathf.Clamp(value, 0f, 24f);
+        }
+
+        public static void SetEnableOutboundIndustryRerouting(bool enabled)
+        {
+            EnableOutboundIndustryRerouting = enabled;
+            SaveUserOverride(nameof(EnableOutboundIndustryRerouting), enabled);
+        }
+
+        public static void SetOutboundIndustryRerouteChance(float value)
+        {
+            OutboundIndustryRerouteChance = Mathf.Clamp01(value);
+            SaveUserOverride(nameof(OutboundIndustryRerouteChance), OutboundIndustryRerouteChance);
+        }
+
+        public static void SetOutboundIndustryFillFactor(float value)
+        {
+            OutboundIndustryFillFactor = ClampOutboundIndustryFillFactor(value);
+            SaveUserOverride(nameof(OutboundIndustryFillFactor), OutboundIndustryFillFactor);
+        }
+
+        public static void SetOutboundIndustryPaymentMultiplier(float value)
+        {
+            OutboundIndustryPaymentMultiplier = ClampOutboundIndustryPaymentMultiplier(value);
+            SaveUserOverride(nameof(OutboundIndustryPaymentMultiplier), OutboundIndustryPaymentMultiplier);
+        }
+
+        public static void SetOutboundIndustryAllowShortTrips(bool enabled)
+        {
+            OutboundIndustryAllowShortTrips = enabled;
+            SaveUserOverride(nameof(OutboundIndustryAllowShortTrips), enabled);
+        }
+
+        public static void SetOutboundIndustryIgnoreOrigin(bool enabled)
+        {
+            OutboundIndustryIgnoreOrigin = enabled;
+            SaveUserOverride(nameof(OutboundIndustryIgnoreOrigin), enabled);
+        }
+
+        public static void SetOutboundIndustryPreventBlocking(bool enabled)
+        {
+            OutboundIndustryPreventBlocking = enabled;
+            SaveUserOverride(nameof(OutboundIndustryPreventBlocking), enabled);
+        }
+
+        public static void SetInterchangeToInterchangeMaximumCars(int value)
+        {
+            InterchangeToInterchangeMaximumCars = ClampInterchangeToInterchangeMaximumCars(value);
+            SaveUserOverride(nameof(InterchangeToInterchangeMaximumCars), InterchangeToInterchangeMaximumCars);
+        }
+
+        internal static int ClampInterchangeToInterchangeMaximumCars(int value)
+        {
+            return Mathf.Clamp(value, 0, 200);
+        }
+
+        public static void SetForYourConvenienceShowCabooseIcons(bool enabled)
+        {
+            ForYourConvenienceShowCabooseIcons = enabled;
+            SaveUserOverride(nameof(ForYourConvenienceShowCabooseIcons), enabled);
+        }
+
+        public static void SetForYourConvenienceShowCarTagMph(bool enabled)
+        {
+            ForYourConvenienceShowCarTagMph = enabled;
+            SaveUserOverride(nameof(ForYourConvenienceShowCarTagMph), enabled);
+        }
+
+        public static void SetForYourConvenienceShowCarTagLoads(bool enabled)
+        {
+            ForYourConvenienceShowCarTagLoads = enabled;
+            SaveUserOverride(nameof(ForYourConvenienceShowCarTagLoads), enabled);
+        }
+
+        internal static float ClampOutboundIndustryFillFactor(float value)
+        {
+            return float.IsNaN(value) ? DefaultOutboundIndustryFillFactor : Mathf.Clamp(value, 0.1f, 3f);
+        }
+
+        internal static float ClampOutboundIndustryPaymentMultiplier(float value)
+        {
+            return float.IsNaN(value) ? DefaultOutboundIndustryPaymentMultiplier : Mathf.Clamp(value, 0f, 10f);
+        }
+
         public static string GetUserSettingsPath()
         {
             return Path.Combine(Application.persistentDataPath, "FUSE", "settings.json");
@@ -611,6 +934,34 @@ namespace FUSE.Infrastructure
             return float.TryParse(
                 token.ToString(),
                 System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out parsed)
+                ? parsed
+                : defaultValue;
+        }
+
+        internal static int ReadInt(JToken settings, string key, int defaultValue)
+        {
+            if (settings == null || string.IsNullOrWhiteSpace(key))
+            {
+                return defaultValue;
+            }
+
+            var token = settings[key];
+            if (token == null)
+            {
+                return defaultValue;
+            }
+
+            if (token.Type == JTokenType.Integer)
+            {
+                return token.Value<int>();
+            }
+
+            int parsed;
+            return int.TryParse(
+                token.ToString(),
+                System.Globalization.NumberStyles.Integer,
                 System.Globalization.CultureInfo.InvariantCulture,
                 out parsed)
                 ? parsed
@@ -781,6 +1132,57 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, nameof(EnableNativeLeakStackTraces), EnableNativeLeakStackTraces);
                 EnableUpdateCheck =
                     ReadBool(settings, nameof(EnableUpdateCheck), EnableUpdateCheck);
+                GraceMinimumDays =
+                    ReadInt(settings, nameof(GraceMinimumDays), GraceMinimumDays);
+                GraceMultiplier =
+                    ReadInt(settings, nameof(GraceMultiplier), GraceMultiplier);
+                GraceAddedDays =
+                    ReadInt(settings, nameof(GraceAddedDays), GraceAddedDays);
+                InterchangeServiceIntervalMinutes = NormalizeInterchangeServiceIntervalMinutes(
+                    ReadInt(
+                        settings,
+                        nameof(InterchangeServiceIntervalMinutes),
+                        InterchangeServiceIntervalMinutes));
+                InterchangeContinuousService =
+                    ReadBool(settings, nameof(InterchangeContinuousService), InterchangeContinuousService);
+                InterchangeNotBeforeHour = ClampInterchangeServiceHour(
+                    ReadFloat(settings, nameof(InterchangeNotBeforeHour), InterchangeNotBeforeHour));
+                InterchangeNotAfterHour = ClampInterchangeServiceHour(
+                    ReadFloat(settings, nameof(InterchangeNotAfterHour), InterchangeNotAfterHour));
+                EnableOutboundIndustryRerouting =
+                    ReadBool(settings, nameof(EnableOutboundIndustryRerouting), EnableOutboundIndustryRerouting);
+                OutboundIndustryRerouteChance = Mathf.Clamp01(
+                    ReadFloat(settings, nameof(OutboundIndustryRerouteChance), OutboundIndustryRerouteChance));
+                OutboundIndustryFillFactor = ClampOutboundIndustryFillFactor(
+                    ReadFloat(settings, nameof(OutboundIndustryFillFactor), OutboundIndustryFillFactor));
+                OutboundIndustryPaymentMultiplier = ClampOutboundIndustryPaymentMultiplier(
+                    ReadFloat(
+                        settings,
+                        nameof(OutboundIndustryPaymentMultiplier),
+                        OutboundIndustryPaymentMultiplier));
+                OutboundIndustryAllowShortTrips =
+                    ReadBool(settings, nameof(OutboundIndustryAllowShortTrips), OutboundIndustryAllowShortTrips);
+                OutboundIndustryIgnoreOrigin =
+                    ReadBool(settings, nameof(OutboundIndustryIgnoreOrigin), OutboundIndustryIgnoreOrigin);
+                OutboundIndustryPreventBlocking =
+                    ReadBool(settings, nameof(OutboundIndustryPreventBlocking), OutboundIndustryPreventBlocking);
+                InterchangeToInterchangeMaximumCars = ClampInterchangeToInterchangeMaximumCars(
+                    ReadInt(
+                        settings,
+                        nameof(InterchangeToInterchangeMaximumCars),
+                        InterchangeToInterchangeMaximumCars));
+                ForYourConvenienceShowCabooseIcons = ReadBool(
+                    settings,
+                    nameof(ForYourConvenienceShowCabooseIcons),
+                    ForYourConvenienceShowCabooseIcons);
+                ForYourConvenienceShowCarTagMph = ReadBool(
+                    settings,
+                    nameof(ForYourConvenienceShowCarTagMph),
+                    ForYourConvenienceShowCarTagMph);
+                ForYourConvenienceShowCarTagLoads = ReadBool(
+                    settings,
+                    nameof(ForYourConvenienceShowCarTagLoads),
+                    ForYourConvenienceShowCarTagLoads);
                 DirectStoreNativeDeserialize =
                     ReadBool(settings, nameof(DirectStoreNativeDeserialize), DirectStoreNativeDeserialize);
                 FuseLog.Info($"FUSE user setting overrides loaded from '{path}'.");
@@ -797,6 +1199,11 @@ namespace FUSE.Infrastructure
         }
 
         private static void SaveUserOverride(string key, float value)
+        {
+            SaveUserOverride(key, new JValue(value));
+        }
+
+        private static void SaveUserOverride(string key, int value)
         {
             SaveUserOverride(key, new JValue(value));
         }

--- a/FUSE/Interface/Console/FuseConsoleCommands.cs
+++ b/FUSE/Interface/Console/FuseConsoleCommands.cs
@@ -31,6 +31,7 @@ namespace FUSE.Interface.Console
             {
                 new FuseReportCommand(),
                 new FuseLoadedCommand(),
+                new FuseStartersCommand(),
                 new FuseUpdateCommand(),
                 new FuseMapsCommand(),
                 new FuseMapLaunchCommand(),
@@ -38,6 +39,8 @@ namespace FUSE.Interface.Console
                 new FuseGraphCommand(),
                 new FuseProgressionsCommand(),
                 new FuseOperationsCommand(),
+                new FuseLiveryRefreshCommand(),
+                new FuseLiveryReportCommand(),
                 new FuseDumpGraphCommand(),
                 new FuseDumpRuntimeGraphCommand(),
                 new FuseDumpMandelasCommand(),
@@ -147,6 +150,45 @@ namespace FUSE.Interface.Console
             }
 
             return string.Join("/", names.ToArray());
+        }
+    }
+
+    [ConsoleCommand(
+        "/cs-livery-refresh",
+        "Reload Confusing Supplements-compatible livery textures and reapply each car's saved selection.")]
+    public sealed class FuseLiveryRefreshCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            try
+            {
+                var refreshed = Compatibility.FuseConfusingSupplementsLiveryRegistry
+                    .RefreshLiveCars();
+                return $"FUSE refreshed Confusing Supplements-compatible liveries on {refreshed} car(s).";
+            }
+            catch (Exception ex)
+            {
+                return "FUSE livery refresh failed: " + ex.GetBaseException().Message;
+            }
+        }
+    }
+
+    [ConsoleCommand(
+        "/fuse.liveries",
+        "Report Confusing Supplements-compatible livery selections, choices, and cached textures.")]
+    public sealed class FuseLiveryReportCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            try
+            {
+                return Compatibility.FuseConfusingSupplementsLiveryRegistry
+                    .BuildDiagnosticReport();
+            }
+            catch (Exception ex)
+            {
+                return "FUSE livery diagnostics failed: " + ex.GetBaseException().Message;
+            }
         }
     }
 
@@ -483,6 +525,20 @@ namespace FUSE.Interface.Console
                     sb.AppendLine("  " + folder);
                 }
 
+                var definitionOverrides = FuseAssetPackRegistry.GetLegacyDefinitionOverrides();
+                var overrideIssues = FuseAssetPackRegistry.GetLegacyDefinitionOverrideIssues();
+                sb.AppendLine($"Definition overrides: active={definitionOverrides.Length}; issues={overrideIssues.Length}.");
+                foreach (var definitionOverride in definitionOverrides)
+                {
+                    sb.AppendLine(
+                        $"  {definitionOverride.StoreIdentifier} <- {definitionOverride.DefinitionsPath} " +
+                        $"(package {definitionOverride.PackageId})");
+                }
+                foreach (var issue in overrideIssues)
+                {
+                    sb.AppendLine("  ISSUE: " + issue);
+                }
+
                 return sb.ToString();
             }
             catch (Exception ex)
@@ -706,6 +762,18 @@ namespace FUSE.Interface.Console
             }
 
             return FuseLoadReport.GetLastDetailReport();
+        }
+    }
+
+    [ConsoleCommand(
+        "/fuse.starters",
+        "Resume placement of retained Appalachian Railway starter equipment.")]
+    public sealed class FuseStartersCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            return FuseCompanyStarterPlacementPatch
+                .ResumePendingPlacements();
         }
     }
 
@@ -1182,14 +1250,17 @@ namespace FUSE.Interface.Console
         public string Execute(string[] components)
         {
             var conflicts = FuseRegistry.Conflicts;
+            var actionable = conflicts.Count(conflict => !conflict.IsCooperativeMerge);
+            var cooperative = conflicts.Count(conflict => conflict.IsCooperativeMerge);
             var sb = new StringBuilder();
             sb.AppendLine(
                 $"FUSE registry: exclusive={FuseRegistry.ExclusiveClaimCount} shared={FuseRegistry.SharedClaimCount} " +
-                $"conflicts={conflicts.Count}");
+                $"conflicts={actionable} sharedExtensionTargets={cooperative} records={conflicts.Count}");
             foreach (var conflict in conflicts.OrderByDescending(c => c.AtUtc))
             {
+                var classification = conflict.IsCooperativeMerge ? "shared-extension" : "actionable";
                 sb.AppendLine(
-                    $"  target='{conflict.Target ?? conflict.Kind.ToString()}' kind='{conflict.Kind}' id='{conflict.Id}': " +
+                    $"  [{classification}] target='{conflict.Target ?? conflict.Kind.ToString()}' kind='{conflict.Kind}' id='{conflict.Id}': " +
                     $"owner='{conflict.OwnerPackageId}' attempted='{conflict.AttemptedPackageId}' " +
                     $"resolution='{conflict.Resolution ?? "claim skipped"}' at={conflict.AtUtc:HH:mm:ss}Z");
             }

--- a/FUSE/Interface/FuseTrackDebugOverlay.cs
+++ b/FUSE/Interface/FuseTrackDebugOverlay.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using FUSE.Runtime.API;
 using FUSE.Infrastructure;
+using FUSE.Compatibility;
 using Model.Ops;
 using Track;
 using UnityEngine;
@@ -240,7 +241,7 @@ namespace FUSE.Interface
             string style;
             try
             {
-                style = segment.style.ToString();
+                style = RailroaderTrackContract.GetStyleName(segment);
             }
             catch
             {

--- a/FUSE/Interface/FuseWorldLabelsOverlay.cs
+++ b/FUSE/Interface/FuseWorldLabelsOverlay.cs
@@ -4,6 +4,7 @@ using FUSE.Runtime.API;
 using FUSE.Runtime.Cache;
 using FUSE.Infrastructure;
 using Track;
+using UI.Common;
 using UnityEngine;
 
 namespace FUSE.Interface
@@ -62,6 +63,7 @@ namespace FUSE.Interface
         public static readonly Color TrackSegmentColor = new Color(1.00f, 0.88f, 0.25f, 1f);   // yellow
 
         private static GameObject _host;
+        private static bool _windowInspectionWarningLogged;
 
         private readonly List<Label> _labels = new List<Label>(256);
         private GUIStyle _labelStyle;
@@ -89,6 +91,8 @@ namespace FUSE.Interface
                 Destroy(_host);
                 _host = null;
             }
+
+            _windowInspectionWarningLogged = false;
         }
 
         private void Update()
@@ -114,7 +118,10 @@ namespace FUSE.Interface
 
         private void OnGUI()
         {
-            if (!FuseSettings.ShowWorldLabelsOverlay)
+            if (!ShouldRender(
+                    FuseSettings.ShowWorldLabelsOverlay,
+                    Time.timeScale <= 0f,
+                    HasShownGameWindow()))
             {
                 return;
             }
@@ -182,6 +189,47 @@ namespace FUSE.Interface
                 GUI.Label(new Rect(rect.x + 4f, rect.y + 2f, rect.width - 8f, rect.height - 4f), content, _labelStyle);
                 painted++;
             }
+        }
+
+        internal static bool ShouldRender(bool enabled, bool gamePaused, bool hasShownGameWindow)
+        {
+            return enabled && !gamePaused && !hasShownGameWindow;
+        }
+
+        private static bool HasShownGameWindow()
+        {
+            var manager = WindowManager.Shared;
+            if (manager == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                var windows = manager.GetComponentsInChildren<Window>(true);
+                for (var index = 0; index < windows.Length; index++)
+                {
+                    if (windows[index] != null && windows[index].IsShown)
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // UI teardown can race OnGUI while returning to the main menu.
+                // Failing open keeps a transient manager state from disabling
+                // the overlay for the rest of the session.
+                if (!_windowInspectionWarningLogged)
+                {
+                    _windowInspectionWarningLogged = true;
+                    FuseLog.Warning(
+                        "FUSE world-labels overlay could not inspect game windows: " +
+                        ex.GetBaseException().Message);
+                }
+            }
+
+            return false;
         }
 
         private void OnDestroy()

--- a/FUSE/Interface/MenuWindow/AssetsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/AssetsToolPage.cs
@@ -2,6 +2,7 @@
 using FUSE.Loading;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -21,13 +22,19 @@ namespace FUSE.Interface.MenuWindow
             builder.AddLabel("This tool shows asset information and a list of any duplicate asset keys.");
 
             var diagnostics = FuseAssetPackRegistry.GetDiagnostics();
+            var duplicateGroups = GroupDuplicateAssets(diagnostics.DuplicateKeys);
             builder.AddSection("Asset Resolution");
             builder.AddField("Mode", AssetPackModeText());
             builder.AddField("Stores Scanned", diagnostics.StoreFolders.Length.ToString());
             builder.AddField("Runtime Stores", FusePerformanceMetrics.FormatCount("direct asset pack store count"));
             builder.AddField("Unique Asset Keys", diagnostics.UniqueAssetKeys.ToString());
-            builder.AddField("Duplicate Keys", diagnostics.DuplicateKeys.Length.ToString());
+            builder.AddField("Overlapping Asset Keys", diagnostics.DuplicateKeys.Length.ToString());
+            builder.AddField("Source Overlap Groups", duplicateGroups.Length.ToString());
+            builder.AddField("Identical Copies", diagnostics.DuplicateKeys.Count(item => !item.DefinitionsDiffer).ToString());
+            builder.AddField("Different Definitions", diagnostics.DuplicateKeys.Count(item => item.DefinitionsDiffer).ToString());
             builder.AddField("Failed Definitions", diagnostics.FailedDefinitionLoads.Length.ToString());
+            builder.AddField("Definition Overrides", diagnostics.LegacyDefinitionOverrides.Length.ToString());
+            builder.AddField("Override Issues", diagnostics.LegacyDefinitionOverrideIssues.Length.ToString());
             builder.AddField("Last Direct Mount", FusePerformanceMetrics.FormatTiming("direct asset pack stores"));
             AddWrappedField(
                 builder,
@@ -55,7 +62,8 @@ namespace FUSE.Interface.MenuWindow
 
             builder.Spacer(4f);
 
-            if (!FuseSettings.ShowAdvancedHealthDetails && diagnostics.DuplicateKeys.Length == 0 && diagnostics.FailedDefinitionLoads.Length == 0)
+            if (!FuseSettings.ShowAdvancedHealthDetails && diagnostics.DuplicateKeys.Length == 0 &&
+                diagnostics.FailedDefinitionLoads.Length == 0 && diagnostics.LegacyDefinitionOverrideIssues.Length == 0)
             {
                 builder.AddField("Status", "No asset issues detected");
             }
@@ -69,26 +77,26 @@ namespace FUSE.Interface.MenuWindow
             }
             else
             {
-                builder.AddSection("Duplicate Asset Keys");
+                builder.AddSection("Asset Source Overlaps");
                 if (diagnostics.DuplicateKeys.Length == 0)
                 {
                     builder.AddField("Status", "None detected");
                 }
                 else
                 {
-                    foreach (var duplicate in diagnostics.DuplicateKeys.Take(20))
+                    foreach (var group in duplicateGroups.Take(20))
                     {
-                        BuildDuplicateAssetPreview(builder, duplicate);
+                        BuildDuplicateAssetGroupPreview(builder, group);
                         builder.Spacer(4f);
                         builder.AddHRule();
                     }
 
-                    if (diagnostics.DuplicateKeys.Length > 20)
+                    if (duplicateGroups.Length > 20)
                     {
                         AddWrappedField(
                             builder,
                             "More",
-                            (diagnostics.DuplicateKeys.Length - 20) + " hidden. Export Asset Report for all duplicate keys.",
+                            (duplicateGroups.Length - 20) + " source group(s) hidden. Export Asset Report for every overlapping key.",
                             34f);
                     }
                 }
@@ -108,38 +116,103 @@ namespace FUSE.Interface.MenuWindow
                         (diagnostics.StoreFolders.Length - 40) + " hidden. Export Asset Report for all store paths.",
                         34f);
                 }
+
+                builder.Spacer(4f);
+                builder.AddSection("Definition Overrides");
+                if (diagnostics.LegacyDefinitionOverrides.Length == 0)
+                {
+                    builder.AddField("Status", "None detected");
+                }
+                else
+                {
+                    foreach (var definitionOverride in diagnostics.LegacyDefinitionOverrides.Take(20))
+                    {
+                        AddWrappedField(
+                            builder,
+                            definitionOverride.StoreIdentifier,
+                            definitionOverride.PackageId + " | " + definitionOverride.DefinitionsPath,
+                            44f);
+                    }
+                }
+
+                foreach (var issue in diagnostics.LegacyDefinitionOverrideIssues.Take(20))
+                {
+                    AddWrappedField(builder, "Override Issue", issue, 58f);
+                }
             }
 
             builder.Spacer(8f);
         }
 
-        private static string BuildAssetSummary(FuseAssetPackDiagnostics diagnostics)
+        internal static string BuildAssetSummary(FuseAssetPackDiagnostics diagnostics)
         {
+            diagnostics = diagnostics ?? new FuseAssetPackDiagnostics();
+            var duplicateGroups = GroupDuplicateAssets(diagnostics.DuplicateKeys);
             var builder = new StringBuilder();
             builder.AppendLine("FUSE Asset Summary");
             builder.AppendLine("Mode: " + AssetPackModeText());
             builder.AppendLine("Stores scanned: " + (diagnostics.StoreFolders?.Length ?? 0));
             builder.AppendLine("Unique asset keys: " + diagnostics.UniqueAssetKeys);
-            builder.AppendLine("Duplicate keys: " + (diagnostics.DuplicateKeys?.Length ?? 0));
+            builder.AppendLine("Overlapping asset keys: " + (diagnostics.DuplicateKeys?.Length ?? 0));
+            builder.AppendLine("Source overlap groups: " + duplicateGroups.Length);
+            builder.AppendLine("Identical duplicate definitions: " + (diagnostics.DuplicateKeys?.Count(item => !item.DefinitionsDiffer) ?? 0));
+            builder.AppendLine("Different duplicate definitions: " + (diagnostics.DuplicateKeys?.Count(item => item.DefinitionsDiffer) ?? 0));
             builder.AppendLine("Failed definitions: " + (diagnostics.FailedDefinitionLoads?.Length ?? 0));
+            builder.AppendLine("Definition overrides: " + (diagnostics.LegacyDefinitionOverrides?.Length ?? 0));
+            builder.AppendLine("Definition override issues: " + (diagnostics.LegacyDefinitionOverrideIssues?.Length ?? 0));
 
-            var duplicates = diagnostics.DuplicateKeys ?? Array.Empty<FuseDuplicateAssetKey>();
-            if (duplicates.Length > 0)
+            if (duplicateGroups.Length > 0)
             {
                 builder.AppendLine();
-                builder.AppendLine("Duplicate preview:");
-                foreach (var duplicate in duplicates.Take(10))
+                builder.AppendLine("Overlap group preview:");
+                foreach (var group in duplicateGroups.Take(10))
                 {
-                    builder.AppendLine("- " + BuildDuplicateAssetPreviewString(duplicate));
+                    builder.AppendLine("- " + BuildDuplicateAssetGroupPreviewString(group));
                 }
 
-                if (duplicates.Length > 10)
+                if (duplicateGroups.Length > 10)
                 {
-                    builder.AppendLine("- " + (duplicates.Length - 10) + " more duplicate key(s); export the asset report for the full list.");
+                    builder.AppendLine("- " + (duplicateGroups.Length - 10) + " more source overlap group(s); export the asset report for every key.");
                 }
             }
 
             return builder.ToString().TrimEnd();
+        }
+
+        internal static FuseDuplicateAssetGroup[] GroupDuplicateAssets(
+            IEnumerable<FuseDuplicateAssetKey> duplicates)
+        {
+            var grouped = new Dictionary<string, FuseDuplicateAssetGroup>(StringComparer.Ordinal);
+            foreach (var duplicate in duplicates ?? Enumerable.Empty<FuseDuplicateAssetKey>())
+            {
+                if (duplicate == null || string.IsNullOrWhiteSpace(duplicate.Key))
+                {
+                    continue;
+                }
+
+                var sources = (duplicate.Sources ?? Array.Empty<string>())
+                    .Where(source => !string.IsNullOrWhiteSpace(source))
+                    .ToArray();
+                var identity = (duplicate.DefinitionsDiffer ? "different" : "identical") +
+                               "\u001e" + string.Join("\u001f", sources);
+                if (!grouped.TryGetValue(identity, out var group))
+                {
+                    group = new FuseDuplicateAssetGroup
+                    {
+                        DefinitionsDiffer = duplicate.DefinitionsDiffer,
+                        Sources = sources
+                    };
+                    grouped.Add(identity, group);
+                }
+
+                group.Keys.Add(duplicate.Key);
+            }
+
+            return grouped.Values
+                .OrderByDescending(group => group.DefinitionsDiffer)
+                .ThenByDescending(group => group.Keys.Count)
+                .ThenBy(group => group.Keys.FirstOrDefault() ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
         }
 
         private static string AssetPackModeText()
@@ -165,11 +238,6 @@ namespace FUSE.Interface.MenuWindow
 
             var sources = duplicateAssetKey.Sources ?? [];
             var preview = sources
-                .Select(source =>
-                {
-                    var name = string.IsNullOrWhiteSpace(source) ? string.Empty : Path.GetFileName(source);
-                    return string.IsNullOrWhiteSpace(name) ? source : name;
-                })
                 .Where(source => !string.IsNullOrWhiteSpace(source))
                 .ToArray();
 
@@ -187,13 +255,17 @@ namespace FUSE.Interface.MenuWindow
             }
         }
 
-        private static void BuildDuplicateAssetPreview(UIPanelBuilder builder, FuseDuplicateAssetKey duplicate)
+        private static void BuildDuplicateAssetGroupPreview(UIPanelBuilder builder, FuseDuplicateAssetGroup group)
         {
-            if (duplicate == null) return;
+            if (group == null)
+            {
+                return;
+            }
 
-            GetDuplicateAssetInfo(duplicate, out string winner, out string[] overridden, out string suffix);
+            GetDuplicateAssetInfo(group.Sources, out string winner, out string[] overridden, out string suffix);
 
-            builder.AddField("Asset Key", duplicate.Key);
+            builder.AddField("Affected Keys", group.Keys.Count.ToString());
+            builder.AddField("Definition Match", group.DefinitionsDiffer ? "Different definitions (review)" : "Identical copies");
 
             if (string.IsNullOrWhiteSpace(winner))
             {
@@ -206,20 +278,53 @@ namespace FUSE.Interface.MenuWindow
             {
                 builder.AddField("Sources Overridden", string.Join(",", overridden) + suffix);
             }
+
+            AddWrappedField(
+                builder,
+                "Example Keys",
+                string.Join(", ", group.Keys.OrderBy(key => key, StringComparer.OrdinalIgnoreCase).Take(4)),
+                44f);
+            AddWrappedField(
+                builder,
+                "Impact",
+                group.DefinitionsDiffer
+                    ? "Definitions differ; FUSE uses the listed winner, so model or behavior can change with source order."
+                    : "Definitions are identical; this is redundant installed content, not a load failure.",
+                44f);
         }
 
-        private static string BuildDuplicateAssetPreviewString(FuseDuplicateAssetKey duplicate)
+        private static string BuildDuplicateAssetGroupPreviewString(FuseDuplicateAssetGroup group)
         {
-            if (duplicate == null)
+            if (group == null)
             {
                 return string.Empty;
             }
 
-            GetDuplicateAssetInfo(duplicate, out string winner, out string[] overridden, out string suffix);
+            GetDuplicateAssetInfo(group.Sources, out string winner, out string[] overridden, out string suffix);
+            var examples = string.Join(", ", group.Keys
+                .OrderBy(key => key, StringComparer.OrdinalIgnoreCase)
+                .Take(3)
+                .Select(InsertBreakHints));
+            var impact = group.DefinitionsDiffer
+                ? "different definitions; winner controls behavior"
+                : "identical copies; no behavior change";
 
             return overridden.Length == 0
-                ? $"{InsertBreakHints(duplicate.Key)} | winner {winner}{suffix}"
-                : $"{InsertBreakHints(duplicate.Key)} | winner {winner} | overridden {string.Join(", ", overridden)}{suffix}";
+                ? $"{group.Keys.Count} key(s) | winner {winner}{suffix} | {impact} | examples {examples}"
+                : $"{group.Keys.Count} key(s) | winner {winner} | overridden {string.Join(", ", overridden)}{suffix} | {impact} | examples {examples}";
+        }
+
+        private static void GetDuplicateAssetInfo(
+            string[] sources,
+            out string winner,
+            out string[] overridden,
+            out string suffix)
+        {
+            GetDuplicateAssetInfo(
+                new FuseDuplicateAssetKey { Sources = sources ?? Array.Empty<string>() },
+                out winner,
+                out overridden,
+                out suffix);
         }
 
         private static string ExportAssetDiagnostics(FuseAssetPackDiagnostics diagnostics, bool openFolder = true)
@@ -248,6 +353,7 @@ namespace FUSE.Interface.MenuWindow
                     duplicates.Add(new JObject
                     {
                         ["key"] = duplicate.Key ?? string.Empty,
+                        ["definitionsDiffer"] = duplicate.DefinitionsDiffer,
                         ["sourceCount"] = sources.Count,
                         ["winner"] = sources.Count > 0 ? sources[0] : string.Empty,
                         ["overridden"] = new JArray(sources.Skip(1)),
@@ -261,6 +367,26 @@ namespace FUSE.Interface.MenuWindow
                     failedDefinitions.Add(failure);
                 }
 
+                var definitionOverrides = new JArray();
+                foreach (var definitionOverride in diagnostics.LegacyDefinitionOverrides ??
+                         Array.Empty<FuseLegacyDefinitionOverrideRegistration>())
+                {
+                    definitionOverrides.Add(new JObject
+                    {
+                        ["storeIdentifier"] = definitionOverride.StoreIdentifier ?? string.Empty,
+                        ["definitionsPath"] = definitionOverride.DefinitionsPath ?? string.Empty,
+                        ["packageId"] = definitionOverride.PackageId ?? string.Empty,
+                        ["packagePath"] = definitionOverride.PackagePath ?? string.Empty,
+                        ["explicit"] = definitionOverride.Explicit
+                    });
+                }
+
+                var definitionOverrideIssues = new JArray();
+                foreach (var issue in diagnostics.LegacyDefinitionOverrideIssues ?? Array.Empty<string>())
+                {
+                    definitionOverrideIssues.Add(issue);
+                }
+
                 var report = new JObject
                 {
                     ["exportedUtc"] = DateTime.UtcNow.ToString("O"),
@@ -269,9 +395,13 @@ namespace FUSE.Interface.MenuWindow
                     ["uniqueAssetKeys"] = diagnostics.UniqueAssetKeys,
                     ["duplicateKeyCount"] = duplicates.Count,
                     ["failedDefinitionLoadCount"] = failedDefinitions.Count,
+                    ["definitionOverrideCount"] = definitionOverrides.Count,
+                    ["definitionOverrideIssueCount"] = definitionOverrideIssues.Count,
                     ["stores"] = stores,
                     ["duplicateKeys"] = duplicates,
-                    ["failedDefinitionLoads"] = failedDefinitions
+                    ["failedDefinitionLoads"] = failedDefinitions,
+                    ["definitionOverrides"] = definitionOverrides,
+                    ["definitionOverrideIssues"] = definitionOverrideIssues
                 };
 
                 File.WriteAllText(path, report.ToString(Newtonsoft.Json.Formatting.Indented));
@@ -291,5 +421,14 @@ namespace FUSE.Interface.MenuWindow
                 return message;
             }
         }
+    }
+
+    internal sealed class FuseDuplicateAssetGroup
+    {
+        internal bool DefinitionsDiffer { get; set; }
+
+        internal string[] Sources { get; set; } = Array.Empty<string>();
+
+        internal List<string> Keys { get; } = new List<string>();
     }
 }

--- a/FUSE/Interface/MenuWindow/AuditsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/AuditsToolPage.cs
@@ -145,13 +145,23 @@ namespace FUSE.Interface.MenuWindow
 
             foreach (var fault in report["packages"]?["faults"] as JArray ?? [])
             {
+                var faultDetail = ReadString(fault["message"], "Package failed during load/apply.") +
+                    " stage='" + ReadString(fault["stage"], "unknown") + "'" +
+                    " package='" + ReadString(fault["packageName"], ReadString(fault["packageId"], "unknown")) + "'" +
+                    " folder='" + ReadString(fault["folderPath"], "unknown") + "'" +
+                    " file='" + ReadString(fault["relativeSourceFile"], ReadString(fault["sourceFile"], "unknown")) + "'" +
+                    " jsonPath='" + ReadString(fault["jsonPath"], "<root>") + "'" +
+                    " expected='" + ReadString(fault["expectedShape"], "see validation message") + "'" +
+                    " received='" + ReadString(fault["receivedValue"], "not captured") + "'";
                 AddFinding(
                     findings,
-                    "Critical",
-                    "Package fault",
+                    "High",
+                    "Package isolated after apply fault",
                     ReadString(fault["packageId"], "(unknown package)"),
-                    ReadString(fault["message"], "Package failed during load/apply."),
-                    "Open Issues, inspect the package fault stage, then fix the source package or compatibility layer.");
+                    faultDetail,
+                    ReadString(
+                        fault["suggestedAction"],
+                        "Inspect the package fault stage, then fix the source package or compatibility layer."));
             }
 
             foreach (var asset in report["unknownSceneryAssets"] as JArray ?? [])
@@ -167,13 +177,17 @@ namespace FUSE.Interface.MenuWindow
 
             foreach (var issue in report["graphPostBindIssues"] as JArray ?? [])
             {
+                var detail = issue.ToString();
+                var isOwnedRemoval = detail.IndexOf(" was removed by '", StringComparison.OrdinalIgnoreCase) >= 0;
                 AddFinding(
                     findings,
-                    "High",
-                    "Graph post-bind issue",
+                    isOwnedRemoval ? "Medium" : "High",
+                    isOwnedRemoval ? "Track package collision" : "Graph post-bind issue",
                     "track graph",
-                    issue.ToString(),
-                    "Inspect the owning track package and verify deleted/replaced node, segment, and span ids.");
+                    detail,
+                    isOwnedRemoval
+                        ? "These packages edit the same route. Disable one package, choose a compatible option/patch, or have the authors coordinate the shared node/segment ownership."
+                        : "Inspect the owning track package and verify deleted/replaced node, segment, and span ids.");
             }
 
             foreach (var skip in report["progressionTransferSkips"] as JArray ?? [])
@@ -189,6 +203,14 @@ namespace FUSE.Interface.MenuWindow
 
             foreach (var conflict in report["conflicts"] as JArray ?? [])
             {
+                if (!ShouldAuditConflictRecord(ReadString(conflict["classification"], string.Empty)))
+                {
+                    // Successful shared industry merges are surfaced as
+                    // informational extension targets on the dedicated Mods
+                    // Fighting page. They are not audit failures.
+                    continue;
+                }
+
                 AddFinding(
                     findings,
                     "Medium",
@@ -226,13 +248,24 @@ namespace FUSE.Interface.MenuWindow
         {
             try
             {
-                foreach (var span in TrackAPI.GetAllSpans() ?? [])
+                foreach (var span in TrackAPI.GetRegisteredSpansForDiagnostics() ?? [])
                 {
                     var id = span?.id ?? "(blank span)";
+                    var owner = FuseRegistry.GetExclusiveOwner(FuseClaimKind.Span, id);
+                    if (!ShouldAuditTrackSpanOwner(owner))
+                    {
+                        // Railroader ships a number of registered placeholder or
+                        // progression spans whose serialized endpoints are empty
+                        // until the game activates them. They are base-game state,
+                        // not FUSE authoring failures. The graph post-bind audit
+                        // separately reports mod-owned spans lost during merging.
+                        continue;
+                    }
+
                     var definition = TrackAPI.GetDefinition(span);
                     if (definition?.Upper == null || definition.Lower == null)
                     {
-                        AddFinding(findings, "High", "Invalid track span", id, "Span definition has missing upper/lower location.", "Inspect the source span and repair or remove invalid endpoints.");
+                        AddFinding(findings, "High", "Invalid FUSE track span", id, $"Owner '{owner}' has a span with missing upper/lower location.", "Inspect the owning package source and repair or remove invalid endpoints.");
                         continue;
                     }
 
@@ -256,6 +289,19 @@ namespace FUSE.Interface.MenuWindow
             }
         }
 
+        internal static bool ShouldAuditConflictRecord(string classification)
+        {
+            return !string.Equals(
+                classification?.Trim(),
+                "shared-extension",
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static bool ShouldAuditTrackSpanOwner(string ownerPackageId)
+        {
+            return !string.IsNullOrWhiteSpace(ownerPackageId);
+        }
+
         private static void AddIndustryAuditFindings(List<AuditFinding> findings)
         {
             try
@@ -273,11 +319,13 @@ namespace FUSE.Interface.MenuWindow
                         AddFinding(findings, "Medium", "Industry missing identifier", id, GetGameObjectPath(industry.gameObject), "Assign a stable industry identifier or remove the orphan scene object.");
                     }
 
-                    var definition = IndustryAPI.GetDefinition(industry);
-                    if (definition == null || definition.Components == null || definition.Components.Count == 0)
-                    {
-                        AddFinding(findings, "Low", "Industry has no components", id, GetGameObjectPath(industry.gameObject), "Verify whether this is scenery-only, a disabled vanilla industry, or a broken industry component binding.");
-                    }
+                    // An Industry is also the game's location container. Base
+                    // depots, passenger/scenery-only locations, fictional
+                    // destinations, and intentionally disabled industries may
+                    // legitimately contain no IndustryComponent children.
+                    // Missing referenced components are already reported by
+                    // package apply/post-bind diagnostics, so emptiness alone
+                    // is not an actionable finding.
                 }
             }
             catch (Exception ex)

--- a/FUSE/Interface/MenuWindow/DependencyGraphPage.cs
+++ b/FUSE/Interface/MenuWindow/DependencyGraphPage.cs
@@ -18,7 +18,7 @@ namespace FUSE.Interface.MenuWindow
             AddWrappedLabel(
                 builder,
                 "Legacy (converted) packages list soft load-order hints: a hint whose target is not installed is optional and does not block loading. " +
-                "Asset-only packs and code-only plugins satisfy a dependency without being FUSE data packages.",
+                "Asset-only packs and code-only plugins satisfy a dependency without being FUSE data packages. Retired package IDs whose runtime capability is replaced by FUSE are labeled PROVIDED BY FUSE.",
                 48f);
 
             builder.Spacer(24f);
@@ -38,13 +38,13 @@ namespace FUSE.Interface.MenuWindow
             // hosted code-only plugins render as PRESENT rather than MISSING
             // (issues #207, #223).
             var undiscovered = manifests
-                .SelectMany(manifest => manifest.LoadAfter.Concat(manifest.LoadBefore))
+                .SelectMany(manifest => manifest.RequiredPackageIds.Concat(manifest.LoadAfter).Concat(manifest.LoadBefore))
                 .Where(id => !string.IsNullOrWhiteSpace(id) && !byId.ContainsKey(id));
             var presentInModsRoot = FuseDataPackageDiscovery.ResolvePackagesPresentInModsRoot(undiscovered);
             var rows = 0;
             foreach (var manifest in manifests)
             {
-                var hasEdges = manifest.LoadAfter.Length > 0 || manifest.LoadBefore.Length > 0 || manifest.Faults.Length > 0;
+                var hasEdges = manifest.RequiredPackageIds.Length > 0 || manifest.LoadAfter.Length > 0 || manifest.LoadBefore.Length > 0 || manifest.Faults.Length > 0;
                 if (!hasEdges && !FuseSettings.ShowAdvancedHealthDetails)
                 {
                     continue;
@@ -57,6 +57,12 @@ namespace FUSE.Interface.MenuWindow
 
                 builder.FieldLabelWidth = 120f;
                 AddWrappedLabel(builder, InsertBreakHints(manifest.Id), 28f);
+                foreach (var dependencyId in manifest.RequiredPackageIds)
+                {
+                    builder.AddField("requires", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId, presentInModsRoot, advisory: false))));
+                    rows++;
+                }
+
                 foreach (var dependencyId in manifest.LoadAfter)
                 {
                     builder.AddField("load after", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId, presentInModsRoot, manifest.IsLegacyConverted))));
@@ -97,7 +103,15 @@ namespace FUSE.Interface.MenuWindow
                 return "(blank) | <color=\"red\">MISSING";
             }
 
-            if (packages != null && packages.TryGetValue(dependencyId, out var dependency))
+            FusePackageManifestSnapshot dependency = null;
+            if (packages != null)
+            {
+                packages.TryGetValue(dependencyId, out dependency);
+                dependency = dependency ?? packages.Values.FirstOrDefault(candidate =>
+                    FuseDeclaredPackageRelationship.SamePackageId(candidate?.Id, dependencyId));
+            }
+
+            if (dependency != null)
             {
                 if (!dependency.Disabled)
                 {
@@ -107,6 +121,11 @@ namespace FUSE.Interface.MenuWindow
                 return advisory
                     ? dependencyId + " | <color=\"grey\">DISABLED (optional hint)"
                     : dependencyId + " | <color=\"yellow\">DISABLED";
+            }
+
+            if (FuseReplacementCapabilityCatalog.IsProvided(dependencyId))
+            {
+                return dependencyId + " | <color=\"green\">PROVIDED BY FUSE";
             }
 
             if (presentInModsRoot != null && presentInModsRoot.Contains(dependencyId))

--- a/FUSE/Interface/MenuWindow/FuseMenuWindow.cs
+++ b/FUSE/Interface/MenuWindow/FuseMenuWindow.cs
@@ -132,6 +132,14 @@ namespace FUSE.Interface.MenuWindow
             {
                 ModsPanelBuilder.CloseAllLegacyModTabs("legacy settings tab no longer visible");
             }
+
+            if (_window != null && _window.IsShown &&
+                _selectedTabState.Value == TabIdTools &&
+                _selectedToolItem.Value == "liveDiagnostics" &&
+                LiveDiagnosticsToolPage.ShouldAutoRefresh(Time.unscaledTime))
+            {
+                RebuildWindow();
+            }
         }
 
         private void BuildFuseMenu(UIPanelBuilder builder)
@@ -442,9 +450,47 @@ namespace FUSE.Interface.MenuWindow
             }
 
             var scrollRects = _window.contentRectTransform.GetComponentsInChildren<ScrollRect>(true);
-            return scrollRects == null || scrollRects.Length == 0
-                ? null
-                : scrollRects[scrollRects.Length - 1];
+            if (scrollRects == null || scrollRects.Length == 0)
+            {
+                return null;
+            }
+
+            // List/detail pages contain two ScrollRects: the navigation list on
+            // the left and the actual page on the right. Component traversal
+            // order is not a UI contract, so choosing the last component made
+            // auto-refresh preserve the left list while the visible page jumped
+            // back to the top. Select the right-most viewport instead; single-
+            // scroll pages naturally select their only viewport.
+            ScrollRect selected = null;
+            var selectedCenterX = float.NegativeInfinity;
+            var selectedArea = float.NegativeInfinity;
+            var corners = new Vector3[4];
+            foreach (var candidate in scrollRects)
+            {
+                if (candidate == null)
+                {
+                    continue;
+                }
+
+                var viewport = candidate.viewport ?? candidate.transform as RectTransform;
+                if (viewport == null)
+                {
+                    continue;
+                }
+
+                viewport.GetWorldCorners(corners);
+                var centerX = (corners[0].x + corners[2].x) * 0.5f;
+                var area = Mathf.Abs((corners[2].x - corners[0].x) * (corners[2].y - corners[0].y));
+                if (centerX > selectedCenterX + 0.01f ||
+                    (Mathf.Abs(centerX - selectedCenterX) <= 0.01f && area > selectedArea))
+                {
+                    selected = candidate;
+                    selectedCenterX = centerX;
+                    selectedArea = area;
+                }
+            }
+
+            return selected ?? scrollRects[0];
         }
 
         public void SetSelectedProfile(string id)

--- a/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
@@ -14,6 +14,7 @@ namespace FUSE.Interface.MenuWindow
         private enum PageId
         {
             General,
+            LegacyGameplay,
         }
 
         private sealed class Page(PageId id)
@@ -30,6 +31,7 @@ namespace FUSE.Interface.MenuWindow
 
             List<UIPanelBuilder.ListItem<Page>> list = [];
             list.Add(new UIPanelBuilder.ListItem<Page>("general", new Page(PageId.General), "Settings", "General"));
+            list.Add(new UIPanelBuilder.ListItem<Page>("legacy-gameplay", new Page(PageId.LegacyGameplay), "Settings", "Legacy Gameplay"));
 
             builder.AddListDetail(list, selectedItem, delegate (UIPanelBuilder builder, Page page)
             {
@@ -48,6 +50,9 @@ namespace FUSE.Interface.MenuWindow
                             case PageId.General:
                                 BuildGeneralSettingsPage(builder);
                                 break;
+                            case PageId.LegacyGameplay:
+                                BuildLegacyGameplaySettingsPage(builder);
+                                break;
                             default:
                                 builder.AddLabel("Unknown page.");
                                 break;
@@ -55,6 +60,249 @@ namespace FUSE.Interface.MenuWindow
                     }, new RectOffset(0, 4, 0, 0));
                 }
             });
+        }
+
+        private static void BuildLegacyGameplaySettingsPage(UIPanelBuilder builder)
+        {
+            builder.AddTitle("Legacy Gameplay Replacements", "");
+            builder.FieldLabelWidth = 200f;
+            builder.Spacing = 6f;
+
+            builder.AddLabel(
+                "FUSE owns these compatibility behaviors so legacy dependencies can be removed. " +
+                "Defaults preserve the base game unless a value below is changed.");
+
+            builder.AddSection("Fall From Grace");
+            builder.AddLabel(
+                "Grace days = max(Minimum, base-game days × Multiplier + Added). " +
+                "The 0 / 1 / 0 defaults are identical to the base game. FUSE also shows the due time in the car inspector.");
+
+            AddIntegerField(builder, "Minimum Days", FuseSettings.GraceMinimumDays, FuseSettings.SetGraceMinimumDays);
+            AddIntegerField(builder, "Multiplier", FuseSettings.GraceMultiplier, FuseSettings.SetGraceMultiplier);
+            AddIntegerField(builder, "Added Days", FuseSettings.GraceAddedDays, FuseSettings.SetGraceAddedDays);
+
+            builder.AddSection("Configurable Interchange Service");
+            builder.AddLabel(
+                "Replaces C1CD. Controls the extra-service interval and optional daily service window for all interchanges.");
+
+            var intervals = new[] { 5, 15, 30, 45, 60, 90, 120, 150, 180, 240, 300, 360, 480, 720, 1080 };
+            var selectedInterval = Array.IndexOf(intervals, FuseSettings.InterchangeServiceIntervalMinutes);
+            if (selectedInterval < 0)
+            {
+                selectedInterval = Array.FindIndex(
+                    intervals,
+                    value => value >= FuseSettings.InterchangeServiceIntervalMinutes);
+                if (selectedInterval < 0)
+                {
+                    selectedInterval = intervals.Length - 1;
+                }
+            }
+
+            builder.AddField(
+                "Serve Interval",
+                builder.AddDropdown(
+                    new List<string>(Array.ConvertAll(intervals, FormatServiceInterval)),
+                    selectedInterval,
+                    index =>
+                    {
+                        if (index >= 0 && index < intervals.Length)
+                        {
+                            FuseSettings.SetInterchangeServiceIntervalMinutes(intervals[index]);
+                        }
+                    }));
+
+            builder.AddField("Continuous Service", control: BuildToggleBoxWithButton(
+                builder,
+                FuseSettings.InterchangeContinuousService,
+                () =>
+                {
+                    FuseSettings.SetInterchangeContinuousService(!FuseSettings.InterchangeContinuousService);
+                    builder.Rebuild();
+                }));
+
+            builder.AddLabel(
+                "When enabled, FUSE schedules the next extra service after every interchange pass, even when no orders remain.");
+
+            builder.AddField("Not Before", control: builder.AddSliderQuantized(
+                () => FuseSettings.InterchangeNotBeforeHour,
+                () => FormatServiceHour(FuseSettings.InterchangeNotBeforeHour),
+                FuseSettings.SetInterchangeNotBeforeHour,
+                0.25f,
+                0f,
+                24f,
+                FuseSettings.SetInterchangeNotBeforeHour));
+
+            builder.AddField("Not After", control: builder.AddSliderQuantized(
+                () => FuseSettings.InterchangeNotAfterHour,
+                () => FormatServiceHour(FuseSettings.InterchangeNotAfterHour),
+                FuseSettings.SetInterchangeNotAfterHour,
+                0.25f,
+                0f,
+                24f,
+                FuseSettings.SetInterchangeNotAfterHour));
+
+            builder.AddLabel(
+                "Use 00:00–24:00 for all-day service. A start later than the end (for example 22:00–06:00) creates an overnight window.");
+
+            builder.AddSection("Outbound Industry Routing");
+            builder.AddLabel(
+                "Native replacement for AbsoluteMadness and SomeKindOfMadness. It activates automatically when an enabled package requests either legacy id. " +
+                "The switch below is an explicit opt-in for profiles that do not declare the old dependency.");
+
+            builder.AddField("Enable Routing", control: BuildToggleBoxWithButton(
+                builder,
+                FuseSettings.EnableOutboundIndustryRerouting,
+                () =>
+                {
+                    FuseSettings.SetEnableOutboundIndustryRerouting(!FuseSettings.EnableOutboundIndustryRerouting);
+                    builder.Rebuild();
+                }));
+
+            builder.AddField("Route Chance", control: builder.AddSliderQuantized(
+                () => FuseSettings.OutboundIndustryRerouteChance,
+                () => (FuseSettings.OutboundIndustryRerouteChance * 100f).ToString("0", System.Globalization.CultureInfo.InvariantCulture) + "%",
+                FuseSettings.SetOutboundIndustryRerouteChance,
+                0.05f,
+                0f,
+                1f,
+                FuseSettings.SetOutboundIndustryRerouteChance));
+
+            builder.AddField("Capacity Target", control: builder.AddSliderQuantized(
+                () => FuseSettings.OutboundIndustryFillFactor,
+                () => FuseSettings.OutboundIndustryFillFactor.ToString("0.0x", System.Globalization.CultureInfo.InvariantCulture),
+                FuseSettings.SetOutboundIndustryFillFactor,
+                0.1f,
+                0.1f,
+                3f,
+                FuseSettings.SetOutboundIndustryFillFactor));
+
+            builder.AddField("Payment", control: builder.AddSliderQuantized(
+                () => FuseSettings.OutboundIndustryPaymentMultiplier,
+                () => FuseSettings.OutboundIndustryPaymentMultiplier.ToString("0.0x", System.Globalization.CultureInfo.InvariantCulture),
+                FuseSettings.SetOutboundIndustryPaymentMultiplier,
+                0.1f,
+                0f,
+                10f,
+                FuseSettings.SetOutboundIndustryPaymentMultiplier));
+
+            AddOutboundRoutingToggle(
+                builder,
+                "Allow Short Trips",
+                FuseSettings.OutboundIndustryAllowShortTrips,
+                FuseSettings.SetOutboundIndustryAllowShortTrips);
+            AddOutboundRoutingToggle(
+                builder,
+                "Ignore Origin",
+                FuseSettings.OutboundIndustryIgnoreOrigin,
+                FuseSettings.SetOutboundIndustryIgnoreOrigin);
+            AddOutboundRoutingToggle(
+                builder,
+                "Shuffle Orders",
+                FuseSettings.OutboundIndustryPreventBlocking,
+                FuseSettings.SetOutboundIndustryPreventBlocking);
+
+            builder.AddLabel(
+                "If both old packages are requested, the configurable SomeKindOfMadness behavior wins. " +
+                "A routing extension can inspect or adjust candidates through FUSE's native outbound-routing event.");
+
+            builder.AddSection("Interchange-to-Interchange Traffic");
+            builder.AddLabel(
+                "Replaces Interchange2Interchange when an enabled package requests it. " +
+                "Each contracted source interchange can create a daily cut for every other enabled interchange.");
+            AddIntegerField(
+                builder,
+                "Maximum Cars / Cut",
+                FuseSettings.InterchangeToInterchangeMaximumCars,
+                FuseSettings.SetInterchangeToInterchangeMaximumCars);
+
+            builder.AddSection("For Your Convenience");
+            builder.AddLabel(
+                "These visual additions activate only when an enabled package requests ForYourConvenience. " +
+                "The live Industry Dashboard is always available under Tools, and station-map actions are attached without replacing existing icon actions.");
+            AddLegacyToggle(
+                builder,
+                "Caboose Map Icons",
+                FuseSettings.ForYourConvenienceShowCabooseIcons,
+                FuseSettings.SetForYourConvenienceShowCabooseIcons);
+            AddLegacyToggle(
+                builder,
+                "Car Tag Speed",
+                FuseSettings.ForYourConvenienceShowCarTagMph,
+                FuseSettings.SetForYourConvenienceShowCarTagMph);
+            AddLegacyToggle(
+                builder,
+                "Car Tag Loads",
+                FuseSettings.ForYourConvenienceShowCarTagLoads,
+                FuseSettings.SetForYourConvenienceShowCarTagLoads);
+
+            builder.Spacer(32f);
+        }
+
+        private static void AddOutboundRoutingToggle(
+            UIPanelBuilder builder,
+            string label,
+            bool enabled,
+            Action<bool> setter)
+        {
+            builder.AddField(label, control: BuildToggleBoxWithButton(
+                builder,
+                enabled,
+                () =>
+                {
+                    setter(!enabled);
+                    builder.Rebuild();
+                }));
+        }
+
+        private static void AddLegacyToggle(
+            UIPanelBuilder builder,
+            string label,
+            bool enabled,
+            Action<bool> setter)
+        {
+            builder.AddField(label, control: BuildToggleBoxWithButton(
+                builder,
+                enabled,
+                () =>
+                {
+                    setter(!enabled);
+                    builder.Rebuild();
+                }));
+        }
+
+        private static void AddIntegerField(UIPanelBuilder builder, string label, int value, Action<int> setter)
+        {
+            builder.AddField(
+                label,
+                builder.AddInputField(
+                    value.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    text =>
+                    {
+                        int parsed;
+                        if (int.TryParse(
+                            text,
+                            System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            out parsed))
+                        {
+                            setter(parsed);
+                        }
+                    }));
+        }
+
+        private static string FormatServiceInterval(int minutes)
+        {
+            return minutes < 60
+                ? minutes + " min"
+                : (minutes / 60f).ToString("0.#", System.Globalization.CultureInfo.InvariantCulture) + " h";
+        }
+
+        private static string FormatServiceHour(float hour)
+        {
+            var totalMinutes = (int)Math.Round(hour * 60f);
+            var displayHour = totalMinutes / 60;
+            var displayMinute = totalMinutes % 60;
+            return $"{displayHour:00}:{displayMinute:00}";
         }
 
         private static void BuildGeneralSettingsPage(UIPanelBuilder builder)

--- a/FUSE/Interface/MenuWindow/IndustryDashboardToolPage.cs
+++ b/FUSE/Interface/MenuWindow/IndustryDashboardToolPage.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using FUSE.Infrastructure;
+using Model.Ops;
+using UI.Builder;
+using static FUSE.Interface.InterfaceUtils;
+
+namespace FUSE.Interface.MenuWindow
+{
+    internal static class IndustryDashboardToolPage
+    {
+        public static void Build(UIPanelBuilder builder)
+        {
+            builder.AddTitle("Industry Dashboard", "");
+            AddWrappedLabel(
+                builder,
+                "A live, read-only view of the industries and component storage known to the game's operations controller. " +
+                "It remains useful for native FUSE packages and replaces the old ForYourConvenience dashboard when that dependency is requested.",
+                58f);
+
+            builder.HStack(row => row.AddButtonCompact("Refresh", builder.Rebuild), 6f).Height(32f);
+            builder.Spacer(8f);
+
+            var industries = OpsController.Shared?.AllIndustries?
+                .Where(industry => industry != null)
+                .OrderBy(industry => industry.ProgressionDisabled)
+                .ThenBy(industry => industry.name, StringComparer.OrdinalIgnoreCase)
+                .ToArray() ?? Array.Empty<Industry>();
+            builder.AddField("Industries", industries.Length.ToString());
+            if (industries.Length == 0)
+            {
+                builder.AddLabelEmptyState("No operations industries are available in the current scene.");
+                return;
+            }
+
+            foreach (var industry in industries)
+            {
+                BuildIndustry(builder, industry);
+            }
+        }
+
+        private static void BuildIndustry(UIPanelBuilder builder, Industry industry)
+        {
+            builder.AddSection(string.IsNullOrWhiteSpace(industry.name) ? industry.identifier : industry.name);
+            builder.AddField("Id", industry.identifier ?? "(none)");
+            builder.AddField("State", industry.ProgressionDisabled ? "Progression disabled" : "Enabled");
+            builder.AddField("Contract", industry.usesContract ? "Uses company contract" : "Not contracted");
+            builder.AddField("Components", (industry.Components?.Count() ?? 0).ToString());
+
+            try
+            {
+                foreach (var pair in industry.EnumerateComponentContexts(0f))
+                {
+                    var component = pair.Item1;
+                    var context = pair.Item2;
+                    if (component == null)
+                    {
+                        continue;
+                    }
+
+                    var title = string.IsNullOrWhiteSpace(component.DisplayName)
+                        ? component.subIdentifier
+                        : component.DisplayName;
+                    var type = component.GetType().Name;
+                    AddWrappedField(builder, title ?? "Component", type + " — " + ComponentState(component), 36f);
+                    foreach (var field in component.PanelFields(context))
+                    {
+                        AddWrappedField(builder, field.Label, field.Text, 34f);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                AddWrappedField(
+                    builder,
+                    "Component details",
+                    "Unavailable: " + ex.GetBaseException().Message,
+                    42f);
+                FuseLog.Warning(
+                    "FUSE Industry Dashboard could not inspect '" + industry.identifier + "': " +
+                    ex.GetBaseException().Message);
+            }
+
+            builder.Spacer(8f);
+        }
+
+        private static string ComponentState(IndustryComponent component)
+        {
+            var state = component.ProgressionDisabled ? "progression disabled" : "active";
+            var spanCount = component.trackSpans?.Length ?? 0;
+            return state + ", " + spanCount + " track span(s), cars " +
+                   (component.carTypeFilter?.queryString ?? "(none)");
+        }
+    }
+}

--- a/FUSE/Interface/MenuWindow/InspectorToolPage.cs
+++ b/FUSE/Interface/MenuWindow/InspectorToolPage.cs
@@ -169,6 +169,7 @@ namespace FUSE.Interface.MenuWindow
             AddInspectorIndexTargets(results, signatures, "Station", FuseStationRuntimeIndex.Instance, FuseClaimKind.Station, term, limit);
             AddInspectorIndexTargets(results, signatures, "Scenery", FuseSceneryRuntimeIndex.Instance, FuseClaimKind.Scenery, term, limit);
             AddInspectorIndexTargets(results, signatures, "Spliney", FuseSplineyRuntimeIndex.Instance, null, term, limit);
+            AddInspectorIndexTargets(results, signatures, "Water Surface", FuseWaterSurfaceRuntimeIndex.Instance, null, term, limit);
             AddInspectorIndexTargets(results, signatures, "Map Label", FuseMapLabelRuntimeIndex.Instance, null, term, limit);
             AddInspectorIndexTargets(results, signatures, "Progression", FuseProgressionRuntimeIndex.Instance, null, term, limit);
             AddInspectorIndexTargets(results, signatures, "Map Feature", FuseMapFeatureRuntimeIndex.Instance, null, term, limit);

--- a/FUSE/Interface/MenuWindow/LiveDiagnosticsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/LiveDiagnosticsToolPage.cs
@@ -1,0 +1,209 @@
+using FUSE.Infrastructure;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UI.Builder;
+using UI.Common;
+using UnityEngine;
+using static FUSE.Interface.InterfaceUtils;
+
+namespace FUSE.Interface.MenuWindow
+{
+    internal static class LiveDiagnosticsToolPage
+    {
+        private static readonly string[] LevelFilters =
+        {
+            "All",
+            "Warnings + Errors",
+            "Errors"
+        };
+
+        private static string _levelFilter = "All";
+        private static string _search = string.Empty;
+        private static bool _autoRefresh;
+        private static float _nextAutoRefreshAt;
+
+        internal static bool ShouldAutoRefresh(float now)
+        {
+            if (!_autoRefresh || now < _nextAutoRefreshAt)
+            {
+                return false;
+            }
+
+            _nextAutoRefreshAt = now + 1f;
+            return true;
+        }
+
+        public static void Build(UIPanelBuilder builder)
+        {
+            builder.AddTitle("Live Diagnostics", "");
+            builder.AddLabel(
+                "Runtime guards and third-party exceptions are diagnostics, not load-health failures. " +
+                "They live here so the Status page stays focused on actionable package, asset, graph, progression, and conflict problems.");
+            builder.Spacer(8f);
+
+            BuildLogViewer(builder);
+            builder.Spacer(12f);
+            BuildContainedEvents(builder);
+        }
+
+        private static void BuildLogViewer(UIPanelBuilder builder)
+        {
+            builder.AddSection("FUSE Log");
+            builder.AddField("File", string.IsNullOrWhiteSpace(FuseLog.LogFilePath) ? "unavailable" : FuseLog.LogFilePath);
+            builder.AddField("Buffered", FuseLiveLogBuffer.Count + " / " + FuseLiveLogBuffer.Capacity + " recent entries");
+
+            var selectedLevel = Math.Max(0, Array.IndexOf(LevelFilters, _levelFilter));
+            builder.AddField(
+                "Level",
+                builder.AddDropdown(LevelFilters.ToList(), selectedLevel, index =>
+                {
+                    if (index >= 0 && index < LevelFilters.Length)
+                    {
+                        _levelFilter = LevelFilters[index];
+                        builder.Rebuild();
+                    }
+                })).Height(32f);
+
+            builder.AddField(
+                "Contains",
+                builder.AddInputField(_search ?? string.Empty, value => _search = value ?? string.Empty));
+
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Refresh", builder.Rebuild);
+                row.AddButtonCompact(_autoRefresh ? "Pause Auto Refresh" : "Start Auto Refresh", () =>
+                {
+                    _autoRefresh = !_autoRefresh;
+                    _nextAutoRefreshAt = 0f;
+                    builder.Rebuild();
+                });
+                row.AddButtonCompact("Clear Filter", () =>
+                {
+                    _levelFilter = "All";
+                    _search = string.Empty;
+                    builder.Rebuild();
+                });
+            }, 6f).Height(32f);
+
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Copy Visible Log", () =>
+                {
+                    GUIUtility.systemCopyBuffer = FormatEntries(VisibleEntries());
+                    Toast.Present("Copied the visible FUSE log entries.");
+                });
+                row.AddButtonCompact("Open Log Folder", () =>
+                {
+                    var directory = string.IsNullOrWhiteSpace(FuseLog.LogFilePath)
+                        ? Application.persistentDataPath
+                        : Path.GetDirectoryName(FuseLog.LogFilePath);
+                    Application.OpenURL(directory);
+                    Toast.Present("Opened the FUSE log folder.");
+                });
+                row.AddButtonCompact(
+                    FuseLiveConsole.IsEnabled ? "Stop Live Console" : "Open Live Console",
+                    () =>
+                    {
+                        var result = FuseLiveConsole.IsEnabled
+                            ? FuseLiveConsole.Disable()
+                            : FuseLiveConsole.Enable();
+                        Toast.Present(result);
+                        builder.Rebuild();
+                    });
+            }, 6f).Height(32f);
+
+            builder.AddField(
+                "Viewer",
+                _autoRefresh
+                    ? "Auto refresh is on (once per second)."
+                    : "This in-game snapshot refreshes on demand. Open Live Console for a continuously scrolling second-screen view.");
+
+            var entries = VisibleEntries();
+            builder.AddField("Visible", entries.Length.ToString());
+            var lines = FormatEntries(entries);
+            AddWrappedLabel(builder, string.IsNullOrWhiteSpace(lines) ? "No matching FUSE log entries." : lines,
+                Math.Min(1400f, Math.Max(100f, entries.Length * 19f)));
+        }
+
+        private static void BuildContainedEvents(UIPanelBuilder builder)
+        {
+            builder.AddSection("Contained Runtime Events");
+            AddWrappedField(builder, "Compatibility Guards", FuseRuntimeGuardCounters.FormatSummary(), 76f);
+            builder.AddField(
+                "Native Leak Stacks",
+                $"{FuseNativeLeakDiagnostic.ModeLabel} (setting: {(FuseSettings.EnableNativeLeakStackTraces ? "enabled" : "disabled")})");
+
+            var exceptionState = FuseModExceptionRegistry.CaptureReportState();
+            builder.AddField("Observed Exceptions", exceptionState.Total.ToString());
+            AddWrappedLabel(
+                builder,
+                exceptionState.Total == 0
+                    ? "No third-party exceptions have been observed this session."
+                    : "These observations do not change FUSE readiness. Use them to identify repeating mod behavior; attach the health report when reporting a real symptom.",
+                48f);
+
+            foreach (var record in exceptionState.Mods.OrderByDescending(item => item.Count))
+            {
+                var display = string.IsNullOrWhiteSpace(record.DisplayName) ? record.ModId : record.DisplayName;
+                var top = record.Signatures == null
+                    ? null
+                    : record.Signatures.OrderByDescending(item => item.Count).FirstOrDefault();
+                var text = record.Count + " occurrence(s) over " + record.Episodes + " episode(s)";
+                if (top != null)
+                {
+                    text += " — " + top.ExceptionType + " @ " + top.TopOwnedFrame;
+                }
+
+                AddWrappedField(builder, display, text, 52f);
+            }
+
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Copy Diagnostics", () =>
+                {
+                    GUIUtility.systemCopyBuffer = BuildDiagnosticsText();
+                    Toast.Present("Copied FUSE runtime diagnostics.");
+                });
+                row.AddButtonCompact("Copy Full Health Report", () =>
+                {
+                    GUIUtility.systemCopyBuffer = FUSE.Loading.FuseLoadReport.GetLastDetailReport();
+                    Toast.Present("Copied the full FUSE health report.");
+                });
+            }, 6f).Height(32f);
+        }
+
+        private static FuseLiveLogEntry[] VisibleEntries() =>
+            FuseLiveLogBuffer.Snapshot(_levelFilter, _search, 120);
+
+        private static string FormatEntries(FuseLiveLogEntry[] entries) =>
+            string.Join(Environment.NewLine, (entries ?? Array.Empty<FuseLiveLogEntry>())
+                .Select(entry => entry.FormatLine())
+                .ToArray());
+
+        private static string BuildDiagnosticsText()
+        {
+            var state = FuseModExceptionRegistry.CaptureReportState();
+            var text = new StringBuilder();
+            text.AppendLine("FUSE Runtime Diagnostics");
+            text.AppendLine("Generated: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+            text.AppendLine("Guards: " + FuseRuntimeGuardCounters.FormatSummary());
+            text.AppendLine(state.SummaryLine);
+            foreach (var record in state.Mods.OrderByDescending(item => item.Count))
+            {
+                var display = string.IsNullOrWhiteSpace(record.DisplayName) ? record.ModId : record.DisplayName;
+                text.AppendLine($"{display} ({record.ModId}): {record.Count} occurrence(s), {record.Episodes} episode(s)");
+                foreach (var signature in (record.Signatures ?? Array.Empty<FuseModExceptionSignatureSnapshot>())
+                             .OrderByDescending(item => item.Count))
+                {
+                    text.AppendLine(
+                        $"  {signature.ExceptionType} @ {signature.TopOwnedFrame}: " +
+                        $"{signature.Count} occurrence(s), {signature.Episodes} episode(s) — {signature.SampleMessage}");
+                }
+            }
+
+            return text.ToString().TrimEnd();
+        }
+    }
+}

--- a/FUSE/Interface/MenuWindow/ModConflictsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/ModConflictsToolPage.cs
@@ -1,0 +1,411 @@
+using FUSE.Runtime.Registry;
+using FUSE.Loading;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UI.Builder;
+using UI.Common;
+using UnityEngine;
+using static FUSE.Interface.InterfaceUtils;
+
+namespace FUSE.Interface.MenuWindow
+{
+    /// <summary>
+    /// Human-readable package-pair view over the registry's object-level
+    /// conflict history. The raw history remains available through
+    /// /fuse.conflicts and the health report.
+    /// </summary>
+    internal static class ModConflictsToolPage
+    {
+        internal sealed class ConflictGroup
+        {
+            public string FirstPackageId { get; set; }
+            public string SecondPackageId { get; set; }
+            public FuseRegistryConflict[] Conflicts { get; set; }
+        }
+
+        internal sealed class DeclaredConflictMatch
+        {
+            public FusePackageManifestSnapshot DeclaringPackage { get; set; }
+            public FusePackageManifestSnapshot ConflictingPackage { get; set; }
+            public FUSE.Authoring.Data.FuseModRequirement Reference { get; set; }
+        }
+
+        public static void Build(UIPanelBuilder builder)
+        {
+            builder.AddTitle("Mod Conflicts", "");
+            AddWrappedLabel(
+                builder,
+                "Packages are grouped in pairs so you can see which mods are changing the same runtime objects. " +
+                "Declared requires/loadAfter/loadBefore and conditional mixinto layering is expected and is not listed here. " +
+                "FUSE keeps unrelated mods unless the resolution below says that one definition won. Spatial track overlap is advisory because nearby track can be intentional.",
+                62f);
+
+            var registryRecords = FuseRegistry.Conflicts.ToArray();
+            var cooperativeRecords = registryRecords.Where(conflict => conflict.IsCooperativeMerge).ToArray();
+            var registryConflicts = registryRecords.Where(conflict => !conflict.IsCooperativeMerge).ToArray();
+            var spatialConflicts = FuseSpatialTrackConflictDetector.Conflicts.ToArray();
+            var packageSnapshots = (FuseDataPackageDiscovery.GetPackageManifestSnapshots() ?? Array.Empty<FusePackageManifestSnapshot>())
+                .ToArray();
+            var knownPackageIds = packageSnapshots
+                .Select(package => package.Id)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .ToArray();
+            var groups = BuildGroups(registryConflicts.Concat(spatialConflicts), knownPackageIds);
+            var cooperativeGroups = BuildGroups(cooperativeRecords, knownPackageIds);
+            var declaredConflicts = BuildDeclaredConflictMatches(packageSnapshots);
+            builder.AddSection("Overview");
+            AddValueField(builder, "Pairs Needing Attention", groups.Count.ToString());
+            AddValueField(builder, "Declared Incompatibilities", declaredConflicts.Count.ToString());
+            AddValueField(builder, "Ownership Conflicts", registryConflicts.Length.ToString());
+            AddValueField(builder, "Shared Extension Targets", cooperativeRecords.Length.ToString());
+            AddValueField(builder, "Spatial Warnings", spatialConflicts.Length.ToString());
+
+            builder.Spacer(8f);
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Refresh", builder.Rebuild);
+                row.AddButtonCompact("Copy Full Report", () =>
+                {
+                    GUIUtility.systemCopyBuffer = BuildReport(groups, declaredConflicts, cooperativeGroups);
+                    Toast.Present("Copied FUSE mod conflict report to clipboard.");
+                });
+            }, 6f).Height(32f);
+            builder.Spacer(8f);
+
+            if (groups.Count == 0 && declaredConflicts.Count == 0 && cooperativeGroups.Count == 0)
+            {
+                builder.AddField("Status", builder.AddLabelMarkup("<color=\"green\">No mod ownership conflicts have been recorded in this session."));
+                return;
+            }
+
+            if (declaredConflicts.Count > 0)
+            {
+                builder.AddSection("Author-Declared Incompatibilities");
+                AddWrappedLabel(
+                    builder,
+                    "These pairs come from a package's conflictsWith declaration, not from FUSE guessing at nearby track. " +
+                    "The declaring package is skipped while the matching incompatible package/version is enabled.",
+                    48f);
+                foreach (var match in declaredConflicts.Take(30))
+                {
+                    AddWrappedField(builder, "Skipped Package", InsertBreakHints(match.DeclaringPackage.Id), 34f);
+                    AddWrappedField(builder, "Conflicts With", InsertBreakHints(match.ConflictingPackage.Id), 34f);
+                    AddWrappedField(builder, "Versions", FormatDeclaredConflict(match), 42f);
+                    builder.Spacer(6f);
+                }
+
+                if (groups.Count == 0 && cooperativeGroups.Count == 0)
+                {
+                    return;
+                }
+            }
+
+            if (groups.Count > 0)
+            {
+                builder.AddSection("Runtime Ownership Needing Attention");
+                foreach (var group in groups.Take(30))
+                {
+                    AddWrappedField(builder, "Mod A", InsertBreakHints(group.FirstPackageId), 34f);
+                    AddWrappedField(builder, "Mod B", InsertBreakHints(group.SecondPackageId), 34f);
+                    builder.AddField("Records", group.Conflicts.Length.ToString());
+                    builder.AddField("Object Types", FormatKinds(group.Conflicts));
+                    builder.AddField("Result", DescribeGroupResult(group.Conflicts));
+
+                    foreach (var conflict in group.Conflicts.Take(12))
+                    {
+                        AddWrappedField(builder, conflict.Kind.ToString(), FormatConflict(conflict), 54f);
+                    }
+
+                    if (group.Conflicts.Length > 12)
+                    {
+                        AddWrappedField(
+                            builder,
+                            "More",
+                            (group.Conflicts.Length - 12) + " additional records are available in Copy Full Report or /fuse.conflicts.",
+                            34f);
+                    }
+
+                    builder.Spacer(8f);
+                    builder.AddHRule();
+                    builder.Spacer(8f);
+                }
+
+                if (groups.Count > 30)
+                {
+                    AddWrappedField(
+                        builder,
+                        "More Pairs",
+                        (groups.Count - 30) + " additional package pairs are available in Copy Full Report or /fuse.conflicts.",
+                        34f);
+                }
+            }
+
+            if (cooperativeGroups.Count > 0)
+            {
+                builder.AddSection("Shared Extension Targets (Informational)");
+                AddWrappedLabel(
+                    builder,
+                    "These mods touched the same cumulative industry target and FUSE merged their contributions. " +
+                    "Nothing was skipped or replaced, so these records do not count as conflicts or load-health problems.",
+                    50f);
+                foreach (var group in cooperativeGroups.Take(30))
+                {
+                    AddWrappedField(builder, "Mod A", InsertBreakHints(group.FirstPackageId), 34f);
+                    AddWrappedField(builder, "Mod B", InsertBreakHints(group.SecondPackageId), 34f);
+                    builder.AddField("Shared Records", group.Conflicts.Length.ToString());
+                    builder.AddField("Object Types", FormatKinds(group.Conflicts));
+                    builder.AddField("Result", "Definitions merged successfully; no mod lost content.");
+                    foreach (var conflict in group.Conflicts.Take(12))
+                    {
+                        AddWrappedField(builder, conflict.Kind.ToString(), FormatConflict(conflict), 54f);
+                    }
+                    builder.Spacer(8f);
+                    builder.AddHRule();
+                    builder.Spacer(8f);
+                }
+            }
+        }
+
+        internal static List<ConflictGroup> BuildGroups(
+            IEnumerable<FuseRegistryConflict> conflicts,
+            IEnumerable<string> knownPackageIds = null)
+        {
+            var packageRoots = (knownPackageIds ?? Enumerable.Empty<string>())
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(id => id.Length)
+                .ToArray();
+            return (conflicts ?? Enumerable.Empty<FuseRegistryConflict>())
+                .Where(conflict => conflict != null)
+                .Select(conflict => new
+                {
+                    Conflict = conflict,
+                    First = FindPackageRoot(conflict.OwnerPackageId, packageRoots),
+                    Second = FindPackageRoot(conflict.AttemptedPackageId, packageRoots)
+                })
+                .GroupBy(item => BuildPairKey(item.First, item.Second), StringComparer.OrdinalIgnoreCase)
+                .Select(group =>
+                {
+                    var first = group.First();
+                    OrderPackagePair(first.First, first.Second, out var firstId, out var secondId);
+                    return new ConflictGroup
+                    {
+                        FirstPackageId = firstId,
+                        SecondPackageId = secondId,
+                        Conflicts = group
+                            .Select(item => item.Conflict)
+                            .OrderBy(conflict => conflict.Kind)
+                            .ThenBy(conflict => conflict.Id, StringComparer.OrdinalIgnoreCase)
+                            .ToArray()
+                    };
+                })
+                .OrderByDescending(group => group.Conflicts.Length)
+                .ThenBy(group => group.FirstPackageId, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(group => group.SecondPackageId, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        internal static string BuildReport(IEnumerable<ConflictGroup> groups)
+        {
+            return BuildReport(groups, Enumerable.Empty<DeclaredConflictMatch>());
+        }
+
+        internal static string BuildReport(
+            IEnumerable<ConflictGroup> groups,
+            IEnumerable<DeclaredConflictMatch> declaredConflicts)
+        {
+            return BuildReport(groups, declaredConflicts, Enumerable.Empty<ConflictGroup>());
+        }
+
+        internal static string BuildReport(
+            IEnumerable<ConflictGroup> groups,
+            IEnumerable<DeclaredConflictMatch> declaredConflicts,
+            IEnumerable<ConflictGroup> cooperativeGroups)
+        {
+            var materialized = (groups ?? Enumerable.Empty<ConflictGroup>()).ToArray();
+            var declared = (declaredConflicts ?? Enumerable.Empty<DeclaredConflictMatch>()).ToArray();
+            var cooperative = (cooperativeGroups ?? Enumerable.Empty<ConflictGroup>()).ToArray();
+            var sb = new StringBuilder();
+            sb.AppendLine("FUSE Mod Conflict Breakdown");
+            sb.AppendLine("Package pairs needing attention: " + materialized.Length);
+            sb.AppendLine("Actionable conflict/warning records: " + materialized.Sum(group => group.Conflicts?.Length ?? 0));
+            sb.AppendLine("Author-declared incompatibilities: " + declared.Length);
+            sb.AppendLine("Informational shared-extension records: " + cooperative.Sum(group => group.Conflicts?.Length ?? 0));
+            foreach (var match in declared)
+            {
+                sb.AppendLine();
+                sb.AppendLine("DECLARED: " + match.DeclaringPackage.Id + "  X  " + match.ConflictingPackage.Id);
+                sb.AppendLine("  " + FormatDeclaredConflict(match));
+            }
+
+            foreach (var group in materialized)
+            {
+                sb.AppendLine();
+                sb.AppendLine(group.FirstPackageId + "  <->  " + group.SecondPackageId);
+                sb.AppendLine("  object types: " + FormatKinds(group.Conflicts));
+                sb.AppendLine("  result: " + DescribeGroupResult(group.Conflicts));
+                foreach (var conflict in group.Conflicts ?? Array.Empty<FuseRegistryConflict>())
+                {
+                    var id = string.IsNullOrWhiteSpace(conflict?.Id) ? "(unknown target)" : conflict.Id;
+                    var resolution = string.IsNullOrWhiteSpace(conflict?.Resolution) ? "No resolution recorded." : conflict.Resolution;
+                    sb.AppendLine(
+                        "  - " + conflict.Kind + " " + id + " — " + resolution +
+                        " [" + conflict.OwnerPackageId + " -> " + conflict.AttemptedPackageId + "]");
+                }
+            }
+
+            foreach (var group in cooperative)
+            {
+                sb.AppendLine();
+                sb.AppendLine("SHARED: " + group.FirstPackageId + "  +  " + group.SecondPackageId);
+                sb.AppendLine("  result: definitions merged successfully; no mod lost content");
+                foreach (var conflict in group.Conflicts ?? Array.Empty<FuseRegistryConflict>())
+                {
+                    sb.AppendLine("  - " + conflict.Kind + " " + conflict.Id + " — " + conflict.Resolution);
+                }
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        internal static List<DeclaredConflictMatch> BuildDeclaredConflictMatches(
+            IEnumerable<FusePackageManifestSnapshot> packages)
+        {
+            var materialized = (packages ?? Enumerable.Empty<FusePackageManifestSnapshot>())
+                .Where(package => package != null && !string.IsNullOrWhiteSpace(package.Id))
+                .ToArray();
+            var result = new List<DeclaredConflictMatch>();
+            foreach (var declaring in materialized)
+            {
+                foreach (var reference in declaring.ConflictsWith ?? Array.Empty<FUSE.Authoring.Data.FuseModRequirement>())
+                {
+                    var target = materialized.FirstOrDefault(candidate =>
+                        !ReferenceEquals(candidate, declaring) &&
+                        FuseDataPackageDiscovery.IsDeclaredConflictMatch(
+                            reference,
+                            candidate.Id,
+                            candidate.Version,
+                            candidate.Disabled));
+                    if (target == null)
+                    {
+                        continue;
+                    }
+
+                    result.Add(new DeclaredConflictMatch
+                    {
+                        DeclaringPackage = declaring,
+                        ConflictingPackage = target,
+                        Reference = reference
+                    });
+                }
+            }
+
+            return result
+                .GroupBy(match =>
+                    match.DeclaringPackage.Id + "\0" + match.ConflictingPackage.Id,
+                    StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .OrderBy(match => match.DeclaringPackage.Id, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(match => match.ConflictingPackage.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static string FormatDeclaredConflict(DeclaredConflictMatch match)
+        {
+            var reference = match?.Reference;
+            var installedVersion = match?.ConflictingPackage?.Version ?? string.Empty;
+            var bounds = string.IsNullOrWhiteSpace(reference?.NotBefore) && string.IsNullOrWhiteSpace(reference?.NotAfter)
+                ? "all versions"
+                : "notBefore=" + (reference?.NotBefore ?? "(none)") + ", notAfter=" + (reference?.NotAfter ?? "(none)");
+            return "Installed version " + (string.IsNullOrWhiteSpace(installedVersion) ? "(unknown)" : installedVersion) +
+                   " matches " + bounds + ".";
+        }
+
+        internal static bool IsSpatialConflict(FuseRegistryConflict conflict)
+        {
+            return conflict != null &&
+                ((conflict.Id ?? string.Empty).StartsWith("spatial-overlap:", StringComparison.OrdinalIgnoreCase) ||
+                 (conflict.Resolution ?? string.Empty).IndexOf("spatial", StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        private static string DescribeGroupResult(IEnumerable<FuseRegistryConflict> conflicts)
+        {
+            var materialized = (conflicts ?? Enumerable.Empty<FuseRegistryConflict>()).ToArray();
+            if (materialized.Any(IsSpatialConflict))
+            {
+                return "Potential track-layout overlap; both mods retained for the author/user to resolve.";
+            }
+
+            if (materialized.Any(conflict => ContainsAny(conflict.Resolution, "won", "suppressed", "skipped", "retained")))
+            {
+                return "At least one conflicting operation was skipped or replaced; see each record below.";
+            }
+
+            return "Both mods contributed to the same target; FUSE retained the shared merge.";
+        }
+
+        private static string FormatKinds(IEnumerable<FuseRegistryConflict> conflicts)
+        {
+            return string.Join(", ", (conflicts ?? Enumerable.Empty<FuseRegistryConflict>())
+                .Select(conflict => conflict.Kind.ToString())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(kind => kind, StringComparer.OrdinalIgnoreCase));
+        }
+
+        private static string FormatConflict(FuseRegistryConflict conflict)
+        {
+            var id = string.IsNullOrWhiteSpace(conflict?.Id) ? "(unknown target)" : conflict.Id;
+            var resolution = string.IsNullOrWhiteSpace(conflict?.Resolution) ? "No resolution recorded." : conflict.Resolution;
+            var definitions = string.IsNullOrWhiteSpace(conflict?.OwnerPackageId) && string.IsNullOrWhiteSpace(conflict?.AttemptedPackageId)
+                ? string.Empty
+                : " [" + conflict.OwnerPackageId + " -> " + conflict.AttemptedPackageId + "]";
+            return InsertBreakHints(id) + " — " + resolution + InsertBreakHints(definitions);
+        }
+
+        private static string FindPackageRoot(string definitionId, IEnumerable<string> packageRoots)
+        {
+            definitionId = string.IsNullOrWhiteSpace(definitionId) ? "(unknown package)" : definitionId.Trim();
+            foreach (var root in packageRoots ?? Enumerable.Empty<string>())
+            {
+                if (string.Equals(definitionId, root, StringComparison.OrdinalIgnoreCase) ||
+                    definitionId.StartsWith(root + ".", StringComparison.OrdinalIgnoreCase))
+                {
+                    return root;
+                }
+            }
+
+            return definitionId;
+        }
+
+        private static string BuildPairKey(string first, string second)
+        {
+            OrderPackagePair(first, second, out var orderedFirst, out var orderedSecond);
+            return orderedFirst + "\0" + orderedSecond;
+        }
+
+        private static void OrderPackagePair(string first, string second, out string orderedFirst, out string orderedSecond)
+        {
+            first = string.IsNullOrWhiteSpace(first) ? "(unknown package)" : first.Trim();
+            second = string.IsNullOrWhiteSpace(second) ? "(unknown package)" : second.Trim();
+            if (StringComparer.OrdinalIgnoreCase.Compare(first, second) <= 0)
+            {
+                orderedFirst = first;
+                orderedSecond = second;
+            }
+            else
+            {
+                orderedFirst = second;
+                orderedSecond = first;
+            }
+        }
+
+        private static bool ContainsAny(string value, params string[] terms)
+        {
+            return !string.IsNullOrWhiteSpace(value) &&
+                terms.Any(term => value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+    }
+}

--- a/FUSE/Interface/MenuWindow/ModsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/ModsPanelBuilder.cs
@@ -15,17 +15,42 @@ using UnityEngine;
 
 namespace FUSE.Interface.MenuWindow
 {
+    internal sealed class FusePackageDisplayStatus
+    {
+        public FusePackageDisplayStatus(string label, string detail, string listGroup, int sortOrder, string markup)
+        {
+            Label = label ?? string.Empty;
+            Detail = detail ?? string.Empty;
+            ListGroup = listGroup ?? string.Empty;
+            SortOrder = sortOrder;
+            Markup = markup ?? string.Empty;
+        }
+
+        public string Label { get; }
+        public string Detail { get; }
+        public string ListGroup { get; }
+        public int SortOrder { get; }
+        public string Markup { get; }
+    }
+
     internal struct ModsPanelBuilder
     {
         public static void Build(UIPanelBuilder builder, UIState<string> selectedItem)
         {
             var manifests = MergeHostedLegacyPackageSnapshots(
                 FuseDataPackageDiscovery.GetPackageManifestSnapshots(),
-                FuseLegacyAssemblyHost.EnumerateAllHostedPlugins().Select(info => info.Manifest));
+                FuseLegacyAssemblyHost.EnumerateAllHostedPlugins().Select(info => info.Manifest))
+                .ToArray();
+            HydratePackageRuntimeState(manifests);
 
             List<UIPanelBuilder.ListItem<FusePackageManifestSnapshot>> list = manifests
-                .OrderBy(m => m.DisplayName)
-                .Select(m => new UIPanelBuilder.ListItem<FusePackageManifestSnapshot>(m.Id, m, "Active Mods", m.DisplayName))
+                .OrderBy(m => ClassifyPackageStatus(m).SortOrder)
+                .ThenBy(m => m.DisplayName)
+                .Select(m => new UIPanelBuilder.ListItem<FusePackageManifestSnapshot>(
+                    m.Id,
+                    m,
+                    ClassifyPackageStatus(m).ListGroup,
+                    m.DisplayName))
                 .ToList();
 
             builder.AddListDetail(list, selectedItem, delegate (UIPanelBuilder builder, FusePackageManifestSnapshot manifest)
@@ -36,7 +61,7 @@ namespace FUSE.Interface.MenuWindow
                     // previously selected mod's handler must not stay open.
                     CloseAllLegacyModTabs("mods selection cleared");
                     builder.AddExpandingVerticalSpacer();
-                    builder.AddLabelEmptyState(manifests.Count == 0 ? "No mods found through UMM." : "Select a mod");
+                    builder.AddLabelEmptyState(manifests.Length == 0 ? "No mods found through UMM." : "Select a mod");
                     builder.AddExpandingVerticalSpacer();
                 }
                 else
@@ -87,7 +112,26 @@ namespace FUSE.Interface.MenuWindow
                     Version = hosted.Version ?? string.Empty,
                     FolderName = folderName,
                     FolderPath = folderPath,
-                    IsLegacyHosted = true
+                    RequiredPackageIds = (hosted.RequiredReferences ?? Array.Empty<Railloader.ModReference>())
+                        .Select(reference => reference.Id)
+                        .Where(referenceId => !string.IsNullOrWhiteSpace(referenceId))
+                        .ToArray(),
+                    LoadAfter = (hosted.LoadAfter ?? Array.Empty<Railloader.ModReference>())
+                        .Select(reference => reference.Id)
+                        .Where(referenceId => !string.IsNullOrWhiteSpace(referenceId))
+                        .ToArray(),
+                    LoadBefore = hosted.LoadBefore ?? Array.Empty<string>(),
+                    ConflictsWith = (hosted.ConflictsWith ?? Array.Empty<Railloader.ModReference>())
+                        .Select(reference => new FUSE.Authoring.Data.FuseModRequirement
+                        {
+                            Id = reference.Id,
+                            NotBefore = reference.NotBefore?.ToString(),
+                            NotAfter = reference.NotAfter?.ToString()
+                        })
+                        .ToArray(),
+                    IsLegacyHosted = true,
+                    LoadedFromDisk = true,
+                    AppliedToRuntime = true
                 });
                 AddPackageIdentity(knownFolders, knownIds, folderPath, id);
             }
@@ -118,7 +162,12 @@ namespace FUSE.Interface.MenuWindow
         {
             builder.AddSection(manifest.DisplayName);
 
-            builder.AddField("Status", PackageStatusTextMarkup(manifest));
+            var status = ClassifyPackageStatus(manifest);
+            builder.AddField("Status", status.Markup);
+            if (!string.IsNullOrWhiteSpace(status.Detail))
+            {
+                builder.AddField("State details", status.Detail);
+            }
             builder.AddField("Version", manifest.Version ?? "Unknown");
             builder.AddField("Id", manifest.Id);
             builder.AddField("Folder", manifest.FolderName);
@@ -128,14 +177,24 @@ namespace FUSE.Interface.MenuWindow
 
             builder.AddField("Settings", CountPackageSettings(definitions).ToString());
 
-            if (manifest.Faults.Length > 0)
+            var faults = GetAllFaults(manifest);
+            if (faults.Length > 0)
             {
-                builder.AddField("Faults", string.Join("; ", manifest.Faults));
+                builder.AddField("Faults", string.Join("; ", faults));
             }
 
             if (manifest.Disabled && !string.IsNullOrEmpty(manifest.DisabledReason))
             {
                 builder.AddField("Disabled", manifest.DisabledReason);
+            }
+
+            var skipReasons = GetSkipReasons(manifest);
+            if (skipReasons.Length > 0)
+            {
+                var label = skipReasons.All(FusePackageFaultRegistry.IsOptionalSkipReason)
+                    ? "Optional content"
+                    : "Skipped";
+                builder.AddField(label, string.Join("; ", skipReasons));
             }
 
             var depSummary = BuildDependencySummary(manifest);
@@ -150,7 +209,7 @@ namespace FUSE.Interface.MenuWindow
             {
                 row.AddButton("Copy Mod Info", () =>
                 {
-                    GUIUtility.systemCopyBuffer = BuildSelectedPackageReport(manifest, definitions);
+                    GUIUtility.systemCopyBuffer = BuildSelectedPackageReport(manifest, definitions, status);
                     Toast.Present("Copied mod info to clipboard");
                     builder.Rebuild();
                 });
@@ -180,6 +239,17 @@ namespace FUSE.Interface.MenuWindow
                 if (definitions.Length > 1)
                 {
                     builder.AddLabel(loaded.Definition.Id);
+                }
+
+                if (loaded.FeatureEvaluation.RuleCount > 0)
+                {
+                    builder.AddField("Active feature set", loaded.FeatureEvaluation.Summary);
+                    if (loaded.FeatureEvaluation.DisabledRuleIds.Length > 0)
+                    {
+                        builder.AddField(
+                            "Disabled options",
+                            string.Join(", ", loaded.FeatureEvaluation.DisabledRuleIds));
+                    }
                 }
 
                 foreach (var pair in loaded.Definition.Settings
@@ -325,6 +395,100 @@ namespace FUSE.Interface.MenuWindow
                 .ToArray();
         }
 
+        private static void HydratePackageRuntimeState(IReadOnlyList<FusePackageManifestSnapshot> manifests)
+        {
+            if (manifests == null || manifests.Count == 0)
+            {
+                return;
+            }
+
+            var loadedIds = new HashSet<string>(
+                FusePackageFaultRegistry.GetLoadedPackageIds(),
+                StringComparer.OrdinalIgnoreCase);
+            var appliedIds = new HashSet<string>(
+                FusePackageFaultRegistry.GetAppliedPackageIds(),
+                StringComparer.OrdinalIgnoreCase);
+            var skipped = FusePackageFaultRegistry.GetSkippedPackages();
+            var disabled = FusePackageFaultRegistry.GetDisabledPackages();
+            var faultsByPackage = FusePackageFaultRegistry.GetFaults()
+                .GroupBy(fault => fault.PackageId, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Select(FormatRuntimeFault).ToArray(),
+                    StringComparer.OrdinalIgnoreCase);
+            var loadedDefinitions = FuseModLoader.GetLoadedModsInOrder()
+                .Where(loaded => loaded?.Definition != null)
+                .ToArray();
+
+            foreach (var manifest in manifests.Where(manifest => manifest != null))
+            {
+                var definitionIds = loadedDefinitions
+                    .Where(loaded => DefinitionBelongsToPackage(loaded, manifest))
+                    .Select(loaded => loaded.Definition.Id)
+                    .Where(id => !string.IsNullOrWhiteSpace(id))
+                    .ToArray();
+                var registryIds = new[] { manifest.Id }
+                    .Concat(definitionIds)
+                    .Where(id => !string.IsNullOrWhiteSpace(id))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                manifest.LoadedFromDisk = manifest.LoadedFromDisk || registryIds.Any(loadedIds.Contains);
+                manifest.AppliedToRuntime = manifest.AppliedToRuntime || registryIds.Any(appliedIds.Contains);
+
+                var skipReasons = registryIds
+                    .Select(id => skipped.TryGetValue(id, out var reason) ? reason : string.Empty)
+                    .Concat(manifest.SkipReasons ?? Array.Empty<string>())
+                    .Concat(string.IsNullOrWhiteSpace(manifest.SkipReason)
+                        ? Array.Empty<string>()
+                        : new[] { manifest.SkipReason })
+                    .Where(reason => !string.IsNullOrWhiteSpace(reason))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                manifest.SkipReasons = skipReasons;
+                manifest.SkipReason = skipReasons.FirstOrDefault() ?? string.Empty;
+
+                if (!manifest.Disabled)
+                {
+                    var disabledReason = registryIds
+                        .Select(id => disabled.TryGetValue(id, out var reason) ? reason : string.Empty)
+                        .FirstOrDefault(reason => !string.IsNullOrWhiteSpace(reason));
+                    if (!string.IsNullOrWhiteSpace(disabledReason))
+                    {
+                        manifest.Disabled = true;
+                        manifest.DisabledReason = disabledReason;
+                    }
+                }
+
+                manifest.RuntimeFaults = registryIds
+                    .SelectMany(id => faultsByPackage.TryGetValue(id, out var packageFaults)
+                        ? packageFaults
+                        : Array.Empty<string>())
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+            }
+        }
+
+        private static bool DefinitionBelongsToPackage(FuseLoadedMod loaded, FusePackageManifestSnapshot manifest)
+        {
+            return loaded?.Definition != null && manifest != null &&
+                   (string.Equals(NormalizePath(loaded.FolderPath), NormalizePath(manifest.FolderPath), StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(loaded.Definition.Id, manifest.Id, StringComparison.OrdinalIgnoreCase) ||
+                    loaded.Definition.Id.StartsWith((manifest.Id ?? string.Empty) + ".", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string FormatRuntimeFault(FusePackageFault fault)
+        {
+            if (fault == null)
+            {
+                return string.Empty;
+            }
+
+            return string.IsNullOrWhiteSpace(fault.Stage)
+                ? fault.Message
+                : fault.Stage + ": " + fault.Message;
+        }
+
         private static int CountPackageSettings(IEnumerable<FuseLoadedMod> definitions)
         {
             return (definitions ?? [])
@@ -341,6 +505,7 @@ namespace FUSE.Interface.MenuWindow
 
             var parts = new[]
             {
+                manifest.RequiredPackageIds.Length == 0 ? string.Empty : "requires: " + string.Join(", ", manifest.RequiredPackageIds),
                 manifest.LoadAfter.Length == 0 ? string.Empty : "after: " + string.Join(", ", manifest.LoadAfter),
                 manifest.LoadBefore.Length == 0 ? string.Empty : "before: " + string.Join(", ", manifest.LoadBefore)
             }.Where(value => !string.IsNullOrWhiteSpace(value)).ToArray();
@@ -366,25 +531,88 @@ namespace FUSE.Interface.MenuWindow
             }
         }
 
-        private static string BuildSelectedPackageReport(FusePackageManifestSnapshot manifest, IReadOnlyList<FuseLoadedMod> definitions)
+        private static string BuildSelectedPackageReport(
+            FusePackageManifestSnapshot manifest,
+            IReadOnlyList<FuseLoadedMod> definitions,
+            FusePackageDisplayStatus status)
         {
             var builder = new StringBuilder();
             builder.AppendLine("FUSE selected mod");
             builder.AppendLine("Name: " + PackageDisplayName(manifest));
             builder.AppendLine("Id: " + manifest.Id);
             builder.AppendLine("Version: " + BlankAs(manifest.Version, "?"));
-            builder.AppendLine("Status: " + PackageStatusText(manifest));
+            builder.AppendLine("Status: " + status.Label);
+            if (!string.IsNullOrWhiteSpace(status.Detail))
+            {
+                builder.AppendLine("State details: " + status.Detail);
+            }
             builder.AppendLine("Folder: " + manifest.FolderPath);
             builder.AppendLine("Definitions: " + (definitions?.Count ?? 0));
             builder.AppendLine("Settings: " + CountPackageSettings(definitions));
-            if (manifest.Faults.Length > 0)
+            var skipReasons = GetSkipReasons(manifest);
+            if (skipReasons.Length > 0)
             {
-                builder.AppendLine("Faults: " + string.Join("; ", manifest.Faults));
+                builder.AppendLine("Skip reasons: " + string.Join("; ", skipReasons));
+            }
+
+            var faults = GetAllFaults(manifest);
+            if (faults.Length > 0)
+            {
+                builder.AppendLine("Faults: " + string.Join("; ", faults));
+            }
+
+            var definitionIds = (definitions ?? Array.Empty<FuseLoadedMod>())
+                .Where(loaded => loaded?.Definition != null)
+                .Select(loaded => loaded.Definition.Id)
+                .ToArray();
+            var detailedFaults = FusePackageFaultRegistry.GetFaults()
+                .Where(fault => string.Equals(fault.PackageId, manifest.Id, StringComparison.OrdinalIgnoreCase)
+                                || definitionIds.Contains(fault.PackageId, StringComparer.OrdinalIgnoreCase)
+                                || (!string.IsNullOrWhiteSpace(fault.FolderPath)
+                                    && string.Equals(NormalizePath(fault.FolderPath), NormalizePath(manifest.FolderPath), StringComparison.OrdinalIgnoreCase)))
+                .ToArray();
+            if (detailedFaults.Length > 0)
+            {
+                builder.AppendLine("Actionable package diagnostics:");
+                foreach (var fault in detailedFaults)
+                {
+                    builder.AppendLine("- Stage: " + BlankAs(fault.Stage, "unknown"));
+                    builder.AppendLine("  Message: " + BlankAs(fault.Message, "unknown"));
+                    builder.AppendLine("  Package: " + BlankAs(fault.PackageName, fault.PackageId)
+                                       + " [" + fault.PackageId + "]");
+                    builder.AppendLine("  Source root: " + BlankAs(fault.FolderPath, "unknown"));
+                    builder.AppendLine("  Relative file: " + BlankAs(fault.RelativeSourceFile, "unknown"));
+                    builder.AppendLine("  Absolute file: " + BlankAs(fault.SourceFile, "unknown"));
+                    if (!string.IsNullOrWhiteSpace(fault.JsonPath) || fault.LineNumber > 0)
+                    {
+                        builder.AppendLine("  JSON location: " + BlankAs(fault.JsonPath, "<root>")
+                                           + (fault.LineNumber > 0
+                                               ? $" line {fault.LineNumber}, position {fault.LinePosition}"
+                                               : string.Empty));
+                    }
+                    if (!string.IsNullOrWhiteSpace(fault.ValidationCode))
+                        builder.AppendLine("  Validation code: " + fault.ValidationCode);
+                    if (!string.IsNullOrWhiteSpace(fault.ExpectedShape))
+                        builder.AppendLine("  Expected: " + fault.ExpectedShape);
+                    if (!string.IsNullOrWhiteSpace(fault.ReceivedValue))
+                        builder.AppendLine("  Received: " + fault.ReceivedValue);
+                    builder.AppendLine("  Fix: " + BlankAs(fault.SuggestedAction, "Correct the named package source and reload the map."));
+                }
             }
 
             foreach (var loaded in definitions ?? Array.Empty<FuseLoadedMod>())
             {
                 builder.AppendLine("Definition: " + loaded.Definition.Id);
+                if (loaded.FeatureEvaluation.RuleCount > 0)
+                {
+                    builder.AppendLine("Feature rules: " + loaded.FeatureEvaluation.Summary);
+                    if (loaded.FeatureEvaluation.DisabledRuleIds.Length > 0)
+                    {
+                        builder.AppendLine(
+                            "Disabled feature rules: " +
+                            string.Join(", ", loaded.FeatureEvaluation.DisabledRuleIds));
+                    }
+                }
             }
 
             return builder.ToString();
@@ -405,46 +633,180 @@ namespace FUSE.Interface.MenuWindow
             return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
         }
 
-        private static string PackageStatusText(FusePackageManifestSnapshot manifest)
+        internal static FusePackageDisplayStatus ClassifyPackageStatus(FusePackageManifestSnapshot manifest)
         {
             if (manifest == null)
             {
-                return "unknown";
+                return new FusePackageDisplayStatus(
+                    "Unknown",
+                    "Package state is unavailable.",
+                    "Unknown",
+                    80,
+                    "<color=\"orange\">Unknown</color>");
             }
 
             if (manifest.Disabled)
             {
-                return "disabled";
+                return new FusePackageDisplayStatus(
+                    "Disabled",
+                    BlankAs(manifest.DisabledReason, "Disabled by the active mod configuration."),
+                    "Disabled Mods",
+                    60,
+                    "<color=\"yellow\">Disabled</color>");
             }
 
-            if (manifest.Faults.Length > 0)
+            var faults = GetAllFaults(manifest);
+            var skipReasons = GetSkipReasons(manifest);
+            var evidence = string.Join(
+                " | ",
+                faults
+                    .Concat(skipReasons.Where(reason => !FusePackageFaultRegistry.IsOptionalSkipReason(reason)))
+                    .Where(value => !string.IsNullOrWhiteSpace(value)));
+            var problem = ClassifyProblem(evidence);
+            var hasSkips = skipReasons.Length > 0;
+            var optionalSkip = hasSkips && skipReasons.All(FusePackageFaultRegistry.IsOptionalSkipReason);
+
+            if (manifest.AppliedToRuntime &&
+                (faults.Length > 0 || (hasSkips && !optionalSkip)))
             {
-                return manifest.Faults.Length + " fault(s)";
+                var actionableSkipDetail = string.Join(
+                    "; ",
+                    skipReasons.Where(reason => !FusePackageFaultRegistry.IsOptionalSkipReason(reason)));
+                var detail = problem.Length == 0
+                    ? (hasSkips ? string.Join("; ", skipReasons) : "One or more definitions failed while other content applied.")
+                    : problem + ". Other content from this package applied successfully.";
+                if (!string.IsNullOrWhiteSpace(actionableSkipDetail))
+                {
+                    detail += " Actionable skip: " + actionableSkipDetail;
+                }
+                return new FusePackageDisplayStatus(
+                    "Partially applied",
+                    detail,
+                    "Mods Needing Attention",
+                    20,
+                    "<color=\"orange\">Partially applied</color>");
             }
 
-            return manifest.IsLegacyConverted || manifest.IsLegacyHosted ? "ready | legacy" : "ready";
+            if (faults.Length > 0)
+            {
+                var label = problem.Length == 0 ? "Failed" : problem;
+                return new FusePackageDisplayStatus(
+                    label,
+                    faults[0],
+                    "Mods Needing Attention",
+                    10,
+                    "<color=\"red\">" + label + "</color>");
+            }
+
+            if (hasSkips && !optionalSkip)
+            {
+                var label = problem.Length == 0 ? "Skipped" : problem;
+                return new FusePackageDisplayStatus(
+                    label,
+                    string.Join("; ", skipReasons),
+                    "Mods Needing Attention",
+                    30,
+                    "<color=\"orange\">" + label + "</color>");
+            }
+
+            if (manifest.AppliedToRuntime)
+            {
+                var detail = optionalSkip
+                    ? "Applied successfully. Optional content is inactive: " + string.Join("; ", skipReasons)
+                    : string.Empty;
+                var legacy = manifest.IsLegacyConverted || manifest.IsLegacyHosted
+                    ? " - Legacy compatibility"
+                    : string.Empty;
+                return new FusePackageDisplayStatus(
+                    "Applied",
+                    detail,
+                    "Applied Mods",
+                    40,
+                    "<color=\"green\">Applied</color>" + legacy);
+            }
+
+            if (manifest.LoadedFromDisk)
+            {
+                return new FusePackageDisplayStatus(
+                    "Loaded; awaiting map apply",
+                    optionalSkip ? "Optional content is inactive: " + string.Join("; ", skipReasons) : string.Empty,
+                    "Ready Mods",
+                    50,
+                    "<color=\"green\">Loaded</color> - awaiting map apply");
+            }
+
+            if (manifest.IsLegacyHosted)
+            {
+                return new FusePackageDisplayStatus(
+                    "Active legacy code",
+                    string.Empty,
+                    "Applied Mods",
+                    40,
+                    "<color=\"green\">Active</color> - Legacy compatibility");
+            }
+
+            return new FusePackageDisplayStatus(
+                "Discovered; ready to load",
+                optionalSkip ? "Optional content is inactive: " + string.Join("; ", skipReasons) : string.Empty,
+                "Ready Mods",
+                50,
+                "<color=\"green\">Ready</color>");
         }
 
-        private static string PackageStatusTextMarkup(FusePackageManifestSnapshot manifest)
+        private static string[] GetAllFaults(FusePackageManifestSnapshot manifest)
         {
-            if (manifest == null)
+            return (manifest?.Faults ?? Array.Empty<string>())
+                .Concat(manifest?.RuntimeFaults ?? Array.Empty<string>())
+                .Where(fault => !string.IsNullOrWhiteSpace(fault))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static string[] GetSkipReasons(FusePackageManifestSnapshot manifest)
+        {
+            return (manifest?.SkipReasons ?? Array.Empty<string>())
+                .Concat(string.IsNullOrWhiteSpace(manifest?.SkipReason)
+                    ? Array.Empty<string>()
+                    : new[] { manifest.SkipReason })
+                .Where(reason => !string.IsNullOrWhiteSpace(reason))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static string ClassifyProblem(string evidence)
+        {
+            if (string.IsNullOrWhiteSpace(evidence))
             {
-                return "<color=\"orange\">Unknown";
+                return string.Empty;
             }
 
-            if (manifest.Disabled)
+            if (ContainsAny(evidence, "conflictswith", "conflicts with", "incompatible"))
             {
-                return "<color=\"yellow\">Disabled";
+                return "Incompatible mod installed";
             }
 
-            if (manifest.Faults.Length > 0)
+            if (ContainsAny(
+                evidence,
+                "dependency missing",
+                "no matching package",
+                " requires '",
+                "required package",
+                "required dependency"))
             {
-                return "<color=\"red\">Error: " + manifest.Faults.Length + " fault(s)";
+                return "Missing dependency";
             }
 
-            return manifest.IsLegacyConverted || manifest.IsLegacyHosted
-                ? "<color=\"green\">Ready</color> - Legacy"
-                : "<color=\"green\"Ready";
+            if (ContainsAny(evidence, "manifest json", "json:", "json ", "deserial", "schema", "could not be parsed"))
+            {
+                return "Invalid package data";
+            }
+
+            return string.Empty;
+        }
+
+        private static bool ContainsAny(string value, params string[] candidates)
+        {
+            return candidates.Any(candidate => value.IndexOf(candidate, StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         private static string GetSettingLabel(string key, FuseModSettingDefinition setting)
@@ -464,7 +826,7 @@ namespace FUSE.Interface.MenuWindow
                     BuildEnumSettingControl(builder, definition, key, setting);
                     break;
                 case "number":
-                    BuildTextSettingControl(builder, definition, key, setting, isNumber: true);
+                    BuildNumberSettingControl(builder, definition, key, setting);
                     break;
                 case "path":
                 case "color":
@@ -474,13 +836,25 @@ namespace FUSE.Interface.MenuWindow
                     break;
             }
 
+            var featureRules = definition?.FeatureRules == null
+                ? Enumerable.Empty<FuseFeatureRule>()
+                : definition.FeatureRules.Values;
+            var controlsFeature = featureRules
+                .Any(rule => rule != null && string.Equals(rule.Setting, key, StringComparison.Ordinal));
             if (FuseSettings.ShowAdvancedHealthDetails)
             {
                 builder.AddField(" ", DescribePackageSetting(key, setting));
             }
-            else if (!string.IsNullOrWhiteSpace(setting?.Description))
+            else if (controlsFeature || !string.IsNullOrWhiteSpace(setting?.Description))
             {
-                builder.AddField(" ", setting.Description);
+                var note = string.IsNullOrWhiteSpace(setting?.Description)
+                    ? string.Empty
+                    : setting.Description.Trim() + " ";
+                if (controlsFeature)
+                {
+                    note += "This option changes authored map content and takes effect after saving/reloading the map.";
+                }
+                builder.AddField(" ", note.Trim());
             }
         }
 
@@ -542,6 +916,46 @@ namespace FUSE.Interface.MenuWindow
                 {
                     SaveTextSetting(definition, key, setting, value, isNumber);
                 });
+                AddResetSettingButton(row, definition, key, setting);
+            }, 8f).Height(32f);
+        }
+
+        private static void BuildNumberSettingControl(
+            UIPanelBuilder builder,
+            FuseModDefinition definition,
+            string key,
+            FuseModSettingDefinition setting)
+        {
+            if (!setting.Min.HasValue || !setting.Max.HasValue
+                || setting.Min.Value >= setting.Max.Value)
+            {
+                BuildTextSettingControl(builder, definition, key, setting, isNumber: true);
+                return;
+            }
+
+            var minimum = (float)setting.Min.Value;
+            var maximum = (float)setting.Max.Value;
+            var step = setting.Step.GetValueOrDefault(0d);
+            builder.HStack(row =>
+            {
+                AddSettingRowLabel(row, GetSettingLabel(key, setting));
+                row.AddSlider(
+                    () => (float)FuseModSettingsStore.GetNumberValue(definition, key, setting),
+                    () => FuseModSettingsStore.GetNumberValue(definition, key, setting)
+                        .ToString("0.###", System.Globalization.CultureInfo.InvariantCulture),
+                    value =>
+                    {
+                        var selected = Math.Max(minimum, Math.Min(maximum, value));
+                        if (step > 0d)
+                        {
+                            selected = minimum
+                                + (float)(Math.Round((selected - minimum) / step) * step);
+                            selected = Math.Max(minimum, Math.Min(maximum, selected));
+                        }
+                        FuseModSettingsStore.SetValue(definition, key, setting, new JValue(selected));
+                    },
+                    minimum,
+                    maximum);
                 AddResetSettingButton(row, definition, key, setting);
             }, 8f).Height(32f);
         }

--- a/FUSE/Interface/MenuWindow/RuntimeActionsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/RuntimeActionsToolPage.cs
@@ -172,11 +172,13 @@ namespace FUSE.Interface.MenuWindow
             builder.AppendLine("Stations: " + SafeCount(() => StationAPI.GetAllStationAgents().Count()));
             builder.AppendLine("Passenger Stops: " + SafeCount(() => StationAPI.GetAllPassengerStops().Count()));
             builder.AppendLine("Scenery: " + SafeCount(() => SceneryAPI.GetAllScenery().Count()));
+            builder.AppendLine("Water Surfaces: " + SafeCount(() => WaterSurfaceAPI.GetAllWaterSurfaces().Count()));
             builder.AppendLine();
             builder.AppendLine("FUSE Registry");
             builder.AppendLine("Exclusive Claims: " + FUSE.Runtime.Registry.FuseRegistry.ExclusiveClaimCount);
             builder.AppendLine("Shared Claims: " + FUSE.Runtime.Registry.FuseRegistry.SharedClaimCount);
-            builder.AppendLine("Conflicts: " + FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count);
+            builder.AppendLine("Conflicts: " + FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => !conflict.IsCooperativeMerge));
+            builder.AppendLine("Shared Extension Targets: " + FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => conflict.IsCooperativeMerge));
             return builder.ToString().TrimEnd();
         }
 
@@ -236,6 +238,7 @@ namespace FUSE.Interface.MenuWindow
                     ["scenery"] = SafeCount(() => SceneryAPI.GetAllScenery().Count()),
                     ["sceneClones"] = SafeCount(() => SceneCloneAPI.GetAllSceneClones().Count()),
                     ["splineys"] = SafeCount(() => SplineyAPI.GetAllSplineys().Count()),
+                    ["waterSurfaces"] = SafeCount(() => WaterSurfaceAPI.GetAllWaterSurfaces().Count()),
                     ["mapLabels"] = SafeCount(() => MapAPI.GetAllMapLabels().Count()),
                     ["mapMasks"] = SafeCount(() => MapAPI.GetAllMapMasks().Count()),
                     ["progressions"] = SafeCount(() => ProgressionAPI.GetAllProgressions().Count()),
@@ -245,7 +248,9 @@ namespace FUSE.Interface.MenuWindow
                 {
                     ["exclusiveClaims"] = FUSE.Runtime.Registry.FuseRegistry.ExclusiveClaimCount,
                     ["sharedClaims"] = FUSE.Runtime.Registry.FuseRegistry.SharedClaimCount,
-                    ["conflicts"] = FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count
+                    ["conflicts"] = FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => !conflict.IsCooperativeMerge),
+                    ["sharedExtensionTargets"] = FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => conflict.IsCooperativeMerge),
+                    ["overlapRecords"] = FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count
                 },
                 ["assets"] = new JObject
                 {

--- a/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
@@ -5,7 +5,6 @@ using FUSE.Authoring.Migrations;
 using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
-using System.Linq;
 using System.Text;
 using UI.Builder;
 using UI.Common;
@@ -51,11 +50,7 @@ namespace FUSE.Interface.MenuWindow
                 return;
             }
             var data = checklistData.Value;
-            var modExceptionState = FuseModExceptionRegistry.CaptureReportState();
-            var hasAdvisories =
-                data.NoticesCount > data.BlockingNoticesCount ||
-                !FuseRuntimeGuardCounters.AllIdle ||
-                modExceptionState.Total > 0;
+            var hasAdvisories = data.NoticesCount > data.BlockingNoticesCount;
 
             builder.AddSection("Overview");
 
@@ -77,83 +72,7 @@ namespace FUSE.Interface.MenuWindow
             AddReadinessRow(builder, "Progression", data.ProgressionTransferSkipCount == 0, "0 transfer skips", data.ProgressionTransferSkipCount + " skip(s)");
             AddReadinessRow(builder, "Registry", data.ConflictCount == 0, "0 conflicts", data.ConflictCount + " conflict(s)");
             AddNoticeRow(builder, data.NoticesCount, data.BlockingNoticesCount);
-            // Live session counters, not snapshot state.
-            AddAdvisoryRow(
-                builder,
-                "Guards",
-                FuseRuntimeGuardCounters.AllIdle,
-                "idle",
-                FuseRuntimeGuardCounters.GuardTotal + " compatibility event(s) contained");
-            // Session-cumulative third-party exception observations — same
-            // live-counter semantics as Guards, sourced from the exception
-            // registry rather than the load snapshot. One atomic capture here
-            // (rows + totals + summary line under the registry's lock), reused
-            // by the readiness row and the breakdown section below so a
-            // concurrent log event can never render contradictory rows.
-            var modExceptions = modExceptionState.Mods;
-            // Same threshold as the health report (FuseLoadReport
-            // HasModExceptionProblem): a one-off third-party exception is
-            // informational, not a "Review" — only a recurring thrower flips
-            // this row (issue #208).
-            var problemModCount = modExceptions.Count(record => record.IsProblem);
-            AddReadinessRow(
-                builder,
-                "Mod Health",
-                problemModCount == 0,
-                modExceptionState.Total == 0
-                    ? "0 exceptions observed"
-                    : $"{modExceptionState.Total} below-threshold exception(s) observed across {modExceptions.Length} mod(s) (informational)",
-                $"{modExceptionState.Total} exception(s) across {modExceptions.Length} mod(s); {problemModCount} recurring");
-            builder.Spacer(6f);
-
-            // Full per-guard breakdown (this window is the only UI surface, so
-            // the counters must be readable here, not just in copied reports).
-            builder.AddSection("Runtime Guards");
-            InterfaceUtils.AddWrappedLabel(builder, FuseRuntimeGuardCounters.FormatSummary(), 76f);
-            builder.AddField(
-                "Native leak stacks",
-                $"{FuseNativeLeakDiagnostic.ModeLabel} (FUSE setting: {(FuseSettings.EnableNativeLeakStackTraces ? "enabled" : "disabled")})");
-            InterfaceUtils.AddWrappedLabel(
-                builder,
-                FuseRuntimeGuardCounters.AllIdle
-                    ? "All idle — no broken content needed containing this session."
-                    : "Non-zero counters show compatibility events FUSE handled successfully. They remain visible for troubleshooting but do not make the session unhealthy by themselves.",
-                48f);
-            builder.Spacer(6f);
-
-            // Per-mod breakdown for the third-party exception registry,
-            // mirroring the Runtime Guards treatment above (this window is
-            // the only UI surface, so the observations must be readable
-            // here, not just in copied reports).
-            builder.AddSection("Mod Health");
-            builder.AddLabel(modExceptionState.SummaryLine);
-            if (modExceptions.Length > 0)
-            {
-                foreach (var record in modExceptions.OrderByDescending(item => item.Count).Take(5))
-                {
-                    var display = string.IsNullOrWhiteSpace(record.DisplayName) ? record.ModId : record.DisplayName;
-                    InterfaceUtils.AddWrappedField(builder, display, DescribeModExceptionRecord(record), 52f);
-                }
-
-                if (modExceptions.Length > 5)
-                {
-                    InterfaceUtils.AddWrappedLabel(
-                        builder,
-                        $"...and {modExceptions.Length - 5} more mod(s) — full list in the health report.",
-                        28f);
-                }
-            }
-
-            InterfaceUtils.AddWrappedLabel(
-                builder,
-                modExceptionState.Total == 0
-                    ? "All idle — no third-party mod exceptions were observed this session."
-                    : problemModCount == 0
-                        ? "Below-threshold third-party exceptions were observed and logged for reference; a mod counts as a problem at (" +
-                          FuseModExceptionRegistry.ProblemEpisodeThreshold + "+ episodes or " +
-                          FuseModExceptionRegistry.ProblemCountThreshold + "+ occurrences). Details are in FUSE.log and the health report."
-                        : "Recurring counts are third-party mod faults FUSE observed or contained; offenders are named in FUSE.log and the health report.",
-                48f);
+            builder.AddField("Runtime Diagnostics", "Tools > Live Diagnostics (guards, observed exceptions, and the live FUSE log)");
             builder.Spacer(6f);
 
             builder.AddSection("Actions");
@@ -253,24 +172,6 @@ namespace FUSE.Interface.MenuWindow
             return token != null && bool.TryParse(token.ToString(), out var value) ? value : fallback;
         }
 
-        /// <summary>
-        /// One-line per-mod value for the Mod Health breakdown: counts plus
-        /// the mod's top signature (by count), matching the per-mod row the
-        /// health report renders so the two surfaces read the same.
-        /// </summary>
-        private static string DescribeModExceptionRecord(FuseModExceptionSnapshot record)
-        {
-            var text = $"{record.Count} exception(s) over {record.Episodes} episode(s)";
-            var signatures = record.Signatures;
-            if (signatures != null && signatures.Length > 0)
-            {
-                var top = signatures.OrderByDescending(item => item.Count).First();
-                text += $" — top: {top.ExceptionType} @ {top.TopOwnedFrame}";
-            }
-
-            return text;
-        }
-
         private static void AddReadinessRow(UIPanelBuilder builder, string label, bool ok, string okText, string problemText)
         {
             var value = ok
@@ -318,7 +219,7 @@ namespace FUSE.Interface.MenuWindow
                 {
                     HasProblems = reportSnapshot.HasProblems,
                     AppliedPackagesCount = reportSnapshot.AppliedPackageIds.Length,
-                    ConflictCount = reportSnapshot.Conflicts.Length,
+                    ConflictCount = reportSnapshot.ActionableConflictCount,
                     FaultCount = reportSnapshot.Faults.Length,
                     GraphIssueCount = reportSnapshot.GraphPostBindIssues.Length,
                     LoadedPackagesCount = reportSnapshot.LoadedPackageIds.Length,
@@ -358,17 +259,13 @@ namespace FUSE.Interface.MenuWindow
             builder.AppendLine("Profile: " + FuseModSetService.ActiveSetName);
             builder.AppendLine("Profile Hash: " + FuseModSetService.GetActiveSetFingerprint());
             builder.AppendLine("Loaded Packages: " + ReadInt(counts["loadedPackages"]));
-            builder.AppendLine("Applied Packages: " + ReadInt(counts["appliedPackages"]));
+            builder.AppendLine("Applied Definitions: " + ReadInt(counts["appliedDefinitions"] ?? counts["appliedPackages"]));
             builder.AppendLine("Faults: " + ReadInt(counts["faultedPackages"]));
             builder.AppendLine("Conflicts: " + ReadInt(counts["conflicts"]));
             builder.AppendLine("Unknown Assets: " + ReadInt(counts["unknownSceneryAssets"]));
             builder.AppendLine("Graph Issues: " + ReadInt(counts["graphIssues"]));
             builder.AppendLine("Transfer Skips: " + ReadInt(counts["progressionTransferSkips"]));
             builder.AppendLine("Suppressions: " + ReadInt(counts["suppressions"]));
-            builder.AppendLine("Runtime Guards: " + FuseRuntimeGuardCounters.FormatSummary());
-            builder.AppendLine(
-                "Native Leak Detection: " + FuseNativeLeakDiagnostic.ModeLabel +
-                " (FUSE stack setting " + (FuseSettings.EnableNativeLeakStackTraces ? "enabled" : "disabled") + ")");
             builder.AppendLine("Map Load: " + FusePerformanceMetrics.FormatTiming("map load total"));
             builder.AppendLine("Runtime Apply: " + FusePerformanceMetrics.FormatTiming("apply resident definitions"));
             return builder.ToString().TrimEnd();

--- a/FUSE/Interface/MenuWindow/ToolsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/ToolsPanelBuilder.cs
@@ -14,7 +14,10 @@ namespace FUSE.Interface.MenuWindow
             Inspector,
             DependencyGraph,
             Assets,
+            Conflicts,
             Audits,
+            LiveDiagnostics,
+            IndustryDashboard,
             Stats,
             Actions,
             Benchmark
@@ -41,7 +44,10 @@ namespace FUSE.Interface.MenuWindow
             list.Add(new UIPanelBuilder.ListItem<Page>("inspector", new Page(PageId.Inspector), "Tools", "Object Inspector"));
             list.Add(new UIPanelBuilder.ListItem<Page>("dependencyGraph", new Page(PageId.DependencyGraph), "Tools", "Dependency Graph"));
             list.Add(new UIPanelBuilder.ListItem<Page>("assets", new Page(PageId.Assets), "Tools", "Assets Report"));
+            list.Add(new UIPanelBuilder.ListItem<Page>("conflicts", new Page(PageId.Conflicts), "Tools", "Mod Conflicts"));
             list.Add(new UIPanelBuilder.ListItem<Page>("audits", new Page(PageId.Audits), "Tools", "Diagnostics Report"));
+            list.Add(new UIPanelBuilder.ListItem<Page>("liveDiagnostics", new Page(PageId.LiveDiagnostics), "Tools", "Live Diagnostics"));
+            list.Add(new UIPanelBuilder.ListItem<Page>("industryDashboard", new Page(PageId.IndustryDashboard), "Tools", "Industry Dashboard"));
             list.Add(new UIPanelBuilder.ListItem<Page>("stats", new Page(PageId.Stats), "Tools", "World Stats"));
             list.Add(new UIPanelBuilder.ListItem<Page>("actions", new Page(PageId.Actions), "Tools", "Runtime Actions"));
             list.Add(new UIPanelBuilder.ListItem<Page>("benchmark", new Page(PageId.Benchmark), "Tools", "Scenery Benchmark"));
@@ -69,8 +75,17 @@ namespace FUSE.Interface.MenuWindow
                             case PageId.Assets:
                                 AssetsToolPage.Build(builder);
                                 break;
+                            case PageId.Conflicts:
+                                ModConflictsToolPage.Build(builder);
+                                break;
                             case PageId.Audits:
                                 AuditsToolPage.Build(builder);
+                                break;
+                            case PageId.LiveDiagnostics:
+                                LiveDiagnosticsToolPage.Build(builder);
+                                break;
+                            case PageId.IndustryDashboard:
+                                IndustryDashboardToolPage.Build(builder);
                                 break;
                             case PageId.Stats:
                                 BuildStatsPage(builder);
@@ -108,6 +123,7 @@ namespace FUSE.Interface.MenuWindow
             builder.AddField("Scenery", SafeCount(() => SceneryAPI.GetAllScenery().Count()).ToString());
             builder.AddField("Scene Clones", SafeCount(() => SceneCloneAPI.GetAllSceneClones().Count()).ToString());
             builder.AddField("Splineys", SafeCount(() => SplineyAPI.GetAllSplineys().Count()).ToString());
+            builder.AddField("Water Surfaces", SafeCount(() => WaterSurfaceAPI.GetAllWaterSurfaces().Count()).ToString());
             builder.AddField("Map Labels", SafeCount(() => MapAPI.GetAllMapLabels().Count()).ToString());
             builder.AddField("Map Masks", SafeCount(() => MapAPI.GetAllMapMasks().Count()).ToString());
             builder.AddField("Progressions", SafeCount(() => ProgressionAPI.GetAllProgressions().Count()).ToString());
@@ -117,7 +133,12 @@ namespace FUSE.Interface.MenuWindow
             builder.AddSection("Registry");
             builder.AddField("Exclusive Claims", FUSE.Runtime.Registry.FuseRegistry.ExclusiveClaimCount.ToString());
             builder.AddField("Shared Claims", FUSE.Runtime.Registry.FuseRegistry.SharedClaimCount.ToString());
-            builder.AddField("Conflicts", FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count.ToString());
+            builder.AddField(
+                "Conflicts",
+                FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => !conflict.IsCooperativeMerge).ToString());
+            builder.AddField(
+                "Shared Extension Targets",
+                FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => conflict.IsCooperativeMerge).ToString());
             builder.AddField("Asset Stores", FUSE.Infrastructure.FusePerformanceMetrics.FormatCount("direct asset pack store count"));
         }
     }

--- a/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
@@ -21,6 +21,8 @@ namespace FUSE.Loading
         private static readonly FieldInfo PrefabStoreStoresField =
             AccessTools.Field(typeof(PrefabStore), "_stores");
 
+        private static PrefabStore _activePrefabStore;
+
         /// <summary>
         /// Mounts a FUSE-generated definitions folder (e.g. the whistle
         /// picker store) as a fuseasset:// direct store on the supplied
@@ -97,10 +99,19 @@ namespace FUSE.Loading
                 return;
             }
 
+            _activePrefabStore = prefabStore;
+
+            // AssetLoader supported definitions-only immediate child folders
+            // in addition to ordinary Catalog.json stores. Build that routing
+            // table before any store's Container is opened.
+            RefreshLegacyDefinitionOverrides();
+            InvalidateLegacyDefinitionOverrideTargetContainers(prefabStore);
+
             var sourcePaths = EnumerateAvailableAssetPackFolders().ToArray();
             if (sourcePaths.Length == 0)
             {
                 ReplaceStoreIdentifierMappings(null);
+                ValidateLegacyDefinitionOverrideTargets(prefabStore);
                 FusePerformanceMetrics.RecordTiming("direct asset pack stores", stopwatch.ElapsedMilliseconds);
                 FusePerformanceMetrics.RecordCount("direct asset pack store count", 0);
                 return;
@@ -258,6 +269,8 @@ namespace FUSE.Loading
             {
                 FuseLog.Exception("FUSE could not warm-mount the generated whistle store", ex);
             }
+
+            ValidateLegacyDefinitionOverrideTargets(prefabStore);
 
             FusePerformanceMetrics.RecordTiming("direct asset pack stores", stopwatch.ElapsedMilliseconds);
             FusePerformanceMetrics.RecordCount("direct asset pack store count", DirectAssetPackStoreIdentifiers.Count);
@@ -734,6 +747,8 @@ namespace FUSE.Loading
                 SanitizeDeserializedDirectContainer(container);
                 RuntimeStoreContainerField?.SetValue(store, container);
 
+                RecordMissingComponentKinds(store.Identifier, removedByKind.Keys);
+
                 if (removedByKind.Count > 0 && SanitizedDirectContainerWarnings.Add(store.Identifier))
                 {
                     var packId = Path.GetFileName(basePath);
@@ -762,6 +777,17 @@ namespace FUSE.Loading
 
         private static Container LoadResilientDirectContainer(string sourceText, string storeIdentifier, IDictionary<string, int> droppedByKind)
         {
+            if (ConsumeLateComponentReload(storeIdentifier) && ContainerSerializerSettingsMethod != null)
+            {
+                // The first cold load already passed its filtered text through the
+                // public ContainerSerialization entry point. Re-entering that method
+                // would make old-loader postfixes (notably Lego's definition edits)
+                // mutate the same pack twice. The newly registered subtype is visible
+                // to the identical serializer settings here, so reload the untouched
+                // source without firing those postfixes again.
+                return BypassDeserialize(sourceText);
+            }
+
             // No reflection-based strict bypass available (rare): defer to the legacy
             // deserialize path, which itself falls back to ContainerSerialization.Deserialize.
             if (ContainerSerializerSettingsMethod == null)
@@ -862,6 +888,98 @@ namespace FUSE.Loading
 
                 return BypassDeserialize(filtered);
             }
+        }
+
+        private static void RecordMissingComponentKinds(string storeIdentifier, IEnumerable<string> kinds)
+        {
+            if (string.IsNullOrWhiteSpace(storeIdentifier) || kinds == null)
+            {
+                return;
+            }
+
+            lock (LateComponentRegistrationLock)
+            {
+                foreach (var kind in kinds)
+                {
+                    if (string.IsNullOrWhiteSpace(kind))
+                    {
+                        continue;
+                    }
+
+                    if (!StoresMissingComponentKind.TryGetValue(kind, out var stores))
+                    {
+                        stores = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        StoresMissingComponentKind[kind] = stores;
+                    }
+
+                    stores.Add(storeIdentifier);
+                }
+            }
+        }
+
+        private static bool ConsumeLateComponentReload(string storeIdentifier)
+        {
+            if (string.IsNullOrWhiteSpace(storeIdentifier))
+            {
+                return false;
+            }
+
+            lock (LateComponentRegistrationLock)
+            {
+                return StoresRequiringLateComponentReload.Remove(storeIdentifier);
+            }
+        }
+
+        internal static void OnLegacyComponentKindRegistered(string kind)
+        {
+            if (string.IsNullOrWhiteSpace(kind))
+            {
+                return;
+            }
+
+            string[] affectedStoreIdentifiers;
+            lock (LateComponentRegistrationLock)
+            {
+                if (!StoresMissingComponentKind.TryGetValue(kind, out var stores) || stores.Count == 0)
+                {
+                    return;
+                }
+
+                affectedStoreIdentifiers = stores.ToArray();
+                StoresMissingComponentKind.Remove(kind);
+                foreach (var identifier in affectedStoreIdentifiers)
+                {
+                    StoresRequiringLateComponentReload.Add(identifier);
+                }
+            }
+
+            var invalidated = 0;
+            try
+            {
+                if (_activePrefabStore != null &&
+                    PrefabStoreStoresField?.GetValue(_activePrefabStore) is System.Collections.IEnumerable stores)
+                {
+                    var affected = new HashSet<string>(affectedStoreIdentifiers, StringComparer.OrdinalIgnoreCase);
+                    foreach (var item in stores)
+                    {
+                        if (item is AssetPackRuntimeStore store && affected.Contains(store.Identifier))
+                        {
+                            RuntimeStoreContainerField?.SetValue(store, null);
+                            invalidated++;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not invalidate asset packs after component kind '{kind}' registered: {ex.Message}");
+            }
+
+            FusePrefabStoreAllCarDefinitionInfosFilterPatch.InvalidateCache(_activePrefabStore);
+            FuseLog.Info(
+                $"FUSE component kind '{kind}' became available after asset-pack discovery; " +
+                $"invalidated {invalidated} affected store(s) so their full definitions load before use.");
         }
 
         private static void NoteNativeDeserializeFallback(string storeIdentifier, Exception ex)

--- a/FUSE/Loading/FuseAssetPackRegistry.LegacyAlias.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.LegacyAlias.cs
@@ -158,6 +158,14 @@ namespace FUSE.Loading
             AddLegacyAssetPackAlias(aliases, resolved, resolved);
             AddLegacyAssetPackAlias(aliases, Path.GetFileName(assetPackFolder), resolved);
 
+            if (string.Equals(
+                    NormalizeAssetPackPhysicalPath(packagePath),
+                    NormalizeAssetPackPhysicalPath(assetPackFolder),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                AddLegacyAssetPackAlias(aliases, packageId, resolved);
+            }
+
             var relative = GetRelativePath(packagePath, assetPackFolder).Replace(Path.DirectorySeparatorChar, '/');
             if (!string.IsNullOrWhiteSpace(packageId) && !string.IsNullOrWhiteSpace(relative))
             {
@@ -213,7 +221,7 @@ namespace FUSE.Loading
                     : Path.GetFileName(packagePath);
                 RecordCatalogInspectionFailure(
                     $"Asset pack Catalog.json could not be read: package='{package}' " +
-                    $"pack='{Path.GetFileName(assetPackFolder)}' reason='{ex.Message}' — " +
+                    $"pack='{Path.GetFileName(assetPackFolder)}' file='{catalogPath}' reason='{ex.Message}' — " +
                     "catalog-declared aliases were skipped; content referencing them may not resolve.");
             }
         }

--- a/FUSE/Loading/FuseAssetPackRegistry.LegacyDefinitionOverrides.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.LegacyDefinitionOverrides.cs
@@ -1,0 +1,551 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using AssetPack.Runtime;
+using Model.Definition;
+using Model.Database;
+using Newtonsoft.Json.Linq;
+using FUSE.Infrastructure;
+
+namespace FUSE.Loading
+{
+    internal static partial class FuseAssetPackRegistry
+    {
+        private const string FuseDefinitionOverridesProperty = "FuseDefinitionOverrides";
+
+        private static readonly object LegacyDefinitionOverrideLock = new object();
+        private static Dictionary<string, FuseLegacyDefinitionOverrideRegistration>
+            LegacyDefinitionOverridesByStore =
+                new Dictionary<string, FuseLegacyDefinitionOverrideRegistration>(StringComparer.Ordinal);
+        private static string[] LegacyDefinitionOverrideIssues = Array.Empty<string>();
+        private static readonly HashSet<string> LoggedLegacyDefinitionOverrideLoads =
+            new HashSet<string>(StringComparer.Ordinal);
+        private static readonly HashSet<string> LoggedLegacyDefinitionOverrideFailures =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Rebuilds the FUSE-owned equivalent of AssetLoader's definitions-only
+        /// child-folder routing. A folder containing Catalog.json remains a normal
+        /// store. An immediate child containing only Definitions.json targets the
+        /// existing store whose identifier equals the child folder name.
+        /// Native packages can opt into nested or differently named files through
+        /// Info.json/FuseDefinitionOverrides.
+        /// </summary>
+        private static void RefreshLegacyDefinitionOverrides()
+        {
+            var candidates = new List<FuseLegacyDefinitionOverrideRegistration>();
+            var issues = new List<string>();
+            var modsRoot = FuseDataPackageDiscovery.GetModsRoot();
+
+            if (!string.IsNullOrWhiteSpace(modsRoot) && Directory.Exists(modsRoot))
+            {
+                string[] packagePaths;
+                try
+                {
+                    packagePaths = Directory.GetDirectories(modsRoot)
+                        .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+                }
+                catch (Exception ex)
+                {
+                    packagePaths = Array.Empty<string>();
+                    issues.Add(
+                        $"Asset definition override discovery could not enumerate '{modsRoot}': " +
+                        ex.GetBaseException().Message);
+                }
+
+                foreach (var packagePath in packagePaths)
+                {
+                    if (!ShouldInspectPackage(packagePath))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        candidates.AddRange(
+                            DiscoverDefinitionOverrideCandidatesForPackage(packagePath, out var packageIssues));
+                        issues.AddRange(packageIssues);
+                    }
+                    catch (Exception ex)
+                    {
+                        issues.Add(
+                            $"Asset definition override discovery failed for package '{packagePath}': " +
+                            ex.GetBaseException().Message);
+                    }
+                }
+            }
+
+            var winners = SelectLegacyDefinitionOverrides(candidates, out var selectionIssues);
+            issues.AddRange(selectionIssues);
+
+            lock (LegacyDefinitionOverrideLock)
+            {
+                LegacyDefinitionOverridesByStore = winners;
+                LegacyDefinitionOverrideIssues = issues
+                    .Where(issue => !string.IsNullOrWhiteSpace(issue))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                LoggedLegacyDefinitionOverrideLoads.Clear();
+                LoggedLegacyDefinitionOverrideFailures.Clear();
+            }
+
+            if (winners.Count > 0)
+            {
+                FuseLog.Info(
+                    $"FUSE discovered {winners.Count} AssetLoader-compatible definition override(s); " +
+                    $"issues={issues.Count}.");
+            }
+        }
+
+        internal static FuseLegacyDefinitionOverrideRegistration[]
+            DiscoverDefinitionOverrideCandidatesForPackage(
+                string packagePath,
+                out string[] issues)
+        {
+            var result = new List<FuseLegacyDefinitionOverrideRegistration>();
+            var issueList = new List<string>();
+            if (string.IsNullOrWhiteSpace(packagePath) || !Directory.Exists(packagePath))
+            {
+                issues = Array.Empty<string>();
+                return Array.Empty<FuseLegacyDefinitionOverrideRegistration>();
+            }
+
+            var packageRoot = Path.GetFullPath(packagePath);
+            var packageId = TryReadPackageId(packageRoot) ?? Path.GetFileName(packageRoot);
+            var infoPath = Path.Combine(packageRoot, "Info.json");
+            if (!File.Exists(infoPath))
+            {
+                var lowerInfoPath = Path.Combine(packageRoot, "info.json");
+                if (File.Exists(lowerInfoPath))
+                {
+                    infoPath = lowerInfoPath;
+                }
+            }
+
+            if (File.Exists(infoPath))
+            {
+                try
+                {
+                    var info = FuseLegacyDataConverter.ReadLegacyObject(infoPath);
+                    AppendExplicitDefinitionOverrideCandidates(
+                        packageRoot,
+                        packageId,
+                        info[FuseDefinitionOverridesProperty],
+                        result,
+                        issueList);
+                }
+                catch (Exception ex)
+                {
+                    issueList.Add(
+                        $"Package '{packageId}' could not parse '{infoPath}' while reading " +
+                        $"{FuseDefinitionOverridesProperty}: {ex.GetBaseException().Message}");
+                }
+            }
+
+            // Preserve AssetLoader 1.0.1's implicit convention exactly: only
+            // immediate child folders, only when Catalog.json is absent.
+            foreach (var child in Directory.GetDirectories(packageRoot)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+            {
+                var definitionsPath = Path.Combine(child, "Definitions.json");
+                if (File.Exists(Path.Combine(child, "Catalog.json")) ||
+                    !File.Exists(definitionsPath))
+                {
+                    continue;
+                }
+
+                result.Add(new FuseLegacyDefinitionOverrideRegistration
+                {
+                    StoreIdentifier = Path.GetFileName(child),
+                    DefinitionsPath = Path.GetFullPath(definitionsPath),
+                    PackageId = packageId,
+                    PackagePath = packageRoot,
+                    Explicit = false
+                });
+            }
+
+            issues = issueList.ToArray();
+            return result
+                .GroupBy(
+                    item => item.StoreIdentifier + "\0" + item.DefinitionsPath,
+                    StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.OrderByDescending(item => item.Explicit).First())
+                .ToArray();
+        }
+
+        private static void AppendExplicitDefinitionOverrideCandidates(
+            string packageRoot,
+            string packageId,
+            JToken token,
+            ICollection<FuseLegacyDefinitionOverrideRegistration> result,
+            ICollection<string> issues)
+        {
+            if (token == null || token.Type == JTokenType.Null)
+            {
+                return;
+            }
+
+            if (token.Type == JTokenType.Array)
+            {
+                foreach (var item in token.Children())
+                {
+                    AppendExplicitDefinitionOverrideCandidates(
+                        packageRoot,
+                        packageId,
+                        item,
+                        result,
+                        issues);
+                }
+                return;
+            }
+
+            string storeIdentifier = null;
+            string relativePath = null;
+            if (token.Type == JTokenType.String)
+            {
+                relativePath = (string)token;
+            }
+            else if (token is JObject obj)
+            {
+                storeIdentifier =
+                    (string)obj["StoreIdentifier"] ??
+                    (string)obj["storeIdentifier"] ??
+                    (string)obj["Identifier"] ??
+                    (string)obj["identifier"];
+                relativePath =
+                    (string)obj["Path"] ??
+                    (string)obj["path"] ??
+                    (string)obj["DefinitionsPath"] ??
+                    (string)obj["definitionsPath"];
+            }
+
+            if (string.IsNullOrWhiteSpace(relativePath))
+            {
+                issues.Add(
+                    $"Package '{packageId}' has a {FuseDefinitionOverridesProperty} entry " +
+                    "without a non-empty Path.");
+                return;
+            }
+
+            string fullPath;
+            try
+            {
+                fullPath = Path.GetFullPath(Path.Combine(packageRoot, relativePath.Trim()));
+                if (Directory.Exists(fullPath))
+                {
+                    fullPath = Path.Combine(fullPath, "Definitions.json");
+                }
+            }
+            catch (Exception ex)
+            {
+                issues.Add(
+                    $"Package '{packageId}' has invalid definition override path " +
+                    $"'{relativePath}': {ex.GetBaseException().Message}");
+                return;
+            }
+
+            if (!IsPathWithinPackage(packageRoot, fullPath))
+            {
+                issues.Add(
+                    $"Package '{packageId}' definition override path '{relativePath}' " +
+                    "escapes the package folder and was ignored.");
+                return;
+            }
+
+            if (!File.Exists(fullPath))
+            {
+                issues.Add(
+                    $"Package '{packageId}' definition override file was not found: '{fullPath}'.");
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(storeIdentifier))
+            {
+                storeIdentifier = Path.GetFileName(Path.GetDirectoryName(fullPath));
+            }
+
+            if (string.IsNullOrWhiteSpace(storeIdentifier))
+            {
+                issues.Add(
+                    $"Package '{packageId}' could not infer a target store for '{relativePath}'.");
+                return;
+            }
+
+            result.Add(new FuseLegacyDefinitionOverrideRegistration
+            {
+                StoreIdentifier = storeIdentifier.Trim(),
+                DefinitionsPath = fullPath,
+                PackageId = packageId,
+                PackagePath = packageRoot,
+                Explicit = true
+            });
+        }
+
+        private static bool IsPathWithinPackage(string packageRoot, string candidatePath)
+        {
+            var normalizedRoot = Path.GetFullPath(packageRoot)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
+                Path.DirectorySeparatorChar;
+            var normalizedCandidate = Path.GetFullPath(candidatePath);
+            return normalizedCandidate.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static Dictionary<string, FuseLegacyDefinitionOverrideRegistration>
+            SelectLegacyDefinitionOverrides(
+                IEnumerable<FuseLegacyDefinitionOverrideRegistration> candidates,
+                out string[] issues)
+        {
+            var winners = new Dictionary<string, FuseLegacyDefinitionOverrideRegistration>(
+                StringComparer.Ordinal);
+            var issueList = new List<string>();
+
+            foreach (var candidate in (candidates ??
+                    Enumerable.Empty<FuseLegacyDefinitionOverrideRegistration>())
+                .Where(item => item != null &&
+                               !string.IsNullOrWhiteSpace(item.StoreIdentifier) &&
+                               !string.IsNullOrWhiteSpace(item.DefinitionsPath))
+                .OrderByDescending(item => item.Explicit)
+                .ThenBy(item => item.PackagePath, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(item => item.DefinitionsPath, StringComparer.OrdinalIgnoreCase))
+            {
+                if (!winners.TryGetValue(candidate.StoreIdentifier, out var existing))
+                {
+                    winners[candidate.StoreIdentifier] = candidate;
+                    continue;
+                }
+
+                if (string.Equals(
+                        existing.DefinitionsPath,
+                        candidate.DefinitionsPath,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                issueList.Add(
+                    $"Multiple packages target asset store '{candidate.StoreIdentifier}'. " +
+                    $"FUSE selected '{existing.DefinitionsPath}' from '{existing.PackageId}' and " +
+                    $"ignored '{candidate.DefinitionsPath}' from '{candidate.PackageId}'.");
+            }
+
+            issues = issueList.ToArray();
+            return winners;
+        }
+
+        private static void ValidateLegacyDefinitionOverrideTargets(PrefabStore prefabStore)
+        {
+            HashSet<string> storeIdentifiers;
+            try
+            {
+                storeIdentifiers = new HashSet<string>(StringComparer.Ordinal);
+                if (PrefabStoreStoresField?.GetValue(prefabStore) is System.Collections.IEnumerable stores)
+                {
+                    foreach (var item in stores)
+                    {
+                        if (item is AssetPackRuntimeStore store &&
+                            !string.IsNullOrWhiteSpace(store.Identifier))
+                        {
+                            storeIdentifiers.Add(store.Identifier);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                AddLegacyDefinitionOverrideIssue(
+                    "FUSE could not validate asset definition override targets: " +
+                    ex.GetBaseException().Message);
+                return;
+            }
+
+            foreach (var registration in GetLegacyDefinitionOverrides())
+            {
+                if (!storeIdentifiers.Contains(registration.StoreIdentifier))
+                {
+                    AddLegacyDefinitionOverrideIssue(
+                        $"Package '{registration.PackageId}' supplies definitions for asset store " +
+                        $"'{registration.StoreIdentifier}', but no store with that exact identifier is installed.");
+                }
+            }
+        }
+
+        private static int InvalidateLegacyDefinitionOverrideTargetContainers(PrefabStore prefabStore)
+        {
+            var targets = new HashSet<string>(
+                GetLegacyDefinitionOverrides().Select(item => item.StoreIdentifier),
+                StringComparer.Ordinal);
+            if (targets.Count == 0 || prefabStore == null || PrefabStoreStoresField == null)
+            {
+                return 0;
+            }
+
+            var invalidated = 0;
+            try
+            {
+                if (PrefabStoreStoresField.GetValue(prefabStore) is System.Collections.IEnumerable stores)
+                {
+                    foreach (var item in stores)
+                    {
+                        if (item is AssetPackRuntimeStore store && targets.Contains(store.Identifier))
+                        {
+                            RuntimeStoreContainerField?.SetValue(store, null);
+                            invalidated++;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                AddLegacyDefinitionOverrideIssue(
+                    "FUSE could not invalidate original containers before applying asset definition overrides: " +
+                    ex.GetBaseException().Message);
+            }
+
+            return invalidated;
+        }
+
+        internal static bool TryLoadLegacyDefinitionOverrideContainer(
+            AssetPackRuntimeStore store,
+            out Container container)
+        {
+            container = null;
+            if (store == null || string.IsNullOrWhiteSpace(store.Identifier))
+            {
+                return false;
+            }
+
+            FuseLegacyDefinitionOverrideRegistration registration;
+            lock (LegacyDefinitionOverrideLock)
+            {
+                if (!LegacyDefinitionOverridesByStore.TryGetValue(
+                        store.Identifier,
+                        out registration))
+                {
+                    return false;
+                }
+            }
+
+            try
+            {
+                var cached = RuntimeStoreContainerField?.GetValue(store) as Container;
+                if (cached != null)
+                {
+                    container = cached;
+                    return true;
+                }
+
+                var sourceText = File.ReadAllText(registration.DefinitionsPath);
+                var droppedByKind = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                container = LoadResilientDirectContainer(
+                    sourceText,
+                    store.Identifier,
+                    droppedByKind);
+                if (container == null)
+                {
+                    throw new InvalidDataException("Definitions deserialized to null.");
+                }
+
+                SanitizeDeserializedDirectContainer(container);
+                RuntimeStoreContainerField?.SetValue(store, container);
+                RecordMissingComponentKinds(store.Identifier, droppedByKind.Keys);
+
+                lock (LegacyDefinitionOverrideLock)
+                {
+                    if (LoggedLegacyDefinitionOverrideLoads.Add(store.Identifier))
+                    {
+                        var dropped = droppedByKind.Count == 0
+                            ? string.Empty
+                            : " Unbindable components dropped: " + string.Join(
+                                ", ",
+                                droppedByKind.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)
+                                    .Select(item => item.Key + "=" + item.Value)) + ".";
+                        FuseLog.Info(
+                            $"FUSE applied AssetLoader-compatible definitions for store " +
+                            $"'{store.Identifier}' from '{registration.DefinitionsPath}'.{dropped}");
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                var message =
+                    $"Package '{registration.PackageId}' could not apply asset definitions " +
+                    $"for store '{store.Identifier}' from '{registration.DefinitionsPath}': " +
+                    $"{ex.GetBaseException().GetType().Name}: {ex.GetBaseException().Message}. " +
+                    "FUSE kept the store's original definitions so other equipment and menus remain usable.";
+                AddLegacyDefinitionOverrideIssue(message);
+
+                lock (LegacyDefinitionOverrideLock)
+                {
+                    if (LoggedLegacyDefinitionOverrideFailures.Add(store.Identifier))
+                    {
+                        FuseLog.Warning(message);
+                    }
+                }
+
+                container = null;
+                return false;
+            }
+        }
+
+        private static void AddLegacyDefinitionOverrideIssue(string issue)
+        {
+            if (string.IsNullOrWhiteSpace(issue))
+            {
+                return;
+            }
+
+            lock (LegacyDefinitionOverrideLock)
+            {
+                if (!LegacyDefinitionOverrideIssues.Contains(issue, StringComparer.Ordinal))
+                {
+                    LegacyDefinitionOverrideIssues = LegacyDefinitionOverrideIssues
+                        .Concat(new[] { issue })
+                        .ToArray();
+                }
+            }
+        }
+
+        internal static FuseLegacyDefinitionOverrideRegistration[] GetLegacyDefinitionOverrides()
+        {
+            lock (LegacyDefinitionOverrideLock)
+            {
+                return LegacyDefinitionOverridesByStore.Values
+                    .OrderBy(item => item.StoreIdentifier, StringComparer.Ordinal)
+                    .ToArray();
+            }
+        }
+
+        internal static string[] GetLegacyDefinitionOverrideIssues()
+        {
+            lock (LegacyDefinitionOverrideLock)
+            {
+                return LegacyDefinitionOverrideIssues.ToArray();
+            }
+        }
+
+        private static void ResetLegacyDefinitionOverrides()
+        {
+            lock (LegacyDefinitionOverrideLock)
+            {
+                LegacyDefinitionOverridesByStore =
+                    new Dictionary<string, FuseLegacyDefinitionOverrideRegistration>(StringComparer.Ordinal);
+                LegacyDefinitionOverrideIssues = Array.Empty<string>();
+                LoggedLegacyDefinitionOverrideLoads.Clear();
+                LoggedLegacyDefinitionOverrideFailures.Clear();
+            }
+        }
+    }
+
+    internal sealed class FuseLegacyDefinitionOverrideRegistration
+    {
+        public string StoreIdentifier { get; set; }
+        public string DefinitionsPath { get; set; }
+        public string PackageId { get; set; }
+        public string PackagePath { get; set; }
+        public bool Explicit { get; set; }
+    }
+}

--- a/FUSE/Loading/FuseAssetPackRegistry.Mounting.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.Mounting.cs
@@ -312,6 +312,14 @@ namespace FUSE.Loading
             // modern saves on the modern bundle.
             var scAssetPacks = Path.Combine(packagePath, "SCAssetPacks");
 
+            // AssetLoader also accepts Catalog.json directly in the UMM
+            // package root and registers it under the package id. This shape
+            // is uncommon but is part of its observable contract.
+            if (IsAssetPackFolder(packagePath))
+            {
+                yield return packagePath;
+            }
+
             foreach (var folder in EnumerateRootAssetPackFolders(packagePath, scAssetPacks))
             {
                 yield return folder;
@@ -385,8 +393,14 @@ namespace FUSE.Loading
 
         private static bool IsAssetPackFolder(string folderPath)
         {
-            return File.Exists(Path.Combine(folderPath, "Bundle")) &&
-                   File.Exists(Path.Combine(folderPath, "Catalog.json"));
+            // AssetLoader's public wire contract is Catalog.json, not Bundle.
+            // Several real rolling-stock packages publish definitions-only or
+            // catalog-plus-definitions stores whose assets live in another pack.
+            // Requiring Bundle here made FUSE silently skip those stores while
+            // still appearing to replace AssetLoader. If a catalog actually
+            // references a missing local bundle, the normal per-asset load and
+            // bundle audit paths report that problem when the asset is requested.
+            return File.Exists(Path.Combine(folderPath, "Catalog.json"));
         }
 
         private static int MountAssetPackFolder(string sourcePath)

--- a/FUSE/Loading/FuseAssetPackRegistry.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.cs
@@ -64,6 +64,11 @@ namespace FUSE.Loading
             new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private static readonly HashSet<string> SanitizedDirectContainerWarnings =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private static readonly object LateComponentRegistrationLock = new object();
+        private static readonly Dictionary<string, HashSet<string>> StoresMissingComponentKind =
+            new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly HashSet<string> StoresRequiringLateComponentReload =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private static readonly object LegacyAssetPackAliasLock = new object();
         private static Dictionary<string, string> LegacyAssetPackAliases;
         // Physical pack folder -> identifier of the store PrefabStore will
@@ -174,6 +179,11 @@ namespace FUSE.Loading
             _mountComplete = false;
             MountedAssetPackSourcesById.Clear();
             DirectAssetPackStoreIdentifiers.Clear();
+            lock (LateComponentRegistrationLock)
+            {
+                StoresMissingComponentKind.Clear();
+                StoresRequiringLateComponentReload.Clear();
+            }
             lock (LegacyAssetPackAliasLock)
             {
                 hadState |= StoreIdentifiersByPhysicalPath.Count > 0 || LegacyAssetPackAliases != null;
@@ -186,6 +196,7 @@ namespace FUSE.Loading
                 CatalogInspectionFailures.Clear();
             }
             FuseLegacyContainerMixintoRegistry.Reset();
+            ResetLegacyDefinitionOverrides();
             FuseAssetCollisionRegistry.Reset();
             FUSE.Runtime.API.SceneryAPI.InvalidateKnownSceneryIdentifierIndex();
             if (hadState)
@@ -214,7 +225,9 @@ namespace FUSE.Loading
         {
             var folders = EnumerateAvailableAssetPackFolders().ToArray();
             var firstSourceByKey = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var firstDefinitionByKey = new Dictionary<string, JObject>(StringComparer.OrdinalIgnoreCase);
             var duplicateKeys = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            var duplicateDefinitionsDiffer = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
             var failedLookups = new List<string>();
 
             foreach (var folder in folders)
@@ -245,6 +258,7 @@ namespace FUSE.Loading
                         if (!firstSourceByKey.TryGetValue(key, out var existing))
                         {
                             firstSourceByKey[key] = folder;
+                            firstDefinitionByKey[key] = obj;
                             continue;
                         }
 
@@ -257,6 +271,13 @@ namespace FUSE.Loading
                         if (!sources.Contains(folder, StringComparer.OrdinalIgnoreCase))
                         {
                             sources.Add(folder);
+                        }
+
+                        if (!duplicateDefinitionsDiffer.TryGetValue(key, out var definitionsDiffer) || !definitionsDiffer)
+                        {
+                            duplicateDefinitionsDiffer[key] =
+                                !firstDefinitionByKey.TryGetValue(key, out var firstDefinition) ||
+                                !JToken.DeepEquals(firstDefinition, obj);
                         }
                     }
                 }
@@ -275,11 +296,48 @@ namespace FUSE.Loading
                     .Select(item => new FuseDuplicateAssetKey
                     {
                         Key = item.Key,
-                        Sources = item.Value.Select(Path.GetFileName).ToArray()
+                        Sources = item.Value.Select(DescribeAssetPackSource).ToArray(),
+                        DefinitionsDiffer = duplicateDefinitionsDiffer.TryGetValue(item.Key, out var differ) && differ
                     })
                     .ToArray(),
-                FailedDefinitionLoads = failedLookups.ToArray()
+                FailedDefinitionLoads = failedLookups.ToArray(),
+                LegacyDefinitionOverrides = GetLegacyDefinitionOverrides(),
+                LegacyDefinitionOverrideIssues = GetLegacyDefinitionOverrideIssues()
             };
+        }
+
+        private static string DescribeAssetPackSource(string folder)
+        {
+            if (string.IsNullOrWhiteSpace(folder))
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                var packageFolder = ReadHostingPackageFolder(folder);
+                if (!string.IsNullOrWhiteSpace(packageFolder))
+                {
+                    var packageName = Path.GetFileName(packageFolder);
+                    var relative = folder.Substring(packageFolder.Length)
+                        .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                        .Replace(Path.DirectorySeparatorChar, '/');
+                    return string.IsNullOrWhiteSpace(relative)
+                        ? packageName
+                        : packageName + "/" + relative;
+                }
+            }
+            catch (Exception ex)
+            {
+                // Diagnostics must never make an otherwise usable asset pack
+                // fail to load, but retaining the reason avoids hiding a path
+                // or permissions problem from the live log.
+                FuseLog.Warning(
+                    $"FUSE could not build a package-relative asset source label for '{folder}': " +
+                    ex.GetBaseException().Message);
+            }
+
+            return Path.GetFileName(folder);
         }
     }
 
@@ -289,11 +347,15 @@ namespace FUSE.Loading
         public int UniqueAssetKeys { get; set; }
         public FuseDuplicateAssetKey[] DuplicateKeys { get; set; } = Array.Empty<FuseDuplicateAssetKey>();
         public string[] FailedDefinitionLoads { get; set; } = Array.Empty<string>();
+        public FuseLegacyDefinitionOverrideRegistration[] LegacyDefinitionOverrides { get; set; } =
+            Array.Empty<FuseLegacyDefinitionOverrideRegistration>();
+        public string[] LegacyDefinitionOverrideIssues { get; set; } = Array.Empty<string>();
     }
 
     internal sealed class FuseDuplicateAssetKey
     {
         public string Key { get; set; } = string.Empty;
         public string[] Sources { get; set; } = Array.Empty<string>();
+        public bool DefinitionsDiffer { get; set; }
     }
 }

--- a/FUSE/Loading/FuseDataPackageDiscovery.cs
+++ b/FUSE/Loading/FuseDataPackageDiscovery.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using FUSE.Authoring.Data;
 using FUSE.Infrastructure;
 using FUSE.Runtime.Lifecycle;
 using Newtonsoft.Json;
@@ -95,6 +96,8 @@ namespace FUSE.Loading
                     Priority = manifest.Priority,
                     LoadAfter = manifest.LoadAfter ?? Array.Empty<string>(),
                     LoadBefore = manifest.LoadBefore ?? Array.Empty<string>(),
+                    RequiredPackageIds = manifest.RequiredPackageIds ?? Array.Empty<string>(),
+                    ConflictsWith = manifest.ConflictsWith ?? Array.Empty<FuseModRequirement>(),
                     Disabled = manifest.Disabled,
                     DisabledReason = manifest.DisabledReason ?? string.Empty,
                     IsLegacyConverted = manifest.IsLegacyDataPackage,
@@ -168,9 +171,36 @@ namespace FUSE.Loading
 
                 if (manifest.HasBlockingFaults)
                 {
-                    foreach (var fault in manifest.Faults)
+                    if (manifest.ManifestReadException != null)
                     {
-                        FusePackageFaultRegistry.RecordFault(manifest.Id, "dependency/load-order", fault);
+                        FusePackageFaultRegistry.RecordFault(
+                            manifest.Id,
+                            "manifest JSON",
+                            manifest.Faults.FirstOrDefault() ?? manifest.ManifestReadException.GetBaseException().Message,
+                            manifest.ManifestReadException,
+                            manifest.FolderPath,
+                            manifest.ManifestPath,
+                            packageName: manifest.DisplayName,
+                            expectedShape: "A valid Info.json or Definition.json package manifest.",
+                            receivedValue: manifest.ManifestReadException.GetBaseException().Message);
+                    }
+                    else
+                    {
+                        foreach (var fault in manifest.Faults)
+                        {
+                            FusePackageFaultRegistry.RecordFault(
+                                manifest.Id,
+                                "dependency/load-order",
+                                fault,
+                                null,
+                                manifest.FolderPath,
+                                manifest.ManifestPath,
+                                InferManifestFaultJsonPath(manifest, fault),
+                                suggestedAction: SuggestedActionForManifestFault(fault),
+                                packageName: manifest.DisplayName,
+                                expectedShape: "Package dependency and load-order declarations accepted by FUSE.",
+                                receivedValue: fault);
+                        }
                     }
 
                     FusePackageFaultRegistry.MarkSkipped(manifest.Id, "dependency/load-order fault");
@@ -178,6 +208,7 @@ namespace FUSE.Loading
                     continue;
                 }
 
+                var faultCountBeforeLoad = FusePackageFaultRegistry.FaultCount;
                 try
                 {
                     var packageStopwatch = Stopwatch.StartNew();
@@ -187,7 +218,7 @@ namespace FUSE.Loading
                     }
                     else
                     {
-                        FuseModLoader.LoadMod(packagePath);
+                        FuseModLoader.LoadMod(packagePath, manifest.Id);
                     }
                     FusePackageFaultRegistry.MarkLoadedFromDisk(manifest.Id);
                     FuseLog.Info($"FUSE loaded package '{Path.GetFileName(packagePath)}' id='{manifest.Id}' from disk into resident definitions in {packageStopwatch.ElapsedMilliseconds} ms. Runtime apply has not run in this step.");
@@ -195,7 +226,15 @@ namespace FUSE.Loading
                 }
                 catch (Exception ex)
                 {
-                    FusePackageFaultRegistry.RecordFault(manifest.Id, "deserialization", ex.Message, ex);
+                    if (FusePackageFaultRegistry.FaultCount == faultCountBeforeLoad)
+                    {
+                        FusePackageFaultRegistry.RecordFault(
+                            manifest.Id,
+                            "package load",
+                            ex.GetBaseException().Message,
+                            ex,
+                            packagePath);
+                    }
                     FusePackageFaultRegistry.MarkSkipped(manifest.Id, "deserialization failed");
                     FuseLog.Exception($"Failed to deserialize FUSE data package '{packagePath}' from disk", ex);
                 }
@@ -268,6 +307,7 @@ namespace FUSE.Loading
 
         public static void ResetDiscovery()
         {
+            FuseLegacyCapabilityActivation.Reset();
             if (!_discoveryComplete && !_definitionsLoadedFromDisk && _discoveredPackageFolders.Length == 0)
             {
                 return;
@@ -338,14 +378,29 @@ namespace FUSE.Loading
             JObject info;
             try
             {
-                info = FuseLegacyDataConverter.ReadLegacyObject(infoPath);
+                info = FuseLegacyDataConverter.ReadManifestObject(infoPath);
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
             {
                 // A malformed Info.json is an authoring error in a FUSE/UMM package, not a signal to
                 // reinterpret the folder as a legacy data package. Surface the parse failure and stop.
                 FuseLog.Exception($"FUSE ignored package '{folderPath}' because Info.json could not be parsed", ex);
-                return false;
+                if (!LooksLikeFusePackageWithBrokenInfo(folderPath))
+                {
+                    return false;
+                }
+
+                var fallbackId = Path.GetFileName(folderPath);
+                manifest = new FusePackageManifest
+                {
+                    Id = fallbackId,
+                    DisplayName = fallbackId,
+                    FolderPath = folderPath,
+                    ManifestPath = infoPath,
+                    ManifestReadException = ex
+                };
+                manifest.Faults.Add(ex.GetBaseException().Message);
+                return true;
             }
 
             var id = ((string)info["Id"] ?? Path.GetFileName(folderPath)).Trim();
@@ -354,10 +409,11 @@ namespace FUSE.Loading
                 return false;
             }
 
-            var hasExplicitDataFiles = HasFuseDataFile(info["FuseDataFile"]) ||
-                HasFuseDataFile(info["FuseDataFiles"]);
-            var isAssetPackOnly = HasFuseAssetPacks(info) && !hasExplicitDataFiles;
-            var isDataPackage = hasExplicitDataFiles ||
+            var dataFileToken = info["FuseDataFile"] ?? info["FuseDataFiles"];
+            var declaresDataFiles = dataFileToken != null;
+            var hasExplicitDataFiles = HasFuseDataFile(dataFileToken);
+            var isAssetPackOnly = HasFuseAssetPacks(info) && !declaresDataFiles;
+            var isDataPackage = declaresDataFiles ||
                 (!isAssetPackOnly && HasRootDefinitionFile(folderPath) && (ContainsFuseReference(info["Requirements"]) || ContainsFuseReference(info["LoadAfter"])));
             if (!isDataPackage)
             {
@@ -384,13 +440,20 @@ namespace FUSE.Loading
                 DisplayName = ((string)info["DisplayName"] ?? (string)info["Name"] ?? (string)info["name"] ?? id ?? string.Empty).Trim(),
                 Version = ((string)info["Version"] ?? (string)info["version"] ?? string.Empty).Trim(),
                 FolderPath = folderPath,
+                ManifestPath = infoPath,
                 Priority = ReadPriority(info["FuseLoadPriority"]),
                 RequiredPackageIds = ReadDependencyIds(info["FuseRequires"]),
                 LoadAfter = ReadDependencyIds(info["FuseLoadAfter"]),
                 LoadBefore = ReadDependencyIds(info["FuseLoadBefore"]),
+                ConflictsWith = ReadPackageReferences(info["FuseConflictsWith"]),
                 Disabled = disabled,
                 DisabledReason = disabledReason
             };
+            if (declaresDataFiles && !hasExplicitDataFiles)
+            {
+                manifest.Faults.Add(
+                    "Info.json field 'FuseDataFile'/'FuseDataFiles' must be a non-empty file name or an array of non-empty file names.");
+            }
             return true;
         }
 
@@ -423,15 +486,88 @@ namespace FUSE.Loading
                 DisplayName = legacy.DisplayName ?? id,
                 Version = legacy.Version ?? string.Empty,
                 FolderPath = folderPath,
+                ManifestPath = Path.Combine(folderPath, "Definition.json"),
                 Priority = ReadPriority(info?["FuseLoadPriority"]),
                 RequiredPackageIds = legacy.RequiredPackageIds ?? Array.Empty<string>(),
                 LoadAfter = legacy.LoadAfter ?? Array.Empty<string>(),
                 LoadBefore = ReadDependencyIds(info?["FuseLoadBefore"]),
+                ConflictsWith = legacy.ConflictsWith ?? Array.Empty<FuseModRequirement>(),
                 Disabled = disabled,
                 DisabledReason = disabledReason,
                 IsLegacyDataPackage = true
             };
             return true;
+        }
+
+        private static bool LooksLikeFusePackageWithBrokenInfo(string folderPath)
+        {
+            try
+            {
+                return File.Exists(Path.Combine(folderPath, "Definition.json")) ||
+                       Directory.GetFiles(folderPath, "*.fuse.json", SearchOption.TopDirectoryOnly).Length > 0 ||
+                       Directory.GetFiles(folderPath, "*.bson", SearchOption.TopDirectoryOnly).Length > 0;
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                FuseLog.Exception($"FUSE could not inspect malformed package folder '{folderPath}'", ex);
+                return false;
+            }
+        }
+
+        private static string InferManifestFaultJsonPath(FusePackageManifest manifest, string message)
+        {
+            if (message?.IndexOf("requires", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return manifest != null && manifest.IsLegacyDataPackage ? "requires" : "FuseRequires";
+            }
+
+            if (message?.IndexOf("LoadAfter", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return manifest != null && manifest.IsLegacyDataPackage ? "loadAfter" : "FuseLoadAfter";
+            }
+
+            if (message?.IndexOf("LoadBefore", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return manifest != null && manifest.IsLegacyDataPackage ? "loadBefore" : "FuseLoadBefore";
+            }
+
+            if (message?.IndexOf("conflictsWith", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return manifest != null && manifest.IsLegacyDataPackage ? "conflictsWith" : "FuseConflictsWith";
+            }
+
+            if (message?.IndexOf("FuseDataFile", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return "FuseDataFiles";
+            }
+
+            return string.Empty;
+        }
+
+        private static string SuggestedActionForManifestFault(string message)
+        {
+            if (message?.IndexOf("FuseDataFile", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return "Correct the FuseDataFile/FuseDataFiles value in Info.json, then reload package discovery.";
+            }
+
+            if (message?.IndexOf("requires", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return "Install and enable the named dependency, or correct this package's required dependency id.";
+            }
+
+            if (message?.IndexOf("LoadAfter", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                message?.IndexOf("LoadBefore", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return "Correct the load-order id or install and enable the referenced package.";
+            }
+
+            if (message?.IndexOf("conflictsWith", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return "Disable one of the author-declared incompatible packages, or correct the conflictsWith declaration if the packages are compatible.";
+            }
+
+            return "Correct the reported package manifest problem, then reload package discovery.";
         }
 
         private static IReadOnlyList<FusePackageManifest> SortPackages(IReadOnlyList<FusePackageManifest> packages)
@@ -441,7 +577,7 @@ namespace FUSE.Loading
                 .ThenBy(package => package.Id, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(package => package.FolderPath, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
-            if (fallbackOrder.Length <= 1)
+            if (fallbackOrder.Length == 0)
             {
                 return fallbackOrder;
             }
@@ -460,6 +596,52 @@ namespace FUSE.Loading
                 FuseLog.Warning($"FUSE {message}");
             }
 
+            var installedMods = FuseModRequirementResolver.CollectInstalledMods();
+            foreach (var package in fallbackOrder)
+            {
+                foreach (var conflict in package.ConflictsWith ?? Array.Empty<FuseModRequirement>())
+                {
+                    string conflictingId;
+                    string conflictingVersion;
+                    string conflictingSource;
+                    if (TryResolvePackage(byId, conflict?.Id, out var conflictingPackage) &&
+                        !ReferenceEquals(package, conflictingPackage) &&
+                        IsDeclaredConflictMatch(
+                            conflict,
+                            conflictingPackage.Id,
+                            conflictingPackage.Version,
+                            conflictingPackage.Disabled))
+                    {
+                        conflictingId = conflictingPackage.Id;
+                        conflictingVersion = conflictingPackage.Version;
+                        conflictingSource = "discovered data package";
+                    }
+                    else if (TryMatchInstalledConflict(
+                                 package.Id,
+                                 package.FolderPath,
+                                 conflict,
+                                 installedMods,
+                                 out var installed))
+                    {
+                        conflictingId = installed.Id;
+                        conflictingVersion = installed.Version;
+                        conflictingSource = installed.Source;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+
+                    var bounds = FormatVersionBounds(conflict);
+                    var message =
+                        $"Package '{package.Id}' conflictsWith '{conflict.Id}'{bounds}; " +
+                        $"matching package '{conflictingId}' version '{conflictingVersion}' is enabled " +
+                        $"(source: {conflictingSource}).";
+                    package.Faults.Add(message);
+                    FuseLog.Warning($"FUSE {message}");
+                }
+            }
+
             var outgoing = fallbackOrder.ToDictionary(package => package, _ => new HashSet<FusePackageManifest>());
             var incomingCount = fallbackOrder.ToDictionary(package => package, _ => 0);
 
@@ -467,7 +649,7 @@ namespace FUSE.Loading
             {
                 foreach (var dependencyId in package.RequiredPackageIds)
                 {
-                    if (byId.TryGetValue(dependencyId, out var dependency))
+                    if (TryResolvePackage(byId, dependencyId, out var dependency))
                     {
                         if (dependency.Disabled)
                         {
@@ -478,6 +660,14 @@ namespace FUSE.Loading
                         }
 
                         AddPackageOrderEdge(dependency, package, outgoing, incomingCount);
+                        continue;
+                    }
+
+                    if (FuseReplacementCapabilityCatalog.IsProvided(dependencyId))
+                    {
+                        FuseLog.Info(
+                            $"FUSE dependency '{dependencyId}' required by '{package.Id}' is supplied by the FUSE runtime; " +
+                            "the runtime initializes before data packages, so no package load-order edge was needed.");
                         continue;
                     }
 
@@ -496,7 +686,7 @@ namespace FUSE.Loading
 
                 foreach (var dependencyId in package.LoadAfter)
                 {
-                    if (byId.TryGetValue(dependencyId, out var dependency))
+                    if (TryResolvePackage(byId, dependencyId, out var dependency))
                     {
                         if (dependency.Disabled)
                         {
@@ -515,6 +705,12 @@ namespace FUSE.Loading
 
                         AddPackageOrderEdge(dependency, package, outgoing, incomingCount);
                     }
+                    else if (FuseReplacementCapabilityCatalog.IsProvided(dependencyId))
+                    {
+                        FuseLog.Info(
+                            $"FUSE loadAfter '{dependencyId}' declared by '{package.Id}' resolves to a FUSE runtime replacement; " +
+                            "the runtime is already initialized before this package.");
+                    }
                     else
                     {
                         var message = $"Package '{package.Id}' declares FuseLoadAfter '{dependencyId}', but no matching FUSE data package was discovered.";
@@ -532,7 +728,7 @@ namespace FUSE.Loading
 
                 foreach (var dependencyId in package.LoadBefore)
                 {
-                    if (byId.TryGetValue(dependencyId, out var dependency))
+                    if (TryResolvePackage(byId, dependencyId, out var dependency))
                     {
                         if (dependency.Disabled)
                         {
@@ -550,6 +746,14 @@ namespace FUSE.Loading
                         }
 
                         AddPackageOrderEdge(package, dependency, outgoing, incomingCount);
+                    }
+                    else if (FuseReplacementCapabilityCatalog.IsProvided(dependencyId))
+                    {
+                        var message =
+                            $"Package '{package.Id}' declares loadBefore '{dependencyId}', but '{dependencyId}' is a FUSE runtime replacement " +
+                            "that necessarily initializes before data packages.";
+                        package.Faults.Add(message);
+                        FuseLog.Warning($"FUSE {message}");
                     }
                     else
                     {
@@ -605,6 +809,117 @@ namespace FUSE.Loading
             return result;
         }
 
+        private static bool TryResolvePackage(
+            IReadOnlyDictionary<string, FusePackageManifest> packagesById,
+            string dependencyId,
+            out FusePackageManifest package)
+        {
+            package = null;
+            if (packagesById == null || string.IsNullOrWhiteSpace(dependencyId))
+            {
+                return false;
+            }
+
+            if (packagesById.TryGetValue(dependencyId.Trim(), out package))
+            {
+                return true;
+            }
+
+            package = packagesById.Values.FirstOrDefault(candidate =>
+                FuseDeclaredPackageRelationship.SamePackageId(candidate?.Id, dependencyId));
+            return package != null;
+        }
+
+        internal static bool IsDeclaredConflictMatch(
+            FuseModRequirement conflict,
+            string targetId,
+            string targetVersion,
+            bool targetDisabled)
+        {
+            if (conflict == null || string.IsNullOrWhiteSpace(conflict.Id) ||
+                string.IsNullOrWhiteSpace(targetId) || targetDisabled ||
+                !FuseDeclaredPackageRelationship.SamePackageId(conflict.Id, targetId))
+            {
+                return false;
+            }
+
+            var installed = new FuseModRequirementResolver.InstalledMod
+            {
+                Id = targetId,
+                Version = targetVersion ?? string.Empty,
+                Source = "discovered data package"
+            };
+            return FuseModRequirementResolver.VersionSatisfies(
+                "declared-conflict",
+                conflict,
+                installed,
+                out _);
+        }
+
+        internal static bool TryMatchInstalledConflict(
+            string declaringPackageId,
+            string declaringFolderPath,
+            FuseModRequirement conflict,
+            Dictionary<string, FuseModRequirementResolver.InstalledMod> installedMods,
+            out FuseModRequirementResolver.InstalledMod installed)
+        {
+            installed = null;
+            if (string.IsNullOrWhiteSpace(declaringPackageId) || conflict == null || string.IsNullOrWhiteSpace(conflict.Id) ||
+                !FuseModRequirementResolver.TryFindInstalled(conflict.Id, installedMods, out var candidate))
+            {
+                return false;
+            }
+
+            if (FuseDeclaredPackageRelationship.SamePackageId(declaringPackageId, candidate.Id) ||
+                (!string.IsNullOrWhiteSpace(declaringFolderPath) &&
+                 !string.IsNullOrWhiteSpace(candidate.FolderPath) &&
+                 string.Equals(
+                     NormalizePackagePath(declaringFolderPath),
+                     NormalizePackagePath(candidate.FolderPath),
+                     StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+
+            if (!candidate.IsReplacementCapability &&
+                !IsDeclaredConflictMatch(conflict, candidate.Id, candidate.Version, targetDisabled: false))
+            {
+                return false;
+            }
+
+            installed = candidate;
+            return true;
+        }
+
+        private static string NormalizePackagePath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                return Path.GetFullPath(path)
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+            catch
+            {
+                return path.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+        }
+
+        private static string FormatVersionBounds(FuseModRequirement reference)
+        {
+            if (reference == null ||
+                (string.IsNullOrWhiteSpace(reference.NotBefore) && string.IsNullOrWhiteSpace(reference.NotAfter)))
+            {
+                return string.Empty;
+            }
+
+            return $" (notBefore='{reference.NotBefore ?? string.Empty}', notAfter='{reference.NotAfter ?? string.Empty}')";
+        }
+
         private static void AddPackageOrderEdge(
             FusePackageManifest before,
             FusePackageManifest after,
@@ -655,6 +970,10 @@ namespace FUSE.Loading
                 .Select(id => id.Trim())
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
+            foreach (var dependencyId in wanted.Where(FuseReplacementCapabilityCatalog.IsProvided))
+            {
+                present.Add(dependencyId);
+            }
             if (wanted.Length == 0)
             {
                 return present;
@@ -712,6 +1031,11 @@ namespace FUSE.Loading
             if (string.IsNullOrWhiteSpace(dependencyId))
             {
                 return false;
+            }
+
+            if (FuseReplacementCapabilityCatalog.IsProvided(dependencyId))
+            {
+                return true;
             }
 
             var modsRoot = GetModsRoot();
@@ -881,6 +1205,35 @@ namespace FUSE.Loading
             return result
                 .Where(id => !string.IsNullOrWhiteSpace(id))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        private static FuseModRequirement[] ReadPackageReferences(JToken token)
+        {
+            if (token == null)
+            {
+                return Array.Empty<FuseModRequirement>();
+            }
+
+            IEnumerable<JToken> items = token.Type == JTokenType.Array
+                ? token.Children()
+                : new[] { token };
+            return items
+                .Select(item => item.Type == JTokenType.String
+                    ? new FuseModRequirement { Id = ((string)item)?.Trim() }
+                    : new FuseModRequirement
+                    {
+                        Id = ((string)item["Id"] ?? (string)item["id"])?.Trim(),
+                        NotBefore = ((string)item["NotBefore"] ?? (string)item["notBefore"])?.Trim(),
+                        NotAfter = ((string)item["NotAfter"] ?? (string)item["notAfter"])?.Trim()
+                    })
+                .Where(reference => !string.IsNullOrWhiteSpace(reference.Id))
+                .GroupBy(reference =>
+                    (reference.Id ?? string.Empty) + "\0" +
+                    (reference.NotBefore ?? string.Empty) + "\0" +
+                    (reference.NotAfter ?? string.Empty),
+                    StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
                 .ToArray();
         }
 
@@ -1083,10 +1436,13 @@ namespace FUSE.Loading
             public string DisplayName { get; set; }
             public string Version { get; set; }
             public string FolderPath { get; set; }
+            public string ManifestPath { get; set; } = string.Empty;
+            public Exception ManifestReadException { get; set; }
             public int Priority { get; set; }
             public string[] RequiredPackageIds { get; set; } = Array.Empty<string>();
             public string[] LoadAfter { get; set; } = Array.Empty<string>();
             public string[] LoadBefore { get; set; } = Array.Empty<string>();
+            public FuseModRequirement[] ConflictsWith { get; set; } = Array.Empty<FuseModRequirement>();
             public bool Disabled { get; set; }
             public string DisabledReason { get; set; } = string.Empty;
             public bool IsLegacyDataPackage { get; set; }
@@ -1106,10 +1462,17 @@ namespace FUSE.Loading
         public int Priority { get; set; }
         public string[] LoadAfter { get; set; } = Array.Empty<string>();
         public string[] LoadBefore { get; set; } = Array.Empty<string>();
+        public string[] RequiredPackageIds { get; set; } = Array.Empty<string>();
+        public FuseModRequirement[] ConflictsWith { get; set; } = Array.Empty<FuseModRequirement>();
         public bool Disabled { get; set; }
         public string DisabledReason { get; set; } = string.Empty;
         public bool IsLegacyConverted { get; set; }
         public bool IsLegacyHosted { get; set; }
         public string[] Faults { get; set; } = Array.Empty<string>();
+        public bool LoadedFromDisk { get; set; }
+        public bool AppliedToRuntime { get; set; }
+        public string SkipReason { get; set; } = string.Empty;
+        public string[] SkipReasons { get; set; } = Array.Empty<string>();
+        public string[] RuntimeFaults { get; set; } = Array.Empty<string>();
     }
 }

--- a/FUSE/Loading/FuseDeclaredPackageRelationship.cs
+++ b/FUSE/Loading/FuseDeclaredPackageRelationship.cs
@@ -1,0 +1,68 @@
+using FUSE.Authoring.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// Classifies an override as expected only when the resolved package graph
+    /// placed the overriding package after a package it explicitly requires or
+    /// names in loadAfter (or the base names it in loadBefore).
+    /// </summary>
+    internal static class FuseDeclaredPackageRelationship
+    {
+        internal static bool IsExpectedLaterOverride(
+            FusePackageManifestSnapshot existingPackage,
+            FusePackageManifestSnapshot laterPackage,
+            FuseModDefinition existingDefinition = null,
+            FuseModDefinition laterDefinition = null)
+        {
+            if (existingPackage == null || laterPackage == null ||
+                SamePackageId(existingPackage.Id, laterPackage.Id))
+            {
+                return false;
+            }
+
+            // Snapshot order is the final topological order. If both values are
+            // populated, do not call a contradicted declaration "expected".
+            if (existingPackage.Order > 0 && laterPackage.Order > 0 &&
+                laterPackage.Order <= existingPackage.Order)
+            {
+                return false;
+            }
+
+            return ContainsPackageId(laterPackage.RequiredPackageIds, existingPackage.Id) ||
+                   ContainsPackageId(laterPackage.LoadAfter, existingPackage.Id) ||
+                   ContainsPackageId(existingPackage.LoadBefore, laterPackage.Id) ||
+                   ContainsPackageId(
+                       laterDefinition?.Mixinto?.Requires?.Select(requirement => requirement?.Id),
+                       existingPackage.Id);
+        }
+
+        internal static bool ContainsPackageId(IEnumerable<string> values, string expected)
+        {
+            return !string.IsNullOrWhiteSpace(expected) &&
+                   (values ?? Enumerable.Empty<string>()).Any(value => SamePackageId(value, expected));
+        }
+
+        internal static bool SamePackageId(string left, string right)
+        {
+            return !string.IsNullOrWhiteSpace(left) &&
+                   !string.IsNullOrWhiteSpace(right) &&
+                   string.Equals(NormalizePackageId(left), NormalizePackageId(right), StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string NormalizePackageId(string value)
+        {
+            value = (value ?? string.Empty).Trim();
+            if (value.EndsWith(".FUSE", StringComparison.OrdinalIgnoreCase) ||
+                value.EndsWith(".RAIL", StringComparison.OrdinalIgnoreCase))
+            {
+                return value.Substring(0, value.Length - 5);
+            }
+
+            return value;
+        }
+    }
+}

--- a/FUSE/Loading/FuseFeatureRuleEvaluator.cs
+++ b/FUSE/Loading/FuseFeatureRuleEvaluator.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using FUSE.Authoring.Data;
+using FUSE.Infrastructure;
+using Newtonsoft.Json.Linq;
+
+namespace FUSE.Loading
+{
+    public sealed class FuseFeatureEvaluation
+    {
+        public int RuleCount { get; internal set; }
+        public int EnabledRuleCount { get; internal set; }
+        public int DisabledRuleCount { get; internal set; }
+        public int RemovedObjectCount { get; internal set; }
+        public string[] DisabledRuleIds { get; internal set; } = Array.Empty<string>();
+
+        public string Summary => RuleCount == 0
+            ? "No feature rules declared."
+            : $"{EnabledRuleCount} enabled, {DisabledRuleCount} disabled; {RemovedObjectCount} authored object(s) omitted until reload.";
+    }
+
+    internal static class FuseFeatureRuleEvaluator
+    {
+        internal static FuseFeatureEvaluation Apply(FuseModDefinition definition)
+        {
+            return Apply(
+                definition,
+                (key, setting) => FuseModSettingsStore.GetValue(definition, key, setting));
+        }
+
+        internal static FuseFeatureEvaluation Apply(
+            FuseModDefinition definition,
+            Func<string, FuseModSettingDefinition, JToken> valueResolver)
+        {
+            if (definition == null)
+                throw new ArgumentNullException(nameof(definition));
+            if (valueResolver == null)
+                throw new ArgumentNullException(nameof(valueResolver));
+
+            var evaluation = new FuseFeatureEvaluation();
+            var disabled = new List<string>();
+            foreach (var pair in (definition.FeatureRules ?? new Dictionary<string, FuseFeatureRule>())
+                .OrderBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                var rule = pair.Value;
+                evaluation.RuleCount++;
+                definition.Settings.TryGetValue(rule.Setting, out var setting);
+                var current = valueResolver(rule.Setting, setting);
+                if (Matches(current, rule.Operator, rule.Value))
+                {
+                    evaluation.EnabledRuleCount++;
+                    continue;
+                }
+
+                evaluation.DisabledRuleCount++;
+                disabled.Add(pair.Key);
+                evaluation.RemovedObjectCount += RemoveTargets(definition, rule.Targets);
+            }
+
+            evaluation.DisabledRuleIds = disabled.ToArray();
+            return evaluation;
+        }
+
+        internal static bool Matches(JToken current, string rawOperator, JToken expected)
+        {
+            var operation = string.IsNullOrWhiteSpace(rawOperator)
+                ? "equals"
+                : rawOperator.Trim();
+            if (operation.Equals("equals", StringComparison.OrdinalIgnoreCase))
+                return ValuesEqual(current, expected);
+            if (operation.Equals("notEquals", StringComparison.OrdinalIgnoreCase))
+                return !ValuesEqual(current, expected);
+
+            if (!TryNumber(current, out var actual) || !TryNumber(expected, out var target))
+                return false;
+            if (operation.Equals("greaterThan", StringComparison.OrdinalIgnoreCase))
+                return actual > target;
+            if (operation.Equals("greaterThanOrEqual", StringComparison.OrdinalIgnoreCase))
+                return actual >= target;
+            if (operation.Equals("lessThan", StringComparison.OrdinalIgnoreCase))
+                return actual < target;
+            if (operation.Equals("lessThanOrEqual", StringComparison.OrdinalIgnoreCase))
+                return actual <= target;
+            return false;
+        }
+
+        private static bool ValuesEqual(JToken left, JToken right)
+        {
+            if (TryNumber(left, out var leftNumber) && TryNumber(right, out var rightNumber))
+                return Math.Abs(leftNumber - rightNumber) <= 0.0000001d;
+            return JToken.DeepEquals(left, right);
+        }
+
+        private static bool TryNumber(JToken value, out double number)
+        {
+            number = 0d;
+            if (value == null)
+                return false;
+            if (value.Type == JTokenType.Integer || value.Type == JTokenType.Float)
+            {
+                number = value.Value<double>();
+                return !double.IsNaN(number) && !double.IsInfinity(number);
+            }
+            return double.TryParse(
+                value.Type == JTokenType.String ? value.Value<string>() : value.ToString(),
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out number) && !double.IsNaN(number) && !double.IsInfinity(number);
+        }
+
+        private static int RemoveTargets(FuseModDefinition definition, FuseFeatureTargets targets)
+        {
+            if (targets == null)
+                return 0;
+            var removed = 0;
+            removed += Remove(definition.Tracks.Nodes, targets.TrackNodes);
+            removed += Remove(definition.Tracks.Segments, targets.TrackSegments);
+            removed += Remove(definition.Tracks.Spans, targets.TrackSpans);
+            removed += Remove(definition.Tracks.Areas, targets.TrackAreas);
+            removed += Remove(definition.Operations.Loads, targets.Loads);
+            removed += Remove(definition.Operations.Industries, targets.Industries);
+            removed += RemoveIndustryComponents(definition, targets.IndustryComponents);
+            removed += Remove(definition.Operations.Loaders, targets.Loaders);
+            removed += Remove(definition.Operations.Turntables, targets.Turntables);
+            removed += Remove(definition.Operations.Stations, targets.Stations);
+            removed += Remove(definition.World.Scenery, targets.Scenery);
+            removed += Remove(definition.World.Splineys, targets.Splineys);
+            removed += Remove(definition.World.WaterSurfaces, targets.WaterSurfaces);
+            removed += Remove(definition.World.TelegraphPoles, targets.TelegraphPoles);
+            removed += Remove(definition.World.MapLabels, targets.MapLabels);
+            removed += Remove(definition.World.MapMasks, targets.MapMasks);
+            removed += Remove(definition.World.MapTiles, targets.MapTiles);
+            removed += Remove(definition.World.SceneClones, targets.SceneClones);
+            removed += Remove(definition.Progression.Progressions, targets.Progressions);
+            removed += Remove(definition.Progression.MapFeatures, targets.MapFeatures);
+            removed += Remove(definition.Audio.Whistles, targets.Whistles);
+            removed += Remove(definition.Audio.Horns, targets.Horns);
+            removed += Remove(definition.Audio.Bells, targets.Bells);
+            return removed;
+        }
+
+        private static int RemoveIndustryComponents(FuseModDefinition definition, IEnumerable<string> ids)
+        {
+            var removed = 0;
+            foreach (var id in ids ?? Array.Empty<string>())
+            {
+                var separator = id.IndexOf('/');
+                if (separator <= 0 || separator == id.Length - 1)
+                    continue;
+                var industryId = id.Substring(0, separator);
+                var componentId = id.Substring(separator + 1);
+                if (definition.Operations.Industries.TryGetValue(industryId, out var industry) &&
+                    industry?.Components?.Remove(componentId) == true)
+                    removed++;
+            }
+            return removed;
+        }
+
+        private static int Remove<T>(IDictionary<string, T> values, IEnumerable<string> ids)
+        {
+            if (values == null)
+                return 0;
+            var removed = 0;
+            foreach (var id in ids ?? Array.Empty<string>())
+                if (!string.IsNullOrWhiteSpace(id) && values.Remove(id))
+                    removed++;
+            return removed;
+        }
+    }
+}

--- a/FUSE/Loading/FuseLegacyAssemblyHost.cs
+++ b/FUSE/Loading/FuseLegacyAssemblyHost.cs
@@ -24,41 +24,16 @@ namespace FUSE.Loading
     {
         private static readonly Dictionary<string, HostedLegacyPlugin> HostedPlugins =
             new Dictionary<string, HostedLegacyPlugin>(StringComparer.OrdinalIgnoreCase);
+        // RailLoader captures its IUpdateHandler instances once after startup.
+        // Keep the same shape here: UpdateHostedPlugins runs every Unity frame,
+        // so enumerating Dictionary.Values.ToArray() and re-reflecting each type
+        // there produces permanent GC pressure in large mod sets.
+        private static HostedLegacyPlugin[] _hostedUpdatePlugins =
+            Array.Empty<HostedLegacyPlugin>();
 
         private static readonly List<IConsoleCommand> PendingConsoleCommands = new List<IConsoleCommand>();
-        // Package IDs that FUSE supersedes natively. When a legacy package
-        // declares itself (e.g. an old loader plugin we no longer host) or
-        // declares one of these as a dependency, the legacy-assembly host
-        // either skips the package itself or — for the dependency case at
-        // line ~399 — considers the dependency satisfied because FUSE
-        // provides the equivalent surface. Per the project's compat
-        // contract, FUSE shims the full public API of Railloader,
-        // StrangeCustoms, ConfusingSupplements, For Your Convenience, and
-        // Alina's Map Mod, so any of those package IDs appearing in a
-        // mod's "requires" must be treated as satisfied without needing
-        // the host binary on disk. Earlier revisions of this set omitted
-        // Zamu.ConfusingSupplements and Zamu.ForYourConvenience, which
-        // caused FUSE to skip every Foxy coal-patch package and any pack
-        // that built on the old For Your Convenience helpers — all of
-        // them must work day-1 of FUSE.
-        private static readonly HashSet<string> FuseReplacedLegacyPackages =
-            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            {
-                "AlinaNova21.AlinasMapMod",
-                "AlinaNova21.MapEditor",
-                "railroader",
-                "Railloader",
-                "RailLoader",
-                "Zamu.StrangeCustoms",
-                "Zamu.ConfusingSupplements",
-                "Zamu.ForYourConvenience",
-                // Defensive coverage for short-form / capitalization
-                // variants we have seen referenced in mod manifests.
-                "StrangeCustoms",
-                "ConfusingSupplements",
-                "ForYourConvenience"
-            };
-
+        private static readonly HashSet<string> ReportedLoadOrderCycles =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private static GameObject _startupHost;
         private static bool _consoleSurfaceUnavailableLogged;
 
@@ -249,16 +224,108 @@ namespace FUSE.Loading
                         continue;
                     }
 
-                    foreach (var fileReference in EnumerateMixintoReferences(property.Value))
+                    foreach (var entry in EnumerateMixintoEntries(property.Value))
                     {
-                        var mixintoPath = ResolvePackageFile(manifest.FolderPath, fileReference);
+                        if (!IsLegacyMixintoActive(manifest, entry))
+                        {
+                            continue;
+                        }
+
+                        var mixintoPath = ResolvePackageFile(manifest.FolderPath, entry.Reference);
                         if (!string.IsNullOrWhiteSpace(mixintoPath))
                         {
-                            yield return new ModMixinto(new FuseLegacyModDefinition(manifest), mixintoPath);
+                            yield return new ModMixinto(
+                                new FuseLegacyModDefinition(manifest),
+                                mixintoPath,
+                                MixintoType.File,
+                                entry.Requires,
+                                entry.ConflictsWith);
                         }
                     }
                 }
             }
+        }
+
+        internal static IReadOnlyCollection<IMod> EnumerateInstalledMods(
+            string modsRoot,
+            Func<string, string, bool> enabledByActiveSet = null)
+        {
+            var mods = new Dictionary<string, IMod>(StringComparer.OrdinalIgnoreCase);
+            var isEnabled = enabledByActiveSet ?? FuseModSetService.IsPackageEnabledByActiveSet;
+            if (!string.IsNullOrWhiteSpace(modsRoot) && Directory.Exists(modsRoot))
+            {
+                foreach (var manifest in DiscoverLegacyManifests(modsRoot))
+                {
+                    if (manifest == null || string.IsNullOrWhiteSpace(manifest.Id) ||
+                        FuseUmmState.TryGetDisabledReason(manifest.FolderPath, manifest.Id, out _) ||
+                        !isEnabled(manifest.Id, manifest.FolderPath))
+                    {
+                        continue;
+                    }
+
+                    mods[manifest.Id] = new FuseLegacyModDefinition(manifest);
+                }
+            }
+
+            // Old plugins commonly use context.Mods as a capability check. A
+            // FUSE-owned replacement must therefore be visible under the legacy
+            // package id even though its superseded DLL is intentionally absent.
+            var fuseVersion = typeof(FuseLegacyAssemblyHost).Assembly.GetName().Version?.ToString() ?? "1.0.0";
+            foreach (var replacedId in FuseReplacementCapabilityCatalog.AdvertisedPackageIds)
+            {
+                if (string.IsNullOrWhiteSpace(replacedId) || mods.ContainsKey(replacedId))
+                {
+                    continue;
+                }
+
+                mods[replacedId] = new FuseLegacyModDefinition(new FuseLegacyAssemblyManifest
+                {
+                    Id = replacedId,
+                    Name = replacedId,
+                    Version = fuseVersion,
+                    FolderPath = modsRoot ?? string.Empty
+                });
+            }
+
+            return mods.Values.ToArray();
+        }
+
+        internal static void UpdateHostedPlugins()
+        {
+            var updatePlugins = _hostedUpdatePlugins;
+            for (var index = 0; index < updatePlugins.Length; index++)
+            {
+                var hosted = updatePlugins[index];
+                if (hosted == null || hosted.Plugin == null || hosted.UpdateFaulted)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    hosted.InvokeUpdate();
+                }
+                catch (Exception ex)
+                {
+                    hosted.UpdateFaulted = true;
+                    FuseModExceptionRegistry.RecordContained(ex, hosted.Manifest.Id, "legacy host update");
+                    FuseLog.Exception(
+                        $"FUSE legacy support disabled the per-frame update callback for '{hosted.Type.FullName}' from '{hosted.Manifest.Id}' after it threw",
+                        ex);
+                }
+            }
+        }
+
+        private static bool ImplementsLegacyUpdateHandler(Type pluginType)
+        {
+            if (pluginType == null)
+            {
+                return false;
+            }
+
+            return typeof(IUpdateHandler).IsAssignableFrom(pluginType) ||
+                   pluginType.GetInterfaces().Any(candidate =>
+                       string.Equals(candidate.FullName, "Railloader.IUpdateHandler", StringComparison.Ordinal));
         }
 
         internal static void RegisterConsoleCommand(IConsoleCommand command)
@@ -317,6 +384,7 @@ namespace FUSE.Loading
             }
 
             HostedPlugins.Clear();
+            _hostedUpdatePlugins = Array.Empty<HostedLegacyPlugin>();
             PendingConsoleCommands.Clear();
             if (_startupHost != null)
             {
@@ -361,7 +429,16 @@ namespace FUSE.Loading
             try
             {
                 InvokePluginLifecycleMethod(plugin, nameof(LegacyPluginBase.OnEnable));
-                HostedPlugins[key] = new HostedLegacyPlugin(manifest, pluginType, plugin);
+                var hosted = new HostedLegacyPlugin(manifest, pluginType, plugin);
+                HostedPlugins[key] = hosted;
+                if (hosted.HasUpdateHandler)
+                {
+                    var existing = _hostedUpdatePlugins;
+                    var replacement = new HostedLegacyPlugin[existing.Length + 1];
+                    Array.Copy(existing, replacement, existing.Length);
+                    replacement[replacement.Length - 1] = hosted;
+                    _hostedUpdatePlugins = replacement;
+                }
                 FuseLog.Info(
                     $"FUSE legacy support enabled hosted old-loader plugin '{pluginType.FullName}' " +
                     $"from package '{manifest.Id}'. This is temporary legacy compatibility, not a native FUSE package.");
@@ -419,11 +496,32 @@ namespace FUSE.Loading
 
         private static bool IsLegacyPluginType(Type type)
         {
-            return type != null &&
-                   type.IsClass &&
-                   !type.IsAbstract &&
-                   (typeof(LegacyPluginBase).IsAssignableFrom(type) ||
-                    InheritsFromFullName(type, "Railloader.PluginBase"));
+            if (type == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                return type.IsClass &&
+                       !type.IsAbstract &&
+                       (typeof(LegacyPluginBase).IsAssignableFrom(type) ||
+                        InheritsFromFullName(type, "Railloader.PluginBase"));
+            }
+            catch (Exception ex) when (
+                ex is TypeLoadException ||
+                ex is FileLoadException ||
+                ex is FileNotFoundException ||
+                ex is BadImageFormatException)
+            {
+                // A UMM package can already have a stale, partially bound copy
+                // of its DLL in the AppDomain before recovery runs. Reflection
+                // over compiler-generated nested types may throw here even
+                // though FuseLegacyUmmRecovery subsequently activates the real
+                // entry. Treat that type as unhostable; the package-level host
+                // must not turn a recoverable probe into a mod error.
+                return false;
+            }
         }
 
         private static bool TryBuildLegacyConstructorArguments(
@@ -455,6 +553,12 @@ namespace FUSE.Loading
                     continue;
                 }
 
+                if (parameterType.IsInstanceOfType(FuseLegacyUIHelper.Shared))
+                {
+                    arguments[i] = FuseLegacyUIHelper.Shared;
+                    continue;
+                }
+
                 if (string.Equals(parameterType.FullName, "Railloader.IModdingContext", StringComparison.Ordinal))
                 {
                     arguments[i] = CreateRealModdingContextProxy(parameterType, context);
@@ -465,6 +569,12 @@ namespace FUSE.Loading
                     string.Equals(parameterType.FullName, "Railloader.IMod", StringComparison.Ordinal))
                 {
                     arguments[i] = CreateRealModDefinitionProxy(parameterType, definition);
+                    continue;
+                }
+
+                if (string.Equals(parameterType.FullName, "Railloader.IUIHelper", StringComparison.Ordinal))
+                {
+                    arguments[i] = CreateRealUIHelperProxy(parameterType);
                     continue;
                 }
 
@@ -536,6 +646,60 @@ namespace FUSE.Loading
                 InvokeRealModdingContext(context, method, args)).GetTransparentProxy();
         }
 
+        private static object CreateRealUIHelperProxy(Type interfaceType)
+        {
+            return new LegacyInterfaceProxy(interfaceType, InvokeRealUIHelper).GetTransparentProxy();
+        }
+
+        private static object InvokeRealUIHelper(MethodInfo method, object[] args)
+        {
+            if (method == null)
+            {
+                return null;
+            }
+
+            if (string.Equals(method.Name, "PopulateWindow", StringComparison.Ordinal))
+            {
+                return FuseLegacyUIHelper.Shared.PopulateWindow(
+                    args != null && args.Length > 0 ? args[0] as UI.Common.Window : null,
+                    args != null && args.Length > 1 ? args[1] as Action<UI.Builder.UIPanelBuilder> : null);
+            }
+
+            if (!string.Equals(method.Name, "CreateWindow", StringComparison.Ordinal))
+            {
+                return DefaultValue(method.ReturnType);
+            }
+
+            if (!method.IsGenericMethod)
+            {
+                if (args != null && args.Length == 3)
+                {
+                    return FuseLegacyUIHelper.Shared.CreateWindow(
+                        (int)args[0],
+                        (int)args[1],
+                        (UI.Common.Window.Position)args[2]);
+                }
+
+                if (args != null && args.Length == 4)
+                {
+                    return FuseLegacyUIHelper.Shared.CreateWindow(
+                        args[0] as string,
+                        (int)args[1],
+                        (int)args[2],
+                        (UI.Common.Window.Position)args[3]);
+                }
+            }
+
+            var genericArguments = method.GetGenericArguments();
+            var target = typeof(FuseLegacyUIHelper)
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                .Where(candidate => candidate.Name == "CreateWindow" && candidate.IsGenericMethodDefinition)
+                .FirstOrDefault(candidate => candidate.GetParameters().Length == (args?.Length ?? 0));
+            return target?.MakeGenericMethod(genericArguments).Invoke(
+                FuseLegacyUIHelper.Shared,
+                args ?? Array.Empty<object>());
+        }
+
         private static object InvokeRealModDefinition(FuseLegacyModDefinition definition, MethodInfo method)
         {
             switch (method?.Name)
@@ -549,10 +713,13 @@ namespace FUSE.Loading
                 case "get_Directory":
                     return definition.Directory;
                 case "get_LoadBefore":
-                    return Array.Empty<string>();
+                    return definition.LoadBefore;
                 case "get_LoadAfter":
+                    return ConvertModReferences(definition.LoadAfter, method.ReturnType);
                 case "get_Requires":
+                    return ConvertModReferences(definition.Requires, method.ReturnType);
                 case "get_ConflictsWith":
+                    return ConvertModReferences(definition.ConflictsWith, method.ReturnType);
                 case "get_Plugins":
                     return CreateEmptyArrayForReturnType(method.ReturnType);
                 case "get_IsEnabled":
@@ -576,7 +743,7 @@ namespace FUSE.Loading
                 case "get_ModsBaseDirectory":
                     return context.ModsBaseDirectory;
                 case "get_Mods":
-                    return CreateEmptyArrayForReturnType(method.ReturnType);
+                    return CreateRealModCollectionForReturnType(context.Mods, method.ReturnType);
                 case "RegisterConsoleCommand":
                     if (args != null && args.Length > 0 && args[0] is IConsoleCommand command)
                     {
@@ -593,16 +760,172 @@ namespace FUSE.Loading
                         args != null && args.Length > 1 ? args[1] : null);
                     return null;
                 case "GetMixintos":
-                    return CreateEmptyArrayForReturnType(method.ReturnType);
+                    return CreateRealMixintoCollectionForReturnType(context, method, args);
                 case "TryResolveFilePath":
                     return TryResolveFilePathFromProxy(context, method, args);
                 case "RegisterSubTypeOverload":
+                    RegisterLegacySubtypeFromProxy(method, args);
+                    return null;
                 case "RegisterComponent":
+                    RegisterLegacyComponentFromProxy(method, args);
                     return null;
                 case "ToString":
                     return "FUSE legacy Railloader context bridge";
                 default:
                     return DefaultValue(method?.ReturnType);
+            }
+        }
+
+        private static void RegisterLegacySubtypeFromProxy(MethodInfo method, object[] args)
+        {
+            var genericArguments = method?.GetGenericArguments() ?? Type.EmptyTypes;
+            if (genericArguments.Length == 2)
+            {
+                FuseLegacyTypeRegistry.RegisterSubType(
+                    genericArguments[0],
+                    args != null && args.Length > 0 ? args[0] as string : null,
+                    genericArguments[1]);
+                return;
+            }
+
+            if (args != null && args.Length >= 3)
+            {
+                FuseLegacyTypeRegistry.RegisterSubType(
+                    args[0] as Type,
+                    args[1] as string,
+                    args[2] as Type);
+                return;
+            }
+
+            throw new MissingMethodException("Unsupported legacy RegisterSubTypeOverload signature.");
+        }
+
+        private static void RegisterLegacyComponentFromProxy(MethodInfo method, object[] args)
+        {
+            var genericArguments = method?.GetGenericArguments() ?? Type.EmptyTypes;
+            if (genericArguments.Length != 2)
+            {
+                throw new MissingMethodException("Unsupported legacy RegisterComponent signature.");
+            }
+
+            FuseLegacyTypeRegistry.RegisterComponent(
+                genericArguments[0],
+                genericArguments[1],
+                args != null && args.Length > 0 ? args[0] as string : null);
+        }
+
+        private static object CreateRealModCollectionForReturnType(IReadOnlyCollection<IMod> mods, Type returnType)
+        {
+            var elementType = returnType?.IsArray == true
+                ? returnType.GetElementType()
+                : returnType?.GetGenericArguments().FirstOrDefault();
+            if (elementType == null)
+            {
+                return CreateEmptyArrayForReturnType(returnType);
+            }
+
+            var definitions = (mods ?? Array.Empty<IMod>()).OfType<FuseLegacyModDefinition>().ToArray();
+            var result = Array.CreateInstance(elementType, definitions.Length);
+            for (var index = 0; index < definitions.Length; index++)
+            {
+                result.SetValue(CreateRealModDefinitionProxy(elementType, definitions[index]), index);
+            }
+
+            return result;
+        }
+
+        private static object CreateRealMixintoCollectionForReturnType(
+            FuseLegacyModdingContext context,
+            MethodInfo method,
+            object[] args)
+        {
+            var targets = args != null && args.Length > 0 && args[0] is string[] many
+                ? many
+                : new[] { args != null && args.Length > 0 ? args[0] as string : null };
+            var mixintos = context.GetMixintos(targets).ToArray();
+            var elementType = method.ReturnType?.IsArray == true
+                ? method.ReturnType.GetElementType()
+                : method.ReturnType?.GetGenericArguments().FirstOrDefault();
+            if (elementType == null)
+            {
+                return CreateEmptyArrayForReturnType(method.ReturnType);
+            }
+
+            var result = Array.CreateInstance(elementType, mixintos.Length);
+            for (var index = 0; index < mixintos.Length; index++)
+            {
+                result.SetValue(ConvertMixintoForForeignContract(mixintos[index], elementType), index);
+            }
+
+            return result;
+        }
+
+        private static object ConvertMixintoForForeignContract(ModMixinto mixinto, Type targetType)
+        {
+            var converted = Activator.CreateInstance(targetType);
+            SetMemberValue(converted, targetType, "Mixinto", mixinto.Mixinto);
+            SetMemberValue(converted, targetType, "Type", ConvertEnumValue(mixinto.Type, GetMemberType(targetType, "Type")));
+
+            var sourceType = GetMemberType(targetType, "Source");
+            if (sourceType != null && mixinto.Source is FuseLegacyModDefinition source)
+            {
+                SetMemberValue(converted, targetType, "Source", CreateRealModDefinitionProxy(sourceType, source));
+            }
+
+            SetMemberValue(converted, targetType, "Requires", ConvertModReferences(mixinto.Requires, GetMemberType(targetType, "Requires")));
+            SetMemberValue(converted, targetType, "ConflictsWith", ConvertModReferences(mixinto.ConflictsWith, GetMemberType(targetType, "ConflictsWith")));
+            SetMemberValue(converted, targetType, "ManagedObject", mixinto.ManagedObject);
+            return converted;
+        }
+
+        private static object ConvertModReferences(ModReference[] references, Type targetType)
+        {
+            if (targetType?.IsArray != true)
+            {
+                return null;
+            }
+
+            var values = references ?? Array.Empty<ModReference>();
+            var elementType = targetType.GetElementType();
+            var result = Array.CreateInstance(elementType, values.Length);
+            for (var index = 0; index < values.Length; index++)
+            {
+                var converted = Activator.CreateInstance(elementType);
+                SetMemberValue(converted, elementType, "Id", values[index].Id);
+                SetMemberValue(converted, elementType, "NotBefore", values[index].NotBefore);
+                SetMemberValue(converted, elementType, "NotAfter", values[index].NotAfter);
+                result.SetValue(converted, index);
+            }
+
+            return result;
+        }
+
+        private static object ConvertEnumValue(object value, Type targetType)
+        {
+            return targetType?.IsEnum == true
+                ? Enum.ToObject(targetType, Convert.ToInt32(value))
+                : value;
+        }
+
+        private static Type GetMemberType(Type declaringType, string name)
+        {
+            return declaringType?.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.PropertyType ??
+                   declaringType?.GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.FieldType;
+        }
+
+        private static void SetMemberValue(object target, Type declaringType, string name, object value)
+        {
+            var property = declaringType?.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (property?.CanWrite == true && (value == null || property.PropertyType.IsInstanceOfType(value)))
+            {
+                property.SetValue(target, value, null);
+                return;
+            }
+
+            var field = declaringType?.GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (field != null && (value == null || field.FieldType.IsInstanceOfType(value)))
+            {
+                field.SetValue(target, value);
             }
         }
 
@@ -668,12 +991,128 @@ namespace FUSE.Loading
 
         private static IEnumerable<FuseLegacyAssemblyManifest> DiscoverLegacyManifests(string modsRoot)
         {
+            var manifests = new List<FuseLegacyAssemblyManifest>();
             foreach (var packagePath in Directory.GetDirectories(modsRoot).OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
             {
                 if (TryReadLegacyManifest(packagePath, out var manifest))
                 {
-                    yield return manifest;
+                    manifests.Add(manifest);
                 }
+            }
+
+            return OrderLegacyManifestsForHosting(manifests);
+        }
+
+        internal static IReadOnlyList<FuseLegacyAssemblyManifest> OrderLegacyManifestsForHosting(
+            IEnumerable<FuseLegacyAssemblyManifest> manifests)
+        {
+            var baseline = (manifests ?? Enumerable.Empty<FuseLegacyAssemblyManifest>())
+                .Where(manifest => manifest != null)
+                .OrderBy(manifest => manifest.FolderPath ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(manifest => manifest.Id ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (baseline.Length <= 1)
+            {
+                return baseline;
+            }
+
+            var baselineIndex = baseline
+                .Select((manifest, index) => new { manifest, index })
+                .ToDictionary(item => item.manifest, item => item.index);
+            var outgoing = baseline.ToDictionary(
+                manifest => manifest,
+                _ => new HashSet<FuseLegacyAssemblyManifest>());
+            var incoming = baseline.ToDictionary(manifest => manifest, _ => 0);
+
+            foreach (var manifest in baseline)
+            {
+                foreach (var reference in (manifest.RequiredReferences ?? Array.Empty<ModReference>())
+                             .Concat(manifest.LoadAfter ?? Array.Empty<ModReference>()))
+                {
+                    if (TryResolveLegacyManifest(baseline, reference.Id, out var dependency))
+                    {
+                        AddLegacyLoadOrderEdge(dependency, manifest, outgoing, incoming);
+                    }
+                }
+
+                foreach (var targetId in manifest.LoadBefore ?? Array.Empty<string>())
+                {
+                    if (TryResolveLegacyManifest(baseline, targetId, out var target))
+                    {
+                        AddLegacyLoadOrderEdge(manifest, target, outgoing, incoming);
+                    }
+                }
+            }
+
+            var ready = baseline
+                .Where(manifest => incoming[manifest] == 0)
+                .OrderBy(manifest => baselineIndex[manifest])
+                .ToList();
+            var ordered = new List<FuseLegacyAssemblyManifest>(baseline.Length);
+            while (ready.Count > 0)
+            {
+                var next = ready[0];
+                ready.RemoveAt(0);
+                ordered.Add(next);
+                foreach (var after in outgoing[next].OrderBy(manifest => baselineIndex[manifest]))
+                {
+                    incoming[after]--;
+                    if (incoming[after] == 0)
+                    {
+                        ready.Add(after);
+                        ready.Sort((left, right) => baselineIndex[left].CompareTo(baselineIndex[right]));
+                    }
+                }
+            }
+
+            if (ordered.Count == baseline.Length)
+            {
+                return ordered;
+            }
+
+            var cycleMembers = baseline.Where(manifest => !ordered.Contains(manifest)).ToArray();
+            var signature = string.Join(",", cycleMembers.Select(manifest => manifest.Id).OrderBy(id => id, StringComparer.OrdinalIgnoreCase));
+            if (ReportedLoadOrderCycles.Add(signature))
+            {
+                FuseLog.Warning(
+                    $"FUSE legacy support found a loadAfter/loadBefore cycle among '{signature}'. " +
+                    "A deterministic folder order will be used for the cycle; correct the declarations to guarantee plugin initialization order.");
+            }
+
+            ordered.AddRange(cycleMembers);
+            return ordered;
+        }
+
+        private static bool TryResolveLegacyManifest(
+            IEnumerable<FuseLegacyAssemblyManifest> manifests,
+            string id,
+            out FuseLegacyAssemblyManifest match)
+        {
+            match = null;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return false;
+            }
+
+            match = manifests.FirstOrDefault(candidate =>
+                candidate != null && FuseDeclaredPackageRelationship.SamePackageId(candidate.Id, id));
+            return match != null;
+        }
+
+        private static void AddLegacyLoadOrderEdge(
+            FuseLegacyAssemblyManifest before,
+            FuseLegacyAssemblyManifest after,
+            IDictionary<FuseLegacyAssemblyManifest, HashSet<FuseLegacyAssemblyManifest>> outgoing,
+            IDictionary<FuseLegacyAssemblyManifest, int> incoming)
+        {
+            if (before == null || after == null || ReferenceEquals(before, after))
+            {
+                return;
+            }
+
+            if (outgoing[before].Add(after))
+            {
+                incoming[after]++;
             }
         }
 
@@ -706,6 +1145,10 @@ namespace FUSE.Loading
                 FolderPath = folderPath,
                 Assemblies = ReadStringArray(definition["assemblies"] ?? definition["Assemblies"]).ToArray(),
                 Requires = ReadLegacyRequirementIds(definition["requires"] ?? definition["Requires"]).ToArray(),
+                RequiredReferences = ReadLegacyModReferences(definition["requires"] ?? definition["Requires"]).ToArray(),
+                LoadAfter = ReadLegacyModReferences(definition["loadAfter"] ?? definition["LoadAfter"]).ToArray(),
+                LoadBefore = ReadLegacyRequirementIds(definition["loadBefore"] ?? definition["LoadBefore"]).ToArray(),
+                ConflictsWith = ReadLegacyModReferences(definition["conflictsWith"] ?? definition["ConflictsWith"]).ToArray(),
                 RawDefinition = definition
             };
             return true;
@@ -723,7 +1166,7 @@ namespace FUSE.Loading
                 return false;
             }
 
-            if (FuseReplacedLegacyPackages.Contains(manifest.Id ?? string.Empty))
+            if (FuseReplacementCapabilityCatalog.IsProvided(manifest.Id))
             {
                 FuseLog.Info(
                     $"FUSE legacy support skipped old-loader package '{manifest.Id}' " +
@@ -753,25 +1196,78 @@ namespace FUSE.Loading
                 return false;
             }
 
-            foreach (var requirementId in manifest.Requires ?? Array.Empty<string>())
+            foreach (var requirement in manifest.RequiredReferences ?? Array.Empty<ModReference>())
             {
-                if (FuseReplacedLegacyPackages.Contains(requirementId ?? string.Empty))
+                if (FuseReplacementCapabilityCatalog.IsProvided(requirement.Id))
                 {
                     continue;
                 }
 
-                if (IsLegacyRequirementPresent(manifest, requirementId))
+                if (IsLegacyReferencePresent(manifest, requirement))
                 {
                     continue;
                 }
 
                 FuseLog.Warning(
                     $"FUSE legacy support skipped old-loader package '{manifest.Id}' " +
-                    $"because required legacy package '{requirementId}' is not installed or enabled.");
+                    $"because required legacy package '{requirement}' is not installed, enabled, or version-compatible.");
+                return false;
+            }
+
+            foreach (var conflict in manifest.ConflictsWith ?? Array.Empty<ModReference>())
+            {
+                if (!IsLegacyReferencePresent(manifest, conflict))
+                {
+                    continue;
+                }
+
+                FuseLog.Warning(
+                    $"FUSE legacy support skipped old-loader package '{manifest.Id}' because its conflictsWith " +
+                    $"reference '{conflict}' matches an enabled package. Disable one of the declared incompatible packages.");
                 return false;
             }
 
             return true;
+        }
+
+        private static bool IsLegacyReferencePresent(FuseLegacyAssemblyManifest manifest, ModReference reference)
+        {
+            if (manifest == null || string.IsNullOrWhiteSpace(reference.Id))
+            {
+                return false;
+            }
+
+            if (FuseReplacementCapabilityCatalog.IsProvided(reference.Id))
+            {
+                return true;
+            }
+
+            var modsRoot = Directory.GetParent(manifest.FolderPath)?.FullName;
+            if (string.IsNullOrWhiteSpace(modsRoot) || !Directory.Exists(modsRoot))
+            {
+                return false;
+            }
+
+            foreach (var packagePath in Directory.GetDirectories(modsRoot))
+            {
+                if (!TryReadLegacyManifest(packagePath, out var candidate) ||
+                    !FuseDeclaredPackageRelationship.SamePackageId(candidate.Id, reference.Id) ||
+                    FuseUmmState.TryGetDisabledReason(candidate.FolderPath, candidate.Id, out _) ||
+                    !FuseModSetService.IsPackageEnabledByActiveSet(candidate.Id, candidate.FolderPath))
+                {
+                    continue;
+                }
+
+                if (!FuseModRequirementResolver.TryParseVersion(candidate.Version, out var installedVersion))
+                {
+                    return true;
+                }
+
+                return (reference.NotBefore == null || installedVersion.CompareTo(reference.NotBefore) >= 0) &&
+                       (reference.NotAfter == null || installedVersion.CompareTo(reference.NotAfter) <= 0);
+            }
+
+            return false;
         }
 
         private static bool IsLegacyRequirementPresent(FuseLegacyAssemblyManifest manifest, string requirementId)
@@ -861,7 +1357,7 @@ namespace FUSE.Loading
             FuseLog.Warning($"FUSE legacy support console command registration is unavailable: {detail}");
         }
 
-        private static IEnumerable<string> EnumerateMixintoReferences(JToken token)
+        private static IEnumerable<FuseLegacyMixintoEntry> EnumerateMixintoEntries(JToken token)
         {
             if (token == null || token.Type == JTokenType.Null)
             {
@@ -873,7 +1369,7 @@ namespace FUSE.Loading
                 var reference = ExtractFileReference(token.Value<string>());
                 if (!string.IsNullOrWhiteSpace(reference))
                 {
-                    yield return reference;
+                    yield return new FuseLegacyMixintoEntry { Reference = reference };
                 }
 
                 yield break;
@@ -883,7 +1379,7 @@ namespace FUSE.Loading
             {
                 foreach (var item in array)
                 {
-                    foreach (var reference in EnumerateMixintoReferences(item))
+                    foreach (var reference in EnumerateMixintoEntries(item))
                     {
                         yield return reference;
                     }
@@ -900,13 +1396,20 @@ namespace FUSE.Loading
                     var reference = ExtractFileReference(direct);
                     if (!string.IsNullOrWhiteSpace(reference))
                     {
-                        yield return reference;
+                        yield return new FuseLegacyMixintoEntry
+                        {
+                            Reference = reference,
+                            Requires = ReadLegacyModReferences(obj["requires"] ?? obj["Requires"]).ToArray(),
+                            ConflictsWith = ReadLegacyModReferences(obj["conflictsWith"] ?? obj["ConflictsWith"]).ToArray()
+                        };
                     }
+
+                    yield break;
                 }
 
                 foreach (var property in obj.Properties())
                 {
-                    foreach (var reference in EnumerateMixintoReferences(property.Value))
+                    foreach (var reference in EnumerateMixintoEntries(property.Value))
                     {
                         yield return reference;
                     }
@@ -1121,16 +1624,120 @@ namespace FUSE.Loading
 
         private sealed class HostedLegacyPlugin
         {
+            private readonly IUpdateHandler _typedUpdateHandler;
+            private readonly MethodInfo _reflectedUpdateMethod;
+
             public HostedLegacyPlugin(FuseLegacyAssemblyManifest manifest, Type type, object plugin)
             {
                 Manifest = manifest;
                 Type = type;
                 Plugin = plugin;
+                _typedUpdateHandler = plugin as IUpdateHandler;
+                if (_typedUpdateHandler == null && ImplementsLegacyUpdateHandler(type))
+                {
+                    _reflectedUpdateMethod = type.GetMethod(
+                        nameof(IUpdateHandler.Update),
+                        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                        null,
+                        Type.EmptyTypes,
+                        null);
+                }
             }
 
             public FuseLegacyAssemblyManifest Manifest { get; }
             public Type Type { get; }
             public object Plugin { get; }
+            public bool UpdateFaulted { get; set; }
+            public bool HasUpdateHandler => _typedUpdateHandler != null || _reflectedUpdateMethod != null;
+
+            public void InvokeUpdate()
+            {
+                if (_typedUpdateHandler != null)
+                {
+                    _typedUpdateHandler.Update();
+                    return;
+                }
+
+                _reflectedUpdateMethod?.Invoke(Plugin, Array.Empty<object>());
+            }
+        }
+
+        private static bool IsLegacyMixintoActive(
+            FuseLegacyAssemblyManifest manifest,
+            FuseLegacyMixintoEntry entry)
+        {
+            if (entry == null)
+            {
+                return false;
+            }
+
+            foreach (var requirement in entry.Requires ?? Array.Empty<ModReference>())
+            {
+                if (!IsLegacyReferencePresent(manifest, requirement))
+                {
+                    return false;
+                }
+            }
+
+            foreach (var conflict in entry.ConflictsWith ?? Array.Empty<ModReference>())
+            {
+                if (IsLegacyReferencePresent(manifest, conflict))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private sealed class FuseLegacyMixintoEntry
+        {
+            public string Reference { get; set; }
+            public ModReference[] Requires { get; set; } = Array.Empty<ModReference>();
+            public ModReference[] ConflictsWith { get; set; } = Array.Empty<ModReference>();
+        }
+
+        private static IEnumerable<ModReference> ReadLegacyModReferences(JToken token)
+        {
+            if (token == null || token.Type == JTokenType.Null)
+            {
+                yield break;
+            }
+
+            if (token is JArray array)
+            {
+                foreach (var item in array)
+                {
+                    foreach (var reference in ReadLegacyModReferences(item))
+                    {
+                        yield return reference;
+                    }
+                }
+
+                yield break;
+            }
+
+            var id = ReadLegacyRequirementId(token);
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                yield break;
+            }
+
+            var obj = token as JObject;
+            var notBeforeText = ReadString(obj, "notBefore", "NotBefore");
+            var notAfterText = ReadString(obj, "notAfter", "NotAfter");
+            var notBefore = FuseModRequirementResolver.TryParseVersion(notBeforeText, out var parsedNotBefore)
+                ? parsedNotBefore
+                : null;
+            var notAfter = FuseModRequirementResolver.TryParseVersion(notAfterText, out var parsedNotAfter)
+                ? parsedNotAfter
+                : null;
+            yield return new ModReference
+            {
+                Id = id,
+                NotBefore = notBefore,
+                NotAfter = notAfter
+            };
         }
 
         private sealed class LegacyInterfaceProxy : RealProxy
@@ -1192,6 +1799,10 @@ namespace FUSE.Loading
             // UnityModManager._Start's foreach has released its enumerator.
             FUSE.Infrastructure.FuseUmmInjector.FlushPendingInjection();
             FuseLegacyAssemblyHost.LoadAllAvailableAssemblies("legacy support startup");
+            // Dual-format packages need their RailLoader plugin instance first:
+            // its singleton/context is part of the UMM patch side's runtime
+            // contract. Recover the failed UMM entry only after hosting succeeds.
+            FUSE.Compatibility.FuseLegacyUmmRecovery.RecoverFailedEntries();
         }
 #pragma warning restore CA1822
     }
@@ -1204,6 +1815,10 @@ namespace FUSE.Loading
         public string FolderPath { get; set; }
         public string[] Assemblies { get; set; } = Array.Empty<string>();
         public string[] Requires { get; set; } = Array.Empty<string>();
+        public ModReference[] RequiredReferences { get; set; } = Array.Empty<ModReference>();
+        public ModReference[] LoadAfter { get; set; } = Array.Empty<ModReference>();
+        public string[] LoadBefore { get; set; } = Array.Empty<string>();
+        public ModReference[] ConflictsWith { get; set; } = Array.Empty<ModReference>();
         public JObject RawDefinition { get; set; }
     }
 
@@ -1215,9 +1830,10 @@ namespace FUSE.Loading
             Name = manifest?.Name ?? Id;
             Version = manifest?.Version ?? string.Empty;
             Directory = manifest?.FolderPath ?? string.Empty;
-            Requires = (manifest?.Requires ?? Array.Empty<string>())
-                .Select(static r => (ModReference)r)
-                .ToArray();
+            Requires = manifest?.RequiredReferences ?? Array.Empty<ModReference>();
+            LoadAfter = manifest?.LoadAfter ?? Array.Empty<ModReference>();
+            LoadBefore = manifest?.LoadBefore ?? Array.Empty<string>();
+            ConflictsWith = manifest?.ConflictsWith ?? Array.Empty<ModReference>();
         }
 
         public string Id { get; }
@@ -1225,10 +1841,10 @@ namespace FUSE.Loading
         public string Version { get; }
         public string Directory { get; }
 
-        public string[] LoadBefore => Array.Empty<string>();
-        public ModReference[] LoadAfter => Array.Empty<ModReference>();
+        public string[] LoadBefore { get; }
+        public ModReference[] LoadAfter { get; }
         public ModReference[] Requires { get; }
-        public ModReference[] ConflictsWith => Array.Empty<ModReference>();
+        public ModReference[] ConflictsWith { get; }
 
         // We host the assembly so by definition it loaded and enabled. We do not
         // track per-plugin fault state from the IMod shim; callers that need it
@@ -1266,7 +1882,7 @@ namespace FUSE.Loading
 
         public System.Version RailloaderVersion => LegacyRailloaderVersion;
         public string ModsBaseDirectory { get; }
-        public IReadOnlyCollection<IMod> Mods => Array.Empty<IMod>();
+        public IReadOnlyCollection<IMod> Mods => FuseLegacyAssemblyHost.EnumerateInstalledMods(ModsBaseDirectory);
 
         public void RegisterConsoleCommand(IConsoleCommand command)
         {
@@ -1511,19 +2127,19 @@ namespace FUSE.Loading
 
         public void RegisterSubTypeOverload<TBaseClass, TImplementation>(string identifier)
         {
-            FuseLog.Warning($"FUSE legacy IModdingContext.RegisterSubTypeOverload<{typeof(TBaseClass).Name}, {typeof(TImplementation).Name}>('{identifier}') is not wired; no-op. Migrate to FUSE registration API.");
+            FuseLegacyTypeRegistry.RegisterSubType(typeof(TBaseClass), identifier, typeof(TImplementation));
         }
 
         public void RegisterSubTypeOverload(System.Type baseClass, string identifier, System.Type implementation)
         {
-            FuseLog.Warning($"FUSE legacy IModdingContext.RegisterSubTypeOverload('{baseClass?.Name}', '{identifier}', '{implementation?.Name}') is not wired; no-op. Migrate to FUSE registration API.");
+            FuseLegacyTypeRegistry.RegisterSubType(baseClass, identifier, implementation);
         }
 
         public void RegisterComponent<TComponent, TComponentBuilder>(string kind)
-            where TComponent : Component
-            where TComponentBuilder : IComponentBuilder
+            where TComponent : Model.Definition.Component
+            where TComponentBuilder : Model.IComponentBuilder
         {
-            FuseLog.Warning($"FUSE legacy IModdingContext.RegisterComponent<{typeof(TComponent).Name}, {typeof(TComponentBuilder).Name}>('{kind}') is not wired; no-op. Migrate to FUSE component registration API.");
+            FuseLegacyTypeRegistry.RegisterComponent(typeof(TComponent), typeof(TComponentBuilder), kind);
         }
     }
 }

--- a/FUSE/Loading/FuseLegacyCapabilityActivation.cs
+++ b/FUSE/Loading/FuseLegacyCapabilityActivation.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// Determines whether a non-identity gameplay replacement was actually
+    /// requested by an enabled package. This lets FUSE advertise a retired
+    /// dependency without globally turning that mod's gameplay choices on for
+    /// every player.
+    /// </summary>
+    internal static class FuseLegacyCapabilityActivation
+    {
+        private static readonly object Gate = new object();
+        private static HashSet<string> _requested;
+
+        internal static bool IsRequested(params string[] packageIds)
+        {
+            var requested = GetRequestedIds();
+            return (packageIds ?? Array.Empty<string>())
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(FuseReplacementCapabilityCatalog.Normalize)
+                .Any(requested.Contains);
+        }
+
+        internal static void Reset()
+        {
+            lock (Gate)
+            {
+                _requested = null;
+            }
+        }
+
+        private static HashSet<string> GetRequestedIds()
+        {
+            lock (Gate)
+            {
+                if (_requested != null)
+                {
+                    return _requested;
+                }
+
+                _requested = BuildRequestedIds(FuseDataPackageDiscovery.GetPackageManifestSnapshots());
+                return _requested;
+            }
+        }
+
+        internal static HashSet<string> BuildRequestedIds(
+            IEnumerable<FusePackageManifestSnapshot> manifests)
+        {
+            var requested = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var manifest in manifests ?? Enumerable.Empty<FusePackageManifestSnapshot>())
+            {
+                if (manifest == null || manifest.Disabled)
+                {
+                    continue;
+                }
+
+                Add(requested, manifest.Id);
+                foreach (var requirement in manifest.RequiredPackageIds ?? Array.Empty<string>())
+                {
+                    Add(requested, requirement);
+                }
+            }
+
+            return requested;
+        }
+
+        private static void Add(HashSet<string> requested, string packageId)
+        {
+            var normalized = FuseReplacementCapabilityCatalog.Normalize(packageId);
+            if (!string.IsNullOrWhiteSpace(normalized))
+            {
+                requested.Add(normalized);
+            }
+        }
+    }
+}

--- a/FUSE/Loading/FuseLegacyDataConverter.Helpers.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.Helpers.cs
@@ -233,7 +233,10 @@ namespace FUSE.Loading
             foreach (var property in obj.Properties())
             {
                 var cleaned = Clean(property.Value);
-                if (cleaned == null || cleaned.Type == JTokenType.Null || IsEmpty(cleaned))
+                if (cleaned == null ||
+                    cleaned.Type == JTokenType.Null ||
+                    cleaned is JValue scalar && scalar.Value == null ||
+                    IsEmpty(cleaned))
                 {
                     continue;
                 }

--- a/FUSE/Loading/FuseLegacyDataConverter.Json.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.Json.cs
@@ -14,10 +14,27 @@ namespace FUSE.Loading
 {
     internal static partial class FuseLegacyDataConverter
     {
+        private static readonly object JsonRepairWarningGate = new object();
+        private static readonly HashSet<string> ReportedControlCharacterFiles =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         internal static JObject ReadLegacyObject(string path)
         {
             return JObject.Parse(ReadLegacyJsonText(path));
+        }
+
+        internal static JObject ReadManifestObject(string path)
+        {
+            // Manifest files decide whether a package is discovered at all. Keep
+            // the harmless RailLoader-era allowances (comments, trailing commas,
+            // and stray control bytes), but never invent missing braces here. A
+            // structurally incomplete Info.json must remain attributable to the
+            // package and surface in /fuse.report with its real line/column.
+            var text = File.ReadAllText(path);
+            text = StripJsonControlCharacters(text, path);
+            text = StripJsonComments(text);
+            text = RemoveTrailingCommas(text);
+            return JObject.Parse(text);
         }
 
         // Counterpart for legacy sources whose top-level token is a JSON
@@ -118,12 +135,23 @@ namespace FUSE.Loading
                     }
                 }
 
-                FuseLog.Warning(
-                    $"FUSE stripped {stripped} stray control byte(s) from legacy file '{path}' " +
-                    $"before parsing (first occurrence: 0x{(int)firstByte:X2} at line {line}, column {column}). " +
-                    "This is almost always an editor accident (e.g. a Ctrl+V verbatim insert) and the " +
-                    "mod author should fix the source file. FUSE only tolerates this on the legacy " +
-                    "pipeline; native FUSE addons (*.fuse.json) must be valid JSON.");
+                var warningKey = path ?? string.Empty;
+                var report = false;
+                lock (JsonRepairWarningGate)
+                {
+                    report = ReportedControlCharacterFiles.Add(warningKey);
+                }
+
+                if (report)
+                {
+                    FuseLog.Warning(
+                        $"FUSE stripped {stripped} stray control byte(s) from legacy file '{path}' " +
+                        $"before parsing (first occurrence: 0x{(int)firstByte:X2} at line {line}, column {column}). " +
+                        "This is almost always an editor accident (e.g. a Ctrl+V verbatim insert) and the " +
+                        "mod author should fix the source file. This warning is shown once per file per session. " +
+                        "FUSE only tolerates this on the legacy pipeline; native FUSE addons (*.fuse.json) " +
+                        "must be valid JSON.");
+                }
             }
 
             return builder == null ? text : builder.ToString();

--- a/FUSE/Loading/FuseLegacyDataConverter.World.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.World.cs
@@ -273,7 +273,8 @@ namespace FUSE.Loading
             {
                 ["position"] = Vector(item["position"] ?? item["localPosition"], false),
                 ["rotation"] = Vector(item["rotation"] ?? item["localRotation"], false),
-                ["flipSwitchStand"] = ReadBool(item, "flipSwitchStand", false)
+                ["flipSwitchStand"] = ReadBool(item, "flipSwitchStand", false),
+                ["isDiamond"] = ReadBool(item, "isDiamond", ReadBool(item, "IsDiamond", false))
             };
         }
 
@@ -293,20 +294,25 @@ namespace FUSE.Loading
             }
 
             var hasStyle = HasAnyProperty(item, "Style", "style");
+            var hasFlags = HasAnyProperty(item, "flags", "Flags");
             var hasTrackClass = HasAnyProperty(item, "trackClass", "TrackClass");
             var hasSpeedLimit = HasAnyProperty(item, "speedLimit", "SpeedLimit");
             var hasPriority = HasAnyProperty(item, "priority");
             var hasGroupId = HasAnyProperty(item, "groupId", "GroupId");
             var partial = string.IsNullOrWhiteSpace(startNodeId) || string.IsNullOrWhiteSpace(endNodeId);
+            var flags = ReadInt(item["flags"] ?? item["Flags"], 0);
+            var style = ReadString(item, "Style", "style");
 
             var result = new JObject
             {
-                ["style"] = ReadString(item, "Style", "style") ?? "standard",
+                ["style"] = style ?? StyleFromTrackFlags(flags),
                 ["trackClass"] = ReadString(item, "trackClass", "TrackClass") ?? "main",
                 ["speedLimit"] = ReadInt(item["speedLimit"] ?? item["SpeedLimit"], 45),
                 ["priority"] = ReadInt(item["priority"], 0),
                 ["groupId"] = ReadString(item, "groupId", "GroupId"),
-                ["gauge"] = ReadString(item, "gauge", "Gauge")
+                ["gauge"] = ReadString(item, "gauge", "Gauge"),
+                ["bridgeSupportsSteel"] = hasFlags && (flags & 4) != 0,
+                ["yard"] = hasFlags && (flags & 16) != 0
             };
 
             if (!string.IsNullOrWhiteSpace(startNodeId))
@@ -323,6 +329,8 @@ namespace FUSE.Loading
             {
                 result["partial"] = true;
                 result["preserveStyle"] = !hasStyle;
+                result["preserveBridgeSupportsSteel"] = !hasFlags && !hasStyle;
+                result["preserveYard"] = !hasFlags && !hasStyle;
                 result["preserveTrackClass"] = !hasTrackClass;
                 result["preserveSpeedLimit"] = !hasSpeedLimit;
                 result["preservePriority"] = !hasPriority;
@@ -330,6 +338,21 @@ namespace FUSE.Loading
             }
 
             return result;
+        }
+
+        private static string StyleFromTrackFlags(int flags)
+        {
+            if ((flags & 8) != 0)
+            {
+                return "tunnel";
+            }
+
+            if ((flags & 2) != 0)
+            {
+                return "bridge";
+            }
+
+            return (flags & 16) != 0 ? "yard" : "standard";
         }
 
         private static JToken ConvertSpan(JToken token)
@@ -416,16 +439,42 @@ namespace FUSE.Loading
 
         private static JObject ConvertArea(string id, JObject item)
         {
-            return CleanObject(new JObject
+            var result = new JObject
             {
-                ["name"] = ReadString(item, "name") ?? id,
-                ["position"] = Vector(item["localPosition"] ?? item["position"], false),
+                ["name"] = ReadString(item, "name"),
                 ["radius"] = Clone(item["radius"]),
                 ["tagColor"] = NormalizeAreaTagColor(id, item["tagColor"] ?? item["TagColor"]),
                 ["order"] = Clone(item["order"]),
                 ["spanIds"] = ToStringArray(item["spanIds"] ?? item["spans"]),
                 ["groupId"] = ReadString(item, "groupId", "GroupId")
-            });
+            };
+
+            var position = item["localPosition"] ?? item["position"];
+            if (position != null && position.Type != JTokenType.Null)
+            {
+                result["position"] = Vector(position, false);
+            }
+
+            return CleanObject(result);
+        }
+
+        private static bool HasLegacyAreaDefinition(JObject item)
+        {
+            if (item == null)
+            {
+                return false;
+            }
+
+            return item.Properties().Any(property =>
+                string.Equals(property.Name, "name", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "localPosition", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "position", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "radius", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "tagColor", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "order", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "spanIds", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "spans", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "groupId", StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -634,6 +683,17 @@ namespace FUSE.Loading
             }
 
             var model = ReadString(item, "assetIdentifier", "model", "modelIdentifier", "prefabIdentifier", "prefab") ?? string.Empty;
+            if (IsLegacyEditorOnlySceneryAsset(model))
+            {
+                // Alina's turntable measurement disc is an authoring overlay,
+                // not part of the finished scene. A small number of old map
+                // packages shipped the helper beside the real turntable. The
+                // old editor hid it outside edit mode; materializing it as
+                // ordinary FUSE scenery leaves a bright yellow disc over the
+                // completed bridge (issue #235).
+                return null;
+            }
+
             if (!string.IsNullOrWhiteSpace(model) && !model.Contains("://"))
             {
                 model = "scenery://" + model;
@@ -647,6 +707,26 @@ namespace FUSE.Loading
                 ["scale"] = Vector(item["scale"] ?? item["localScale"], true),
                 ["anchorSpanIds"] = ToStringArray(item["anchorSpanIds"] ?? item["spanIds"] ?? item["spans"] ?? item["trackSpanIds"] ?? item["trackSpans"])
             });
+        }
+
+        internal static bool IsLegacyEditorOnlySceneryAsset(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var normalized = value.Trim();
+            var scheme = normalized.IndexOf("://", StringComparison.Ordinal);
+            if (scheme >= 0)
+            {
+                normalized = normalized.Substring(scheme + 3);
+            }
+
+            return string.Equals(
+                normalized,
+                "TurntableMeasurementTool",
+                StringComparison.OrdinalIgnoreCase);
         }
 
         private static void ConvertSplineys(JObject source, JObject root)
@@ -733,7 +813,8 @@ namespace FUSE.Loading
                 FuseLog.Info(
                     "FUSE legacy spliney plugin host dispatched GraphWillChangeEvent " +
                     $"pendingSplineys={flush.PendingSplineyCount} " +
-                    $"nodesAdded={flush.NodesAdded} segmentsAdded={flush.SegmentsAdded}.");
+                    $"nodesAdded={flush.NodesAdded} nodesUpdated={flush.NodesUpdated} " +
+                    $"segmentsAdded={flush.SegmentsAdded} segmentsUpdated={flush.SegmentsUpdated}.");
             }
         }
 
@@ -789,6 +870,16 @@ namespace FUSE.Loading
                 ["tailStyle"] = ReadString(item, "tailStyle", "tailstyle"),
                 ["points"] = points
             });
+        }
+
+        internal static JObject ConvertSplineyForCompatibility(JObject item)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            return ConvertSpliney(item);
         }
 
         private static string InferSplineyType(JObject item, string handler)

--- a/FUSE/Loading/FuseLegacyDataConverter.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.cs
@@ -187,6 +187,7 @@ namespace FUSE.Loading
                 Author = ReadString(definition, "author", "Author") ?? string.Empty,
                 RequiredPackageIds = ReadLegacyRequiredDependencyIds(definition),
                 LoadAfter = ReadLegacyDependencyIds(definition),
+                ConflictsWith = ReadLegacyConflictRequirements(definition),
                 SourceFiles = sourceFiles,
                 MapTileSources = mapTileSources
             };
@@ -247,14 +248,32 @@ namespace FUSE.Loading
                 // Route them through the audio-specific converter so the
                 // entries land in the FUSE audio dict instead of being
                 // dropped by the "not an object" branch in ReadLegacyObject.
-                if (TryClassifyLegacyAudioFile(sourceFile, out var audioKind))
+                try
                 {
-                    ConvertLegacyAudioSource(sourceFile, audioKind, root);
+                    if (TryClassifyLegacyAudioFile(sourceFile, out var audioKind))
+                    {
+                        ConvertLegacyAudioSource(sourceFile, audioKind, root);
+                    }
+                    else
+                    {
+                        var source = ReadLegacyObject(sourceFile);
+                        ConvertSource(source, root, manifest);
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    var source = ReadLegacyObject(sourceFile);
-                    ConvertSource(source, root, manifest);
+                    FusePackageFaultRegistry.RecordFault(
+                        manifest.PackageId,
+                        "legacy JSON conversion",
+                        ex.GetBaseException().Message,
+                        ex,
+                        folderPath,
+                        sourceFile,
+                        packageName: manifest.DisplayName,
+                        expectedShape: "RailLoader/Strange Customs JSON data supported by the FUSE legacy compatibility converter.",
+                        receivedValue: ex.GetBaseException().Message,
+                        suggestedAction: "Correct the named legacy JSON file at the reported property/line, or remove that optional source from the package manifest, then reload the map.");
+                    throw;
                 }
                 var definition = FuseSerializer.FromJson(root.ToString(Formatting.None));
                 var definitionPath = "legacy://" + sourceKey;
@@ -488,7 +507,7 @@ namespace FUSE.Loading
 
             if (value.Type == JTokenType.String)
             {
-                RecordMixinto(target, value.Value<string>(), null, result, order++);
+                RecordMixinto(target, value.Value<string>(), null, null, result, order++);
                 return;
             }
 
@@ -508,12 +527,19 @@ namespace FUSE.Loading
                     target,
                     ReadString(obj, "mixinto", "Mixinto"),
                     ConvertRequirements(obj["requires"] ?? obj["Requires"]),
+                    ConvertLegacyReferences(obj["conflictsWith"] ?? obj["ConflictsWith"], false),
                     result,
                     order++);
             }
         }
 
-        private static void RecordMixinto(string target, string reference, JArray requirements, IDictionary<string, JObject> result, int order)
+        private static void RecordMixinto(
+            string target,
+            string reference,
+            JArray requirements,
+            JArray conflictsWith,
+            IDictionary<string, JObject> result,
+            int order)
         {
             var sourceFile = ExtractFileReference(reference);
             if (string.IsNullOrWhiteSpace(sourceFile))
@@ -527,7 +553,8 @@ namespace FUSE.Loading
                 ["target"] = target ?? string.Empty,
                 ["sourceFile"] = key,
                 ["order"] = order,
-                ["requires"] = requirements ?? new JArray()
+                ["requires"] = requirements ?? new JArray(),
+                ["conflictsWith"] = conflictsWith ?? new JArray()
             });
         }
 
@@ -587,6 +614,11 @@ namespace FUSE.Loading
 
         private static JArray ConvertRequirements(JToken value)
         {
+            return ConvertLegacyReferences(value, true);
+        }
+
+        private static JArray ConvertLegacyReferences(JToken value, bool filterReplacementCapabilities)
+        {
             var result = new JArray();
             if (!(value is JArray array))
             {
@@ -598,7 +630,8 @@ namespace FUSE.Loading
                 var id = item.Type == JTokenType.String
                     ? item.Value<string>()
                     : ReadString(item as JObject, "id", "Id");
-                if (string.IsNullOrWhiteSpace(id) || IsCoreLegacyRequirement(id))
+                if (string.IsNullOrWhiteSpace(id) ||
+                    (filterReplacementCapabilities && IsCoreLegacyRequirement(id)))
                 {
                     continue;
                 }
@@ -614,6 +647,22 @@ namespace FUSE.Loading
             return result;
         }
 
+        private static FuseModRequirement[] ReadLegacyConflictRequirements(JObject definition)
+        {
+            return ConvertLegacyReferences(
+                    definition?["conflictsWith"] ?? definition?["ConflictsWith"],
+                    false)
+                .OfType<JObject>()
+                .Select(item => new FuseModRequirement
+                {
+                    Id = ReadString(item, "id", "Id"),
+                    NotBefore = ReadString(item, "notBefore", "NotBefore"),
+                    NotAfter = ReadString(item, "notAfter", "NotAfter")
+                })
+                .Where(item => !string.IsNullOrWhiteSpace(item.Id))
+                .ToArray();
+        }
+
         private static string[] ReadLegacyDependencyIds(JObject definition)
         {
             var result = new List<string>(ReadLegacyRequiredDependencyIds(definition));
@@ -626,7 +675,68 @@ namespace FUSE.Loading
                 }
             }
 
+            // A conditional legacy mixinto is optional when its requirement is
+            // absent, but it must run after that package when the dependency is
+            // present. Carry those ids into advisory ordering rather than hard
+            // requirements so discovery can build the correct topological edge
+            // without disabling the package when an optional layer is missing.
+            foreach (var id in ReadMixintoRequirementIds(definition?["mixintos"] ?? definition?["Mixintos"]))
+            {
+                if (!IsCoreLegacyRequirement(id))
+                {
+                    result.Add(EnsureFusePackageId(id));
+                }
+            }
+
             return result.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        }
+
+        private static IEnumerable<string> ReadMixintoRequirementIds(JToken value)
+        {
+            if (value == null || value.Type == JTokenType.Null)
+            {
+                yield break;
+            }
+
+            if (value is JArray array)
+            {
+                foreach (var item in array)
+                {
+                    foreach (var id in ReadMixintoRequirementIds(item))
+                    {
+                        yield return id;
+                    }
+                }
+
+                yield break;
+            }
+
+            if (!(value is JObject obj))
+            {
+                yield break;
+            }
+
+            foreach (var requirement in ConvertRequirements(obj["requires"] ?? obj["Requires"]).OfType<JObject>())
+            {
+                var id = ReadString(requirement, "id");
+                if (!string.IsNullOrWhiteSpace(id))
+                {
+                    yield return id;
+                }
+            }
+
+            foreach (var property in obj.Properties())
+            {
+                if (string.Equals(property.Name, "requires", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                foreach (var id in ReadMixintoRequirementIds(property.Value))
+                {
+                    yield return id;
+                }
+            }
         }
 
         private static string[] ReadLegacyRequiredDependencyIds(JObject definition)
@@ -654,22 +764,7 @@ namespace FUSE.Loading
 
         private static bool IsCoreLegacyRequirement(string id)
         {
-            var value = (id ?? string.Empty).Trim().ToLowerInvariant();
-            return value == "railroader" ||
-                   value == "railloader" ||
-                   value == "rail-loader" ||
-                   value == "alinanova21.alinasmapmod" ||
-                   value == "alinasmapmod" ||
-                   value == "alinamapmod" ||
-                   value == "alinanova21.mapeditor" ||
-                   value == "mapeditor" ||
-                   value == "mmapeditor" ||
-                   value == "alinanova21.alinasmapexpansion" ||
-                   value == "alinasmapexpansion" ||
-                   value == "zamu.strangecustoms" ||
-                   value == "strangecustoms" ||
-                   value == "zamu.confusingsupplements" ||
-                   value == "confusingsupplements";
+            return FuseReplacementCapabilityCatalog.IsProvided(id);
         }
 
         internal static JObject CreateSkeleton(FuseLegacyPackageManifest manifest, string fragment)
@@ -786,7 +881,16 @@ namespace FUSE.Loading
                         continue;
                     }
 
-                    (root["tracks"]["areas"] as JObject)[area.Name] = ConvertArea(area.Name, areaObject);
+                    // In Strange Customs game-graph files an area object is often
+                    // only a namespace around `industries`. It is not an area
+                    // mutation. Converting that wrapper used to manufacture a
+                    // zero position and update the live base area, moving every
+                    // Whittier industry away from its tracks (issues #210/#239).
+                    if (HasLegacyAreaDefinition(areaObject))
+                    {
+                        (root["tracks"]["areas"] as JObject)[area.Name] =
+                            ConvertArea(area.Name, areaObject);
+                    }
                     var industries = areaObject["industries"] as JObject;
                     if (industries == null)
                     {
@@ -978,6 +1082,7 @@ namespace FUSE.Loading
         public string Author { get; set; }
         public string[] RequiredPackageIds { get; set; } = Array.Empty<string>();
         public string[] LoadAfter { get; set; } = Array.Empty<string>();
+        public FuseModRequirement[] ConflictsWith { get; set; } = Array.Empty<FuseModRequirement>();
         public string[] SourceFiles { get; set; } = Array.Empty<string>();
         public FuseLegacyMapTileSource[] MapTileSources { get; set; } = Array.Empty<FuseLegacyMapTileSource>();
     }

--- a/FUSE/Loading/FuseLegacyGameGraphCompatibility.cs
+++ b/FUSE/Loading/FuseLegacyGameGraphCompatibility.cs
@@ -152,7 +152,7 @@ namespace FUSE.Loading
             }
         }
 
-        private static bool ShouldExpand(FuseLoadedMod loaded)
+        internal static bool ShouldExpand(FuseLoadedMod loaded)
         {
             var definition = loaded?.Definition;
             if (definition == null || !IsLegacyConverted(definition) || IsExpanded(definition))
@@ -161,8 +161,9 @@ namespace FUSE.Loading
             }
 
             var target = definition.Mixinto?.Target;
-            return string.IsNullOrWhiteSpace(target) ||
-                   string.Equals(target, GameGraphTarget, StringComparison.OrdinalIgnoreCase);
+            return (string.IsNullOrWhiteSpace(target) ||
+                    string.Equals(target, GameGraphTarget, StringComparison.OrdinalIgnoreCase)) &&
+                   !string.IsNullOrWhiteSpace(ResolveSourcePath(loaded));
         }
 
         private static bool IsLegacyConverted(FuseModDefinition definition)

--- a/FUSE/Loading/FuseLegacyUIHelper.cs
+++ b/FUSE/Loading/FuseLegacyUIHelper.cs
@@ -1,0 +1,109 @@
+using System;
+using FUSE.Infrastructure;
+using Railloader;
+using UI;
+using UI.Builder;
+using UI.Common;
+using UnityEngine;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// FUSE-owned implementation of the legacy window service. Hosted plugins
+    /// receive this object through constructor injection; no legacy loader code
+    /// is required at runtime.
+    /// </summary>
+    internal sealed class FuseLegacyUIHelper : IUIHelper
+    {
+        internal static FuseLegacyUIHelper Shared { get; } = new FuseLegacyUIHelper();
+
+        private FuseLegacyUIHelper()
+        {
+        }
+
+        public Window CreateWindow(int width, int height, Window.Position position)
+        {
+            return WindowCreatorHelper.CreateWindow(width, height, position);
+        }
+
+        public Window CreateWindow(string identifier, int width, int height, Window.Position position)
+        {
+            return WindowCreatorHelper.CreateWindow(identifier, width, height, position);
+        }
+
+        public Window CreateWindow<TWindow>(
+            string identifier,
+            int width,
+            int height,
+            Window.Position position,
+            Action<TWindow> configure = null)
+            where TWindow : Component, IBuilderWindow
+        {
+            var creator = FindCreator();
+            var window = InstantiateWindow(creator);
+            if (window == null)
+            {
+                return null;
+            }
+
+            window.SetInitialPositionSize(
+                identifier,
+                new Vector2(width, height),
+                position,
+                Window.Sizing.Fixed(new Vector2Int(width, height)));
+            window.name = typeof(TWindow).FullName ?? typeof(TWindow).Name;
+
+            var component = window.gameObject.AddComponent<TWindow>();
+            component.BuilderAssets = creator.builderAssets;
+            configure?.Invoke(component);
+            window.CloseWindow();
+            return window;
+        }
+
+        public Window CreateWindow<TWindow>(Action<TWindow> configure = null)
+            where TWindow : Component, IProgrammaticWindow
+        {
+            var creator = FindCreator();
+            var window = InstantiateWindow(creator);
+            if (window == null)
+            {
+                return null;
+            }
+
+            window.name = typeof(TWindow).FullName ?? typeof(TWindow).Name;
+            var component = window.gameObject.AddComponent<TWindow>();
+            component.BuilderAssets = creator.builderAssets;
+            configure?.Invoke(component);
+            window.SetInitialPositionSize(
+                component.WindowIdentifier,
+                component.DefaultSize,
+                component.DefaultPosition,
+                component.Sizing);
+            window.CloseWindow();
+            return window;
+        }
+
+        public UIPanel PopulateWindow(Window window, Action<UIPanelBuilder> closure)
+        {
+            return WindowCreatorHelper.PopulateWindow(window, closure);
+        }
+
+        private static ProgrammaticWindowCreator FindCreator()
+        {
+            return UnityEngine.Object.FindObjectOfType<ProgrammaticWindowCreator>(true);
+        }
+
+        private static Window InstantiateWindow(ProgrammaticWindowCreator creator)
+        {
+            if (creator == null || creator.windowPrefab == null)
+            {
+                FuseLog.Warning(
+                    "FUSE legacy UI helper could not create a window because the game's " +
+                    "ProgrammaticWindowCreator is not available yet.");
+                return null;
+            }
+
+            return UnityEngine.Object.Instantiate(creator.windowPrefab, creator.transform, false);
+        }
+    }
+}

--- a/FUSE/Loading/FuseLoadReport.cs
+++ b/FUSE/Loading/FuseLoadReport.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using FUSE.Authoring.Data;
 using FUSE.Infrastructure;
+using FUSE.Compatibility;
 using FUSE.Runtime.Registry;
 using Newtonsoft.Json.Linq;
 using UI.Common;
@@ -233,7 +234,8 @@ namespace FUSE.Loading
             var snapshot = CaptureCurrentSnapshot();
             _lastReportSnapshot = snapshot;
             var summary = BuildSummary(snapshot);
-            return BuildDetails(snapshot, summary);
+            return FuseLegacyDebugInformation.AppendToReport(
+                BuildDetails(snapshot, summary));
         }
 
         public static string GetLastJsonReport()
@@ -480,11 +482,11 @@ namespace FUSE.Loading
 
             return
                 $"FUSE: {loadedCount} loaded | faults {snapshot.FaultedPackageCount} | " +
-                $"conflicts {snapshot.Conflicts.Length} | assets {snapshot.UnknownSceneryAssets.Length} | " +
+                $"conflicts {snapshot.ActionableConflictCount} | assets {snapshot.UnknownSceneryAssets.Length} | " +
                 $"brokenAssets {snapshot.SceneryLoadFailureCount} | " +
                 $"graph {snapshot.GraphPostBindIssues.Length} | transfers {snapshot.ProgressionTransferSkips.Length} | " +
                 $"suppressions {suppressionCount} | orphans {snapshot.OrphanedCarCount} | " +
-                $"modErrors {snapshot.ModExceptionTotal} | /fuse.report";
+                "/fuse.report";
         }
 
         private static string BuildDetails(ReportSnapshot snapshot, string summary)
@@ -495,17 +497,21 @@ namespace FUSE.Loading
                 $"Reason: {snapshot.Reason}; disk-loaded this pass={snapshot.LoadedFromDiskThisPass}; " +
                 $"runtime-applied this pass={snapshot.AppliedToRuntimeThisPass}; resident definitions={snapshot.ResidentDefinitionCount}.");
             sb.AppendLine(
-                $"Packages: loaded={snapshot.LoadedPackageIds.Length}; applied={snapshot.AppliedPackageIds.Length}; " +
-                $"skipped={snapshot.SkippedPackages.Count}; disabled={snapshot.DisabledPackages.Count}; " +
+                $"Package folders: loaded={snapshot.LoadedPackageIds.Length}; disabled={snapshot.DisabledPackages.Count}; " +
                 $"faulted={snapshot.FaultedPackageCount}.");
+            sb.AppendLine(
+                $"Runtime definitions: resident={snapshot.ResidentDefinitionCount}; applied={snapshot.AppliedPackageIds.Length}; " +
+                $"actionable skips={snapshot.ActionableSkippedPackages.Count}; " +
+                $"optional fragments inactive={snapshot.OptionalSkippedPackages.Count}.");
             sb.AppendLine(
                 $"Post-bind: graphIssues={snapshot.GraphPostBindIssues.Length}; " +
                 $"progressionTransferSkips={snapshot.ProgressionTransferSkips.Length}.");
 
-            AppendList(sb, "Loaded packages", snapshot.LoadedPackageIds);
-            AppendList(sb, "Applied packages", snapshot.AppliedPackageIds);
+            AppendList(sb, "Loaded package folders", snapshot.LoadedPackageIds);
+            AppendList(sb, "Applied definitions", snapshot.AppliedPackageIds);
             AppendList(sb, "Legacy-converted packages", snapshot.LegacyConvertedPackageIds);
-            AppendMap(sb, "Skipped packages", snapshot.SkippedPackages);
+            AppendMap(sb, "Definitions skipped with actionable problems", snapshot.ActionableSkippedPackages);
+            AppendMap(sb, "Optional conditional fragments inactive", snapshot.OptionalSkippedPackages);
             AppendMap(sb, "Disabled packages", snapshot.DisabledPackages);
 
             if (snapshot.Faults.Length > 0)
@@ -513,11 +519,50 @@ namespace FUSE.Loading
                 sb.AppendLine("Faults:");
                 foreach (var fault in snapshot.Faults)
                 {
-                    sb.AppendLine($"  {fault.PackageId} [{fault.Stage}] {fault.Message}");
+                    var packageName = string.IsNullOrWhiteSpace(fault.PackageName)
+                        || string.Equals(fault.PackageName, fault.PackageId, StringComparison.OrdinalIgnoreCase)
+                        ? string.Empty
+                        : $" ({fault.PackageName})";
+                    sb.AppendLine($"  {fault.PackageId}{packageName} [{fault.Stage}] {fault.Message}");
+                    if (!string.IsNullOrWhiteSpace(fault.FolderPath))
+                    {
+                        sb.AppendLine($"    source root: {fault.FolderPath}");
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(fault.SourceFile))
+                    {
+                        sb.AppendLine($"    file: {fault.SourceFile}");
+                        if (!string.IsNullOrWhiteSpace(fault.RelativeSourceFile))
+                            sb.AppendLine($"    relative file: {fault.RelativeSourceFile}");
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(fault.ValidationCode))
+                        sb.AppendLine($"    validation code: {fault.ValidationCode}");
+                    if (!string.IsNullOrWhiteSpace(fault.ExpectedShape))
+                        sb.AppendLine($"    expected: {fault.ExpectedShape}");
+                    if (!string.IsNullOrWhiteSpace(fault.ReceivedValue))
+                        sb.AppendLine($"    received: {fault.ReceivedValue}");
+
+                    if (!string.IsNullOrWhiteSpace(fault.JsonPath) || fault.LineNumber > 0)
+                    {
+                        var path = string.IsNullOrWhiteSpace(fault.JsonPath) ? "<root>" : fault.JsonPath;
+                        var line = fault.LineNumber > 0
+                            ? $" line {fault.LineNumber}, position {fault.LinePosition}"
+                            : string.Empty;
+                        sb.AppendLine($"    JSON location: {path}{line}");
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(fault.SuggestedAction))
+                    {
+                        sb.AppendLine($"    action: {fault.SuggestedAction}");
+                    }
                 }
             }
 
-            sb.AppendLine($"Conflicts recorded: {snapshot.Conflicts.Length} (details: /fuse.conflicts).");
+            sb.AppendLine(
+                $"Ownership conflicts requiring attention: {snapshot.ActionableConflictCount}; " +
+                $"shared extension targets merged successfully: {snapshot.CooperativeConflictCount} " +
+                "(details: /fuse.conflicts).");
 
             // Live session counters, not part of the load snapshot: every guard FUSE
             // keeps around broken content, so a pasted report answers "did the guards
@@ -642,12 +687,19 @@ namespace FUSE.Loading
                     ["appliedToRuntimeThisPass"] = snapshot.AppliedToRuntimeThisPass,
                     ["residentDefinitions"] = snapshot.ResidentDefinitionCount,
                     ["loadedPackages"] = snapshot.LoadedPackageIds.Length,
+                    ["appliedDefinitions"] = snapshot.AppliedPackageIds.Length,
+                    ["actionableSkippedDefinitions"] = snapshot.ActionableSkippedPackages.Count,
+                    ["optionalInactiveDefinitions"] = snapshot.OptionalSkippedPackages.Count,
+                    ["registryOverlapRecords"] = snapshot.Conflicts.Length,
+                    ["sharedExtensionOverlaps"] = snapshot.CooperativeConflictCount,
+                    // Backward-compatible aliases retained for report consumers
+                    // written before definition/package terminology was fixed.
                     ["appliedPackages"] = snapshot.AppliedPackageIds.Length,
                     ["skippedPackages"] = snapshot.SkippedPackages.Count,
                     ["disabledPackages"] = snapshot.DisabledPackages.Count,
                     ["legacyConvertedPackages"] = snapshot.LegacyConvertedPackageIds.Length,
                     ["faultedPackages"] = snapshot.FaultedPackageCount,
-                    ["conflicts"] = snapshot.Conflicts.Length,
+                    ["conflicts"] = snapshot.ActionableConflictCount,
                     ["unknownSceneryAssets"] = snapshot.UnknownSceneryAssets.Length,
                     ["graphIssues"] = snapshot.GraphPostBindIssues.Length,
                     ["progressionTransferSkips"] = snapshot.ProgressionTransferSkips.Length,
@@ -660,6 +712,9 @@ namespace FUSE.Loading
                 ["packages"] = new JObject
                 {
                     ["loaded"] = ToArray(snapshot.LoadedPackageIds),
+                    ["appliedDefinitions"] = ToArray(snapshot.AppliedPackageIds),
+                    ["actionableSkippedDefinitions"] = ToObject(snapshot.ActionableSkippedPackages),
+                    ["optionalInactiveDefinitions"] = ToObject(snapshot.OptionalSkippedPackages),
                     ["applied"] = ToArray(snapshot.AppliedPackageIds),
                     ["legacyConverted"] = ToArray(snapshot.LegacyConvertedPackageIds),
                     ["skipped"] = ToObject(snapshot.SkippedPackages),
@@ -668,7 +723,19 @@ namespace FUSE.Loading
                     {
                         ["packageId"] = fault.PackageId ?? string.Empty,
                         ["stage"] = fault.Stage ?? string.Empty,
-                        ["message"] = fault.Message ?? string.Empty
+                        ["message"] = fault.Message ?? string.Empty,
+                        ["folderPath"] = fault.FolderPath ?? string.Empty,
+                        ["sourceFile"] = fault.SourceFile ?? string.Empty,
+                        ["jsonPath"] = fault.JsonPath ?? string.Empty,
+                        ["lineNumber"] = fault.LineNumber,
+                        ["linePosition"] = fault.LinePosition,
+                        ["packageName"] = fault.PackageName ?? string.Empty,
+                        ["relativeSourceFile"] = fault.RelativeSourceFile ?? string.Empty,
+                        ["validationCode"] = fault.ValidationCode ?? string.Empty,
+                        ["expectedShape"] = fault.ExpectedShape ?? string.Empty,
+                        ["receivedValue"] = fault.ReceivedValue ?? string.Empty,
+                        ["suggestedAction"] = fault.SuggestedAction ?? string.Empty,
+                        ["details"] = fault.Details ?? string.Empty
                     }))
                 },
                 ["conflicts"] = new JArray(snapshot.Conflicts.Select(conflict => new JObject
@@ -677,8 +744,9 @@ namespace FUSE.Loading
                     ["target"] = conflict.Target ?? string.Empty,
                     ["objectId"] = conflict.Id ?? string.Empty,
                     ["ownerPackageId"] = conflict.OwnerPackageId ?? string.Empty,
-                    ["attemptedPackageId"] = conflict.AttemptedPackageId ?? string.Empty,
-                    ["resolution"] = conflict.Resolution ?? string.Empty
+                        ["attemptedPackageId"] = conflict.AttemptedPackageId ?? string.Empty,
+                        ["resolution"] = conflict.Resolution ?? string.Empty,
+                        ["classification"] = conflict.IsCooperativeMerge ? "shared-extension" : "actionable"
                 })),
                 // Live session counters (see BuildDetails); intentionally outside
                 // "counts" so they do not read as load-snapshot state.
@@ -692,6 +760,7 @@ namespace FUSE.Loading
                     ["curveMeshSuppressed"] = FuseRuntimeGuardCounters.CurveMeshSuppressed,
                     ["sceneryCarDecalsDisabled"] = FuseRuntimeGuardCounters.SceneryDecalComponentsDisabled,
                     ["sceneryLoadFailures"] = FuseRuntimeGuardCounters.SceneryLoadFailures,
+                    ["passengerStopSpansSanitized"] = FuseRuntimeGuardCounters.PassengerStopSpansSanitized,
                     ["flaresSuppressed"] = FuseRuntimeGuardCounters.FlareSuppressed,
                     ["frameSpikes"] = FuseRuntimeGuardCounters.FrameSpikes,
                     ["frameSpikeWorstMs"] = FuseRuntimeGuardCounters.FrameSpikeWorstMs
@@ -898,6 +967,18 @@ namespace FUSE.Loading
             public long ModExceptionTotal { get; set; }
             public long ModExceptionUnattributed { get; set; }
 
+            public IReadOnlyDictionary<string, string> ActionableSkippedPackages =>
+                FilterSkippedPackages(optional: false);
+
+            public IReadOnlyDictionary<string, string> OptionalSkippedPackages =>
+                FilterSkippedPackages(optional: true);
+
+            public int ActionableConflictCount =>
+                Conflicts?.Count(conflict => conflict != null && !conflict.IsCooperativeMerge) ?? 0;
+
+            public int CooperativeConflictCount =>
+                Conflicts?.Count(conflict => conflict?.IsCooperativeMerge == true) ?? 0;
+
             public int FaultedPackageCount =>
                 Faults == null
                     ? 0
@@ -913,15 +994,21 @@ namespace FUSE.Loading
 
             public bool HasProblems =>
                 FaultedPackageCount > 0 ||
-                (Conflicts != null && Conflicts.Length > 0) ||
+                ActionableConflictCount > 0 ||
                 (UnknownSceneryAssets != null && UnknownSceneryAssets.Length > 0) ||
                 (GraphPostBindIssues != null && GraphPostBindIssues.Length > 0) ||
                 (ProgressionTransferSkips != null && ProgressionTransferSkips.Length > 0) ||
                 (SkippedPackages != null && SkippedPackages.Any(item => !FusePackageFaultRegistry.IsOptionalSkipReason(item.Value))) ||
                 BlockingNoticeCount > 0 ||
                 SceneryLoadFailureCount > 0 ||
-                OrphanedCarCount > 0 ||
-                HasModExceptionProblem;
+                OrphanedCarCount > 0;
+
+            private IReadOnlyDictionary<string, string> FilterSkippedPackages(bool optional)
+            {
+                return (SkippedPackages ?? new Dictionary<string, string>())
+                    .Where(item => FusePackageFaultRegistry.IsOptionalSkipReason(item.Value) == optional)
+                    .ToDictionary(item => item.Key, item => item.Value, StringComparer.OrdinalIgnoreCase);
+            }
 
             // Notices preserve useful diagnostics (for example, a malformed
             // optional alias catalog) but do not by themselves mean the
@@ -931,10 +1018,9 @@ namespace FUSE.Loading
             // above.
             public bool HasAdvisories => AdvisoryNoticeCount > 0;
 
-            // A single one-off third-party exception must not flip the report
-            // red, but a per-cycle thrower (world moves, update ticks) crosses
-            // the registry's thresholds within seconds of the fault starting.
-            // The Status page shares this predicate (issue #208).
+            // Exception observations are diagnostics, not package readiness.
+            // This predicate remains available to the diagnostics page and
+            // structured report, but it deliberately does not feed HasProblems.
             public bool HasModExceptionProblem =>
                 ModExceptions != null &&
                 ModExceptions.Any(record => record.IsProblem);

--- a/FUSE/Loading/FuseLoadedMod.cs
+++ b/FUSE/Loading/FuseLoadedMod.cs
@@ -4,15 +4,24 @@ namespace FUSE.Loading
 {
     public sealed class FuseLoadedMod
     {
-        public FuseLoadedMod(string folderPath, string definitionPath, FuseModDefinition definition)
+        public FuseLoadedMod(
+            string folderPath,
+            string definitionPath,
+            FuseModDefinition definition,
+            FuseModDefinition sourceDefinition = null,
+            FuseFeatureEvaluation featureEvaluation = null)
         {
             FolderPath = folderPath ?? string.Empty;
             DefinitionPath = definitionPath ?? string.Empty;
             Definition = definition;
+            SourceDefinition = sourceDefinition ?? definition;
+            FeatureEvaluation = featureEvaluation ?? new FuseFeatureEvaluation();
         }
 
         public string FolderPath { get; }
         public string DefinitionPath { get; }
         public FuseModDefinition Definition { get; }
+        public FuseModDefinition SourceDefinition { get; }
+        public FuseFeatureEvaluation FeatureEvaluation { get; }
     }
 }

--- a/FUSE/Loading/FuseMapTileRegistry.cs
+++ b/FUSE/Loading/FuseMapTileRegistry.cs
@@ -47,6 +47,61 @@ namespace FUSE.Loading
             }
         }
 
+        internal static bool RegisterTileSource(
+            string modId,
+            string modFolder,
+            string sourceId,
+            FuseMapTileSource tileSource)
+        {
+            if (string.IsNullOrWhiteSpace(modId)
+                || string.IsNullOrWhiteSpace(sourceId)
+                || tileSource == null)
+            {
+                return false;
+            }
+
+            string resolvedFolder;
+            try
+            {
+                resolvedFolder = ResolveSourceFolder(
+                    modFolder,
+                    tileSource.SourceFolder);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception(
+                    $"Skipping map tile source '{sourceId}' in '{modId}' "
+                    + "because its sourceFolder threw while resolving",
+                    ex);
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(resolvedFolder))
+            {
+                FuseLog.Warning(
+                    $"Skipping map tile source '{sourceId}' in '{modId}' "
+                    + "because its sourceFolder could not be resolved.");
+                return false;
+            }
+
+            lock (Sync)
+            {
+                var key = BuildSourceKey(modId, sourceId);
+                Sources[key] = new RegisteredTileSource
+                {
+                    SourceKey = key,
+                    ModId = modId,
+                    DirectoryName = NormalizeDirectoryName(
+                        tileSource.Directory),
+                    ResolvedFolder = resolvedFolder,
+                    Priority = tileSource.Priority
+                };
+                _sourceVersion++;
+            }
+
+            return true;
+        }
+
         internal static int MountIntoStore(MapStore store, string directoryName)
         {
             if (store == null)

--- a/FUSE/Loading/FuseModLoader.Apply.cs
+++ b/FUSE/Loading/FuseModLoader.Apply.cs
@@ -449,15 +449,24 @@ namespace FUSE.Loading
                 return true;
             }
 
-            if (CanReplaceSiblingClaim(owner, packageId))
+            var siblingHandoff = CanReplaceSiblingClaim(owner, packageId);
+            var declaredLayeringHandoff = !siblingHandoff && IsExpectedDeclaredLayering(owner, packageId);
+            if (siblingHandoff || declaredLayeringHandoff)
             {
                 var previousOwner = owner;
                 FuseRegistry.Release(kind, id, owner);
                 if (FuseRegistry.TryClaim(kind, id, packageId, out owner))
                 {
-                    FuseLog.Info(
-                        $"FUSE reassigned sibling claim package='{packageId}' operation='claim runtime object' " +
-                        $"kind='{transactionKind}' id='{id}' previousOwner='{previousOwner ?? string.Empty}'.");
+                    if (declaredLayeringHandoff)
+                    {
+                        LogExpectedDeclaredLayering(previousOwner, packageId);
+                    }
+                    else
+                    {
+                        FuseLog.Info(
+                            $"FUSE reassigned sibling claim package='{packageId}' operation='claim runtime object' " +
+                            $"kind='{transactionKind}' id='{id}' previousOwner='{previousOwner ?? string.Empty}'.");
+                    }
                     return true;
                 }
             }
@@ -772,6 +781,10 @@ namespace FUSE.Loading
                     }
 
                     var industryDefinition = industry.Value;
+                    RecordIndustryComponentOwnership(
+                        definition.Id,
+                        industry.Key,
+                        industryDefinition);
                     var exists = IndustryAPI.GetIndustry(industry.Key) != null;
                     // Diagnostic: surface the actual deserialized flag values so we
                     // can match converter intent against what the apply path sees.
@@ -885,6 +898,124 @@ namespace FUSE.Loading
             }
         }
 
+        private static void RecordIndustryComponentOwnership(
+            string packageId,
+            string industryId,
+            FuseIndustry industry)
+        {
+            if (string.IsNullOrWhiteSpace(packageId) || industry?.Components == null)
+            {
+                return;
+            }
+
+            foreach (var component in industry.Components)
+            {
+                var target = BuildIndustryComponentClaimId(industryId, component.Key, component.Value);
+                if (string.IsNullOrWhiteSpace(target))
+                {
+                    continue;
+                }
+
+                var existingOwners = new List<string>();
+                foreach (var owner in FuseRegistry.GetSharedOwners(FuseClaimKind.Industry, target))
+                {
+                    if (string.Equals(owner, packageId, StringComparison.OrdinalIgnoreCase) ||
+                        CanReplaceSiblingClaim(owner, packageId))
+                    {
+                        continue;
+                    }
+
+                    if (IsExpectedDeclaredLayering(owner, packageId))
+                    {
+                        LogExpectedDeclaredLayering(owner, packageId);
+                        continue;
+                    }
+
+                    existingOwners.Add(owner);
+                }
+
+                FuseRegistry.TryClaim(FuseClaimKind.Industry, target, packageId);
+                foreach (var owner in existingOwners)
+                {
+                    var resolution = component.Value?.Remove == true
+                        ? "shared industry component removal overlap; later removal applied"
+                        : "shared industry destination overlap; definitions merged into the same runtime location";
+                    FuseRegistry.RecordPlannedConflict(
+                        FuseClaimKind.Industry,
+                        target,
+                        owner,
+                        packageId,
+                        resolution);
+                }
+            }
+        }
+
+        internal static string BuildIndustryComponentClaimId(
+            string industryId,
+            string componentId,
+            FuseIndustryComponent component)
+        {
+            var directId = $"component:{industryId ?? string.Empty}.{componentId ?? string.Empty}";
+            if (component == null || component.Remove)
+            {
+                return directId;
+            }
+
+            var spanIds = EnumerateComponentClaimSpanIds(component)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var name = component.Name?.Trim();
+            if (spanIds.Length == 0 || string.IsNullOrWhiteSpace(name))
+            {
+                return directId;
+            }
+
+            return
+                $"destination:type={component.Type?.Trim() ?? "component"};" +
+                $"name={name};spans={string.Join(",", spanIds)}";
+        }
+
+        private static IEnumerable<string> EnumerateComponentClaimSpanIds(
+            FuseIndustryComponent component)
+        {
+            if (component?.TrackSpanIds != null)
+            {
+                foreach (var id in component.TrackSpanIds)
+                {
+                    yield return id;
+                }
+            }
+
+            var patch = component?.TrackSpanPatch;
+            if (patch == null)
+            {
+                yield break;
+            }
+
+            foreach (var values in new[]
+            {
+                patch.Replace,
+                patch.Add,
+                patch.Append,
+                patch.Prepend,
+                patch.Insert
+            })
+            {
+                if (values == null)
+                {
+                    continue;
+                }
+
+                foreach (var id in values)
+                {
+                    yield return id;
+                }
+            }
+        }
+
         private static bool LoaderDependenciesAvailable(FuseLoader loader, out string reason)
         {
             reason = string.Empty;
@@ -945,6 +1076,16 @@ namespace FUSE.Loading
             {
                 foreach (var scenery in definition.World.Scenery)
                 {
+                    var allowUnverifiedLegacyAsset = false;
+                    if (SceneryAPI.IsEditorOnlyLegacySceneryReference(scenery.Value))
+                    {
+                        FuseLog.Info(
+                            $"FUSE omitted editor-only turntable measurement helper '{scenery.Key}' " +
+                            $"from runtime package '{definition.Id}'.");
+                        transaction.Skipped("scenery", scenery.Key, "editor-only legacy measurement helper");
+                        continue;
+                    }
+
                     if (!SceneryAPI.TryResolveAssetIdentifier(scenery.Key, scenery.Value, out _))
                     {
                         if (SceneryAPI.IsKnownOptionalLegacyAssetReference(scenery.Value))
@@ -956,17 +1097,25 @@ namespace FUSE.Loading
                             continue;
                         }
 
-                        FuseLog.Warning(
-                            $"FUSE skipping scenery '{scenery.Key}' in package '{definition.Id}': " +
-                            $"AssetIdentifier='{scenery.Value?.AssetIdentifier ?? string.Empty}', " +
-                            $"Model='{scenery.Value?.Model ?? string.Empty}' did not resolve to a known PrefabStore asset.");
-                        FuseLoadReport.RecordUnknownSceneryAsset(
-                            definition.Id,
-                            scenery.Key,
-                            scenery.Value?.AssetIdentifier,
-                            scenery.Value?.Model);
-                        transaction.Skipped("scenery", scenery.Key, "unknown asset identifier");
-                        continue;
+                        if (!string.IsNullOrWhiteSpace(definitionPath) &&
+                            definitionPath.StartsWith("legacy://", StringComparison.OrdinalIgnoreCase))
+                        {
+                            allowUnverifiedLegacyAsset = true;
+                        }
+                        else
+                        {
+                            FuseLog.Warning(
+                                $"FUSE skipping scenery '{scenery.Key}' in package '{definition.Id}': " +
+                                $"AssetIdentifier='{scenery.Value?.AssetIdentifier ?? string.Empty}', " +
+                                $"Model='{scenery.Value?.Model ?? string.Empty}' did not resolve to a known PrefabStore asset.");
+                            FuseLoadReport.RecordUnknownSceneryAsset(
+                                definition.Id,
+                                scenery.Key,
+                                scenery.Value?.AssetIdentifier,
+                                scenery.Value?.Model);
+                            transaction.Skipped("scenery", scenery.Key, "unknown asset identifier");
+                            continue;
+                        }
                     }
 
                     if (!TryClaimOrSkip(FuseClaimKind.Scenery, "scenery", scenery.Key, definition.Id, transaction))
@@ -981,6 +1130,7 @@ namespace FUSE.Loading
                                      new FuseSceneryEntity(scenery.Key, definition.Id);
                         entity.InitializeIdentity(scenery.Key, definition.Id);
                         entity.BindDefinition(definition, definitionPath);
+                        entity.AllowUnverifiedLegacyAsset = allowUnverifiedLegacyAsset;
                         entity.LoadDefinition(scenery.Value);
                         if (!FuseAuthoringPersistenceService.ApplyPackageEntityToRuntime(entity))
                         {
@@ -1043,6 +1193,21 @@ namespace FUSE.Loading
                         {
                             SplineyAPI.AddSpliney(spliney.Key, spliney.Value);
                         }
+                    });
+                }
+            }
+
+            if (definition.World.WaterSurfaces != null)
+            {
+                foreach (var waterSurface in definition.World.WaterSurfaces)
+                {
+                    var exists = WaterSurfaceAPI.GetWaterSurface(waterSurface.Key) != null;
+                    transaction.TryApply("water surface", waterSurface.Key, exists, () =>
+                    {
+                        if (exists)
+                            WaterSurfaceAPI.UpdateWaterSurface(waterSurface.Key, waterSurface.Value);
+                        else
+                            WaterSurfaceAPI.AddWaterSurface(waterSurface.Key, waterSurface.Value);
                     });
                 }
             }
@@ -1158,6 +1323,7 @@ namespace FUSE.Loading
             RemoveWorldItems("scene clone", removals.SceneClones, SceneCloneAPI.TryRemoveSceneClone, transaction);
             RemoveWorldItems("scenery", removals.Scenery, SceneryAPI.TryRemoveScenery, transaction);
             RemoveWorldItems("spliney", removals.Splineys, SplineyAPI.TryRemoveSpliney, transaction);
+            RemoveWorldItems("water surface", removals.WaterSurfaces, WaterSurfaceAPI.TryRemoveWaterSurface, transaction);
             RemoveWorldItems("telegraph pole set", removals.TelegraphPoles, MapAPI.TryRemoveTelegraphPoles, transaction);
             RemoveWorldItems("map label", removals.MapLabels, MapAPI.TryRemoveMapLabel, transaction);
             RemoveWorldItems("map mask", removals.MapMasks, MapAPI.TryRemoveMapMask, transaction);

--- a/FUSE/Loading/FuseModLoader.TrackMerging.cs
+++ b/FUSE/Loading/FuseModLoader.TrackMerging.cs
@@ -19,6 +19,9 @@ namespace FUSE.Loading
 {
     public static partial class FuseModLoader
     {
+        private static readonly object DeclaredLayeringLogSync = new object();
+        private static readonly HashSet<string> DeclaredLayeringLogPairs =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         private sealed class FuseStagedApplyCandidate
         {
@@ -154,6 +157,8 @@ namespace FUSE.Loading
                 new Dictionary<string, FuseMergedTrackRemoval>(StringComparer.OrdinalIgnoreCase);
             public readonly Dictionary<string, FuseMergedTrackRemoval> Splineys =
                 new Dictionary<string, FuseMergedTrackRemoval>(StringComparer.OrdinalIgnoreCase);
+            public readonly Dictionary<string, FuseMergedTrackRemoval> WaterSurfaces =
+                new Dictionary<string, FuseMergedTrackRemoval>(StringComparer.OrdinalIgnoreCase);
             public readonly Dictionary<string, FuseMergedTrackRemoval> MapLabels =
                 new Dictionary<string, FuseMergedTrackRemoval>(StringComparer.OrdinalIgnoreCase);
             public readonly Dictionary<string, FuseMergedTrackRemoval> MapMasks =
@@ -164,7 +169,7 @@ namespace FUSE.Loading
                 new Dictionary<string, FuseMergedTrackRemoval>(StringComparer.OrdinalIgnoreCase);
 
             public bool HasAny =>
-                Scenery.Count > 0 || SceneClones.Count > 0 || Splineys.Count > 0 ||
+                Scenery.Count > 0 || SceneClones.Count > 0 || Splineys.Count > 0 || WaterSurfaces.Count > 0 ||
                 MapLabels.Count > 0 || MapMasks.Count > 0 || TelegraphPoles.Count > 0 ||
                 Industries.Count > 0;
         }
@@ -215,7 +220,14 @@ namespace FUSE.Loading
                     }
                     catch (Exception ex)
                     {
-                        FusePackageFaultRegistry.RecordFault(definition.Id, "runtime apply", ex.Message, ex);
+                        FusePackageFaultRegistry.RecordFault(
+                            definition.Id,
+                            "runtime apply",
+                            ex.Message,
+                            ex,
+                            candidate.Loaded.FolderPath,
+                            candidate.Loaded.DefinitionPath,
+                            suggestedAction: "Review this package file and the exception details, correct the referenced runtime definition, then reload the map.");
                         FusePackageFaultRegistry.MarkSkipped(definition.Id, "runtime apply exception");
                         outcomes.Add(PackageApplyOutcome.ForErrored(definition.Id, ex.Message));
                         FuseLog.Exception($"Failed to prepare FUSE definition '{definition.Id}' for staged runtime apply", ex);
@@ -255,6 +267,7 @@ namespace FUSE.Loading
                         "merged graph pre-apply");
 
                     ApplyMergedTrackGraph(mergedTrackPlan, reason);
+                    FuseSplineyPluginHost.NotifyGraphDidChange();
 
                     foreach (var candidate in active.Where(item => !item.Transaction.Report.IsFatal))
                     {
@@ -435,7 +448,13 @@ namespace FUSE.Loading
 
                     if (transaction.Report.IsFatal)
                     {
-                        FusePackageFaultRegistry.RecordFault(definition.Id, "runtime apply", transaction.Report.FatalReason);
+                        FusePackageFaultRegistry.RecordFault(
+                            definition.Id,
+                            "runtime apply",
+                            transaction.Report.FatalReason,
+                            folderPath: candidate.Loaded.FolderPath,
+                            sourceFile: candidate.Loaded.DefinitionPath,
+                            suggestedAction: "Review the per-object errors for this package in the health report, correct the referenced file, then reload the map.");
                         FusePackageFaultRegistry.MarkSkipped(definition.Id, transaction.Report.FatalReason);
                         if (HasRuntimeMutations(transaction.Report))
                         {
@@ -447,7 +466,13 @@ namespace FUSE.Loading
                     }
                     else if (transaction.Report.HasErrors)
                     {
-                        FusePackageFaultRegistry.RecordFault(definition.Id, "runtime apply", $"Runtime apply completed with {transaction.Report.Errors.Count} error(s).");
+                        FusePackageFaultRegistry.RecordFault(
+                            definition.Id,
+                            "runtime apply",
+                            $"Runtime apply completed with {transaction.Report.Errors.Count} error(s).",
+                            folderPath: candidate.Loaded.FolderPath,
+                            sourceFile: candidate.Loaded.DefinitionPath,
+                            suggestedAction: "Review the per-object errors for this package in the health report, correct the referenced file, then reload the map.");
                         if (HasRuntimeMutations(transaction.Report))
                         {
                             candidate.RegistryTransaction?.Commit();
@@ -518,6 +543,39 @@ namespace FUSE.Loading
                 .SelectMany(group => group.OrderBy(item => item.index))
                 .ToArray();
 
+            var manifestSnapshots = FuseDataPackageDiscovery.GetPackageManifestSnapshots() ??
+                                    Array.Empty<FusePackageManifestSnapshot>();
+            FuseSpatialTrackConflictDetector.Replace(
+                ordered
+                    .GroupBy(item => item.folder, StringComparer.OrdinalIgnoreCase)
+                    .Select(group =>
+                    {
+                        var loaded = group
+                            .Select(item => item.candidate?.Loaded)
+                            .FirstOrDefault(candidate => candidate?.Definition != null);
+                        var manifest = FindPackageManifestSnapshot(loaded, manifestSnapshots);
+                        var conditionalRequirements = group
+                            .SelectMany(item => item.candidate?.Loaded?.Definition?.Mixinto?.Requires ??
+                                                Array.Empty<FuseModRequirement>())
+                            .Select(requirement => requirement?.Id)
+                            .Where(id => !string.IsNullOrWhiteSpace(id));
+                        return new FuseSpatialTrackPackage
+                        {
+                            PackageId = manifest?.Id ?? loaded?.Definition?.Id ?? string.Empty,
+                            FolderPath = loaded?.FolderPath ?? string.Empty,
+                            RequiredPackageIds = (manifest?.RequiredPackageIds ?? Array.Empty<string>())
+                                .Concat(conditionalRequirements)
+                                .Distinct(StringComparer.OrdinalIgnoreCase)
+                                .ToArray(),
+                            LoadAfter = manifest?.LoadAfter ?? Array.Empty<string>(),
+                            LoadBefore = manifest?.LoadBefore ?? Array.Empty<string>(),
+                            TrackDefinitions = group
+                                .Select(item => item.candidate?.Loaded?.Definition?.Tracks)
+                                .Where(tracks => tracks != null)
+                                .ToArray()
+                        };
+                    }));
+
             var sequence = 0;
             var baseGraphSnapshot = TrackAPI.GetBaseGraphSnapshotDefinition();
             foreach (var item in ordered)
@@ -530,7 +588,7 @@ namespace FUSE.Loading
                 }
 
                 plan.OrderedCandidates.Add(candidate);
-                MergeFinalDefinitions(plan.Turntables, definition.Operations?.Turntables, candidate, ref sequence);
+                MergeFinalDefinitions(plan.Turntables, definition.Operations?.Turntables, candidate, FuseClaimKind.Turntable, ref sequence);
 
                 var tracks = definition.Tracks;
                 if (tracks == null)
@@ -538,13 +596,13 @@ namespace FUSE.Loading
                     continue;
                 }
 
-                MergeFinalDeletes(plan.RemovedSpans, plan.Spans, tracks.Removals?.Spans, candidate, ref sequence);
-                MergeFinalDeletes(plan.RemovedSegments, plan.Segments, tracks.Removals?.Segments, candidate, ref sequence);
-                MergeFinalDeletes(plan.RemovedNodes, plan.Nodes, tracks.Removals?.Nodes, candidate, ref sequence);
+                MergeFinalDeletes(plan.RemovedSpans, plan.Spans, tracks.Removals?.Spans, candidate, FuseClaimKind.Span, ref sequence);
+                MergeFinalDeletes(plan.RemovedSegments, plan.Segments, tracks.Removals?.Segments, candidate, FuseClaimKind.Segment, ref sequence);
+                MergeFinalDeletes(plan.RemovedNodes, plan.Nodes, tracks.Removals?.Nodes, candidate, FuseClaimKind.Node, ref sequence);
 
-                MergeFinalDefinitions(plan.Nodes, plan.RemovedNodes, tracks.Nodes, candidate, ref sequence);
+                MergeFinalDefinitions(plan.Nodes, plan.RemovedNodes, tracks.Nodes, candidate, FuseClaimKind.Node, ref sequence);
                 MergeFinalSegmentDefinitions(plan, tracks.Segments, candidate, baseGraphSnapshot, ref sequence);
-                MergeFinalDefinitions(plan.Spans, plan.RemovedSpans, tracks.Spans, candidate, ref sequence);
+                MergeFinalDefinitions(plan.Spans, plan.RemovedSpans, tracks.Spans, candidate, FuseClaimKind.Span, ref sequence);
             }
 
             FuseLog.Info(
@@ -579,11 +637,114 @@ namespace FUSE.Loading
             }
         }
 
+        private static FusePackageManifestSnapshot FindPackageManifestSnapshot(
+            FuseLoadedMod loaded,
+            IEnumerable<FusePackageManifestSnapshot> snapshots = null)
+        {
+            if (loaded == null)
+            {
+                return null;
+            }
+
+            var normalizedFolder = NormalizePackageFolder(loaded.FolderPath);
+            var available = snapshots ?? FuseDataPackageDiscovery.GetPackageManifestSnapshots() ??
+                            Array.Empty<FusePackageManifestSnapshot>();
+            var byFolder = available.FirstOrDefault(snapshot =>
+                !string.IsNullOrWhiteSpace(normalizedFolder) &&
+                string.Equals(
+                    NormalizePackageFolder(snapshot?.FolderPath),
+                    normalizedFolder,
+                    StringComparison.OrdinalIgnoreCase));
+            if (byFolder != null)
+            {
+                return byFolder;
+            }
+
+            return available.FirstOrDefault(snapshot =>
+                FuseDeclaredPackageRelationship.SamePackageId(snapshot?.Id, loaded.Definition?.Id));
+        }
+
+        private static bool IsExpectedDeclaredLayering(
+            FuseStagedApplyCandidate existing,
+            FuseStagedApplyCandidate later)
+        {
+            return IsExpectedDeclaredLayering(existing?.Loaded, later?.Loaded);
+        }
+
+        private static bool IsExpectedDeclaredLayering(string existingOwner, string laterOwner)
+        {
+            if (string.IsNullOrWhiteSpace(existingOwner) ||
+                string.IsNullOrWhiteSpace(laterOwner) ||
+                !LoadedMods.TryGetValue(existingOwner, out var existing) ||
+                !LoadedMods.TryGetValue(laterOwner, out var later))
+            {
+                return false;
+            }
+
+            return IsExpectedDeclaredLayering(existing, later);
+        }
+
+        private static bool IsExpectedDeclaredLayering(FuseLoadedMod existing, FuseLoadedMod later)
+        {
+            if (existing == null || later == null)
+            {
+                return false;
+            }
+
+            var snapshots = FuseDataPackageDiscovery.GetPackageManifestSnapshots() ??
+                            Array.Empty<FusePackageManifestSnapshot>();
+            return FuseDeclaredPackageRelationship.IsExpectedLaterOverride(
+                FindPackageManifestSnapshot(existing, snapshots),
+                FindPackageManifestSnapshot(later, snapshots),
+                existing.Definition,
+                later.Definition);
+        }
+
+        private static void LogExpectedDeclaredLayering(
+            FuseStagedApplyCandidate existing,
+            FuseStagedApplyCandidate later)
+        {
+            LogExpectedDeclaredLayering(existing?.Loaded, later?.Loaded);
+        }
+
+        private static void LogExpectedDeclaredLayering(string existingOwner, string laterOwner)
+        {
+            if (LoadedMods.TryGetValue(existingOwner ?? string.Empty, out var existing) &&
+                LoadedMods.TryGetValue(laterOwner ?? string.Empty, out var later))
+            {
+                LogExpectedDeclaredLayering(existing, later);
+            }
+        }
+
+        private static void LogExpectedDeclaredLayering(FuseLoadedMod existing, FuseLoadedMod later)
+        {
+            var snapshots = FuseDataPackageDiscovery.GetPackageManifestSnapshots() ??
+                            Array.Empty<FusePackageManifestSnapshot>();
+            var existingManifest = FindPackageManifestSnapshot(existing, snapshots);
+            var laterManifest = FindPackageManifestSnapshot(later, snapshots);
+            var existingId = existingManifest?.Id ?? existing?.Definition?.Id ?? string.Empty;
+            var laterId = laterManifest?.Id ?? later?.Definition?.Id ?? string.Empty;
+            var key = existingId + "\0" + laterId;
+            lock (DeclaredLayeringLogSync)
+            {
+                if (!DeclaredLayeringLogPairs.Add(key))
+                {
+                    return;
+                }
+            }
+
+            FuseLog.Info(
+                $"FUSE recognized intentional package layering base='{existingId}' extension='{laterId}' " +
+                "from the resolved requires/loadAfter/loadBefore/mixinto graph; later definitions apply in resolved order " +
+                "and this relationship is excluded from Mod Conflicts.");
+        }
+
         private static void MergeFinalDeletes<T>(
             Dictionary<string, FuseMergedTrackRemoval> removals,
             Dictionary<string, FuseMergedTrackEntry<T>> definitions,
             IEnumerable<string> ids,
             FuseStagedApplyCandidate owner,
+            FuseClaimKind claimKind,
             ref int sequence)
         {
             if (ids == null)
@@ -600,15 +761,53 @@ namespace FUSE.Loading
 
                 var id = rawId.Trim();
                 sequence++;
+                if (definitions.TryGetValue(id, out var displaced) &&
+                    IsCrossPackagePlanCollision(displaced?.Owner, owner))
+                {
+                    if (IsExpectedDeclaredLayering(displaced.Owner, owner))
+                    {
+                        LogExpectedDeclaredLayering(displaced.Owner, owner);
+                    }
+                    else
+                    {
+                        FuseRegistry.RecordPlannedConflict(
+                            claimKind,
+                            id,
+                            displaced.Owner.Loaded.Definition.Id,
+                            owner.Loaded.Definition.Id,
+                            "later package removal won; earlier package definition suppressed");
+                    }
+                }
                 definitions.Remove(id);
                 removals[id] = new FuseMergedTrackRemoval(id, owner, sequence);
             }
+        }
+
+        private static bool IsCrossPackagePlanCollision(
+            FuseStagedApplyCandidate existing,
+            FuseStagedApplyCandidate attempted)
+        {
+            var existingId = existing?.Loaded?.Definition?.Id;
+            var attemptedId = attempted?.Loaded?.Definition?.Id;
+            if (string.IsNullOrWhiteSpace(existingId) ||
+                string.IsNullOrWhiteSpace(attemptedId) ||
+                string.Equals(existingId, attemptedId, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var existingFolder = NormalizePackageFolder(existing.Loaded.FolderPath);
+            var attemptedFolder = NormalizePackageFolder(attempted.Loaded.FolderPath);
+            return string.IsNullOrWhiteSpace(existingFolder) ||
+                   string.IsNullOrWhiteSpace(attemptedFolder) ||
+                   !string.Equals(existingFolder, attemptedFolder, StringComparison.OrdinalIgnoreCase);
         }
 
         private static void MergeFinalDefinitions<T>(
             Dictionary<string, FuseMergedTrackEntry<T>> definitions,
             IDictionary<string, T> values,
             FuseStagedApplyCandidate owner,
+            FuseClaimKind claimKind,
             ref int sequence)
             where T : class
         {
@@ -626,6 +825,7 @@ namespace FUSE.Loading
 
                 var id = pair.Key.Trim();
                 sequence++;
+                RecordDefinitionReplacementConflict(definitions, id, owner, claimKind);
                 definitions[id] = new FuseMergedTrackEntry<T>(id, pair.Value, owner, sequence);
             }
         }
@@ -635,6 +835,7 @@ namespace FUSE.Loading
             Dictionary<string, FuseMergedTrackRemoval> removals,
             IDictionary<string, T> values,
             FuseStagedApplyCandidate owner,
+            FuseClaimKind claimKind,
             ref int sequence)
             where T : class
         {
@@ -653,6 +854,7 @@ namespace FUSE.Loading
                 var id = pair.Key.Trim();
                 sequence++;
                 removals.Remove(id);
+                RecordDefinitionReplacementConflict(definitions, id, owner, claimKind);
                 definitions[id] = new FuseMergedTrackEntry<T>(id, pair.Value, owner, sequence);
             }
         }
@@ -692,7 +894,33 @@ namespace FUSE.Loading
                 }
 
                 plan.RemovedSegments.Remove(id);
+                RecordDefinitionReplacementConflict(plan.Segments, id, owner, FuseClaimKind.Segment);
                 plan.Segments[id] = new FuseMergedTrackEntry<FuseSegment>(id, pair.Value, owner, sequence);
+            }
+        }
+
+        private static void RecordDefinitionReplacementConflict<T>(
+            IDictionary<string, FuseMergedTrackEntry<T>> definitions,
+            string id,
+            FuseStagedApplyCandidate owner,
+            FuseClaimKind claimKind)
+        {
+            if (definitions != null &&
+                definitions.TryGetValue(id, out var existing) &&
+                IsCrossPackagePlanCollision(existing?.Owner, owner))
+            {
+                if (IsExpectedDeclaredLayering(existing.Owner, owner))
+                {
+                    LogExpectedDeclaredLayering(existing.Owner, owner);
+                    return;
+                }
+
+                FuseRegistry.RecordPlannedConflict(
+                    claimKind,
+                    id,
+                    existing.Owner.Loaded.Definition.Id,
+                    owner.Loaded.Definition.Id,
+                    "later package definition won; earlier package definition suppressed");
             }
         }
 
@@ -814,6 +1042,7 @@ namespace FUSE.Loading
                     MergeRemovalIds(plan.Scenery, worldRemovals.Scenery, candidate, ref sequence);
                     MergeRemovalIds(plan.SceneClones, worldRemovals.SceneClones, candidate, ref sequence);
                     MergeRemovalIds(plan.Splineys, worldRemovals.Splineys, candidate, ref sequence);
+                    MergeRemovalIds(plan.WaterSurfaces, worldRemovals.WaterSurfaces, candidate, ref sequence);
                     MergeRemovalIds(plan.MapLabels, worldRemovals.MapLabels, candidate, ref sequence);
                     MergeRemovalIds(plan.MapMasks, worldRemovals.MapMasks, candidate, ref sequence);
                     MergeRemovalIds(plan.TelegraphPoles, worldRemovals.TelegraphPoles, candidate, ref sequence);
@@ -834,6 +1063,7 @@ namespace FUSE.Loading
                     CancelRemovalsByAdds(plan.Scenery, world.Scenery?.Keys, ref sequence);
                     CancelRemovalsByAdds(plan.SceneClones, world.SceneClones?.Keys, ref sequence);
                     CancelRemovalsByAdds(plan.Splineys, world.Splineys?.Keys, ref sequence);
+                    CancelRemovalsByAdds(plan.WaterSurfaces, world.WaterSurfaces?.Keys, ref sequence);
                     CancelRemovalsByAdds(plan.MapLabels, world.MapLabels?.Keys, ref sequence);
                     CancelRemovalsByAdds(plan.MapMasks, world.MapMasks?.Keys, ref sequence);
                     CancelRemovalsByAdds(plan.TelegraphPoles, world.TelegraphPoles?.Keys, ref sequence);
@@ -850,7 +1080,7 @@ namespace FUSE.Loading
                 $"FUSE merged removal plan operation='build merged removal plan' " +
                 $"packages={ordered.Select(item => item.folder).Distinct(StringComparer.OrdinalIgnoreCase).Count()} " +
                 $"definitions={ordered.Length} " +
-                $"scenery={plan.Scenery.Count} sceneClones={plan.SceneClones.Count} splineys={plan.Splineys.Count} " +
+                $"scenery={plan.Scenery.Count} sceneClones={plan.SceneClones.Count} splineys={plan.Splineys.Count} waterSurfaces={plan.WaterSurfaces.Count} " +
                 $"mapLabels={plan.MapLabels.Count} mapMasks={plan.MapMasks.Count} telegraphPoles={plan.TelegraphPoles.Count} " +
                 $"industries={plan.Industries.Count}.");
             return plan;
@@ -920,6 +1150,7 @@ namespace FUSE.Loading
             ApplyMergedRemovalsForKind(plan.Scenery, "scenery", SceneryAPI.TryRemoveScenery);
             ApplyMergedRemovalsForKind(plan.SceneClones, "scene clone", SceneCloneAPI.TryRemoveSceneClone);
             ApplyMergedRemovalsForKind(plan.Splineys, "spliney", SplineyAPI.TryRemoveSpliney);
+            ApplyMergedRemovalsForKind(plan.WaterSurfaces, "water surface", WaterSurfaceAPI.TryRemoveWaterSurface);
             ApplyMergedRemovalsForKind(plan.MapLabels, "map label", MapAPI.TryRemoveMapLabel);
             ApplyMergedRemovalsForKind(plan.MapMasks, "map mask", MapAPI.TryRemoveMapMask);
             ApplyMergedRemovalsForKind(plan.TelegraphPoles, "telegraph pole set", MapAPI.TryRemoveTelegraphPoles);
@@ -1416,6 +1647,8 @@ namespace FUSE.Loading
                 StartNodeId = hasStartNode ? definition.StartNodeId : current.StartNodeId,
                 EndNodeId = hasEndNode ? definition.EndNodeId : current.EndNodeId,
                 Style = definition.PreserveStyle ? current.Style : definition.Style,
+                BridgeSupportsSteel = definition.PreserveBridgeSupportsSteel ? current.BridgeSupportsSteel : definition.BridgeSupportsSteel,
+                Yard = definition.PreserveYard ? current.Yard : definition.Yard,
                 TrackClass = definition.PreserveTrackClass ? current.TrackClass : definition.TrackClass,
                 SpeedLimit = definition.PreserveSpeedLimit ? current.SpeedLimit : definition.SpeedLimit,
                 Priority = definition.PreservePriority ? current.Priority : definition.Priority,
@@ -1483,8 +1716,7 @@ namespace FUSE.Loading
                     // to succeed, then disappear when Unity finishes the pending
                     // destroy. A fresh graph child is required when the endpoint
                     // segment set changes (ARC Whittier's Pyc3/Pap9 case).
-                    TrackAPI.RemoveSpan(entry.Id);
-                    TrackAPI.AddSpan(entry.Id, entry.Value);
+                    TrackAPI.ReplaceSpan(entry.Id, entry.Value);
                     FuseLog.Info(
                         $"FUSE recreated track span package='{definition.Id}' operation='apply-merged-spans' " +
                         $"kind='track span' id='{entry.Id}' message='endpoint topology changed; avoided reusing retiring runtime span instance'.");

--- a/FUSE/Loading/FuseModLoader.Validation.cs
+++ b/FUSE/Loading/FuseModLoader.Validation.cs
@@ -537,6 +537,12 @@ namespace FUSE.Loading
                 }
             }
 
+            foreach (var waterSurfaceId in definition.World?.WaterSurfaces?.Keys ?? Enumerable.Empty<string>())
+            {
+                if (WaterSurfaceAPI.GetWaterSurface(waterSurfaceId) == null)
+                    transaction.Warning("water surface", waterSurfaceId, "missing after apply");
+            }
+
             foreach (var sceneCloneId in definition.World?.SceneClones?.Keys ?? Enumerable.Empty<string>())
             {
                 if (SceneCloneAPI.GetSceneClone(sceneCloneId) == null)

--- a/FUSE/Loading/FuseModLoader.cs
+++ b/FUSE/Loading/FuseModLoader.cs
@@ -35,7 +35,7 @@ namespace FUSE.Loading
                 .ToArray();
         }
 
-        public static FuseLoadedMod LoadMod(string modFolder)
+        public static FuseLoadedMod LoadMod(string modFolder, string packageId = null)
         {
             if (string.IsNullOrWhiteSpace(modFolder))
             {
@@ -48,11 +48,43 @@ namespace FUSE.Loading
             for (var index = 0; index < definitionPaths.Length; index++)
             {
                 var definitionPath = definitionPaths[index];
-                var definition = FuseSerializer.Load(definitionPath);
+                FuseModDefinition definition;
+                try
+                {
+                    definition = FuseSerializer.Load(definitionPath);
+                }
+                catch (Exception ex)
+                {
+                    var reportedId = string.IsNullOrWhiteSpace(packageId)
+                        ? Path.GetFileName(modFolder)
+                        : packageId;
+                    FusePackageFaultRegistry.RecordFault(
+                        reportedId,
+                        "JSON deserialization",
+                        ex.GetBaseException().Message,
+                        ex,
+                        modFolder,
+                        definitionPath,
+                        expectedShape: "A valid native FUSE definition object matching fuse-mod.schema.json.",
+                        receivedValue: ex.GetBaseException().Message);
+                    throw;
+                }
                 var definitionId = definition?.Id;
                 if (string.IsNullOrWhiteSpace(definitionId))
                 {
-                    FusePackageFaultRegistry.RecordFault(Path.GetFileName(modFolder), "validation", $"Definition file '{definitionPath}' is missing an id.");
+                    FusePackageFaultRegistry.RecordFault(
+                        string.IsNullOrWhiteSpace(packageId) ? Path.GetFileName(modFolder) : packageId,
+                        "schema validation",
+                        "Definition is missing the required 'id' field.",
+                        null,
+                        modFolder,
+                        definitionPath,
+                        "id",
+                        suggestedAction: "Add a unique, non-empty 'id' to this definition.",
+                        packageName: definition?.Name,
+                        validationCode: "fuse.required",
+                        expectedShape: "A unique, non-empty native FUSE definition id.",
+                        receivedValue: definitionId);
                     throw new InvalidOperationException($"FUSE definition file '{definitionPath}' is missing an id.");
                 }
 
@@ -61,7 +93,19 @@ namespace FUSE.Loading
                     var message =
                         $"Duplicate FUSE definition id '{definitionId}' in package folder '{modFolder}'. " +
                         $"First file='{firstPath}', duplicate file='{definitionPath}'.";
-                    FusePackageFaultRegistry.RecordFault(definitionId, "validation", message);
+                    FusePackageFaultRegistry.RecordFault(
+                        definitionId,
+                        "schema validation",
+                        message,
+                        null,
+                        modFolder,
+                        definitionPath,
+                        "id",
+                        suggestedAction: "Give every definition file in this package a unique id.",
+                        packageName: definition?.Name,
+                        validationCode: "fuse.id.duplicate",
+                        expectedShape: "A definition id used only once in this package.",
+                        receivedValue: definitionId);
                     throw new InvalidOperationException(message);
                 }
 
@@ -92,6 +136,21 @@ namespace FUSE.Loading
                     FuseLog.Error(
                         $"FUSE validation error package='{packageId}' operation='load definition' " +
                         $"kind='{error.Field ?? string.Empty}' message='{error.Message ?? string.Empty}'{code}{value}.");
+                    FusePackageFaultRegistry.RecordFault(
+                        packageId,
+                        "schema validation",
+                        error.Message,
+                        null,
+                        folderPath,
+                        definitionPath,
+                        error.Field,
+                        suggestedAction:
+                            $"Correct '{error.Field ?? "<root>"}' in this definition" +
+                            (string.IsNullOrWhiteSpace(error.Code) ? "." : $" (validation code {error.Code})."),
+                        packageName: definition?.Name,
+                        validationCode: error.Code,
+                        expectedShape: error.Message,
+                        receivedValue: error.Value?.ToString());
                 }
 
                 foreach (var warning in validation.Warnings)
@@ -103,11 +162,23 @@ namespace FUSE.Loading
                         $"kind='{warning.Field ?? string.Empty}' message='{warning.Message ?? string.Empty}'{code}{value}.");
                 }
 
-                FusePackageFaultRegistry.RecordFault(packageId, "validation", $"Definition failed validation with {validation.Errors.Count} error(s).");
                 throw new InvalidOperationException($"FUSE definition '{definition?.Id ?? "<null>"}' failed validation with {validation.Errors.Count} error(s).");
             }
 
-            RegisterLoadedDefinition(definition, folderPath, definitionPath);
+            var sourceDefinition = definition;
+            var runtimeDefinition = definition;
+            var featureEvaluation = new FuseFeatureEvaluation();
+            if (definition.FeatureRules != null && definition.FeatureRules.Count > 0)
+            {
+                runtimeDefinition = FuseSerializer.FromJson(FuseSerializer.ToJson(definition));
+                featureEvaluation = FuseFeatureRuleEvaluator.Apply(runtimeDefinition);
+                FuseLog.Info(
+                    $"FUSE evaluated package feature rules package='{definition.Id}' " +
+                    $"rules={featureEvaluation.RuleCount} enabled={featureEvaluation.EnabledRuleCount} " +
+                    $"disabled={featureEvaluation.DisabledRuleCount} omittedObjects={featureEvaluation.RemovedObjectCount}.");
+            }
+
+            RegisterLoadedDefinition(runtimeDefinition, folderPath, definitionPath, sourceDefinition, featureEvaluation);
         }
 
         public static int ApplyLoadedDefinitions(string reason)
@@ -163,7 +234,14 @@ namespace FUSE.Loading
                 }
                 catch (Exception ex)
                 {
-                    FusePackageFaultRegistry.RecordFault(id, "runtime apply", ex.Message, ex);
+                    FusePackageFaultRegistry.RecordFault(
+                        id,
+                        "runtime apply",
+                        ex.Message,
+                        ex,
+                        loaded.FolderPath,
+                        loaded.DefinitionPath,
+                        suggestedAction: "Review this package file and the exception details, correct the referenced runtime definition, then reload the map.");
                     FusePackageFaultRegistry.MarkSkipped(id, "runtime apply exception");
                     outcomes.Add(PackageApplyOutcome.ForErrored(id, ex.Message));
                     FuseLog.Exception($"Failed to prepare loaded FUSE definition '{id}' for runtime apply '{reason ?? "unspecified"}'", ex);
@@ -210,7 +288,12 @@ namespace FUSE.Loading
             }
         }
 
-        private static void RegisterLoadedDefinition(FuseModDefinition definition, string folderPath, string definitionPath)
+        private static void RegisterLoadedDefinition(
+            FuseModDefinition definition,
+            string folderPath,
+            string definitionPath,
+            FuseModDefinition sourceDefinition,
+            FuseFeatureEvaluation featureEvaluation)
         {
             if (definition == null || string.IsNullOrWhiteSpace(definition.Id))
             {
@@ -231,7 +314,12 @@ namespace FUSE.Loading
                     $"FUSE definition replacement package='{definition.Id}' operation='replace loaded definition' id='{definition.Id}' releasedClaims={released}.");
             }
 
-            LoadedMods[definition.Id] = new FuseLoadedMod(folderPath, definitionPath, definition);
+            LoadedMods[definition.Id] = new FuseLoadedMod(
+                folderPath,
+                definitionPath,
+                definition,
+                sourceDefinition,
+                featureEvaluation);
             if (firstLoad && !LoadedOrder.Contains(definition.Id, StringComparer.OrdinalIgnoreCase))
             {
                 LoadedOrder.Add(definition.Id);
@@ -575,6 +663,11 @@ namespace FUSE.Loading
             // Per-mod claims were released in UnloadMod; reset registry to drop
             // any orphaned shared claims and the conflict history.
             FuseRegistry.Reset();
+            FuseSpatialTrackConflictDetector.Clear();
+            lock (DeclaredLayeringLogSync)
+            {
+                DeclaredLayeringLogPairs.Clear();
+            }
             if (resetDiscovery)
             {
                 FuseDataPackageDiscovery.ResetDiscovery();
@@ -658,6 +751,13 @@ namespace FUSE.Loading
                 : null;
         }
 
+        public static FuseModDefinition GetLoadedSourceDefinition(string modId)
+        {
+            return !string.IsNullOrWhiteSpace(modId) && LoadedMods.TryGetValue(modId, out var loaded)
+                ? loaded.SourceDefinition
+                : null;
+        }
+
         public static bool TryGetLoadedMod(string modId, out FuseLoadedMod loaded)
         {
             if (string.IsNullOrWhiteSpace(modId))
@@ -682,7 +782,7 @@ namespace FUSE.Loading
 
         public static void ExportToJson(string modId, string outputPath)
         {
-            var definition = GetLoadedDefinition(modId);
+            var definition = GetLoadedSourceDefinition(modId);
             if (definition == null)
             {
                 throw new InvalidOperationException($"FUSE mod '{modId}' is not loaded.");

--- a/FUSE/Loading/FuseModRequirementResolver.cs
+++ b/FUSE/Loading/FuseModRequirementResolver.cs
@@ -24,40 +24,80 @@ namespace FUSE.Loading
                 .Where(requirement => !string.IsNullOrWhiteSpace(requirement?.Id))
                 .ToArray() ?? Array.Empty<FuseModRequirement>();
 
-            if (requirements.Length == 0)
+            var conflictsWith = mixinto?.ConflictsWith?
+                .Where(requirement => !string.IsNullOrWhiteSpace(requirement?.Id))
+                .ToArray() ?? Array.Empty<FuseModRequirement>();
+
+            if (requirements.Length == 0 && conflictsWith.Length == 0)
             {
                 return true;
             }
 
             var installedMods = CollectInstalledMods();
+            var sourceFile = string.IsNullOrWhiteSpace(loaded.DefinitionPath)
+                ? mixinto?.SourceFile ?? string.Empty
+                : loaded.DefinitionPath;
             foreach (var requirement in requirements)
             {
                 if (!TryFindInstalled(requirement.Id, installedMods, out var installed))
                 {
                     reason =
-                        $"mixinto dependency missing id='{requirement.Id}' " +
-                        $"target='{mixinto?.Target ?? string.Empty}' sourceFile='{mixinto?.SourceFile ?? string.Empty}'";
+                        $"package='{definition?.Id ?? string.Empty}' mixinto dependency missing id='{requirement.Id}' " +
+                        $"target='{mixinto?.Target ?? string.Empty}' folder='{loaded.FolderPath}' sourceFile='{sourceFile}' " +
+                        "action='Install and enable the named dependency, or correct mixinto.requires in this file.'";
                     return false;
                 }
 
-                if (!VersionSatisfies(definition?.Id, requirement, installed, out reason))
+                // Replacement capabilities use FUSE's version line, not the
+                // retired package's version line. Once the capability is
+                // declared provided, legacy notBefore/notAfter values do not
+                // compare meaningfully and must not reject the mixinto.
+                if (!installed.IsReplacementCapability &&
+                    !VersionSatisfies(definition?.Id, requirement, installed, out reason))
                 {
                     reason =
-                        $"mixinto dependency version mismatch id='{requirement.Id}' installedVersion='{installed.Version}' " +
+                        $"package='{definition?.Id ?? string.Empty}' mixinto dependency version mismatch id='{requirement.Id}' installedVersion='{installed.Version}' " +
                         $"notBefore='{requirement.NotBefore ?? string.Empty}' notAfter='{requirement.NotAfter ?? string.Empty}' " +
-                        $"target='{mixinto?.Target ?? string.Empty}' sourceFile='{mixinto?.SourceFile ?? string.Empty}'";
+                        $"target='{mixinto?.Target ?? string.Empty}' folder='{loaded.FolderPath}' sourceFile='{sourceFile}' " +
+                        "action='Install a compatible dependency version, or correct the version bounds in mixinto.requires.'";
                     return false;
                 }
             }
 
-            reason = $"mixinto requirements satisfied target='{mixinto?.Target ?? string.Empty}' sourceFile='{mixinto?.SourceFile ?? string.Empty}'";
+            foreach (var conflict in conflictsWith)
+            {
+                if (!TryFindInstalled(conflict.Id, installedMods, out var installed))
+                {
+                    continue;
+                }
+
+                var matchesVersion = installed.IsReplacementCapability ||
+                    VersionSatisfies(definition?.Id, conflict, installed, out _);
+                if (!matchesVersion)
+                {
+                    continue;
+                }
+
+                reason =
+                    $"package='{definition?.Id ?? string.Empty}' mixinto conflict matched id='{conflict.Id}' " +
+                    $"installedVersion='{installed.Version}' target='{mixinto?.Target ?? string.Empty}' " +
+                    $"folder='{loaded.FolderPath}' sourceFile='{sourceFile}' " +
+                    "action='This conditional fragment is intentionally inactive while the conflicting package is enabled.'";
+                return false;
+            }
+
+            reason = $"mixinto requirements satisfied; conflicts clear target='{mixinto?.Target ?? string.Empty}' sourceFile='{sourceFile}'";
             return true;
         }
 
-        private static Dictionary<string, InstalledMod> CollectInstalledMods()
+        internal static Dictionary<string, InstalledMod> CollectInstalledMods()
         {
             var result = new Dictionary<string, InstalledMod>(StringComparer.OrdinalIgnoreCase);
-            AddInstalled(result, "FUSE", "1.0.0", "runtime");
+            var fuseVersion = typeof(FuseModRequirementResolver).Assembly.GetName().Version?.ToString() ?? "1.0.0";
+            foreach (var capabilityId in FuseReplacementCapabilityCatalog.AdvertisedPackageIds)
+            {
+                AddInstalled(result, capabilityId, fuseVersion, "FUSE replacement capability", true);
+            }
 
             foreach (var loaded in FuseModLoader.GetLoadedModsInOrder())
             {
@@ -67,7 +107,12 @@ namespace FUSE.Loading
                     continue;
                 }
 
-                AddInstalled(result, definition.Id, definition.ModVersion, "loaded definition");
+                AddInstalled(
+                    result,
+                    definition.Id,
+                    definition.ModVersion,
+                    "loaded definition",
+                    folderPath: loaded.FolderPath);
                 TryReadFolderManifests(loaded.FolderPath, result);
             }
 
@@ -90,6 +135,14 @@ namespace FUSE.Loading
 
             foreach (var folder in folders)
             {
+                var packageId = TryReadPrimaryPackageId(folder);
+                if (IsManifestDisabled(folder) ||
+                    FuseUmmState.TryGetDisabledReason(folder, packageId, out _) ||
+                    !FuseModSetService.IsPackageEnabledByActiveSet(packageId, folder))
+                {
+                    continue;
+                }
+
                 TryReadFolderManifests(folder, result);
             }
 
@@ -111,9 +164,83 @@ namespace FUSE.Loading
                 return;
             }
 
-            AddInstalled(result, Path.GetFileName(folder), string.Empty, "mod folder");
+            AddInstalled(result, Path.GetFileName(folder), string.Empty, "mod folder", folderPath: folder);
             TryReadManifest(infoPath, "Id", "Version", "Info.json", result);
             TryReadManifest(definitionPath, "id", "version", "Definition.json", result);
+        }
+
+        private static string TryReadPrimaryPackageId(string folder)
+        {
+            foreach (var candidate in new[]
+                     {
+                         new { Path = Path.Combine(folder, "Info.json"), Id = "Id" },
+                         new { Path = Path.Combine(folder, "Definition.json"), Id = "id" }
+                     })
+            {
+                if (!File.Exists(candidate.Path))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var manifest = FuseLegacyDataConverter.ReadLegacyObject(candidate.Path);
+                    var id = ReadString(manifest, candidate.Id, "Id", "id");
+                    if (!string.IsNullOrWhiteSpace(id))
+                    {
+                        return id;
+                    }
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
+                {
+                    // The normal manifest reader reports the parse problem. The
+                    // folder name remains sufficient for enabled-state checks.
+                    FuseLog.Info(
+                        $"FUSE dependency scan could not read primary package id from '{candidate.Path}'; " +
+                        $"using folder identity instead. reason='{ex.Message}'");
+                }
+            }
+
+            return Path.GetFileName(folder) ?? string.Empty;
+        }
+
+        private static bool IsManifestDisabled(string folder)
+        {
+            var infoPath = Path.Combine(folder, "Info.json");
+            if (!File.Exists(infoPath))
+            {
+                return false;
+            }
+
+            try
+            {
+                var info = FuseLegacyDataConverter.ReadLegacyObject(infoPath);
+                return ReadBoolean(info, "FuseDisabled", false) ||
+                       ReadBoolean(info, "Disabled", false) ||
+                       ReadBoolean(info, "disabled", false) ||
+                       !ReadBoolean(info, "Enabled", true) ||
+                       !ReadBoolean(info, "enabled", true);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
+            {
+                return false;
+            }
+        }
+
+        private static bool ReadBoolean(JObject manifest, string propertyName, bool defaultValue)
+        {
+            var token = manifest?[propertyName];
+            if (token == null)
+            {
+                return defaultValue;
+            }
+
+            if (token.Type == JTokenType.Boolean)
+            {
+                return (bool)token;
+            }
+
+            return bool.TryParse(token.ToString(), out var value) ? value : defaultValue;
         }
 
         private static void TryReadManifest(
@@ -138,7 +265,7 @@ namespace FUSE.Loading
                 }
 
                 var version = ReadString(manifest, versionProperty, versionProperty.ToLowerInvariant(), "Version", "version");
-                AddInstalled(result, id, version, sourceName);
+                AddInstalled(result, id, version, sourceName, folderPath: Path.GetDirectoryName(path));
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
             {
@@ -178,7 +305,13 @@ namespace FUSE.Loading
             return string.Empty;
         }
 
-        private static void AddInstalled(IDictionary<string, InstalledMod> result, string id, string version, string source)
+        private static void AddInstalled(
+            IDictionary<string, InstalledMod> result,
+            string id,
+            string version,
+            string source,
+            bool isReplacementCapability = false,
+            string folderPath = null)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
@@ -186,15 +319,27 @@ namespace FUSE.Loading
             }
 
             var normalizedId = id.Trim();
-            AddAlias(result, normalizedId, version, source);
+            AddAlias(result, normalizedId, version, source, isReplacementCapability, folderPath);
             if (normalizedId.EndsWith(".FUSE", StringComparison.OrdinalIgnoreCase) ||
                 normalizedId.EndsWith(".RAIL", StringComparison.OrdinalIgnoreCase))
             {
-                AddAlias(result, normalizedId.Substring(0, normalizedId.Length - 5), version, source);
+                AddAlias(
+                    result,
+                    normalizedId.Substring(0, normalizedId.Length - 5),
+                    version,
+                    source,
+                    isReplacementCapability,
+                    folderPath);
             }
         }
 
-        private static void AddAlias(IDictionary<string, InstalledMod> result, string id, string version, string source)
+        private static void AddAlias(
+            IDictionary<string, InstalledMod> result,
+            string id,
+            string version,
+            string source,
+            bool isReplacementCapability,
+            string folderPath)
         {
             if (string.IsNullOrWhiteSpace(id) || result.ContainsKey(id))
             {
@@ -205,16 +350,40 @@ namespace FUSE.Loading
             {
                 Id = id,
                 Version = version ?? string.Empty,
-                Source = source ?? string.Empty
+                Source = source ?? string.Empty,
+                IsReplacementCapability = isReplacementCapability,
+                FolderPath = folderPath ?? string.Empty
             };
         }
 
-        private static bool TryFindInstalled(string id, Dictionary<string, InstalledMod> installedMods, out InstalledMod installed)
+        internal static bool TryFindInstalled(string id, Dictionary<string, InstalledMod> installedMods, out InstalledMod installed)
         {
             installed = null;
-            return !string.IsNullOrWhiteSpace(id) &&
-                   installedMods != null &&
-                   installedMods.TryGetValue(id.Trim(), out installed);
+            if (string.IsNullOrWhiteSpace(id) || installedMods == null)
+            {
+                return false;
+            }
+
+            if (installedMods.TryGetValue(id.Trim(), out installed))
+            {
+                return true;
+            }
+
+            if (!FuseReplacementCapabilityCatalog.IsProvided(id))
+            {
+                return false;
+            }
+
+            var fuseVersion = typeof(FuseModRequirementResolver).Assembly.GetName().Version?.ToString() ?? "1.0.0";
+            installed = new InstalledMod
+            {
+                Id = id.Trim(),
+                Version = fuseVersion,
+                Source = "FUSE replacement capability",
+                IsReplacementCapability = true,
+                FolderPath = string.Empty
+            };
+            return true;
         }
 
         internal static bool VersionSatisfies(
@@ -337,6 +506,8 @@ namespace FUSE.Loading
             public string Id { get; set; }
             public string Version { get; set; }
             public string Source { get; set; }
+            public bool IsReplacementCapability { get; set; }
+            public string FolderPath { get; set; }
         }
     }
 }

--- a/FUSE/Loading/FusePackageFaultRegistry.cs
+++ b/FUSE/Loading/FusePackageFaultRegistry.cs
@@ -1,30 +1,126 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using FUSE.Infrastructure;
+using Newtonsoft.Json;
 
 namespace FUSE.Loading
 {
     internal sealed class FusePackageFault
     {
         public FusePackageFault(string packageId, string stage, string message, string details)
+            : this(packageId, stage, message, details, string.Empty, string.Empty, string.Empty, 0, 0, string.Empty)
+        {
+        }
+
+        public FusePackageFault(
+            string packageId,
+            string stage,
+            string message,
+            string details,
+            string folderPath,
+            string sourceFile,
+            string jsonPath,
+            int lineNumber,
+            int linePosition,
+            string suggestedAction,
+            string packageName = null,
+            string validationCode = null,
+            string expectedShape = null,
+            string receivedValue = null)
         {
             PackageId = packageId ?? string.Empty;
+            PackageName = string.IsNullOrWhiteSpace(packageName)
+                ? InferPackageName(PackageId, folderPath)
+                : packageName.Trim();
             Stage = stage ?? string.Empty;
             Message = message ?? string.Empty;
             Details = details ?? string.Empty;
+            FolderPath = folderPath ?? string.Empty;
+            SourceFile = sourceFile ?? string.Empty;
+            RelativeSourceFile = MakeRelativeSourceFile(FolderPath, SourceFile);
+            JsonPath = jsonPath ?? string.Empty;
+            LineNumber = Math.Max(0, lineNumber);
+            LinePosition = Math.Max(0, linePosition);
+            SuggestedAction = suggestedAction ?? string.Empty;
+            ValidationCode = validationCode ?? string.Empty;
+            ExpectedShape = expectedShape ?? string.Empty;
+            ReceivedValue = receivedValue ?? string.Empty;
             TimestampUtc = DateTime.UtcNow;
         }
 
         public string PackageId { get; }
+        public string PackageName { get; }
         public string Stage { get; }
         public string Message { get; }
         public string Details { get; }
+        public string FolderPath { get; }
+        public string SourceFile { get; }
+        public string RelativeSourceFile { get; }
+        public string JsonPath { get; }
+        public int LineNumber { get; }
+        public int LinePosition { get; }
+        public string SuggestedAction { get; }
+        public string ValidationCode { get; }
+        public string ExpectedShape { get; }
+        public string ReceivedValue { get; }
         public DateTime TimestampUtc { get; }
 
         public override string ToString()
         {
-            return $"package='{PackageId}' stage='{Stage}' message='{Message}' details='{Details}'";
+            return
+                $"package='{PackageId}' packageName='{PackageName}' stage='{Stage}' message='{Message}' " +
+                $"folder='{FolderPath}' file='{SourceFile}' relativeFile='{RelativeSourceFile}' jsonPath='{JsonPath}' " +
+                $"line={LineNumber} position={LinePosition} code='{ValidationCode}' expected='{ExpectedShape}' " +
+                $"received='{ReceivedValue}' action='{SuggestedAction}' details='{Details}'";
+        }
+
+        private static string InferPackageName(string packageId, string folderPath)
+        {
+            if (!string.IsNullOrWhiteSpace(folderPath))
+            {
+                try
+                {
+                    var folderName = Path.GetFileName(folderPath.TrimEnd(
+                        Path.DirectorySeparatorChar,
+                        Path.AltDirectorySeparatorChar));
+                    if (!string.IsNullOrWhiteSpace(folderName))
+                        return folderName;
+                }
+                catch (Exception ex) when (
+                    ex is ArgumentException ||
+                    ex is NotSupportedException ||
+                    ex is PathTooLongException)
+                {
+                    // Keep the package id fallback; diagnostics must not fail
+                    // while formatting an already-broken path.
+                    return packageId ?? string.Empty;
+                }
+            }
+            return packageId ?? string.Empty;
+        }
+
+        private static string MakeRelativeSourceFile(string folderPath, string sourceFile)
+        {
+            if (string.IsNullOrWhiteSpace(sourceFile))
+                return string.Empty;
+            if (string.IsNullOrWhiteSpace(folderPath))
+                return Path.GetFileName(sourceFile) ?? sourceFile;
+            try
+            {
+                var root = Path.GetFullPath(folderPath).TrimEnd(
+                    Path.DirectorySeparatorChar,
+                    Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+                var file = Path.GetFullPath(sourceFile);
+                return file.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+                    ? file.Substring(root.Length)
+                    : Path.GetFileName(file);
+            }
+            catch
+            {
+                return Path.GetFileName(sourceFile) ?? sourceFile;
+            }
         }
     }
 
@@ -68,11 +164,65 @@ namespace FUSE.Loading
             AppliedPackages.Remove(packageId);
         }
 
-        public static void RecordFault(string packageId, string stage, string message, Exception exception = null)
+        public static void RecordFault(
+            string packageId,
+            string stage,
+            string message,
+            Exception exception = null,
+            string folderPath = null,
+            string sourceFile = null,
+            string jsonPath = null,
+            int lineNumber = 0,
+            int linePosition = 0,
+            string suggestedAction = null,
+            string packageName = null,
+            string validationCode = null,
+            string expectedShape = null,
+            string receivedValue = null)
         {
             packageId = NormalizePackageId(packageId);
+            ExtractJsonLocation(exception, ref jsonPath, ref lineNumber, ref linePosition);
+            if (string.IsNullOrWhiteSpace(folderPath) && !string.IsNullOrWhiteSpace(sourceFile))
+            {
+                try
+                {
+                    folderPath = Path.GetDirectoryName(sourceFile);
+                }
+                catch
+                {
+                    folderPath = string.Empty;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(suggestedAction) && IsJsonException(exception))
+            {
+                suggestedAction =
+                    "Correct the JSON at the reported location, validate the file against the bundled FUSE schema, then reload the package.";
+            }
+            if (IsJsonException(exception))
+            {
+                if (string.IsNullOrWhiteSpace(expectedShape))
+                    expectedShape = "Valid JSON matching the declared FUSE or package manifest schema.";
+                if (string.IsNullOrWhiteSpace(receivedValue))
+                    receivedValue = exception.GetBaseException().Message;
+            }
+
             var details = exception == null ? string.Empty : exception.ToString();
-            var fault = new FusePackageFault(packageId, stage, message, details);
+            var fault = new FusePackageFault(
+                packageId,
+                stage,
+                message,
+                details,
+                folderPath,
+                sourceFile,
+                jsonPath,
+                lineNumber,
+                linePosition,
+                suggestedAction,
+                packageName,
+                validationCode,
+                expectedShape,
+                receivedValue);
 
             if (!Faults.TryGetValue(packageId, out var packageFaults))
             {
@@ -82,13 +232,54 @@ namespace FUSE.Loading
 
             if (packageFaults.Any(existing =>
                 string.Equals(existing.Stage, fault.Stage, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(existing.Message, fault.Message, StringComparison.Ordinal)))
+                string.Equals(existing.Message, fault.Message, StringComparison.Ordinal) &&
+                string.Equals(existing.SourceFile, fault.SourceFile, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(existing.JsonPath, fault.JsonPath, StringComparison.Ordinal)))
             {
                 return;
             }
 
             packageFaults.Add(fault);
             FuseLog.Error($"FUSE package fault recorded: {fault}");
+        }
+
+        private static void ExtractJsonLocation(
+            Exception exception,
+            ref string jsonPath,
+            ref int lineNumber,
+            ref int linePosition)
+        {
+            for (var current = exception; current != null; current = current.InnerException)
+            {
+                if (current is JsonReaderException reader)
+                {
+                    jsonPath = string.IsNullOrWhiteSpace(jsonPath) ? reader.Path : jsonPath;
+                    lineNumber = lineNumber > 0 ? lineNumber : reader.LineNumber;
+                    linePosition = linePosition > 0 ? linePosition : reader.LinePosition;
+                    return;
+                }
+
+                if (current is JsonSerializationException serialization)
+                {
+                    jsonPath = string.IsNullOrWhiteSpace(jsonPath) ? serialization.Path : jsonPath;
+                    lineNumber = lineNumber > 0 ? lineNumber : serialization.LineNumber;
+                    linePosition = linePosition > 0 ? linePosition : serialization.LinePosition;
+                    return;
+                }
+            }
+        }
+
+        private static bool IsJsonException(Exception exception)
+        {
+            for (var current = exception; current != null; current = current.InnerException)
+            {
+                if (current is JsonException)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public static void MarkDisabled(string packageId, string reason)

--- a/FUSE/Loading/FuseReplacementCapabilityCatalog.cs
+++ b/FUSE/Loading/FuseReplacementCapabilityCatalog.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// Legacy package identifiers whose runtime contract is supplied by FUSE.
+    /// These are virtual capabilities, not ordinary data packages: they satisfy
+    /// dependency checks, but do not create a data-package ordering node because
+    /// the FUSE runtime is initialized before discovered packages are applied.
+    /// </summary>
+    internal static class FuseReplacementCapabilityCatalog
+    {
+        private static readonly string[] ExplicitPackageIds =
+        {
+            "FUSE",
+            "railroader",
+            "Railloader",
+            "RailLoader.Injector",
+            "RailLoader.Interchange",
+            "AssetLoader",
+            "AlinaNova21.AlinasMapMod",
+            "AlinasMapMod",
+            "AlinaMapMod",
+            "AlinaNova21.MapEditor",
+            "MapEditor",
+            "MMapEditor",
+            "Zamu.ConfusingSupplements",
+            "Zamu.C1CD",
+            "Zamu.FallFromGrace",
+            "Zamu.AbsoluteMadness",
+            "Zamu.SomeKindOfMadness",
+            "Zamu.Interchange2Interchange",
+            "Zamu.ForYourConvenience",
+            "Zamu.StrangeCustoms",
+            "StrangeCustoms",
+            "ConfusingSupplements",
+            "C1CD",
+            "FallFromGrace",
+            "AbsoluteMadness",
+            "SomeKindOfMadness",
+            "Interchange2Interchange",
+            "ForYourConvenience"
+        };
+
+        private static readonly HashSet<string> ExplicitPackageIdSet =
+            new HashSet<string>(ExplicitPackageIds.Select(Normalize), StringComparer.OrdinalIgnoreCase);
+
+        internal static IEnumerable<string> AdvertisedPackageIds => ExplicitPackageIds;
+
+        internal static bool IsProvided(string packageId)
+        {
+            var normalized = Normalize(packageId);
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                return false;
+            }
+
+            // Do not use a broad Zamu.* match here. Several ZAMU gameplay mods
+            // are still hosted and do not yet have native parity; advertising
+            // those ids would silently waive a real dependency and regress the
+            // dependent package.
+            return ExplicitPackageIdSet.Contains(normalized);
+        }
+
+        internal static string Normalize(string packageId)
+        {
+            var value = (packageId ?? string.Empty).Trim();
+            while (value.EndsWith(".FUSE", StringComparison.OrdinalIgnoreCase) ||
+                   value.EndsWith(".RAIL", StringComparison.OrdinalIgnoreCase))
+            {
+                value = value.Substring(0, value.Length - 5);
+            }
+
+            if (string.Equals(value, "rail-loader", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Railloader";
+            }
+
+            return value;
+        }
+    }
+}

--- a/FUSE/Loading/FuseSpatialTrackConflictDetector.cs
+++ b/FUSE/Loading/FuseSpatialTrackConflictDetector.cs
@@ -1,0 +1,296 @@
+using FUSE.Authoring.Data;
+using FUSE.Runtime.Registry;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+
+namespace FUSE.Loading
+{
+    internal sealed class FuseSpatialTrackPackage
+    {
+        public string PackageId { get; set; }
+        public string FolderPath { get; set; }
+        public string[] RequiredPackageIds { get; set; } = Array.Empty<string>();
+        public string[] LoadAfter { get; set; } = Array.Empty<string>();
+        public string[] LoadBefore { get; set; } = Array.Empty<string>();
+        public FuseTrackDefinition[] TrackDefinitions { get; set; } = Array.Empty<FuseTrackDefinition>();
+    }
+
+    /// <summary>
+    /// Finds conservative, advisory overlap between independent track
+    /// packages. This is deliberately separate from FuseRegistry: nearby
+    /// custom track may be a legitimate extension, so these findings must not
+    /// affect ownership, apply order, or the main Status conflict count.
+    /// </summary>
+    internal static class FuseSpatialTrackConflictDetector
+    {
+        private const float NearbyHorizontalDistance = 20f;
+        private const float NearbyVerticalDistance = 10f;
+        private static readonly object Sync = new object();
+        private static FuseRegistryConflict[] _conflicts = Array.Empty<FuseRegistryConflict>();
+
+        public static IReadOnlyList<FuseRegistryConflict> Conflicts
+        {
+            get
+            {
+                lock (Sync)
+                {
+                    return _conflicts.ToArray();
+                }
+            }
+        }
+
+        public static void Replace(IEnumerable<FuseSpatialTrackPackage> packages)
+        {
+            var detected = Detect(packages);
+            lock (Sync)
+            {
+                _conflicts = detected;
+            }
+        }
+
+        public static void Clear()
+        {
+            lock (Sync)
+            {
+                _conflicts = Array.Empty<FuseRegistryConflict>();
+            }
+        }
+
+        internal static FuseRegistryConflict[] Detect(IEnumerable<FuseSpatialTrackPackage> packages)
+        {
+            var footprints = (packages ?? Enumerable.Empty<FuseSpatialTrackPackage>())
+                .Select(BuildFootprint)
+                .Where(footprint => footprint != null && footprint.Nodes.Length >= 2 && footprint.SegmentCount >= 2)
+                .ToArray();
+            var conflicts = new List<FuseRegistryConflict>();
+
+            for (var leftIndex = 0; leftIndex < footprints.Length; leftIndex++)
+            {
+                var left = footprints[leftIndex];
+                for (var rightIndex = leftIndex + 1; rightIndex < footprints.Length; rightIndex++)
+                {
+                    var right = footprints[rightIndex];
+                    if (SamePackageFolder(left.FolderPath, right.FolderPath) ||
+                        IsExpectedLayering(left, right) ||
+                        !BoundsMayOverlap(left, right, NearbyHorizontalDistance))
+                    {
+                        continue;
+                    }
+
+                    var nearby = FindNearbyNodePairs(left.Nodes, right.Nodes);
+                    if (nearby.Count < 2)
+                    {
+                        continue;
+                    }
+
+                    var centerX = nearby.Average(pair => (pair.Left.Position.x + pair.Right.Position.x) * 0.5f);
+                    var centerZ = nearby.Average(pair => (pair.Left.Position.z + pair.Right.Position.z) * 0.5f);
+                    conflicts.Add(new FuseRegistryConflict
+                    {
+                        Kind = FuseClaimKind.Segment,
+                        Target = "SpatialTrackOverlap",
+                        Id = $"spatial-overlap:{Math.Round(centerX)},{Math.Round(centerZ)}",
+                        OwnerPackageId = left.PackageId,
+                        AttemptedPackageId = right.PackageId,
+                        Resolution =
+                            $"spatial track overlap detected from {nearby.Count} nearby node pair(s) within {NearbyHorizontalDistance:0}m; " +
+                            "both packages retained because proximity may be intentional",
+                        AtUtc = DateTime.UtcNow
+                    });
+                }
+            }
+
+            return conflicts.ToArray();
+        }
+
+        private static TrackFootprint BuildFootprint(FuseSpatialTrackPackage package)
+        {
+            if (package == null || string.IsNullOrWhiteSpace(package.PackageId))
+            {
+                return null;
+            }
+
+            var nodes = new Dictionary<string, PositionedNode>(StringComparer.OrdinalIgnoreCase);
+            var segmentCount = 0;
+            foreach (var tracks in package.TrackDefinitions ?? Array.Empty<FuseTrackDefinition>())
+            {
+                segmentCount += tracks?.Segments?.Count ?? 0;
+                if (tracks?.Nodes == null)
+                {
+                    continue;
+                }
+
+                foreach (var pair in tracks.Nodes)
+                {
+                    if (string.IsNullOrWhiteSpace(pair.Key) || pair.Value == null || !IsUsablePosition(pair.Value.Position))
+                    {
+                        continue;
+                    }
+
+                    nodes[pair.Key] = new PositionedNode(pair.Key, pair.Value.Position);
+                }
+            }
+
+            if (nodes.Count == 0)
+            {
+                return null;
+            }
+
+            var values = nodes.Values.ToArray();
+            return new TrackFootprint
+            {
+                PackageId = package.PackageId.Trim(),
+                FolderPath = package.FolderPath ?? string.Empty,
+                RequiredPackageIds = package.RequiredPackageIds ?? Array.Empty<string>(),
+                LoadAfter = package.LoadAfter ?? Array.Empty<string>(),
+                LoadBefore = package.LoadBefore ?? Array.Empty<string>(),
+                Nodes = values,
+                SegmentCount = segmentCount,
+                MinX = values.Min(node => node.Position.x),
+                MaxX = values.Max(node => node.Position.x),
+                MinZ = values.Min(node => node.Position.z),
+                MaxZ = values.Max(node => node.Position.z)
+            };
+        }
+
+        private static List<NearbyNodePair> FindNearbyNodePairs(
+            IReadOnlyList<PositionedNode> left,
+            IReadOnlyList<PositionedNode> right)
+        {
+            var maxDistanceSquared = NearbyHorizontalDistance * NearbyHorizontalDistance;
+            var candidates = new List<NearbyNodePair>();
+            foreach (var leftNode in left)
+            {
+                foreach (var rightNode in right)
+                {
+                    var vertical = Math.Abs(leftNode.Position.y - rightNode.Position.y);
+                    if (vertical > NearbyVerticalDistance)
+                    {
+                        continue;
+                    }
+
+                    var x = leftNode.Position.x - rightNode.Position.x;
+                    var z = leftNode.Position.z - rightNode.Position.z;
+                    var distanceSquared = (x * x) + (z * z);
+                    if (distanceSquared <= maxDistanceSquared)
+                    {
+                        candidates.Add(new NearbyNodePair(leftNode, rightNode, distanceSquared));
+                    }
+                }
+            }
+
+            // Greedy nearest matching prevents one dense package node from
+            // satisfying the two-node threshold more than once.
+            var usedLeft = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var usedRight = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var selected = new List<NearbyNodePair>();
+            foreach (var pair in candidates.OrderBy(candidate => candidate.DistanceSquared))
+            {
+                if (usedLeft.Contains(pair.Left.Id) || usedRight.Contains(pair.Right.Id))
+                {
+                    continue;
+                }
+
+                usedLeft.Add(pair.Left.Id);
+                usedRight.Add(pair.Right.Id);
+                selected.Add(pair);
+            }
+
+            return selected;
+        }
+
+        private static bool BoundsMayOverlap(TrackFootprint left, TrackFootprint right, float padding)
+        {
+            return left.MinX - padding <= right.MaxX && left.MaxX + padding >= right.MinX &&
+                   left.MinZ - padding <= right.MaxZ && left.MaxZ + padding >= right.MinZ;
+        }
+
+        private static bool IsExpectedLayering(TrackFootprint existing, TrackFootprint later)
+        {
+            return FuseDeclaredPackageRelationship.ContainsPackageId(later.RequiredPackageIds, existing.PackageId) ||
+                   FuseDeclaredPackageRelationship.ContainsPackageId(later.LoadAfter, existing.PackageId) ||
+                   FuseDeclaredPackageRelationship.ContainsPackageId(existing.LoadBefore, later.PackageId);
+        }
+
+        private static bool SamePackageFolder(string left, string right)
+        {
+            if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+            {
+                return false;
+            }
+
+            try
+            {
+                left = Path.GetFullPath(left).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                right = Path.GetFullPath(right).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+            catch (Exception ex)
+            {
+                // Compare the original values when a synthetic/test path is
+                // not valid for the current platform.
+                FUSE.Infrastructure.FuseLog.Warning(
+                    "FUSE spatial track overlap check could not normalize package folders " +
+                    $"left='{left}' right='{right}' message='{ex.GetBaseException().Message}'.");
+            }
+
+            return string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsUsablePosition(Vector3 position)
+        {
+            // A zero vector is the deserializer default for legacy partial
+            // node declarations, not reliable spatial evidence.
+            return position != Vector3.zero &&
+                   IsFinite(position.x) && IsFinite(position.y) && IsFinite(position.z);
+        }
+
+        private static bool IsFinite(float value)
+        {
+            return !float.IsNaN(value) && !float.IsInfinity(value);
+        }
+
+        private sealed class TrackFootprint
+        {
+            public string PackageId { get; set; }
+            public string FolderPath { get; set; }
+            public string[] RequiredPackageIds { get; set; }
+            public string[] LoadAfter { get; set; }
+            public string[] LoadBefore { get; set; }
+            public PositionedNode[] Nodes { get; set; }
+            public int SegmentCount { get; set; }
+            public float MinX { get; set; }
+            public float MaxX { get; set; }
+            public float MinZ { get; set; }
+            public float MaxZ { get; set; }
+        }
+
+        private sealed class PositionedNode
+        {
+            public PositionedNode(string id, Vector3 position)
+            {
+                Id = id;
+                Position = position;
+            }
+
+            public string Id { get; }
+            public Vector3 Position { get; }
+        }
+
+        private sealed class NearbyNodePair
+        {
+            public NearbyNodePair(PositionedNode left, PositionedNode right, float distanceSquared)
+            {
+                Left = left;
+                Right = right;
+                DistanceSquared = distanceSquared;
+            }
+
+            public PositionedNode Left { get; }
+            public PositionedNode Right { get; }
+            public float DistanceSquared { get; }
+        }
+    }
+}

--- a/FUSE/Loading/FuseSplineyPluginHost.cs
+++ b/FUSE/Loading/FuseSplineyPluginHost.cs
@@ -35,6 +35,12 @@ namespace FUSE.Loading
         private static readonly List<LegacyBuilderTask> BuilderTasks =
             new List<LegacyBuilderTask>();
 
+        // GraphDidChange must be raised after the merged graph has been committed
+        // to the live game graph, not while the legacy JSON is still being
+        // converted. Keep the state from the most recent conversion until the
+        // staged apply reaches that commit point.
+        private static StrangeCustoms.Tracks.TrackState _pendingDidChangeState;
+
         /// <summary>
         /// Defers a legacy spliney whose handler FUSE doesn't recognize natively
         /// to the GraphWillChangeEvent path so loaded old-loader plugins can
@@ -107,10 +113,14 @@ namespace FUSE.Loading
             var existingSegmentIds = new HashSet<string>(
                 state.Tracks.Segments.Keys,
                 StringComparer.OrdinalIgnoreCase);
+            var changedNodeIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var changedSegmentIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             try
             {
-                var evt = new StrangeCustoms.GraphWillChangeEvent(state, _ => { });
+                var evt = new StrangeCustoms.GraphWillChangeEvent(
+                    state,
+                    path => RecordChangedGraphPath(path, changedNodeIds, changedSegmentIds));
                 Messenger.Default.Send(evt);
             }
             catch (Exception ex)
@@ -122,15 +132,64 @@ namespace FUSE.Loading
                     ex);
             }
 
-            result.NodesAdded = MergeNewNodes(state, existingNodeIds, root);
-            result.SegmentsAdded = MergeNewSegments(state, existingSegmentIds, root);
+            result.NodesAdded = MergeNodes(state, existingNodeIds, changedNodeIds, root, out var nodesUpdated);
+            result.NodesUpdated = nodesUpdated;
+            result.SegmentsAdded = MergeSegments(state, existingSegmentIds, changedSegmentIds, root, out var segmentsUpdated);
+            result.SegmentsUpdated = segmentsUpdated;
+            _pendingDidChangeState = state;
             return result;
+        }
+
+        /// <summary>
+        /// Completes the legacy graph-event transaction after FUSE has committed
+        /// the merged track plan to the live graph. Signals Everywhere and other
+        /// hosted plugins use this notification to rebuild runtime objects.
+        /// </summary>
+        public static void NotifyGraphDidChange()
+        {
+            var state = _pendingDidChangeState ?? new StrangeCustoms.Tracks.TrackState();
+            _pendingDidChangeState = null;
+
+            try
+            {
+                Messenger.Default.Send(new StrangeCustoms.GraphDidChangeEvent(state));
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception(
+                    "FUSE spliney plugin host caught an exception while dispatching " +
+                    "GraphDidChangeEvent to legacy plugin handlers",
+                    ex);
+            }
         }
 
         public static void Reset()
         {
             Pending.Clear();
             BuilderTasks.Clear();
+            _pendingDidChangeState = null;
+        }
+
+        private static void RecordChangedGraphPath(
+            string[] path,
+            HashSet<string> changedNodeIds,
+            HashSet<string> changedSegmentIds)
+        {
+            if (path == null || path.Length < 3 ||
+                !string.Equals(path[0], "tracks", StringComparison.OrdinalIgnoreCase) ||
+                string.IsNullOrWhiteSpace(path[2]))
+            {
+                return;
+            }
+
+            if (string.Equals(path[1], "nodes", StringComparison.OrdinalIgnoreCase))
+            {
+                changedNodeIds.Add(path[2]);
+            }
+            else if (string.Equals(path[1], "segments", StringComparison.OrdinalIgnoreCase))
+            {
+                changedSegmentIds.Add(path[2]);
+            }
         }
 
         private static StrangeCustoms.Tracks.TrackState BuildState(
@@ -189,10 +248,29 @@ namespace FUSE.Loading
             {
                 StartId = segment["startNodeId"]?.Value<string>() ?? segment["startId"]?.Value<string>(),
                 EndId = segment["endNodeId"]?.Value<string>() ?? segment["endId"]?.Value<string>(),
+                Style = ParseEnum(segment["style"]?.Value<string>(), Track.TrackSegment.Style.Standard),
+                TrackClass = ParseTrackClass(segment["trackClass"]?.Value<string>()),
                 Priority = segment["priority"]?.Value<int>() ?? 0,
                 SpeedLimit = segment["speedLimit"]?.Value<int>() ?? 45,
                 GroupId = segment["groupId"]?.Value<string>(),
             };
+        }
+
+        private static TEnum ParseEnum<TEnum>(string value, TEnum fallback) where TEnum : struct
+        {
+            return !string.IsNullOrWhiteSpace(value) && Enum.TryParse(value, true, out TEnum parsed)
+                ? parsed
+                : fallback;
+        }
+
+        private static Track.TrackClass ParseTrackClass(string value)
+        {
+            if (string.Equals(value, "main", StringComparison.OrdinalIgnoreCase))
+            {
+                return Track.TrackClass.Mainline;
+            }
+
+            return ParseEnum(value, Track.TrackClass.Mainline);
         }
 
         private static Vector3 ReadVector3(JToken token)
@@ -208,11 +286,14 @@ namespace FUSE.Loading
                 obj["z"]?.Value<float>() ?? 0f);
         }
 
-        private static int MergeNewNodes(
+        private static int MergeNodes(
             StrangeCustoms.Tracks.TrackState state,
             HashSet<string> existingIds,
-            JObject root)
+            HashSet<string> changedIds,
+            JObject root,
+            out int updated)
         {
+            updated = 0;
             var rootNodes = root?["tracks"]?["nodes"] as JObject;
             if (rootNodes == null)
             {
@@ -222,23 +303,34 @@ namespace FUSE.Loading
             var added = 0;
             foreach (var entry in state.Tracks.Nodes)
             {
-                if (existingIds.Contains(entry.Key))
+                var exists = existingIds.Contains(entry.Key);
+                if (exists && !changedIds.Contains(entry.Key))
                 {
                     continue;
                 }
 
                 rootNodes[entry.Key] = SerializeNode(entry.Value);
-                added++;
+                if (exists)
+                {
+                    updated++;
+                }
+                else
+                {
+                    added++;
+                }
             }
 
             return added;
         }
 
-        private static int MergeNewSegments(
+        private static int MergeSegments(
             StrangeCustoms.Tracks.TrackState state,
             HashSet<string> existingIds,
-            JObject root)
+            HashSet<string> changedIds,
+            JObject root,
+            out int updated)
         {
+            updated = 0;
             var rootSegments = root?["tracks"]?["segments"] as JObject;
             if (rootSegments == null)
             {
@@ -248,13 +340,21 @@ namespace FUSE.Loading
             var added = 0;
             foreach (var entry in state.Tracks.Segments)
             {
-                if (existingIds.Contains(entry.Key))
+                var exists = existingIds.Contains(entry.Key);
+                if (exists && !changedIds.Contains(entry.Key))
                 {
                     continue;
                 }
 
                 rootSegments[entry.Key] = SerializeSegment(entry.Value);
-                added++;
+                if (exists)
+                {
+                    updated++;
+                }
+                else
+                {
+                    added++;
+                }
             }
 
             return added;
@@ -286,8 +386,10 @@ namespace FUSE.Loading
             {
                 ["startNodeId"] = segment.StartId,
                 ["endNodeId"] = segment.EndId,
-                ["style"] = "standard",
-                ["trackClass"] = "main",
+                ["style"] = segment.Style.ToString(),
+                ["trackClass"] = segment.TrackClass == Track.TrackClass.Mainline
+                    ? "main"
+                    : segment.TrackClass.ToString(),
                 ["speedLimit"] = segment.SpeedLimit,
                 ["priority"] = segment.Priority,
             };
@@ -524,7 +626,9 @@ namespace FUSE.Loading
         {
             public int PendingSplineyCount { get; set; }
             public int NodesAdded { get; set; }
+            public int NodesUpdated { get; set; }
             public int SegmentsAdded { get; set; }
+            public int SegmentsUpdated { get; set; }
         }
 
         public sealed class BuilderInvocationResult

--- a/FUSE/Loading/FuseTrackRemovalSnapshotStore.cs
+++ b/FUSE/Loading/FuseTrackRemovalSnapshotStore.cs
@@ -6,6 +6,7 @@ using FUSE.Authoring.Data;
 using FUSE.Authoring.Data.Common;
 using FUSE.Infrastructure;
 using FUSE.Runtime.Registry;
+using FUSE.Compatibility;
 using Track;
 using UnityEngine;
 
@@ -463,6 +464,7 @@ namespace FUSE.Loading
                 Position = node.transform.localPosition,
                 Rotation = node.transform.localEulerAngles,
                 FlipSwitchStand = node.flipSwitchStand,
+                IsDiamond = RailroaderTrackContract.GetNodeIsDiamond(node),
                 IsThrown = node.isThrown,
                 IsCtcSwitch = node.IsCTCSwitch,
                 IsCtcSwitchUnlocked = node.IsCTCSwitchUnlocked
@@ -490,7 +492,8 @@ namespace FUSE.Loading
                 Id = segment.id,
                 StartNodeId = segment.a.id,
                 EndNodeId = segment.b.id,
-                Style = segment.style.ToString(),
+                Style = RailroaderTrackContract.GetStyleName(segment),
+                StructureFlags = RailroaderTrackContract.GetStructureFlags(segment),
                 TrackClass = segment.trackClass == TrackClass.Mainline ? "main" : segment.trackClass.ToString(),
                 GroupId = segment.groupId,
                 Priority = segment.priority,
@@ -581,6 +584,7 @@ namespace FUSE.Loading
                 var restored = TrackAPI.GetNode(snapshot.Id);
                 if (restored != null)
                 {
+                    RailroaderTrackContract.SetNodeIsDiamond(restored, snapshot.IsDiamond);
                     restored.IsCTCSwitch = snapshot.IsCtcSwitch;
                     restored.IsCTCSwitchUnlocked = snapshot.IsCtcSwitchUnlocked;
                     restored.isThrown = snapshot.IsThrown;
@@ -615,6 +619,8 @@ namespace FUSE.Loading
                 StartNodeId = snapshot.StartNodeId,
                 EndNodeId = snapshot.EndNodeId,
                 Style = snapshot.Style,
+                BridgeSupportsSteel = (snapshot.StructureFlags & 4) != 0,
+                Yard = (snapshot.StructureFlags & 16) != 0,
                 TrackClass = snapshot.TrackClass,
                 SpeedLimit = snapshot.SpeedLimit,
                 Priority = snapshot.Priority,

--- a/FUSE/Patches/FuseAlinasUtilitiesCompatibility.cs
+++ b/FUSE/Patches/FuseAlinasUtilitiesCompatibility.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using FUSE.Infrastructure;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Keeps the supported, separately-installed Alina Utilities mod usable
+    /// when its RailLoader and UMM entry points are both discovered during the
+    /// same startup. Older builds can leave the RailLoader singleton alive
+    /// without an <c>IModdingContext</c>; its Settings getter then throws from
+    /// camera-distance, damage, and main-menu patches before it can fall back
+    /// to the UMM settings object.
+    ///
+    /// FUSE does not replace Alina Utilities. It only supplies the missing
+    /// settings reference on that partially-bound instance. The original mod
+    /// continues to own its settings UI and feature patches.
+    /// </summary>
+    internal static class FuseAlinasUtilitiesCompatibility
+    {
+        private const string PluginTypeName = "AlinasUtils.AlinasUtilsPlugin";
+        private const string UmmModTypeName = "AlinasUtils.UMM.Mod";
+        private const string SettingsFieldName = "_settings";
+
+        private static readonly HashSet<object> RepairedInstances =
+            new HashSet<object>(ReferenceEqualityComparer.Instance);
+
+        internal static string EnsureInstalled()
+        {
+            var foundAssembly = false;
+            var foundShared = false;
+            var repaired = 0;
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (assembly == null || assembly.IsDynamic)
+                {
+                    continue;
+                }
+
+                Type pluginType;
+                try
+                {
+                    pluginType = assembly.GetType(PluginTypeName, false);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (pluginType == null)
+                {
+                    continue;
+                }
+
+                foundAssembly = true;
+                try
+                {
+                    var shared = ReadSharedInstance(pluginType);
+                    if (shared == null)
+                    {
+                        continue;
+                    }
+
+                    foundShared = true;
+                    var settingsField = pluginType.GetField(
+                        SettingsFieldName,
+                        BindingFlags.Instance | BindingFlags.NonPublic);
+                    if (settingsField == null || settingsField.GetValue(shared) != null)
+                    {
+                        continue;
+                    }
+
+                    var settings = ReadUmmSettings(assembly, settingsField.FieldType) ??
+                                   CreateDefaultSettings(settingsField.FieldType);
+                    if (settings == null)
+                    {
+                        continue;
+                    }
+
+                    settingsField.SetValue(shared, settings);
+                    if (RepairedInstances.Add(shared))
+                    {
+                        repaired++;
+                        FuseLog.Info(
+                            "FUSE repaired a partially-bound Alina Utilities legacy instance by " +
+                            "connecting it to the mod's working settings object. Alina Utilities " +
+                            "remains installed and owns its original features.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Recovered distributions can contain more than one assembly
+                    // with an AlinasUtils identity. One stale or incompatible copy
+                    // must not prevent the compatible copy from being repaired.
+                    FuseLog.Warning(
+                        $"FUSE could not inspect one Alina Utilities assembly " +
+                        $"assembly='{assembly.GetName().Name}': {ex.Message}");
+                }
+            }
+
+            if (repaired > 0)
+            {
+                return $"repaired ({repaired})";
+            }
+
+            if (!foundAssembly)
+            {
+                return "idle (not present)";
+            }
+
+            return foundShared ? "ready" : "idle (no legacy instance)";
+        }
+
+        internal static bool IsTargetAssemblyName(string assemblyName)
+        {
+            return !string.IsNullOrWhiteSpace(assemblyName) &&
+                   assemblyName.StartsWith("AlinasUtils", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static object ResolveSettingsForTests(
+            object currentSettings,
+            object ummSettings,
+            Func<object> createDefault)
+        {
+            if (currentSettings != null)
+            {
+                return currentSettings;
+            }
+
+            return ummSettings ?? createDefault?.Invoke();
+        }
+
+        private static object ReadSharedInstance(Type pluginType)
+        {
+            try
+            {
+                var baseType = pluginType.BaseType;
+                var property = baseType?.GetProperty(
+                    "Shared",
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                return property?.GetValue(null, null);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static object ReadUmmSettings(Assembly assembly, Type settingsType)
+        {
+            try
+            {
+                var modType = assembly.GetType(UmmModTypeName, false);
+                var property = modType?.GetProperty(
+                    "Settings",
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                var value = property?.GetValue(null, null);
+                return value != null && settingsType.IsInstanceOfType(value) ? value : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static object CreateDefaultSettings(Type settingsType)
+        {
+            try
+            {
+                return settingsType == null ? null : Activator.CreateInstance(settingsType);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private sealed class ReferenceEqualityComparer : IEqualityComparer<object>
+        {
+            internal static readonly ReferenceEqualityComparer Instance =
+                new ReferenceEqualityComparer();
+
+            bool IEqualityComparer<object>.Equals(object left, object right)
+            {
+                return ReferenceEquals(left, right);
+            }
+
+            int IEqualityComparer<object>.GetHashCode(object value)
+            {
+                return value == null
+                    ? 0
+                    : System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(value);
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseAssetLoaderReplacementCompatibility.cs
+++ b/FUSE/Patches/FuseAssetLoaderReplacementCompatibility.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using HarmonyLib;
+using FUSE.Infrastructure;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// FUSE replaces AssetLoader's asset-pack discovery. Leaving the old mod's
+    /// CheckDefinitions prefix active creates a second set of stores outside
+    /// FUSE's quarantine path; one malformed Definitions.json can then abort
+    /// the Equipment or Customize window while it enumerates those stores.
+    /// Remove only patches owned by AssetLoader. The assembly stays loaded so
+    /// packages with a historical UMM dependency continue to see it installed.
+    /// </summary>
+    internal static class FuseAssetLoaderReplacementCompatibility
+    {
+        internal const string LegacyHarmonyOwner = "AssetLoader";
+
+        internal static string EnsureInstalled(Harmony harmony)
+        {
+            if (harmony == null)
+            {
+                return "unavailable";
+            }
+
+            var assetLoaderType = AccessTools.TypeByName("AssetLoader.Patches.AssetLoaderPatch");
+            if (assetLoaderType == null ||
+                !IsTargetAssemblyName(assetLoaderType.Assembly.GetName().Name))
+            {
+                return "absent";
+            }
+
+            var ownedBefore = CountOwnedPatches();
+            if (ownedBefore == 0)
+            {
+                return "replaced (no active legacy patches)";
+            }
+
+            harmony.UnpatchAll(LegacyHarmonyOwner);
+            var ownedAfter = CountOwnedPatches();
+            if (ownedAfter > 0)
+            {
+                return $"failed ({ownedAfter} patch(es) remain)";
+            }
+
+            FuseLog.Info(
+                $"FUSE disabled {ownedBefore} legacy AssetLoader Harmony patch(es). " +
+                "FUSE asset discovery remains active; the AssetLoader assembly was not removed.");
+            return $"replaced ({ownedBefore} patch(es) disabled)";
+        }
+
+        internal static bool IsTargetAssemblyName(string assemblyName) =>
+            string.Equals(assemblyName, "AssetLoader", StringComparison.OrdinalIgnoreCase);
+
+        private static int CountOwnedPatches()
+        {
+            try
+            {
+                return Harmony.GetAllPatchedMethods()
+                    .Select(Harmony.GetPatchInfo)
+                    .Where(info => info != null)
+                    .Sum(info =>
+                        info.Prefixes.Count(patch => IsLegacyOwner(patch.owner)) +
+                        info.Postfixes.Count(patch => IsLegacyOwner(patch.owner)) +
+                        info.Transpilers.Count(patch => IsLegacyOwner(patch.owner)) +
+                        info.Finalizers.Count(patch => IsLegacyOwner(patch.owner)));
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        private static bool IsLegacyOwner(string owner) =>
+            string.Equals(owner, LegacyHarmonyOwner, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/FUSE/Patches/FuseAssetPackRuntimeStoreContainerPatch.cs
+++ b/FUSE/Patches/FuseAssetPackRuntimeStoreContainerPatch.cs
@@ -25,6 +25,12 @@ namespace FUSE.Patches
                     __result = container;
                     return false;
                 }
+
+                if (FuseAssetPackRegistry.TryLoadLegacyDefinitionOverrideContainer(__instance, out container))
+                {
+                    __result = container;
+                    return false;
+                }
             }
             catch (System.Exception ex)
             {

--- a/FUSE/Patches/FuseAudioPatches.cs
+++ b/FUSE/Patches/FuseAudioPatches.cs
@@ -182,4 +182,42 @@ namespace FUSE.Patches
         }
 
     }
+
+    /// <summary>
+    /// Contains a bad whistle/horn/bell provider at the individual picker
+    /// boundary. Asset packs are third-party inputs; one provider throwing
+    /// while its definitions are enumerated must not abort construction of the
+    /// entire customize window and leave the player locked out of its controls.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FuseCarCustomizeSoundPickerGuardPatch
+    {
+        private static IEnumerable<MethodBase> TargetMethods()
+        {
+            var windowType = typeof(UI.CarCustomizeWindow.CarCustomizeWindow);
+            foreach (var name in new[] { "BuildSoundTabWhistle", "BuildSoundTabHorn", "BuildSoundTabBell" })
+            {
+                var method = AccessTools.DeclaredMethod(windowType, name);
+                if (method != null)
+                {
+                    yield return method;
+                }
+            }
+        }
+
+        private static Exception Finalizer(Exception __exception, MethodBase __originalMethod)
+        {
+            if (__exception == null)
+            {
+                return null;
+            }
+
+            var picker = (__originalMethod?.Name ?? "sound picker").Replace("BuildSoundTab", string.Empty);
+            FuseLog.Warning(
+                $"FUSE contained a broken {picker} definition provider while building the car customize window: " +
+                $"{__exception.GetBaseException().GetType().Name}: {__exception.GetBaseException().Message}. " +
+                "Only that sound picker was omitted; the rest of the window remains available.");
+            return null;
+        }
+    }
 }

--- a/FUSE/Patches/FuseC1CdCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseC1CdCompatibilityPatch.cs
@@ -1,0 +1,65 @@
+using FUSE.Infrastructure;
+using Game;
+using HarmonyLib;
+using Model.Ops;
+
+namespace FUSE.Patches
+{
+    [HarmonyPatch(typeof(Interchange), nameof(Interchange.NextAvailableServiceTime))]
+    internal static class FuseC1CdNextServiceTimePatch
+    {
+        private static bool Prefix(GameDateTime now, ref GameDateTime __result)
+        {
+            __result = FuseC1CdSchedulePolicy.CalculateNextServiceTime(
+                now,
+                FuseSettings.InterchangeServiceIntervalMinutes,
+                FuseSettings.InterchangeNotBeforeHour,
+                FuseSettings.InterchangeNotAfterHour);
+            return false;
+        }
+    }
+
+    internal static class FuseC1CdSchedulePolicy
+    {
+        internal static GameDateTime CalculateNextServiceTime(
+            GameDateTime now,
+            int intervalMinutes,
+            float notBeforeHour,
+            float notAfterHour)
+        {
+            var interval = FuseSettings.NormalizeInterchangeServiceIntervalMinutes(intervalMinutes);
+            var start = FuseSettings.ClampInterchangeServiceHour(notBeforeHour);
+            var end = FuseSettings.ClampInterchangeServiceHour(notAfterHour);
+            var candidate = now.AddingMinutes(interval).RoundingMinutes(5);
+
+            if (start <= 0f && end >= 24f)
+            {
+                return candidate;
+            }
+
+            if (start <= end)
+            {
+                if (candidate.Hours < start)
+                {
+                    return candidate.WithHours(start).RoundingMinutes(5);
+                }
+
+                if (candidate.Hours > end)
+                {
+                    return candidate.AddingDays(1f).WithHours(start).RoundingMinutes(5);
+                }
+
+                return candidate;
+            }
+
+            // A window whose start is later than its end crosses midnight
+            // (for example 22:00–06:00). Only the daytime gap is excluded.
+            if (candidate.Hours > end && candidate.Hours < start)
+            {
+                return candidate.WithHours(start).RoundingMinutes(5);
+            }
+
+            return candidate;
+        }
+    }
+}

--- a/FUSE/Patches/FuseCompanyStarterPlacementPatch.cs
+++ b/FUSE/Patches/FuseCompanyStarterPlacementPatch.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using FUSE.Loading;
 using FUSE.Infrastructure;
 using Game.Messages;
 using Game.Progression;
+using Game.Scripting.Interactive;
 using Game.State;
 using HarmonyLib;
 using KeyValue.Runtime;
@@ -13,25 +15,40 @@ using Model.Definition;
 using Model.Ops;
 using Model.Ops.Definition;
 using Track;
+using UI.Common;
 using UnityEngine;
 
 namespace FUSE.Patches
 {
     /// <summary>
     /// Moves the stock East Whittier Company starter equipment into an
-    /// interactive placement queue, and does the same for invalid placements
-    /// from any other setup. This lets the player choose live track after the
-    /// progression has settled instead of depending on one fixed scene marker.
+    /// interactive placement queue when Appalachian Railway's Whittier start
+    /// package is active. This lets the player choose live track after the
+    /// progression and tutorial have settled instead of depending on one fixed
+    /// scene marker.
     /// </summary>
     [HarmonyPatch(typeof(CompanyModeSetup), nameof(CompanyModeSetup.Setup))]
     internal static class FuseCompanyStarterPlacementPatch
     {
+        private const string AppalachianWhittierStartId =
+            "KingG.Appalachian-Railway.start-whit";
+        private static readonly Queue<SetupDescriptor.CarPlacement>
+            PendingPlacements =
+                new Queue<SetupDescriptor.CarPlacement>();
+        private static bool _presenting;
+
         [HarmonyPostfix]
         private static void SetupPostfix(
             SetupDescriptor setupDescriptor,
             ref IEnumerator __result)
         {
-            if (__result != null && setupDescriptor != null)
+            PendingPlacements.Clear();
+            _presenting = false;
+            if (__result != null
+                && setupDescriptor != null
+                && ShouldQueueStarterSetup(
+                    setupDescriptor.identifier,
+                    FuseModLoader.GetLoadedMods()))
             {
                 __result = RepairAfterInitialDelay(__result, setupDescriptor);
             }
@@ -42,7 +59,6 @@ namespace FUSE.Patches
             SetupDescriptor setupDescriptor)
         {
             var repairPending = true;
-            var placementQueue = new Queue<SetupDescriptor.CarPlacement>();
             while (original.MoveNext())
             {
                 yield return original.Current;
@@ -52,14 +68,36 @@ namespace FUSE.Patches
                 }
 
                 repairPending = false;
-                QueueStarterPlacements(setupDescriptor, placementQueue);
+                QueueStarterPlacements(
+                    setupDescriptor,
+                    PendingPlacements);
             }
 
-            if (placementQueue.Count > 0)
+            if (PendingPlacements.Count > 0)
             {
                 yield return null;
-                PresentNextPlacement(placementQueue);
+                while (InteractiveBookWindow.Shared != null
+                       && InteractiveBookWindow.Shared.IsShown)
+                {
+                    yield return null;
+                }
+                PresentNextPlacement();
             }
+        }
+
+        internal static bool ShouldQueueStarterSetup(
+            string setupIdentifier,
+            IEnumerable<string> loadedDefinitionIds)
+        {
+            return !string.IsNullOrWhiteSpace(setupIdentifier)
+                   && setupIdentifier.StartsWith(
+                       "ewh-",
+                       StringComparison.OrdinalIgnoreCase)
+                   && (loadedDefinitionIds ?? Array.Empty<string>()).Any(id =>
+                       string.Equals(
+                           id,
+                           AppalachianWhittierStartId,
+                           StringComparison.OrdinalIgnoreCase));
         }
 
         internal static int QueueStarterPlacements(
@@ -74,16 +112,9 @@ namespace FUSE.Patches
             }
 
             var queued = 0;
-            var queueEntireSetup = IsStockEastWhittierSetup(setupDescriptor);
             var retained = new List<SetupDescriptor.CarPlacement>(source.Length);
             foreach (var placement in source)
             {
-                if (!queueEntireSetup && PlacementIsUsable(placement))
-                {
-                    retained.Add(placement);
-                    continue;
-                }
-
                 placementQueue?.Enqueue(placement);
                 queued++;
                 FuseLog.Info(
@@ -96,45 +127,19 @@ namespace FUSE.Patches
             return queued;
         }
 
-        private static bool IsStockEastWhittierSetup(
-            SetupDescriptor setupDescriptor)
+        private static void PresentNextPlacement()
         {
-            return setupDescriptor != null &&
-                   !string.IsNullOrWhiteSpace(setupDescriptor.identifier) &&
-                   setupDescriptor.identifier.StartsWith(
-                       "ewh-",
-                       StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static bool PlacementIsUsable(
-            SetupDescriptor.CarPlacement placement)
-        {
-            if (placement?.marker == null)
-            {
-                return false;
-            }
-
-            var location = placement.marker.Location;
-            return location.HasValue &&
-                   location.Value.IsValid &&
-                   location.Value.segment != null &&
-                   location.Value.segment.GroupEnabled &&
-                   location.Value.segment.Available;
-        }
-
-        private static void PresentNextPlacement(
-            Queue<SetupDescriptor.CarPlacement> placementQueue)
-        {
-            if (placementQueue == null || placementQueue.Count == 0)
+            if (_presenting || PendingPlacements.Count == 0)
             {
                 return;
             }
 
-            var placement = placementQueue.Dequeue();
+            var placement = PendingPlacements.Peek();
             var descriptors = BuildDescriptors(placement);
             if (descriptors.Count == 0)
             {
-                PresentNextPlacement(placementQueue);
+                PendingPlacements.Dequeue();
+                PresentNextPlacement();
                 return;
             }
 
@@ -142,22 +147,112 @@ namespace FUSE.Patches
             if (placer == null)
             {
                 FuseLog.Warning(
-                    $"FUSE could not present {placementQueue.Count + 1} queued Company starter cut(s): " +
+                    $"FUSE could not present {PendingPlacements.Count} queued Company starter cut(s): " +
                     "the game's consist placer is unavailable.");
                 return;
             }
 
-            placer.Present(
-                descriptors,
-                null,
-                _ => placer.StartCoroutine(PresentAfterFrame(placementQueue)));
+            _presenting = true;
+            var trainController = TrainController.Shared;
+            if (trainController != null)
+            {
+                // The current game build reports `placed=true` even when its
+                // caught PlaceTrain call failed. Clearing and checking this
+                // public result prevents that false callback from consuming
+                // the retained starter cut.
+                trainController.LastPlacedTrain = null;
+            }
+            try
+            {
+                placer.Present(
+                    descriptors,
+                    null,
+                    placed =>
+                    {
+                        _presenting = false;
+                        var placedCount = TrainController.Shared?
+                            .LastPlacedTrain?.Count ?? 0;
+                        if (!WasPlacementCommitted(
+                                placed,
+                                descriptors.Count,
+                                placedCount))
+                        {
+                            FuseLog.Info(
+                                "FUSE retained "
+                                + PendingPlacements.Count
+                                + " Appalachian Railway starter cut(s) after "
+                                + (placed
+                                    ? "the game did not confirm every car was created."
+                                    : "placement was cancelled."));
+                            Toast.Present(
+                                "Starter equipment retained. Run /fuse.starters "
+                                + "when you are ready to place it.",
+                                ToastPosition.Middle);
+                            return;
+                        }
+
+                        if (PendingPlacements.Count > 0
+                            && ReferenceEquals(
+                                PendingPlacements.Peek(),
+                                placement))
+                        {
+                            PendingPlacements.Dequeue();
+                        }
+                        placer.StartCoroutine(PresentAfterFrame());
+                    });
+            }
+            catch (Exception ex)
+            {
+                _presenting = false;
+                FuseLog.Exception(
+                    "FUSE could not open Appalachian Railway starter placement; "
+                    + "the cut remains queued.",
+                    ex);
+                Toast.Present(
+                    "Starter equipment retained. Run /fuse.starters when "
+                    + "placement is available.",
+                    ToastPosition.Middle);
+            }
         }
 
-        private static IEnumerator PresentAfterFrame(
-            Queue<SetupDescriptor.CarPlacement> placementQueue)
+        internal static bool WasPlacementCommitted(
+            bool callbackReportedPlaced,
+            int expectedCarCount,
+            int placedCarCount)
+        {
+            return callbackReportedPlaced
+                   && expectedCarCount > 0
+                   && placedCarCount == expectedCarCount;
+        }
+
+        private static IEnumerator PresentAfterFrame()
         {
             yield return null;
-            PresentNextPlacement(placementQueue);
+            PresentNextPlacement();
+        }
+
+        internal static string ResumePendingPlacements()
+        {
+            if (PendingPlacements.Count == 0)
+                return "No Appalachian Railway starter equipment is pending.";
+            if (_presenting)
+            {
+                return "Starter equipment placement is already active ("
+                       + PendingPlacements.Count
+                       + " cut(s) remaining).";
+            }
+            if (InteractiveBookWindow.Shared != null
+                && InteractiveBookWindow.Shared.IsShown)
+            {
+                return "Close the tutorial, then run /fuse.starters again. "
+                       + PendingPlacements.Count
+                       + " starter cut(s) are safely retained.";
+            }
+
+            PresentNextPlacement();
+            return "Opened Appalachian Railway starter equipment placement ("
+                   + PendingPlacements.Count
+                   + " cut(s) remaining).";
         }
 
         private static List<CarDescriptor> BuildDescriptors(

--- a/FUSE/Patches/FuseCustomIndustryTitlePatch.cs
+++ b/FUSE/Patches/FuseCustomIndustryTitlePatch.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using Model.Ops;
+using StrangeCustoms.Tracks.Industries;
+using UI;
+
+namespace FUSE.Patches
+{
+    [HarmonyPatch]
+    internal static class FuseCustomIndustryTitlePatch
+    {
+        internal static MethodBase TargetMethod()
+        {
+            return AccessTools.GetDeclaredMethods(typeof(DropdownLocationPickerRowData))
+                .FirstOrDefault(method =>
+                    method.Name.IndexOf(
+                        "TitleForComponent",
+                        StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        internal static bool Prefix(IndustryComponent ic, ref string __result)
+        {
+            if (!(ic is ICustomIndustryTitle titled)
+                || string.IsNullOrWhiteSpace(titled.Title))
+            {
+                return true;
+            }
+
+            __result = titled.Title;
+            return false;
+        }
+    }
+}

--- a/FUSE/Patches/FuseEquipmentCatalogWarmup.cs
+++ b/FUSE/Patches/FuseEquipmentCatalogWarmup.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using AssetPack.Runtime;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model.Database;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Spreads the Equipment catalogue's cold Definitions.json work over
+    /// multiple frames. AssetPackRuntimeStore caches Container(), so touching
+    /// one store per frame performs exactly the same deserialization and legacy
+    /// Harmony edits the stock EquipmentWindow would trigger, without doing the
+    /// entire mounted set synchronously when the player clicks Buy.
+    /// </summary>
+    internal static class FuseEquipmentCatalogWarmup
+    {
+        private static readonly FieldInfo StoresField =
+            AccessTools.Field(typeof(PrefabStore), "_stores");
+
+        private static PrefabStore _owner;
+        private static AssetPackRuntimeStore[] _stores = Array.Empty<AssetPackRuntimeStore>();
+        private static int _nextStore;
+        private static int _failedStores;
+        private static long _elapsedTicks;
+
+        internal static int PendingStoreCount => Math.Max(0, _stores.Length - _nextStore);
+
+        internal static void Schedule(PrefabStore owner)
+        {
+            FusePrefabStoreAllCarDefinitionInfosFilterPatch.InvalidateCache();
+            _owner = owner;
+            _stores = SnapshotStores(owner);
+            _nextStore = 0;
+            _failedStores = 0;
+            _elapsedTicks = 0;
+
+            if (_stores.Length > 0)
+            {
+                FuseLog.Info(
+                    $"FUSE scheduled Equipment catalogue warm-up stores={_stores.Length}; " +
+                    "one cold definition store will be prepared per frame.");
+            }
+        }
+
+        internal static void Update()
+        {
+            if (_owner == null || _nextStore >= _stores.Length)
+            {
+                return;
+            }
+
+            if (ReadStoreCount(_owner) != _stores.Length)
+            {
+                Schedule(_owner);
+                return;
+            }
+
+            var store = _stores[_nextStore++];
+            if (store != null)
+            {
+                var started = Stopwatch.GetTimestamp();
+                try
+                {
+                    store.Container();
+                }
+                catch (Exception ex)
+                {
+                    _failedStores++;
+                    FuseLog.Warning(
+                        $"FUSE Equipment catalogue warm-up skipped store='{store.Identifier ?? "<unknown>"}' " +
+                        $"reason='{ex.GetBaseException().Message}'. The remaining stores will still be prepared.");
+                }
+                finally
+                {
+                    _elapsedTicks += Stopwatch.GetTimestamp() - started;
+                }
+            }
+
+            if (_nextStore != _stores.Length)
+            {
+                return;
+            }
+
+            var elapsedMs = _elapsedTicks * 1000d / Stopwatch.Frequency;
+            FuseLog.Info(
+                $"FUSE Equipment catalogue warm-up completed stores={_stores.Length} " +
+                $"failed={_failedStores} cumulativeWorkMs={elapsedMs:0.0}. " +
+                "Opening the buy menu will reuse the prepared containers.");
+        }
+
+        private static AssetPackRuntimeStore[] SnapshotStores(PrefabStore owner)
+        {
+            if (owner == null || StoresField == null)
+            {
+                return Array.Empty<AssetPackRuntimeStore>();
+            }
+
+            try
+            {
+                if (!(StoresField.GetValue(owner) is IEnumerable<AssetPackRuntimeStore> stores))
+                {
+                    return Array.Empty<AssetPackRuntimeStore>();
+                }
+
+                return new List<AssetPackRuntimeStore>(stores).ToArray();
+            }
+            catch
+            {
+                return Array.Empty<AssetPackRuntimeStore>();
+            }
+        }
+
+        private static int ReadStoreCount(PrefabStore owner)
+        {
+            if (owner == null || StoresField == null)
+            {
+                return -1;
+            }
+
+            try
+            {
+                return StoresField.GetValue(owner) is System.Collections.ICollection stores
+                    ? stores.Count
+                    : -1;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseFallFromGraceCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseFallFromGraceCompatibilityPatch.cs
@@ -1,0 +1,81 @@
+using System;
+using FUSE.Infrastructure;
+using Game;
+using HarmonyLib;
+using Model.Ops;
+using Track;
+using UI.Builder;
+using UI.CarInspector;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Native FUSE implementation of the small public behavior contract exposed
+    /// by ZAMU FallFromGrace. The default transform is an identity operation, so
+    /// advertising the replacement cannot silently alter an existing railroad.
+    /// </summary>
+    [HarmonyPatch(typeof(OpsController), "CalculateGraceDays", new[] { typeof(Location), typeof(Location) })]
+    internal static class FuseFallFromGraceCalculationPatch
+    {
+        private static void Postfix(ref int __result)
+        {
+            __result = AdjustGraceDays(
+                __result,
+                FuseSettings.GraceMinimumDays,
+                FuseSettings.GraceMultiplier,
+                FuseSettings.GraceAddedDays);
+        }
+
+        internal static int AdjustGraceDays(int baseDays, int minimumDays, int multiplier, int addedDays)
+        {
+            var adjusted = ((long)baseDays * multiplier) + addedDays;
+            adjusted = Math.Max(minimumDays, adjusted);
+            return adjusted > int.MaxValue
+                ? int.MaxValue
+                : adjusted < int.MinValue
+                    ? int.MinValue
+                    : (int)adjusted;
+        }
+    }
+
+    [HarmonyPatch(typeof(CarInspector), "PopulateWaybillPanel", new[] { typeof(UIPanelBuilder), typeof(Waybill) })]
+    internal static class FuseFallFromGraceInspectorPatch
+    {
+        private static void Postfix(UIPanelBuilder builder, Waybill waybill)
+        {
+            if (waybill.PaymentOnArrival <= 0)
+            {
+                return;
+            }
+
+            try
+            {
+                var row = builder.AddField(
+                    "Due",
+                    () => FormatDue(waybill, TimeWeather.Now),
+                    UIPanelBuilder.Frequency.Periodic);
+                row.RectTransform.SetSiblingIndex(2);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a FallFromGrace-compatible inspector-row error; " +
+                    $"the rest of the car inspector remains usable: {ex.GetBaseException().Message}");
+            }
+        }
+
+        internal static string FormatDue(Waybill waybill, GameDateTime now)
+        {
+            if (waybill.Completed)
+            {
+                return "Completed";
+            }
+
+            var due = waybill.Created.AddingDays(waybill.GraceDays);
+            var interval = due.IntervalString(now, GameDateTimeInterval.Style.Full);
+            return due.TotalSeconds >= now.TotalSeconds
+                ? interval + " remaining"
+                : interval + " overdue";
+        }
+    }
+}

--- a/FUSE/Patches/FuseForYourConvenienceCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseForYourConvenienceCompatibilityPatch.cs
@@ -1,0 +1,297 @@
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using HarmonyLib;
+using Model;
+using Model.Ops;
+using RollingStock;
+using UI;
+using UI.Map;
+using UI.Tags;
+using TMPro;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    internal static class FuseForYourConveniencePolicy
+    {
+        internal static bool IsActive()
+        {
+            return FuseLegacyCapabilityActivation.IsRequested(
+                "Zamu.ForYourConvenience",
+                "ForYourConvenience");
+        }
+
+        internal static string FormatSpeed(float metersPerSecond)
+        {
+            return Math.Abs(metersPerSecond * 2.23694f)
+                .ToString("0.0", CultureInfo.InvariantCulture) + " MPH";
+        }
+
+        internal static string FormatLoad(float quantity, float capacity, string description)
+        {
+            var percentage = capacity > 0.001f
+                ? Mathf.Clamp01(quantity / capacity) * 100f
+                : 0f;
+            return percentage.ToString("0", CultureInfo.InvariantCulture) + "% " +
+                   (description ?? "Unknown load");
+        }
+    }
+
+    [HarmonyPatch(typeof(Car), nameof(Car.Setup))]
+    internal static class FuseForYourConvenienceCabooseMapIconPatch
+    {
+        private static readonly FieldInfo MapIconField = AccessTools.Field(typeof(Car), "MapIcon");
+
+        private static void Postfix(Car __instance, Car.SetupPrefabs prefabs, bool isGhost)
+        {
+            if (!FuseForYourConveniencePolicy.IsActive() ||
+                !FuseSettings.ForYourConvenienceShowCabooseIcons ||
+                isGhost || __instance == null || __instance.CarType != "NE" ||
+                prefabs.LocomotiveMapIcon == null || MapIconField == null ||
+                MapIconField.GetValue(__instance) != null)
+            {
+                return;
+            }
+
+            try
+            {
+                var icon = UnityEngine.Object.Instantiate(prefabs.LocomotiveMapIcon, __instance.transform);
+                icon.SetText(__instance.Ident.RoadNumber);
+                icon.OnClick = () => CarPickable.HandleShowInspector(__instance);
+                MapIconField.SetValue(__instance, icon);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not add the optional caboose map icon for '" +
+                    __instance.DisplayName + "': " + ex.GetBaseException().Message);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(TagController), "UpdateTag")]
+    internal static class FuseForYourConvenienceCarTagPatch
+    {
+        private static void Postfix(Car car, TagCallout tagCallout)
+        {
+            if (!FuseForYourConveniencePolicy.IsActive() || car == null || tagCallout?.callout == null ||
+                (!FuseSettings.ForYourConvenienceShowCarTagMph &&
+                 !FuseSettings.ForYourConvenienceShowCarTagLoads))
+            {
+                return;
+            }
+
+            try
+            {
+                var text = new StringBuilder(tagCallout.callout.Text ?? string.Empty);
+                if (FuseSettings.ForYourConvenienceShowCarTagMph)
+                {
+                    AppendLine(text, FuseForYourConveniencePolicy.FormatSpeed(car.velocity));
+                }
+
+                if (FuseSettings.ForYourConvenienceShowCarTagLoads && car.Definition?.LoadSlots != null)
+                {
+                    for (var slotIndex = 0; slotIndex < car.Definition.LoadSlots.Count; slotIndex++)
+                    {
+                        var info = car.GetLoadInfo(slotIndex);
+                        if (!info.HasValue)
+                        {
+                            continue;
+                        }
+
+                        var load = CarPrototypeLibrary.instance?.LoadForId(info.Value.LoadId);
+                        var description = load == null
+                            ? info.Value.LoadId
+                            : info.Value.LoadString(load);
+                        AppendLine(
+                            text,
+                            FuseForYourConveniencePolicy.FormatLoad(
+                                info.Value.Quantity,
+                                car.Definition.LoadSlots[slotIndex].MaximumCapacity,
+                                description));
+                    }
+                }
+
+                tagCallout.callout.Text = text.ToString();
+                tagCallout.callout.Layout();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not append optional information to car tag '" +
+                    car.DisplayName + "': " + ex.GetBaseException().Message);
+            }
+        }
+
+        private static void AppendLine(StringBuilder builder, string value)
+        {
+            if (builder.Length > 0)
+            {
+                builder.AppendLine();
+            }
+
+            builder.Append(value);
+        }
+    }
+
+    [HarmonyPatch(typeof(MapBuilder), nameof(MapBuilder.Rebuild))]
+    internal static class FuseForYourConvenienceStationMapPatch
+    {
+        private const float MaximumStationDistance = 250f;
+        private static readonly string[] IdentityRoleSuffixes =
+        {
+            "stationagent",
+            "station",
+            "depot",
+            "agent",
+            "area"
+        };
+        private static readonly FieldInfo AreaIdField = AccessTools.Field(typeof(StationAgent), "areaId");
+        private static readonly FieldInfo PassengerStopIdField = AccessTools.Field(typeof(StationAgent), "passengerStopId");
+
+        private static void Postfix()
+        {
+            if (!FuseForYourConveniencePolicy.IsActive())
+            {
+                return;
+            }
+
+            try
+            {
+                var agents = UnityEngine.Object.FindObjectsOfType<StationAgent>(true);
+                if (agents == null || agents.Length == 0)
+                {
+                    return;
+                }
+
+                foreach (var icon in UnityEngine.Object.FindObjectsOfType<MapIcon>(true))
+                {
+                    if (icon == null || icon.OnClick != null || icon.GetComponentInParent<Car>() != null)
+                    {
+                        continue;
+                    }
+
+                    var nearest = FindNearest(
+                        icon.transform.position,
+                        BuildIconIdentity(icon),
+                        agents);
+                    if (nearest != null)
+                    {
+                        icon.OnClick = () => nearest.Activate(default(PickableActivateEvent));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not attach optional station-map actions: " +
+                    ex.GetBaseException().Message);
+            }
+        }
+
+        internal static bool IsStationIdentityMatch(
+            string iconIdentity,
+            string areaId,
+            string passengerStopId)
+        {
+            var normalizedIcon = NormalizeIdentity(iconIdentity);
+            if (normalizedIcon.Length < 3)
+            {
+                return false;
+            }
+
+            return IdentityMatches(normalizedIcon, areaId) ||
+                   IdentityMatches(normalizedIcon, passengerStopId);
+        }
+
+        private static bool IdentityMatches(string normalizedIcon, string stationIdentity)
+        {
+            var normalizedStation = NormalizeIdentity(stationIdentity);
+            return normalizedStation.Length >= 3 &&
+                   string.Equals(normalizedIcon, normalizedStation, StringComparison.Ordinal);
+        }
+
+        private static string NormalizeIdentity(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            var normalized = new StringBuilder(value.Length);
+            for (var index = 0; index < value.Length; index++)
+            {
+                if (char.IsLetterOrDigit(value[index]))
+                {
+                    normalized.Append(char.ToLowerInvariant(value[index]));
+                }
+            }
+
+            var result = normalized.ToString();
+            for (var index = 0; index < IdentityRoleSuffixes.Length; index++)
+            {
+                var suffix = IdentityRoleSuffixes[index];
+                if (result.Length > suffix.Length + 2 &&
+                    result.EndsWith(suffix, StringComparison.Ordinal))
+                {
+                    return result.Substring(0, result.Length - suffix.Length);
+                }
+            }
+
+            return result;
+        }
+
+        private static string BuildIconIdentity(MapIcon icon)
+        {
+            var identity = new StringBuilder();
+            var label = icon.GetComponentInChildren<TMP_Text>(true);
+            if (label != null && !string.IsNullOrWhiteSpace(label.text))
+            {
+                return label.text;
+            }
+
+            for (var current = icon.transform; current != null; current = current.parent)
+            {
+                identity.Append(' ').Append(current.name);
+            }
+
+            return identity.ToString();
+        }
+
+        private static StationAgent FindNearest(
+            Vector3 position,
+            string iconIdentity,
+            StationAgent[] agents)
+        {
+            StationAgent nearest = null;
+            var best = MaximumStationDistance * MaximumStationDistance;
+            for (var index = 0; index < agents.Length; index++)
+            {
+                var candidate = agents[index];
+                if (candidate == null || !candidate.isActiveAndEnabled ||
+                    !IsStationIdentityMatch(
+                        iconIdentity,
+                        AreaIdField?.GetValue(candidate) as string,
+                        PassengerStopIdField?.GetValue(candidate) as string))
+                {
+                    continue;
+                }
+
+                var offset = candidate.transform.position - position;
+                offset.y = 0f;
+                var distance = offset.sqrMagnitude;
+                if (distance < best)
+                {
+                    nearest = candidate;
+                    best = distance;
+                }
+            }
+
+            return nearest;
+        }
+    }
+}

--- a/FUSE/Patches/FuseInterchangePatches.cs
+++ b/FUSE/Patches/FuseInterchangePatches.cs
@@ -1,6 +1,7 @@
 using System;
 using FUSE.Runtime.API;
 using FUSE.Infrastructure;
+using Game.State;
 using HarmonyLib;
 using Model.Ops;
 
@@ -23,6 +24,20 @@ namespace FUSE.Patches
                 {
                     var componentContext = unloader.CreateContext(ctx.Now, 0f);
                     unloader.ServeInterchange(componentContext, __instance);
+                }
+
+                // C1CD compatibility: continuous service means an interchange
+                // receives another extra-service slot even when this pass did
+                // not leave any pending orders. Scheduling here avoids the old
+                // brittle IL edit inside OpsController.CheckServiceInterchanges.
+                if (FuseSettings.InterchangeContinuousService && StateManager.IsHost)
+                {
+                    __instance.ScheduleExtra(new Game.GameDateTime?(
+                        FuseC1CdSchedulePolicy.CalculateNextServiceTime(
+                            ctx.Now,
+                            FuseSettings.InterchangeServiceIntervalMinutes,
+                            FuseSettings.InterchangeNotBeforeHour,
+                            FuseSettings.InterchangeNotAfterHour)));
                 }
             }
             catch (Exception ex)

--- a/FUSE/Patches/FuseInterchangeToInterchangeCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseInterchangeToInterchangeCompatibilityPatch.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using HarmonyLib;
+using Model.Ops;
+using Model.Ops.Definition;
+using UI.CarInspector;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    internal static class FuseInterchangeToInterchangePolicy
+    {
+        internal static bool IsActive()
+        {
+            return FuseLegacyCapabilityActivation.IsRequested(
+                "Zamu.Interchange2Interchange",
+                "Interchange2Interchange");
+        }
+
+        internal static int ScaleMaximumCars(int configuredMaximum, float contractMultiplier)
+        {
+            if (configuredMaximum <= 0 || contractMultiplier <= 0f || float.IsNaN(contractMultiplier))
+            {
+                return 0;
+            }
+
+            return Mathf.Clamp(
+                Mathf.RoundToInt(configuredMaximum * contractMultiplier),
+                0,
+                200);
+        }
+    }
+
+    [HarmonyPatch(typeof(OpsController), "RebuildCollections")]
+    internal static class FuseInterchangeToInterchangeContractSetupPatch
+    {
+        private static void Postfix(OpsController __instance)
+        {
+            if (!FuseInterchangeToInterchangePolicy.IsActive() || __instance?.AllInterchanges == null)
+            {
+                return;
+            }
+
+            foreach (var interchange in __instance.AllInterchanges)
+            {
+                if (interchange?.Industry != null)
+                {
+                    interchange.Industry.usesContract = true;
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(Interchange), nameof(Interchange.OrderCars))]
+    internal static class FuseInterchangeToInterchangeOrderPatch
+    {
+        private const string LastOrderTimeKey = "fuse.i2i.lastOrderTime";
+
+        private static void Postfix(Interchange __instance, IIndustryContext ctx)
+        {
+            if (!FuseInterchangeToInterchangePolicy.IsActive() || __instance == null || ctx == null)
+            {
+                return;
+            }
+
+            try
+            {
+                AddInterchangeOrders(__instance, ctx);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not create interchange-to-interchange orders for " +
+                    $"'{__instance.DisplayName}'; normal interchange service remains available: " +
+                    ex.GetBaseException().Message);
+            }
+        }
+
+        private static void AddInterchangeOrders(Interchange source, IIndustryContext ctx)
+        {
+            if (source.Industry == null)
+            {
+                return;
+            }
+
+            source.Industry.usesContract = true;
+            var multiplier = source.Industry.GetContractMultiplier();
+            var maximumCars = FuseInterchangeToInterchangePolicy.ScaleMaximumCars(
+                FuseSettings.InterchangeToInterchangeMaximumCars,
+                multiplier);
+            if (maximumCars <= 0 ||
+                ctx.Now.DaysSince(ctx.GetDateTime(LastOrderTimeKey, Game.GameDateTime.Zero)) < 1f)
+            {
+                return;
+            }
+
+            var controller = OpsController.Shared;
+            var destinations = (controller?.EnabledInterchanges ?? Enumerable.Empty<Interchange>())
+                .Where(candidate => candidate != null && candidate != source && candidate.Industry != null)
+                .ToArray();
+            var cargo = CollectCargo(controller).ToArray();
+            if (destinations.Length == 0 || cargo.Length == 0)
+            {
+                return;
+            }
+
+            var added = 0;
+            foreach (var destination in destinations)
+            {
+                var remaining = UnityEngine.Random.Range(0, maximumCars + 1);
+                while (remaining > 0)
+                {
+                    var count = UnityEngine.Random.Range(1, Math.Min(3, remaining) + 1);
+                    remaining -= count;
+                    var selection = cargo[UnityEngine.Random.Range(0, cargo.Length)];
+                    source.AddOrder(new Order(
+                        new CarTypeFilter(selection.CarFilter),
+                        selection.Load,
+                        destination,
+                        count,
+                        null,
+                        false));
+                    added += count;
+                }
+            }
+
+            if (added > 0)
+            {
+                ctx.SetDateTime(LastOrderTimeKey, ctx.Now);
+                FuseLog.Info(
+                    $"FUSE scheduled {added} interchange-to-interchange car(s) from '{source.DisplayName}'.");
+            }
+        }
+
+        private static IEnumerable<CargoTarget> CollectCargo(OpsController controller)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var industry in controller?.AllIndustries ?? Array.Empty<Industry>())
+            {
+                if (industry == null || industry.ProgressionDisabled)
+                {
+                    continue;
+                }
+
+                foreach (var component in industry.Components ?? Array.Empty<IndustryComponent>())
+                {
+                    if (component == null || component.ProgressionDisabled || component.carTypeFilter == null ||
+                        component.carTypeFilter.Matches("PB") || component.carTypeFilter.Matches("PBO"))
+                    {
+                        continue;
+                    }
+
+                    var load = LoadFor(component);
+                    var filter = component.carTypeFilter.queryString;
+                    var key = (filter ?? string.Empty) + "\n" + (load?.id ?? string.Empty);
+                    if (load != null && !string.IsNullOrWhiteSpace(filter) && seen.Add(key))
+                    {
+                        yield return new CargoTarget(filter, load);
+                    }
+                }
+            }
+        }
+
+        private static Load LoadFor(IndustryComponent component)
+        {
+            if (component is IndustryLoaderBase loader)
+            {
+                return loader.load;
+            }
+
+            if (component is IndustryUnloader unloader)
+            {
+                return unloader.load;
+            }
+
+            return (component as TeleportLoadingIndustry)?.load;
+        }
+
+        private readonly struct CargoTarget
+        {
+            internal CargoTarget(string carFilter, Load load)
+            {
+                CarFilter = carFilter;
+                Load = load;
+            }
+
+            internal string CarFilter { get; }
+            internal Load Load { get; }
+        }
+    }
+
+    [HarmonyPatch]
+    internal static class FuseInterchangeToInterchangeInspectorPatch
+    {
+        private static MethodBase TargetMethod()
+        {
+            return AccessTools.GetDeclaredMethods(typeof(CarInspector))
+                .FirstOrDefault(method => method.Name.IndexOf("ShouldShowIndustry", StringComparison.Ordinal) >= 0);
+        }
+
+        private static void Postfix(Industry industry, ref bool __result)
+        {
+            if (!__result && FuseInterchangeToInterchangePolicy.IsActive() &&
+                industry != null && !industry.ProgressionDisabled &&
+                industry.Components.OfType<Interchange>().Any())
+            {
+                __result = true;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseLegosLibraryCompatibility.cs
+++ b/FUSE/Patches/FuseLegosLibraryCompatibility.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Reflection;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model.Definition;
+using Newtonsoft.Json;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Gives LegosLibraryOfStuff's definition clone operation the same Unity
+    /// value converters used by the game. The library's default Newtonsoft
+    /// clone walks calculated Vector2/Vector3 properties and can report a
+    /// self-referencing loop, aborting the remainder of its catalog edits.
+    /// </summary>
+    internal static class FuseLegosLibraryCompatibility
+    {
+        private const string PatchTypeName =
+            "LegosLibraryOfStuff.ContainerSerializationDeserializePatch";
+
+        private static readonly MethodInfo SerializerSettingsMethod =
+            AccessTools.Method(typeof(ContainerSerialization), "JsonSerializerSettings");
+
+        private static bool _installed;
+        private static int _cloneFailures;
+
+        internal static string EnsureInstalled(Harmony harmony)
+        {
+            if (_installed)
+            {
+                return "installed";
+            }
+
+            if (harmony == null)
+            {
+                return "unavailable (no harmony)";
+            }
+
+            var patchType = AccessTools.TypeByName(PatchTypeName);
+            if (patchType == null)
+            {
+                return "idle (not present)";
+            }
+
+            var cloneItem = AccessTools.DeclaredMethod(
+                patchType,
+                "CloneItem",
+                new[] { typeof(ContainerItem) });
+            if (cloneItem == null || SerializerSettingsMethod == null)
+            {
+                return "idle (surface changed)";
+            }
+
+            harmony.Patch(
+                cloneItem,
+                prefix: new HarmonyMethod(
+                    typeof(FuseLegosLibraryCompatibility),
+                    nameof(CloneItemPrefix)));
+            _installed = true;
+            return "installed";
+        }
+
+        private static bool CloneItemPrefix(ContainerItem item, ref ContainerItem __result)
+        {
+            if (item == null)
+            {
+                return true;
+            }
+
+            try
+            {
+                var settings = SerializerSettingsMethod.Invoke(null, null) as JsonSerializerSettings;
+                if (settings == null)
+                {
+                    return true;
+                }
+
+                var json = JsonConvert.SerializeObject(item, Formatting.None, settings);
+                var clone = JsonConvert.DeserializeObject<ContainerItem>(json, settings);
+                if (clone == null)
+                {
+                    return true;
+                }
+
+                __result = clone;
+                return false;
+            }
+            catch (Exception ex)
+            {
+                _cloneFailures++;
+                if (FuseGuardLog.ShouldLog(_cloneFailures))
+                {
+                    FuseLog.Exception(
+                        $"FUSE could not safely clone Lego definition '{item.Identifier}'; " +
+                        "the library's original clone path will be attempted",
+                        ex);
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseLocationPickerDeduplicationPatch.cs
+++ b/FUSE/Patches/FuseLocationPickerDeduplicationPatch.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model.Ops;
+using UI.Builder;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Removes semantically duplicate destinations from the car inspector's
+    /// automatic-waybill picker. Legacy packages can leave multiple runtime
+    /// component objects with the same identifier; Railroader otherwise shows
+    /// every object as a separate, indistinguishable picker row.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FuseLocationPickerDeduplicationPatch
+    {
+        private const string EmptyDestinationKey = "\u0000none";
+        private static int _reported;
+
+        private static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(
+                typeof(UIPanelBuilder),
+                nameof(UIPanelBuilder.AddLocationPicker),
+                new[]
+                {
+                    typeof(string),
+                    typeof(List<ValueTuple<IndustryComponent, Area>>),
+                    typeof(IndustryComponent),
+                    typeof(Action<IndustryComponent>)
+                });
+        }
+
+        private static void Prefix(
+            ref List<ValueTuple<IndustryComponent, Area>> options,
+            ref IndustryComponent selected)
+        {
+            var selectedKey = SelectedDestinationKey(selected, options);
+            var removed = DeduplicateByKey(options, DestinationKey, out var deduplicated);
+            if (removed == 0)
+            {
+                return;
+            }
+
+            options = deduplicated;
+            selected = ResolveCanonicalSelection(selected, selectedKey, deduplicated);
+
+            if (Interlocked.Exchange(ref _reported, 1) == 0)
+            {
+                FuseLog.Info(
+                    $"FUSE removed {removed} duplicate automatic-waybill destination row(s). " +
+                    "The first matching destination remains selectable; runtime industry data was not deleted.");
+            }
+        }
+
+        private static string DestinationKey(ValueTuple<IndustryComponent, Area> option)
+        {
+            var component = option.Item1;
+            var identifier = DestinationKey(component);
+            if (component == null || identifier == null)
+            {
+                return identifier;
+            }
+
+            try
+            {
+                var spanIds = (component.trackSpans ?? Array.Empty<Track.TrackSpan>())
+                    .Where(span => span != null && !string.IsNullOrWhiteSpace(span.id))
+                    .Select(span => span.id.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                var displayName = component.DisplayName?.Trim();
+                if (spanIds.Length == 0 || string.IsNullOrWhiteSpace(displayName))
+                {
+                    return identifier;
+                }
+
+                return string.Join(
+                    "\u001f",
+                    "semantic",
+                    component.GetType().FullName ?? component.GetType().Name,
+                    option.Item2?.identifier?.Trim() ?? string.Empty,
+                    displayName,
+                    string.Join("\u001e", spanIds));
+            }
+            catch
+            {
+                return identifier;
+            }
+        }
+
+        private static string DestinationKey(IndustryComponent component)
+        {
+            if (component == null)
+            {
+                return EmptyDestinationKey;
+            }
+
+            try
+            {
+                var identifier = component.Identifier?.Trim();
+                return string.IsNullOrWhiteSpace(identifier) ? null : identifier;
+            }
+            catch
+            {
+                // A malformed component must not be allowed to break the UI.
+                // A null key tells the helper to preserve that row unchanged.
+                return null;
+            }
+        }
+
+        private static string SelectedDestinationKey(
+            IndustryComponent selected,
+            IList<ValueTuple<IndustryComponent, Area>> options)
+        {
+            if (selected == null || options == null)
+            {
+                return DestinationKey(selected);
+            }
+
+            foreach (var option in options)
+            {
+                if (ReferenceEquals(option.Item1, selected) || option.Item1 == selected)
+                {
+                    return DestinationKey(option);
+                }
+            }
+
+            return DestinationKey(selected);
+        }
+
+        private static IndustryComponent ResolveCanonicalSelection(
+            IndustryComponent selected,
+            string selectedKey,
+            IList<ValueTuple<IndustryComponent, Area>> options)
+        {
+            if (selected == null || selectedKey == null || options == null)
+            {
+                return selected;
+            }
+
+            foreach (var option in options)
+            {
+                if (string.Equals(
+                    selectedKey,
+                    DestinationKey(option),
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return option.Item1;
+                }
+            }
+
+            return selected;
+        }
+
+        internal static int DeduplicateByKey<T>(
+            IList<T> source,
+            Func<T, string> keySelector,
+            out List<T> result)
+        {
+            result = source == null ? new List<T>() : new List<T>(source.Count);
+            if (source == null || source.Count == 0 || keySelector == null)
+            {
+                return 0;
+            }
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var item in source)
+            {
+                var key = keySelector(item);
+                if (key == null || seen.Add(key))
+                {
+                    result.Add(item);
+                }
+            }
+
+            return source.Count - result.Count;
+        }
+
+        internal static T ResolveCanonicalByKey<T>(
+            T selected,
+            IList<T> options,
+            Func<T, string> keySelector)
+        {
+            if (ReferenceEquals(selected, null) || options == null || keySelector == null)
+            {
+                return selected;
+            }
+
+            var selectedKey = keySelector(selected);
+            if (selectedKey == null)
+            {
+                return selected;
+            }
+
+            foreach (var option in options)
+            {
+                var optionKey = keySelector(option);
+                if (string.Equals(selectedKey, optionKey, StringComparison.OrdinalIgnoreCase))
+                {
+                    return option;
+                }
+            }
+
+            return selected;
+        }
+    }
+}

--- a/FUSE/Patches/FuseMessengerIsolationPatch.cs
+++ b/FUSE/Patches/FuseMessengerIsolationPatch.cs
@@ -8,7 +8,7 @@ using HarmonyLib;
 namespace FUSE.Patches
 {
     /// <summary>
-    /// Contains exceptions thrown by map lifecycle event listeners so one broken
+    /// Contains exceptions thrown by guarded messenger event listeners so one broken
     /// listener can never disturb delivery to anyone else — and so the offender is
     /// actually NAMED in the log.
     ///
@@ -28,9 +28,9 @@ namespace FUSE.Patches
     /// (throttled) with the recipient type and handler method name, and dispatch
     /// continues so later-registered listeners still receive the event.
     ///
-    /// Deliberately scoped to the four map lifecycle events only — this is not a
-    /// blanket "never throw from Messenger" patch; every other event keeps its
-    /// stock semantics.
+    /// Deliberately scoped to map lifecycle events and the legacy debug-report
+    /// contribution event — this is not a blanket "never throw from Messenger"
+    /// patch; every other event keeps its stock semantics.
     ///
     /// Generic-method caveat: this targets the CONSTRUCTED <c>WeakAction&lt;T&gt;</c>
     /// methods, one instantiation per event type. That is only reliable because
@@ -49,12 +49,13 @@ namespace FUSE.Patches
         // whole patch class. (If EVERY entry failed to resolve, the empty target
         // set would make Harmony reject the class as a whole — FusePatchResilience
         // contains that to a logged skip of this one class.)
-        private static readonly string[] LifecycleEventTypeNames =
+        private static readonly string[] GuardedEventTypeNames =
         {
             "Game.Events.MapWillLoadEvent",
             "Game.Events.MapDidLoadEvent",
             "Game.Events.MapWillUnloadEvent",
-            "Game.Events.MapDidUnloadEvent"
+            "Game.Events.MapDidUnloadEvent",
+            "Railloader.Events.WillCopyDebugInformation"
         };
 
         private static long _suppressed;
@@ -80,7 +81,7 @@ namespace FUSE.Patches
         internal static IEnumerable<MethodBase> TargetMethods()
         {
             var targets = new HashSet<MethodBase>();
-            foreach (var eventTypeName in LifecycleEventTypeNames)
+            foreach (var eventTypeName in GuardedEventTypeNames)
             {
                 // WeakAction<T> and the lifecycle event structs are defined in the
                 // SAME assembly: MvvmLight is compiled into the game's Assembly-CSharp
@@ -168,7 +169,7 @@ namespace FUSE.Patches
                 // BEFORE the throttle decision so every containment is counted
                 // even when its log line below is suppressed.
                 FuseModExceptionRegistry.RecordContained(
-                    __exception, ResolveRecipientType(__instance), "map lifecycle listener");
+                    __exception, ResolveRecipientType(__instance), "messenger listener");
 
                 // First few individually, every previously-unseen offender once, then
                 // heartbeat only — a permanently-broken listener re-throws on every
@@ -180,7 +181,7 @@ namespace FUSE.Patches
                 if (_suppressed <= 5 || newOffender || _suppressed % 100 == 0)
                 {
                     FuseLog.Exception(
-                        $"FUSE contained map lifecycle listener exception #{_suppressed} from {listener}; " +
+                        $"FUSE contained messenger listener exception #{_suppressed} from {listener}; " +
                         "the exception was suppressed and dispatch continued, so later-registered listeners " +
                         "still received the event", __exception);
                     _logged++;

--- a/FUSE/Patches/FuseOutboundIndustryRoutingPatch.cs
+++ b/FUSE/Patches/FuseOutboundIndustryRoutingPatch.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using FUSE.Runtime.Events;
+using Game;
+using HarmonyLib;
+using Model.Ops;
+using Model.Ops.Definition;
+using Track;
+using Track.Search;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    internal enum FuseOutboundRoutingMode
+    {
+        Disabled,
+        Absolute,
+        Configurable,
+    }
+
+    [HarmonyPatch]
+    internal static class FuseOutboundIndustryRoutingPatch
+    {
+        private const float MinimumTripDistanceMeters = 200f;
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(OpsController), nameof(OpsController.AddOrderForOutboundEmptyCar))]
+        private static bool RouteEmpty(
+            OpsController __instance,
+            IOpsCar car,
+            OpsCarPosition carPosition,
+            string orderTag,
+            bool noPayment)
+        {
+            return TryRoute(__instance, car, carPosition, orderTag, noPayment, loaded: false);
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(OpsController), nameof(OpsController.AddOrderForOutboundLoadedCar))]
+        private static bool RouteLoaded(
+            OpsController __instance,
+            IOpsCar car,
+            OpsCarPosition carPosition,
+            string orderTag,
+            bool noPayment)
+        {
+            return TryRoute(__instance, car, carPosition, orderTag, noPayment, loaded: true);
+        }
+
+        private static bool TryRoute(
+            OpsController controller,
+            IOpsCar car,
+            OpsCarPosition origin,
+            string orderTag,
+            bool noPayment,
+            bool loaded)
+        {
+            var mode = ResolveMode(
+                FuseSettings.EnableOutboundIndustryRerouting,
+                FuseLegacyCapabilityActivation.IsRequested("Zamu.AbsoluteMadness", "AbsoluteMadness"),
+                FuseLegacyCapabilityActivation.IsRequested("Zamu.SomeKindOfMadness", "SomeKindOfMadness"));
+            if (mode == FuseOutboundRoutingMode.Disabled || controller == null || car == null)
+            {
+                return true;
+            }
+
+            if (mode == FuseOutboundRoutingMode.Configurable &&
+                UnityEngine.Random.value >= FuseSettings.OutboundIndustryRerouteChance)
+            {
+                return true;
+            }
+
+            try
+            {
+                var candidates = CollectCandidates(controller, car, origin, loaded, mode);
+                var context = new FuseOutboundRoutingContext(car, origin, loaded, candidates);
+                FuseOutboundRoutingEvents.RaisePreparing(context);
+                var selectedIndex = SelectWeightedIndex(
+                    candidates.Select(candidate => candidate.Weight).ToArray(),
+                    UnityEngine.Random.value);
+                if (selectedIndex < 0 || selectedIndex >= candidates.Count)
+                {
+                    return true;
+                }
+
+                var selected = candidates[selectedIndex];
+                var destination = selected.Component;
+                var multiplier = mode == FuseOutboundRoutingMode.Absolute
+                    ? 1f
+                    : FuseSettings.OutboundIndustryPaymentMultiplier;
+                var payment = noPayment
+                    ? 0
+                    : Mathf.RoundToInt(
+                        selected.ProposedPayment ??
+                        (controller.PaymentForMove(origin, destination, car.WeightInTons) * multiplier));
+                var graceDays = selected.ProposedGraceDays ?? controller.CalculateGraceDays(origin, destination);
+                var waybill = new Waybill(
+                    TimeWeather.Now,
+                    origin,
+                    destination,
+                    payment,
+                    false,
+                    orderTag,
+                    graceDays);
+
+                car.SetWaybill(waybill, destination, "FUSE outbound industry routing");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE outbound industry routing failed safely; the base-game interchange route will be used: " +
+                    ex.GetBaseException().Message);
+                return true;
+            }
+        }
+
+        internal static FuseOutboundRoutingMode ResolveMode(
+            bool explicitOptIn,
+            bool absoluteRequested,
+            bool configurableRequested)
+        {
+            if (explicitOptIn || configurableRequested)
+            {
+                return FuseOutboundRoutingMode.Configurable;
+            }
+
+            return absoluteRequested ? FuseOutboundRoutingMode.Absolute : FuseOutboundRoutingMode.Disabled;
+        }
+
+        private static List<FuseOutboundRoutingCandidate> CollectCandidates(
+            OpsController controller,
+            IOpsCar car,
+            OpsCarPosition origin,
+            bool loaded,
+            FuseOutboundRoutingMode mode)
+        {
+            var candidates = new List<FuseOutboundRoutingCandidate>();
+            var fillFactor = mode == FuseOutboundRoutingMode.Absolute
+                ? 1f
+                : FuseSettings.OutboundIndustryFillFactor;
+            var allowShortTrips = mode == FuseOutboundRoutingMode.Absolute || FuseSettings.OutboundIndustryAllowShortTrips;
+
+            foreach (var industry in controller.AllIndustries ?? Array.Empty<Industry>())
+            {
+                if (industry == null || industry.ProgressionDisabled ||
+                    (mode == FuseOutboundRoutingMode.Configurable && !industry.ShouldOrderCars()))
+                {
+                    continue;
+                }
+
+                foreach (var pair in industry.EnumerateComponentContexts(0f))
+                {
+                    var component = pair.Item1;
+                    var componentContext = pair.Item2;
+                    if (component == null || component.ProgressionDisabled ||
+                        !component.carTypeFilter.Matches(car.CarType) ||
+                        !TryGetTarget(component, loaded, out var load, out var maxStorage))
+                    {
+                        continue;
+                    }
+
+                    if (loaded && car.QuantityOfLoad(load).Item1 <= load.ZeroThreshold)
+                    {
+                        continue;
+                    }
+
+                    if (!allowShortTrips && !IsLongEnoughTrip(origin, component))
+                    {
+                        continue;
+                    }
+
+                    var committed = componentContext.QuantityInStorage(load) +
+                                    componentContext.QuantityOnOrder(load) +
+                                    componentContext.AvailableCapacityInCars(component.carTypeFilter, load);
+                    var remaining = (maxStorage * fillFactor) - committed;
+                    if (remaining > load.ZeroThreshold)
+                    {
+                        candidates.Add(new FuseOutboundRoutingCandidate(component, remaining));
+                    }
+                }
+            }
+
+            return candidates;
+        }
+
+        private static bool TryGetTarget(
+            IndustryComponent component,
+            bool loaded,
+            out Load load,
+            out float maxStorage)
+        {
+            load = null;
+            maxStorage = 0f;
+            if (!loaded && component is IndustryLoaderBase loader && loader.orderEmpties)
+            {
+                load = loader.load;
+                maxStorage = loader.maxStorage;
+                return load != null;
+            }
+
+            if (loaded && component is IndustryUnloader unloader && unloader.orderLoads)
+            {
+                load = unloader.load;
+                maxStorage = unloader.maxStorage;
+                return load != null;
+            }
+
+            return false;
+        }
+
+        private static bool IsLongEnoughTrip(OpsCarPosition origin, IndustryComponent destination)
+        {
+            if (origin.Spans == null || origin.Spans.Length == 0 ||
+                destination.trackSpans == null || destination.trackSpans.Length == 0)
+            {
+                return false;
+            }
+
+            return Graph.Shared.TryFindDistance(
+                       (Location)origin,
+                       (Location)(OpsCarPosition)destination,
+                       out var distance,
+                       out _) &&
+                   distance > MinimumTripDistanceMeters;
+        }
+
+        internal static int SelectWeightedIndex(IReadOnlyList<float> weights, float unitSample)
+        {
+            if (weights == null || weights.Count == 0)
+            {
+                return -1;
+            }
+
+            var minimum = weights.Min();
+            var offset = minimum < 0f ? -minimum : 0f;
+            var total = weights.Sum(weight => Math.Max(0f, weight + offset));
+            if (total <= 0f || float.IsNaN(total))
+            {
+                return Math.Min(weights.Count - 1, Mathf.FloorToInt(Mathf.Clamp01(unitSample) * weights.Count));
+            }
+
+            var cursor = Mathf.Clamp01(unitSample) * total;
+            for (var index = 0; index < weights.Count; index++)
+            {
+                cursor -= Math.Max(0f, weights[index] + offset);
+                if (cursor <= 0f)
+                {
+                    return index;
+                }
+            }
+
+            return weights.Count - 1;
+        }
+
+    }
+
+    [HarmonyPatch(typeof(OpsController), "InterchangeForPosition", new[] { typeof(OpsCarPosition), typeof(OpsCarPosition?) })]
+    internal static class FuseOutboundIndustryDirectionPatch
+    {
+        private static void Prefix(ref OpsCarPosition? origin)
+        {
+            var requested = FuseLegacyCapabilityActivation.IsRequested(
+                "Zamu.SomeKindOfMadness",
+                "SomeKindOfMadness");
+            if ((FuseSettings.EnableOutboundIndustryRerouting || requested) &&
+                FuseSettings.OutboundIndustryIgnoreOrigin)
+            {
+                origin = null;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(IndustryContext), "AddOrderedCars")]
+    internal static class FuseOutboundIndustryBlockingPatch
+    {
+        private static readonly object RandomGate = new object();
+        private static readonly System.Random Random = new System.Random();
+
+        private static void Prefix(List<IOrder> orders)
+        {
+            var requested = FuseLegacyCapabilityActivation.IsRequested(
+                "Zamu.SomeKindOfMadness",
+                "SomeKindOfMadness");
+            if (orders == null || orders.Count < 2 ||
+                !(FuseSettings.EnableOutboundIndustryRerouting || requested) ||
+                !FuseSettings.OutboundIndustryPreventBlocking)
+            {
+                return;
+            }
+
+            lock (RandomGate)
+            {
+                Shuffle(orders, Random);
+            }
+        }
+
+        internal static void Shuffle<T>(IList<T> items, System.Random random)
+        {
+            if (items == null || random == null)
+            {
+                return;
+            }
+
+            for (var index = items.Count - 1; index > 0; index--)
+            {
+                var swap = random.Next(index + 1);
+                var value = items[index];
+                items[index] = items[swap];
+                items[swap] = value;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FusePassengerStopInvalidSpanGuardPatch.cs
+++ b/FUSE/Patches/FusePassengerStopInvalidSpanGuardPatch.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model.Ops;
+using Track;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Prevents PassengerStop.OnEnable from interpolating a span whose segment
+    /// was removed by a conflicting track package. Railroader only checks that
+    /// nullable endpoints have values before calling Graph.Lerp; a resolved
+    /// location can still contain a null segment and throw from Location.Flipped.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FusePassengerStopInvalidSpanGuardPatch
+    {
+        private static MethodInfo TargetMethod()
+        {
+            return AccessTools.Method(typeof(PassengerStop), "OnEnable");
+        }
+
+        private static void Prefix(PassengerStop __instance)
+        {
+            if (__instance == null)
+            {
+                return;
+            }
+
+            TrackSpan[] spans;
+            try
+            {
+                spans = __instance.GetComponentsInChildren<TrackSpan>(true);
+            }
+            catch
+            {
+                return;
+            }
+
+            foreach (var span in spans.Where(span => !IsUsable(span)))
+            {
+                var id = span?.id ?? "<unknown>";
+                try
+                {
+                    // Keep the TrackSpan object available for diagnostics, but
+                    // clear endpoints so PassengerStop's own null checks skip it.
+                    span.lower = null;
+                    span.upper = null;
+                    var count = FuseRuntimeGuardCounters.RecordPassengerStopSpanSanitized();
+                    if (count <= 10)
+                    {
+                        FuseLog.Warning(
+                            $"FUSE sanitized invalid passenger-stop span '{id}' on " +
+                            $"'{__instance.identifier ?? __instance.name}'. A conflicting track package removed " +
+                            "an endpoint segment; the stop remains loaded without that span.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not sanitize invalid passenger-stop span '{id}': " +
+                        ex.GetBaseException().Message);
+                }
+            }
+        }
+
+        private static bool IsUsable(TrackSpan span)
+        {
+            if (span == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                return span.IsValid;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FusePrefabStoreAllCarDefinitionInfosFilterPatch.cs
+++ b/FUSE/Patches/FusePrefabStoreAllCarDefinitionInfosFilterPatch.cs
@@ -36,23 +36,47 @@ namespace FUSE.Patches
     [HarmonyPatch]
     internal static class FusePrefabStoreAllCarDefinitionInfosFilterPatch
     {
+        private static readonly FieldInfo StoresField =
+            AccessTools.Field(typeof(PrefabStore), "_stores");
+        private static PrefabStore _cachedOwner;
+        private static int _cachedStoreCount = -1;
+        private static TypedContainerItem<CarDefinition>[] _cachedDefinitions;
+
         private static MethodInfo TargetMethod()
         {
             return AccessTools.PropertyGetter(typeof(PrefabStore), "AllCarDefinitionInfos");
         }
 
+        private static bool Prefix(
+            PrefabStore __instance,
+            ref System.Collections.Generic.IEnumerable<TypedContainerItem<CarDefinition>> __result,
+            out bool __state)
+        {
+            __state = TryGetCached(__instance, out var cached);
+            if (__state)
+            {
+                __result = cached;
+                return false;
+            }
+
+            return true;
+        }
+
         private static void Postfix(
             PrefabStore __instance,
-            ref System.Collections.Generic.IEnumerable<TypedContainerItem<CarDefinition>> __result)
+            ref System.Collections.Generic.IEnumerable<TypedContainerItem<CarDefinition>> __result,
+            bool __state)
         {
-            if (__result == null)
+            if (__state || __result == null)
             {
                 return;
             }
 
             try
             {
-                __result = FilterLoserDefinitions(__instance, __result);
+                var filtered = FilterLoserDefinitions(__instance, __result).ToArray();
+                PublishCache(__instance, filtered);
+                __result = filtered;
             }
             catch (Exception ex)
             {
@@ -81,15 +105,14 @@ namespace FUSE.Patches
                 loserIdentifiers = null;
             }
 
-            if (loserIdentifiers == null || loserIdentifiers.Count == 0)
-            {
-                // No collisions recorded, or we failed to compute the
-                // set — keep the original enumeration verbatim so we
-                // never silently drop content the game expected.
-                return source;
-            }
-
-            return EnumerateNonLoser(source, loserIdentifiers);
+            // Always put the game/third-party enumeration behind the resilient
+            // boundary, even when no duplicate-pack losers were recorded. A
+            // malformed car provider can otherwise throw lazily while the
+            // Equipment window builds its purchase catalogue and leave the
+            // entire window unusable. The empty set preserves every valid item.
+            return EnumerateNonLoser(
+                source,
+                loserIdentifiers ?? new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal));
         }
 
         private static System.Collections.Generic.IEnumerable<TypedContainerItem<CarDefinition>>
@@ -112,6 +135,8 @@ namespace FUSE.Patches
             // going" semantics for free.
             using (var enumerator = source.GetEnumerator())
             {
+                var consecutiveFailures = 0;
+                var reportedFailure = false;
                 while (true)
                 {
                     bool hasNext;
@@ -124,17 +149,35 @@ namespace FUSE.Patches
                             current = enumerator.Current;
                         }
                     }
-                    catch (Model.Database.PrefabStore.UnknownIdentifierException)
+                    catch (Model.Database.PrefabStore.UnknownIdentifierException ex)
                     {
                         // Loser identifier the filter rejected.
                         // Move past it and keep going.
+                        consecutiveFailures++;
+                        ReportEnumerationFailureOnce(ex, ref reportedFailure);
+                        if (consecutiveFailures >= 16)
+                        {
+                            FuseLog.Warning(
+                                "FUSE stopped a repeatedly failing car-definition provider after 16 consecutive errors; " +
+                                "valid definitions already enumerated remain available in the Equipment window.");
+                            yield break;
+                        }
                         continue;
                     }
-                    catch
+                    catch (Exception ex)
                     {
                         // Any other failure inside the selector —
                         // skip the item but don't tear the whole
                         // enumeration down.
+                        consecutiveFailures++;
+                        ReportEnumerationFailureOnce(ex, ref reportedFailure);
+                        if (consecutiveFailures >= 16)
+                        {
+                            FuseLog.Warning(
+                                "FUSE stopped a repeatedly failing car-definition provider after 16 consecutive errors; " +
+                                "valid definitions already enumerated remain available in the Equipment window.");
+                            yield break;
+                        }
                         continue;
                     }
 
@@ -142,9 +185,9 @@ namespace FUSE.Patches
                     {
                         yield break;
                     }
+                    consecutiveFailures = 0;
                     if (current == null || current.Identifier == null)
                     {
-                        yield return current;
                         continue;
                     }
                     if (loserIdentifiers.Contains(current.Identifier))
@@ -154,6 +197,83 @@ namespace FUSE.Patches
                     yield return current;
                 }
             }
+        }
+
+        internal static void InvalidateCache(PrefabStore owner = null)
+        {
+            if (owner != null && !ReferenceEquals(owner, _cachedOwner))
+            {
+                return;
+            }
+
+            _cachedOwner = null;
+            _cachedStoreCount = -1;
+            _cachedDefinitions = null;
+        }
+
+        private static bool TryGetCached(
+            PrefabStore owner,
+            out TypedContainerItem<CarDefinition>[] definitions)
+        {
+            definitions = null;
+            if (owner == null || !ReferenceEquals(owner, _cachedOwner) || _cachedDefinitions == null)
+            {
+                return false;
+            }
+
+            var storeCount = ReadStoreCount(owner);
+            if (storeCount < 0 || storeCount != _cachedStoreCount)
+            {
+                InvalidateCache(owner);
+                return false;
+            }
+
+            definitions = _cachedDefinitions;
+            return true;
+        }
+
+        private static void PublishCache(
+            PrefabStore owner,
+            TypedContainerItem<CarDefinition>[] definitions)
+        {
+            var storeCount = ReadStoreCount(owner);
+            if (owner == null || definitions == null || storeCount < 0)
+            {
+                return;
+            }
+
+            _cachedOwner = owner;
+            _cachedStoreCount = storeCount;
+            _cachedDefinitions = definitions;
+        }
+
+        private static int ReadStoreCount(PrefabStore owner)
+        {
+            try
+            {
+                return StoresField?.GetValue(owner) is System.Collections.ICollection stores
+                    ? stores.Count
+                    : -1;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+
+        private static void ReportEnumerationFailureOnce(Exception exception, ref bool reported)
+        {
+            if (reported)
+            {
+                return;
+            }
+
+            reported = true;
+            var cause = exception?.GetBaseException();
+            FuseLog.Warning(
+                "FUSE contained a broken car-definition provider while building the Equipment catalogue: " +
+                $"{cause?.GetType().Name ?? "Exception"}: {cause?.Message ?? "unknown error"}. " +
+                "The invalid entry was skipped so remaining equipment stays purchasable.");
         }
 
         /// <summary>
@@ -171,13 +291,12 @@ namespace FUSE.Patches
                 return result;
             }
 
-            var storesField = AccessTools.Field(typeof(PrefabStore), "_stores");
-            if (storesField == null)
+            if (StoresField == null)
             {
                 return result;
             }
 
-            if (!(storesField.GetValue(prefabStore) is System.Collections.Generic.IList<AssetPackRuntimeStore> stores))
+            if (!(StoresField.GetValue(prefabStore) is System.Collections.Generic.IList<AssetPackRuntimeStore> stores))
             {
                 return result;
             }

--- a/FUSE/Patches/FusePrefabStoreAssetPackPatch.cs
+++ b/FUSE/Patches/FusePrefabStoreAssetPackPatch.cs
@@ -29,6 +29,7 @@ namespace FUSE.Patches
             {
                 // Even a partial store add changes the identifier population.
                 FUSE.Runtime.API.SceneryAPI.InvalidateKnownSceneryIdentifierIndex();
+                FuseEquipmentCatalogWarmup.Schedule(__result);
             }
         }
     }

--- a/FUSE/Patches/FusePrefabStoreDefinitionCheckPerformancePatch.cs
+++ b/FUSE/Patches/FusePrefabStoreDefinitionCheckPerformancePatch.cs
@@ -15,12 +15,11 @@ namespace FUSE.Patches
     /// active, so malformed assets still fail at their actual point of use.
     /// </summary>
     [HarmonyPatch(typeof(PrefabStore), "CheckDefinitions")]
-    // AssetLoader 1.0.1 performs all UMM mod-folder asset-store discovery in
-    // its own CheckDefinitions prefix. If this skip prefix runs first,
-    // Harmony suppresses AssetLoader's state-mutating prefix along with the
-    // original method: UMM reports the rolling-stock mods active, but their
-    // Definitions.json files never enter PrefabStore. Run after AssetLoader so
-    // its discovery completes before FUSE skips only the stock diagnostic pass.
+    // Keep this ordering marker for transitional installs that still contain
+    // AssetLoader.dll. FUSE normally disables that mod's patches and performs
+    // catalog plus definitions-only discovery itself. If an older FUSE build
+    // leaves AssetLoader active, running after its prefix avoids suppressing
+    // the legacy discovery side effect along with the stock diagnostic pass.
     [HarmonyAfter("AssetLoader")]
     internal static class FusePrefabStoreDefinitionCheckPerformancePatch
     {

--- a/FUSE/Patches/FuseThirdPartyGuardInstaller.cs
+++ b/FUSE/Patches/FuseThirdPartyGuardInstaller.cs
@@ -175,6 +175,39 @@ namespace FUSE.Patches
                 bmanLocomotiveAudioStatus = "failed";
             }
 
+            string legosLibraryStatus;
+            try
+            {
+                legosLibraryStatus = FuseLegosLibraryCompatibility.EnsureInstalled(_harmony);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE Legos Library compatibility failed to install", ex);
+                legosLibraryStatus = "failed";
+            }
+
+            string assetLoaderStatus;
+            try
+            {
+                assetLoaderStatus = FuseAssetLoaderReplacementCompatibility.EnsureInstalled(_harmony);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE AssetLoader replacement compatibility failed", ex);
+                assetLoaderStatus = "failed";
+            }
+
+            string alinasUtilitiesStatus;
+            try
+            {
+                alinasUtilitiesStatus = FuseAlinasUtilitiesCompatibility.EnsureInstalled();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE Alina Utilities compatibility failed", ex);
+                alinasUtilitiesStatus = "failed";
+            }
+
             var summary =
                 $"FUSE third-party guards: mapEnhancerCulling='{mapEnhancerStatus}' " +
                 $"rebillIndustryCars='{rebillStatus}' brssModMenu='{brssStatus}' " +
@@ -183,7 +216,10 @@ namespace FUSE.Patches
                 $"utilitiesMapLoad='{utilitiesMapLoadStatus}' " +
                 $"realisticRerail='{realisticRerailStatus}' " +
                 $"memoryLeakFps='{memoryLeakFpsStatus}' " +
-                $"bmanLocomotiveAudio='{bmanLocomotiveAudioStatus}'.";
+                $"bmanLocomotiveAudio='{bmanLocomotiveAudioStatus}' " +
+                $"legosLibrary='{legosLibraryStatus}' " +
+                $"assetLoader='{assetLoaderStatus}' " +
+                $"alinasUtilities='{alinasUtilitiesStatus}'.";
             if (!string.Equals(summary, _lastSummary, StringComparison.Ordinal))
             {
                 _lastSummary = summary;
@@ -210,7 +246,15 @@ namespace FUSE.Patches
                 assemblyName,
                 "GP38Scripts",
                 StringComparison.Ordinal);
-            if (!isRealisticRerail && !isUtilities && !isMemoryLeakFps && !isBmanLocomotiveAudio)
+            var isLegosLibrary = string.Equals(
+                assemblyName,
+                "LegosLibraryOfStuff",
+                StringComparison.Ordinal);
+            var isAssetLoader = FuseAssetLoaderReplacementCompatibility.IsTargetAssemblyName(assemblyName);
+            var isAlinasUtilities = FuseAlinasUtilitiesCompatibility.IsTargetAssemblyName(assemblyName);
+            if (!isRealisticRerail && !isUtilities && !isMemoryLeakFps &&
+                !isBmanLocomotiveAudio && !isLegosLibrary && !isAssetLoader &&
+                !isAlinasUtilities)
             {
                 return;
             }

--- a/FUSE/Runtime/API/FuseCaptiveConversionIndustryComponents.cs
+++ b/FUSE/Runtime/API/FuseCaptiveConversionIndustryComponents.cs
@@ -1,0 +1,230 @@
+using System;
+using FUSE.Infrastructure;
+using Game;
+using Model.Ops;
+using Model.Ops.Definition;
+using UnityEngine;
+
+namespace FUSE.Runtime.API
+{
+    /// <summary>
+    /// FUSE-owned implementation of the legacy captive conversion loader
+    /// contract. A source material held in industry storage is converted into
+    /// a different load while it is transferred into captive-service cars.
+    /// The public field names intentionally match the legacy JSON surface so
+    /// <see cref="IndustryAPI"/> can bind converted definitions without the
+    /// Confusing Supplements assembly being installed.
+    /// </summary>
+    public sealed class FuseCaptiveConversionLoader : IndustryLoaderBase
+    {
+        public Load convertedLoad;
+        public float carLoadRate = 1f;
+        public string title;
+
+        public override string DisplayName => string.IsNullOrWhiteSpace(title) ? name : title;
+
+        public override void OrderCars(IIndustryContext ctx)
+        {
+            // Captive service never requests cars from an interchange.
+        }
+
+        public override bool WantsAutoDestination(AutoDestinationType type)
+        {
+            return type == AutoDestinationType.Empty;
+        }
+
+        public override bool AcceptsCarsWithLoad(Load checkLoad)
+        {
+            return convertedLoad != null && checkLoad == convertedLoad;
+        }
+
+        public override void Service(IIndustryContext ctx)
+        {
+            if (ctx == null || Industry == null || load == null || convertedLoad == null)
+            {
+                return;
+            }
+
+            var available = ctx.QuantityInStorage(load);
+            if (available <= load.ZeroThreshold)
+            {
+                return;
+            }
+
+            var contractMultiplier = Industry.GetContractMultiplier();
+            var transferBudget = RateToValue(Mathf.Max(0f, carLoadRate) * contractMultiplier, ctx.DeltaTime);
+            if (transferBudget <= 0f)
+            {
+                return;
+            }
+
+            foreach (var car in EnumerateCars(ctx, requireWaybill: true))
+            {
+                if (car == null || !car.IsEmptyOrContains(convertedLoad))
+                {
+                    continue;
+                }
+
+                var requested = Mathf.Min(available, transferBudget);
+                if (requested <= load.ZeroThreshold)
+                {
+                    break;
+                }
+
+                var transferred = car.Load(convertedLoad, requested);
+                if (transferred > 0f)
+                {
+                    ctx.RemoveFromStorage(load, transferred);
+                    available -= transferred;
+                    transferBudget -= transferred;
+                }
+
+                if (car.IsFull(convertedLoad))
+                {
+                    car.SetWaybill(null, this, "Full");
+                }
+
+                if (available <= load.ZeroThreshold || transferBudget <= 0f)
+                {
+                    break;
+                }
+            }
+        }
+
+        protected override void ValidateIndustryComponent()
+        {
+            base.ValidateIndustryComponent();
+            ValidateLoads("loader", load, convertedLoad);
+        }
+
+        internal static void ValidateLoads(string role, Load source, Load converted)
+        {
+            if (source == null || converted == null)
+            {
+                FuseLog.Warning($"FUSE captive conversion {role} is missing its source or converted load and will remain inert.");
+                return;
+            }
+
+            if (source.units != converted.units)
+            {
+                FuseLog.Warning(
+                    $"FUSE captive conversion {role} cannot convert '{source.id}' to '{converted.id}' because their units differ.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// FUSE-owned counterpart to <see cref="FuseCaptiveConversionLoader"/>.
+    /// It removes the captive-car load, deposits the configured source
+    /// material in industry storage, and settles the converted load's daily
+    /// receivable through the game's industry context.
+    /// </summary>
+    public sealed class FuseCaptiveConversionUnloader : IndustryComponent
+    {
+        public Load load;
+        public Load convertedLoad;
+        public float maxStorage;
+        public float carUnloadRate = 1f;
+        public string title;
+
+        public override string DisplayName => string.IsNullOrWhiteSpace(title) ? name : title;
+
+        private string UnloadedCounterKey => "fuse-captive-unloaded-" + (convertedLoad?.id ?? subIdentifier ?? "load");
+
+        public override bool WantsAutoDestination(AutoDestinationType type)
+        {
+            return type == AutoDestinationType.Load;
+        }
+
+        public override bool AcceptsCarsWithLoad(Load checkLoad)
+        {
+            return convertedLoad != null && checkLoad == convertedLoad;
+        }
+
+        public override void OrderCars(IIndustryContext ctx)
+        {
+            // Captive service never orders cars; it only services cars placed
+            // on its configured spans.
+        }
+
+        public override void Service(IIndustryContext ctx)
+        {
+            if (ctx == null || Industry == null || load == null || convertedLoad == null)
+            {
+                return;
+            }
+
+            var contractMultiplier = Industry.GetContractMultiplier();
+            var transferBudget = RateToValue(Mathf.Max(0f, carUnloadRate) * contractMultiplier, ctx.DeltaTime);
+            var effectiveStorage = Mathf.Max(0f, maxStorage * contractMultiplier);
+            var zeroThreshold = Mathf.Max(load.ZeroThreshold, convertedLoad.ZeroThreshold);
+            if (transferBudget > 0f && transferBudget < zeroThreshold)
+            {
+                transferBudget = zeroThreshold * 2f;
+            }
+
+            var unloadedThisTick = 0f;
+            foreach (var car in EnumerateCars(ctx, requireWaybill: true))
+            {
+                if (car == null || !car.IsEmptyOrContains(convertedLoad))
+                {
+                    continue;
+                }
+
+                var remainingStorage = effectiveStorage - ctx.QuantityInStorage(load);
+                var requested = Mathf.Min(transferBudget, remainingStorage);
+                if (requested < zeroThreshold)
+                {
+                    break;
+                }
+
+                var transferred = car.Unload(convertedLoad, requested);
+                if (transferred > 0f)
+                {
+                    ctx.AddToStorage(load, transferred, effectiveStorage);
+                    transferBudget -= transferred;
+                    unloadedThisTick += transferred;
+                }
+
+                var remainingLoad = car.QuantityOfLoad(convertedLoad).Item1;
+                if (remainingLoad < zeroThreshold)
+                {
+                    car.SetWaybill(null, this, "Empty completed");
+                }
+
+                if (transferBudget <= 0f)
+                {
+                    break;
+                }
+            }
+
+            if (unloadedThisTick > 0f && convertedLoad.payPerQuantity > 0f)
+            {
+                ctx.CounterIncrement(UnloadedCounterKey, unloadedThisTick);
+            }
+        }
+
+        public override void DailyReceivables(GameDateTime now, IIndustryContext ctx)
+        {
+            if (ctx == null || convertedLoad == null || convertedLoad.payPerQuantity <= 0f)
+            {
+                return;
+            }
+
+            var unloaded = ctx.CounterIncrement(UnloadedCounterKey, 0f);
+            if (unloaded < 1f)
+            {
+                return;
+            }
+
+            ctx.PayLoad(convertedLoad, unloaded);
+            ctx.CounterClear(UnloadedCounterKey);
+        }
+
+        protected override void ValidateIndustryComponent()
+        {
+            base.ValidateIndustryComponent();
+            FuseCaptiveConversionLoader.ValidateLoads("unloader", load, convertedLoad);
+        }
+    }
+}

--- a/FUSE/Runtime/API/FuseDefinitionKind.cs
+++ b/FUSE/Runtime/API/FuseDefinitionKind.cs
@@ -15,6 +15,7 @@ namespace FUSE.Runtime.API
         public const string Scenery = "world.scenery";
         public const string SpawnPoint = "world.spawnPoint";
         public const string Spliney = "world.spliney";
+        public const string WaterSurface = "world.waterSurface";
         public const string TelegraphPoles = "world.telegraphPoles";
         public const string MapLabel = "world.mapLabel";
         public const string MapMask = "world.mapMask";

--- a/FUSE/Runtime/API/FuseLegacyPlaceholderIndustryComponent.cs
+++ b/FUSE/Runtime/API/FuseLegacyPlaceholderIndustryComponent.cs
@@ -5,10 +5,18 @@ namespace FUSE.Runtime.API
 {
     public sealed class FuseLegacyPlaceholderIndustryComponent : IndustryComponent
     {
-        public override bool IsVisible => false;
-
         protected override void ValidateIndustryComponent()
         {
+        }
+
+        public override bool WantsAutoDestination(AutoDestinationType type)
+        {
+            // Confusing Supplements' Empty component is a visible, span-bound
+            // destination marker. It performs no service work, but accepts
+            // every automatic destination class so authors can reserve/highlight
+            // tracks such as "Loaded Coal Output Tracks: KEEP CLEAR!" without
+            // creating a loader whose null Load later throws during Industry.Tick.
+            return true;
         }
 
         public override void Service(IIndustryContext ctx)

--- a/FUSE/Runtime/API/FuseObjectLineLayout.cs
+++ b/FUSE/Runtime/API/FuseObjectLineLayout.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Authoring.Data;
+using UnityEngine;
+
+namespace FUSE.Runtime.API
+{
+    internal static class FuseObjectLineLayout
+    {
+        internal sealed class Placement
+        {
+            internal Vector3 Position;
+            internal Vector3 Forward;
+        }
+
+        internal static IReadOnlyList<Placement> Build(
+            IReadOnlyList<FuseSplineyPoint> points,
+            float spacing,
+            bool placeAtEnd,
+            int maximumInstances)
+        {
+            if (points == null || points.Count < 2)
+                throw new InvalidOperationException("An object line requires at least two points.");
+            if (spacing <= 0f)
+                throw new InvalidOperationException("Object-line spacing must be greater than zero.");
+            if (maximumInstances < 1 || maximumInstances > 4096)
+                throw new InvalidOperationException("Object-line maximumInstances must be between 1 and 4096.");
+
+            var segments = new List<Segment>();
+            var totalLength = 0f;
+            for (var index = 1; index < points.Count; index++)
+            {
+                if (points[index - 1] == null || points[index] == null)
+                    continue;
+                var start = points[index - 1].Position;
+                var end = points[index].Position;
+                var delta = end - start;
+                var length = delta.magnitude;
+                if (length <= 0.001f)
+                    continue;
+                segments.Add(new Segment(start, end, delta / length, totalLength, length));
+                totalLength += length;
+            }
+            if (segments.Count == 0)
+                throw new InvalidOperationException("Object-line points must describe a non-zero path.");
+
+            var distances = new List<float>();
+            for (var distance = 0f; distance <= totalLength + 0.0001f; distance += spacing)
+            {
+                distances.Add(Mathf.Min(distance, totalLength));
+                if (distances.Count > maximumInstances)
+                    throw TooManyInstances(maximumInstances, spacing, totalLength);
+            }
+            if (placeAtEnd && totalLength - distances[distances.Count - 1] > 0.001f)
+            {
+                distances.Add(totalLength);
+                if (distances.Count > maximumInstances)
+                    throw TooManyInstances(maximumInstances, spacing, totalLength);
+            }
+
+            var placements = new List<Placement>(distances.Count);
+            var segmentIndex = 0;
+            foreach (var distance in distances)
+            {
+                while (segmentIndex + 1 < segments.Count
+                       && distance > segments[segmentIndex].EndDistance + 0.0001f)
+                {
+                    segmentIndex++;
+                }
+                var segment = segments[segmentIndex];
+                var local = Mathf.Clamp(distance - segment.StartDistance, 0f, segment.Length);
+                placements.Add(new Placement
+                {
+                    Position = segment.Start + segment.Forward * local,
+                    Forward = segment.Forward,
+                });
+            }
+            return placements;
+        }
+
+        private static InvalidOperationException TooManyInstances(
+            int maximumInstances,
+            float spacing,
+            float length)
+        {
+            return new InvalidOperationException(
+                $"Object line would exceed its {maximumInstances} instance safety limit "
+                + $"(path {length:0.##} m, spacing {spacing:0.##} m). Increase spacing or maximumInstances.");
+        }
+
+        private sealed class Segment
+        {
+            internal Segment(
+                Vector3 start,
+                Vector3 end,
+                Vector3 forward,
+                float startDistance,
+                float length)
+            {
+                Start = start;
+                End = end;
+                Forward = forward;
+                StartDistance = startDistance;
+                Length = length;
+            }
+
+            internal Vector3 Start { get; }
+            internal Vector3 End { get; }
+            internal Vector3 Forward { get; }
+            internal float StartDistance { get; }
+            internal float Length { get; }
+            internal float EndDistance => StartDistance + Length;
+        }
+    }
+}

--- a/FUSE/Runtime/API/FusePay4ResourceIndustryComponent.cs
+++ b/FUSE/Runtime/API/FusePay4ResourceIndustryComponent.cs
@@ -35,7 +35,8 @@ namespace FUSE.Runtime.API
     /// <see cref="IndustryAPI.ApplyCustomIndustryComponentFields"/> — keep
     /// the names intact.
     /// </summary>
-    public class FusePay4ResourceIndustryComponent : IndustryComponent
+    public class FusePay4ResourceIndustryComponent : IndustryComponent,
+        StrangeCustoms.Tracks.Industries.ICustomIndustryTitle
     {
         [Tooltip("Load the component will fill cars with (e.g. 'coal' for a locomotive-fuelling depot).")]
         public Load load;
@@ -83,6 +84,17 @@ namespace FUSE.Runtime.API
         private readonly Dictionary<string, float> _pendingUnitsPerCar = new Dictionary<string, float>();
 
         public override string DisplayName => string.IsNullOrWhiteSpace(title) ? name : title;
+
+        public string Title
+        {
+            get
+            {
+                var resourceName = load == null || string.IsNullOrWhiteSpace(load.description)
+                    ? "resource"
+                    : load.description;
+                return $"Acquire {resourceName} at {DisplayName}";
+            }
+        }
 
         public override bool IsVisible
         {

--- a/FUSE/Runtime/API/FuseRuntimeDefinitionCache.cs
+++ b/FUSE/Runtime/API/FuseRuntimeDefinitionCache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FUSE.Authoring.Data;
+using FUSE.Authoring.Data.Common;
 using FUSE.Infrastructure;
 
 namespace FUSE.Runtime.API
@@ -84,6 +85,12 @@ namespace FUSE.Runtime.API
                     return CloneStation(station) as T;
                 if (definition is FuseTurntable turntable)
                     return CloneTurntable(turntable) as T;
+                if (definition is FuseSpan span)
+                    return CloneSpan(span) as T;
+                if (definition is FuseSpliney spliney)
+                    return CloneSpliney(spliney) as T;
+                if (definition is FuseWaterSurface waterSurface)
+                    return CloneWaterSurface(waterSurface) as T;
 
                 // Unknown type — return original (best-effort, same as before).
                 return definition;
@@ -223,6 +230,82 @@ namespace FUSE.Runtime.API
                     ControllerType        = src.Visuals.ControllerType,
                     InteractionRadius     = src.Visuals.InteractionRadius,
                 },
+            };
+        }
+
+        private static FuseWaterSurface CloneWaterSurface(FuseWaterSurface src)
+        {
+            if (src == null) return null;
+            return new FuseWaterSurface
+            {
+                Points = src.Points?.ToArray(),
+                SourceLakePath = src.SourceLakePath,
+                MaterialName = src.MaterialName,
+                LockHeight = src.LockHeight,
+                SnapToTerrain = src.SnapToTerrain,
+                EnableCollider = src.EnableCollider,
+                UvScale = src.UvScale,
+                TriangleDensity = src.TriangleDensity,
+                MaximumTriangleArea = src.MaximumTriangleArea,
+                YOffset = src.YOffset,
+            };
+        }
+
+        private static FuseSpliney CloneSpliney(FuseSpliney src)
+        {
+            if (src == null) return null;
+            return new FuseSpliney
+            {
+                Type = src.Type,
+                Profile = src.Profile,
+                Style = src.Style,
+                OffsetY = src.OffsetY,
+                HeadStyle = src.HeadStyle,
+                TailStyle = src.TailStyle,
+                AssetIdentifier = src.AssetIdentifier,
+                Prefab = src.Prefab,
+                Spacing = src.Spacing,
+                InstanceScale = src.InstanceScale,
+                RotationOffset = src.RotationOffset,
+                LateralOffset = src.LateralOffset,
+                VerticalOffset = src.VerticalOffset,
+                SnapToTerrain = src.SnapToTerrain,
+                AlignToSlope = src.AlignToSlope,
+                PlaceAtEnd = src.PlaceAtEnd,
+                MaximumInstances = src.MaximumInstances,
+                Points = src.Points?.Select(point => point == null
+                    ? null
+                    : new FuseSplineyPoint
+                    {
+                        Position = point.Position,
+                        Rotation = point.Rotation,
+                        Width = point.Width,
+                    }).ToArray(),
+            };
+        }
+
+        private static FuseSpan CloneSpan(FuseSpan src)
+        {
+            if (src == null) return null;
+            return new FuseSpan
+            {
+                Upper = CloneTrackLocation(src.Upper),
+                Lower = CloneTrackLocation(src.Lower),
+                Normalize = src.Normalize,
+                GroupId = src.GroupId,
+            };
+        }
+
+        private static FuseTrackLocation CloneTrackLocation(FuseTrackLocation src)
+        {
+            if (src == null) return null;
+            return new FuseTrackLocation
+            {
+                SegmentId = src.SegmentId,
+                Normalized = src.Normalized,
+                Distance = src.Distance,
+                End = src.End,
+                Offset = src.Offset,
             };
         }
 

--- a/FUSE/Runtime/API/IndustryAPI.Cache.cs
+++ b/FUSE/Runtime/API/IndustryAPI.Cache.cs
@@ -404,6 +404,61 @@ namespace FUSE.Runtime.API
             return pruned;
         }
 
+        internal static int ReplaceTrackSpanReferences(TrackSpan previousSpan, TrackSpan replacementSpan, string source)
+        {
+            if (previousSpan == null || replacementSpan == null || ReferenceEquals(previousSpan, replacementSpan))
+            {
+                return 0;
+            }
+
+            var rebound = 0;
+            foreach (var component in UnityEngine.Object.FindObjectsOfType<IndustryComponent>(true))
+            {
+                if (!IsLiveIndustryComponent(component) || component.trackSpans == null || component.trackSpans.Length == 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var spans = component.trackSpans;
+                    var changed = false;
+                    for (var index = 0; index < spans.Length; index++)
+                    {
+                        if (!TrackSpanReferencesRemovedInstance(spans[index], previousSpan))
+                        {
+                            continue;
+                        }
+
+                        spans[index] = replacementSpan;
+                        changed = true;
+                        rebound++;
+                    }
+
+                    if (changed)
+                    {
+                        component.trackSpans = spans;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception(
+                        $"FUSE could not rebind industry component '{DescribeComponent(component)}' to replacement TrackSpan " +
+                        $"spanId='{SafeTrackSpanId(replacementSpan)}' after '{source ?? "unspecified"}'",
+                        ex);
+                }
+            }
+
+            if (rebound > 0)
+            {
+                FuseLog.Info(
+                    $"FUSE rebound {rebound} industry component TrackSpan reference(s) to replacement " +
+                    $"spanId='{SafeTrackSpanId(replacementSpan)}' after '{source ?? "unspecified"}'.");
+            }
+
+            return rebound;
+        }
+
         private static bool TrackSpanReferencesRemovedInstance(TrackSpan candidate, TrackSpan removedSpan)
         {
             if (ReferenceEquals(candidate, removedSpan))

--- a/FUSE/Runtime/API/IndustryAPI.Reflection.cs
+++ b/FUSE/Runtime/API/IndustryAPI.Reflection.cs
@@ -105,6 +105,16 @@ namespace FUSE.Runtime.API
                 return typeof(FusePay4ResourceIndustryComponent);
             }
 
+            if (string.Equals(normalized, "ConfusingSupplements.IndustryComponents.CaptiveConversionLoader", StringComparison.OrdinalIgnoreCase))
+            {
+                return typeof(FuseCaptiveConversionLoader);
+            }
+
+            if (string.Equals(normalized, "ConfusingSupplements.IndustryComponents.CaptiveConversionUnloader", StringComparison.OrdinalIgnoreCase))
+            {
+                return typeof(FuseCaptiveConversionUnloader);
+            }
+
             var reflected = TryResolveIndustryComponentType(normalized);
             if (reflected == null && !string.Equals(normalized, type, StringComparison.OrdinalIgnoreCase))
             {
@@ -225,6 +235,21 @@ namespace FUSE.Runtime.API
             if (component is FuseLegacyPlaceholderIndustryComponent)
             {
                 return LegacyEmptyComponentType;
+            }
+
+            if (component is FuseCaptiveConversionLoader)
+            {
+                return "ConfusingSupplements.IndustryComponents.CaptiveConversionLoader";
+            }
+
+            if (component is FuseCaptiveConversionUnloader)
+            {
+                return "ConfusingSupplements.IndustryComponents.CaptiveConversionUnloader";
+            }
+
+            if (component is FusePay4ResourceIndustryComponent)
+            {
+                return "ConfusingSupplements.IndustryComponents.Pay4Resource";
             }
 
             return component.GetType().FullName;
@@ -515,6 +540,14 @@ namespace FUSE.Runtime.API
                     continue;
                 }
 
+                if (!IsUsableTrackSpan(span))
+                {
+                    FuseLog.Warning(
+                        $"FUSE track span '{id}' has a missing or invalid endpoint after graph conflict resolution; " +
+                        "it was omitted from the industry component so opening operations UI cannot crash.");
+                    continue;
+                }
+
                 spans.Add(span);
             }
 
@@ -537,7 +570,7 @@ namespace FUSE.Runtime.API
             var result = new List<TrackSpan>();
             foreach (var span in existing.Concat(additions))
             {
-                if (span == null)
+                if (!IsUsableTrackSpan(span))
                 {
                     continue;
                 }
@@ -550,6 +583,23 @@ namespace FUSE.Runtime.API
             }
 
             return result.ToArray();
+        }
+
+        internal static bool IsUsableTrackSpan(TrackSpan span)
+        {
+            if (span == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                return span.IsValid;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private static Load ResolveLoad(string loadId)

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -8,6 +9,7 @@ using Map.Runtime.MaskComponents;
 using FUSE.Runtime.Cache;
 using FUSE.Authoring.Data;
 using FUSE.Infrastructure;
+using FUSE.Loading;
 using TelegraphPoles;
 using TMPro;
 using UI.Map;
@@ -48,6 +50,70 @@ namespace FUSE.Runtime.API
         private static Transform _worldRoot;
         private static Transform _indexedDecoupledMaskRoot;
         private static Sprite _speedLimitCircleSprite;
+
+        /// <summary>
+        /// Registers or refreshes one package-owned terrain tile folder and
+        /// mounts it into the active map store. This is primarily useful to
+        /// authoring tools that create the first tile in a previously empty
+        /// overlay folder while the game is running.
+        /// </summary>
+        public static int RegisterMapTileSource(
+            string packageId,
+            string packageFolder,
+            string sourceId,
+            string directory,
+            string sourceFolder,
+            int priority = 100)
+        {
+            RequireId(packageId, nameof(packageId));
+            RequireId(sourceId, nameof(sourceId));
+            if (string.IsNullOrWhiteSpace(packageFolder))
+            {
+                throw new ArgumentException(
+                    "Package folder is required.",
+                    nameof(packageFolder));
+            }
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                throw new ArgumentException(
+                    "Map directory is required.",
+                    nameof(directory));
+            }
+            if (string.IsNullOrWhiteSpace(sourceFolder))
+            {
+                throw new ArgumentException(
+                    "Tile source folder is required.",
+                    nameof(sourceFolder));
+            }
+
+            var fullPackageFolder = Path.GetFullPath(packageFolder);
+            if (!Directory.Exists(fullPackageFolder))
+            {
+                throw new DirectoryNotFoundException(
+                    "Package folder was not found: "
+                    + fullPackageFolder);
+            }
+
+            var registered = FuseMapTileRegistry.RegisterTileSource(
+                packageId,
+                fullPackageFolder,
+                sourceId,
+                new FuseMapTileSource
+                {
+                    Directory = directory,
+                    SourceFolder = sourceFolder,
+                    Priority = priority
+                });
+            if (!registered)
+            {
+                throw new InvalidOperationException(
+                    "FUSE rejected the map tile source. Keep sourceFolder "
+                    + "inside the package directory.");
+            }
+
+            return FuseMapTileRegistry.MountForActiveMapIfLoaded(
+                "MapAPI.RegisterMapTileSource");
+        }
 
         public static MapLabel AddMapLabel(string id, FuseMapLabel definition)
         {

--- a/FUSE/Runtime/API/SceneryAPI.cs
+++ b/FUSE/Runtime/API/SceneryAPI.cs
@@ -17,6 +17,8 @@ namespace FUSE.Runtime.API
     public static class SceneryAPI
     {
         private static Transform _fallbackRoot;
+        private static readonly HashSet<string> LoggedUnverifiedLegacyAssets =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private static readonly Dictionary<string, string> LegacySceneryAssetAliases =
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -49,7 +51,11 @@ namespace FUSE.Runtime.API
                 "rlw Spen"
             };
 
-        public static SceneryAssetInstance AddScenery(string id, FuseScenery definition, Action onDeferredActivated = null)
+        public static SceneryAssetInstance AddScenery(
+            string id,
+            FuseScenery definition,
+            Action onDeferredActivated = null,
+            bool allowUnverifiedLegacyAsset = false)
         {
             RequireId(id, nameof(id));
             if (definition == null)
@@ -63,12 +69,23 @@ namespace FUSE.Runtime.API
             }
 
             string assetIdentifier;
-            if (!TryResolveAssetIdentifier(id, definition, out assetIdentifier))
+            if (!TryResolveAssetIdentifier(id, definition, out assetIdentifier) &&
+                !(allowUnverifiedLegacyAsset && TryGetLegacyUnverifiedAssetIdentifier(definition, out assetIdentifier)))
             {
                 FuseLog.Warning(
                     $"FUSE skipped AddScenery '{id}' because no valid asset identifier could be resolved " +
                     $"(AssetIdentifier='{definition.AssetIdentifier ?? string.Empty}', Model='{definition.Model ?? string.Empty}').");
                 return null;
+            }
+
+            if (allowUnverifiedLegacyAsset && !IsCachedKnownResolution(assetIdentifier))
+            {
+                if (LoggedUnverifiedLegacyAssets.Add(assetIdentifier))
+                {
+                    FuseLog.Info(
+                        $"FUSE legacy scenery will attempt guarded runtime asset '{assetIdentifier}' (first placement '{id}') even though it is not in the mounted asset-pack index. " +
+                        "A genuine load failure will be reported and quarantined without stopping other scenery or menus.");
+                }
             }
 
             var gameObject = new GameObject(id);
@@ -171,7 +188,10 @@ namespace FUSE.Runtime.API
             public bool IsPriorityStructure;
         }
 
-        public static void UpdateScenery(string id, FuseScenery definition)
+        public static void UpdateScenery(
+            string id,
+            FuseScenery definition,
+            bool allowUnverifiedLegacyAsset = false)
         {
             var scenery = RequireScenery(id);
             if (definition == null)
@@ -180,7 +200,8 @@ namespace FUSE.Runtime.API
             }
 
             string assetIdentifier;
-            if (!TryResolveAssetIdentifier(id, definition, out assetIdentifier))
+            if (!TryResolveAssetIdentifier(id, definition, out assetIdentifier) &&
+                !(allowUnverifiedLegacyAsset && TryGetLegacyUnverifiedAssetIdentifier(definition, out assetIdentifier)))
             {
                 FuseLog.Warning(
                     $"FUSE skipped UpdateScenery '{id}' because no valid asset identifier could be resolved " +
@@ -341,6 +362,26 @@ namespace FUSE.Runtime.API
             return false;
         }
 
+        private static bool TryGetLegacyUnverifiedAssetIdentifier(
+            FuseScenery definition,
+            out string assetIdentifier)
+        {
+            assetIdentifier = NormalizeSceneryIdentifier(definition?.AssetIdentifier);
+            if (!string.IsNullOrWhiteSpace(assetIdentifier))
+            {
+                return true;
+            }
+
+            assetIdentifier = NormalizeSceneryIdentifier(definition?.Model);
+            return !string.IsNullOrWhiteSpace(assetIdentifier);
+        }
+
+        private static bool IsCachedKnownResolution(string candidate)
+        {
+            return TryGetCachedIdentifierResolution(candidate, out var resolved) &&
+                   !string.IsNullOrWhiteSpace(resolved);
+        }
+
         public static bool IsKnownOptionalLegacyAssetReference(FuseScenery definition)
         {
             if (definition == null)
@@ -350,6 +391,31 @@ namespace FUSE.Runtime.API
 
             return IsKnownOptionalLegacyAssetReference(definition.AssetIdentifier) ||
                    IsKnownOptionalLegacyAssetReference(definition.Model);
+        }
+
+        /// <summary>
+        /// Identifies editor-only legacy helper models that must never be
+        /// instantiated in a playable map. Alina's editor used the bright
+        /// yellow turntable measurement plate as an authoring aid; loading it
+        /// as ordinary scenery leaves the yellow "Pac-Man" shape reported at
+        /// Stryker/Bryson and East Whittier.
+        /// </summary>
+        public static bool IsEditorOnlyLegacySceneryReference(FuseScenery definition)
+        {
+            if (definition == null)
+            {
+                return false;
+            }
+
+            return IsEditorOnlyLegacySceneryReference(definition.AssetIdentifier) ||
+                   IsEditorOnlyLegacySceneryReference(definition.Model);
+        }
+
+        private static bool IsEditorOnlyLegacySceneryReference(string value)
+        {
+            var key = NormalizeLegacyAssetKey(value);
+            return string.Equals(key, "TurntableMeasurementTool", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(key, "ALW_ModRes_TurntableMeasurementTool", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool TryResolveKnownSceneryAssetIdentifier(string candidate, out string resolvedIdentifier)

--- a/FUSE/Runtime/API/SplineyAPI.cs
+++ b/FUSE/Runtime/API/SplineyAPI.cs
@@ -17,6 +17,7 @@ namespace FUSE.Runtime.API
         private static readonly FieldInfo RiverBuilderSplineProfileField = typeof(RiverBuilder).GetField("splineProfile", BindingFlags.Instance | BindingFlags.NonPublic);
         private static Transform _fallbackRiverRoot;
         private static Transform _fallbackTrestleRoot;
+        private static Transform _fallbackObjectLineRoot;
         private static List<SplineProfile> _splineProfiles;
         private static List<AutoTrestleProfile> _autoTrestleProfiles;
 
@@ -34,10 +35,19 @@ namespace FUSE.Runtime.API
             }
 
             var root = new GameObject(id);
-            ApplyDefinition(root, id, definition, false);
-            FuseSplineyRuntimeIndex.Instance.Set(id, root);
-            FuseApiPersistence.RecordDefinition(FuseDefinitionKind.Spliney, id, definition);
-            return root;
+            try
+            {
+                ApplyDefinition(root, id, definition, false);
+                FuseSplineyRuntimeIndex.Instance.Set(id, root);
+                FuseApiPersistence.RecordDefinition(FuseDefinitionKind.Spliney, id, definition);
+                return root;
+            }
+            catch
+            {
+                root.SetActive(false);
+                UnityEngine.Object.Destroy(root);
+                throw;
+            }
         }
 
         public static void UpdateSpliney(string id, FuseSpliney definition)
@@ -196,6 +206,9 @@ namespace FUSE.Runtime.API
                 case SplineyKind.Trestle:
                     ConfigureTrestle(root, definition, points);
                     break;
+                case SplineyKind.ObjectLine:
+                    ConfigureObjectLine(root, id, definition, points);
+                    break;
                 default:
                     throw new NotSupportedException($"Unsupported spliney kind '{kind}'.");
             }
@@ -218,6 +231,9 @@ namespace FUSE.Runtime.API
                 trestle?.Generate();
                 return;
             }
+
+            if (kind == SplineyKind.ObjectLine)
+                return;
 
             var builder = root.GetComponent<RiverBuilder>();
             builder?.BuildSpline();
@@ -500,6 +516,168 @@ namespace FUSE.Runtime.API
             }
         }
 
+        private static void ConfigureObjectLine(
+            GameObject root,
+            string id,
+            FuseSpliney definition,
+            IReadOnlyList<FuseSplineyPoint> points)
+        {
+            if (string.IsNullOrWhiteSpace(definition.AssetIdentifier)
+                && string.IsNullOrWhiteSpace(definition.Prefab))
+            {
+                throw new InvalidOperationException(
+                    $"Object-line spliney '{id}' requires assetIdentifier or prefab.");
+            }
+            if (!string.IsNullOrWhiteSpace(definition.AssetIdentifier)
+                && !string.IsNullOrWhiteSpace(definition.Prefab))
+            {
+                throw new InvalidOperationException(
+                    $"Object-line spliney '{id}' must use either assetIdentifier or prefab, not both.");
+            }
+
+            string assetIdentifier = null;
+            GameObject prefab = null;
+            if (!string.IsNullOrWhiteSpace(definition.AssetIdentifier))
+            {
+                var scenery = new FuseScenery
+                {
+                    AssetIdentifier = definition.AssetIdentifier,
+                };
+                if (!SceneryAPI.TryResolveAssetIdentifier(id, scenery, out assetIdentifier))
+                {
+                    throw new InvalidOperationException(
+                        $"Object-line scenery asset '{definition.AssetIdentifier}' was not found for '{id}'.");
+                }
+            }
+            else
+            {
+                prefab = FusePrefabResolver.Resolve(definition.Prefab);
+                if (prefab == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Object-line prefab '{definition.Prefab}' was not found for '{id}'.");
+                }
+            }
+
+            var placements = FuseObjectLineLayout.Build(
+                points,
+                definition.Spacing,
+                definition.PlaceAtEnd,
+                definition.MaximumInstances);
+            root.transform.SetParent(GetObjectLineRoot(), false);
+            root.transform.localPosition = Vector3.zero;
+            root.transform.localRotation = Quaternion.identity;
+            root.transform.localScale = Vector3.one;
+
+            var instances = root.transform.Find("FUSE Object Line Instances");
+            if (instances == null)
+            {
+                var container = new GameObject("FUSE Object Line Instances");
+                container.transform.SetParent(root.transform, false);
+                instances = container.transform;
+            }
+
+            // Older object-line builds placed generated modules directly on
+            // the root. Remove only those named instances during migration;
+            // editor overlays and other helper children must survive a live
+            // UpdateSpliney call.
+            var generatedPrefix = id + ":";
+            for (var childIndex = root.transform.childCount - 1; childIndex >= 0; childIndex--)
+            {
+                var child = root.transform.GetChild(childIndex);
+                if (child == null
+                    || ReferenceEquals(child, instances)
+                    || !child.name.StartsWith(generatedPrefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                child.gameObject.SetActive(false);
+                UnityEngine.Object.Destroy(child.gameObject);
+            }
+
+            for (var childIndex = instances.childCount - 1; childIndex >= 0; childIndex--)
+            {
+                var child = instances.GetChild(childIndex);
+                if (child == null)
+                    continue;
+                child.gameObject.SetActive(false);
+                UnityEngine.Object.Destroy(child.gameObject);
+            }
+
+            for (var index = 0; index < placements.Count; index++)
+            {
+                var placement = placements[index];
+                var position = placement.Position;
+                var forward = placement.Forward;
+                if (definition.SnapToTerrain
+                    && TrySnapObjectLineToTerrain(position, out var snapped))
+                {
+                    position.y = snapped.y;
+                }
+                if (!definition.AlignToSlope)
+                {
+                    forward.y = 0f;
+                    if (forward.sqrMagnitude <= 0.0001f)
+                        forward = Vector3.forward;
+                    else
+                        forward.Normalize();
+                }
+
+                var rotation = Quaternion.LookRotation(forward, Vector3.up);
+                var right = rotation * Vector3.right;
+                position += right * definition.LateralOffset;
+                position.y += definition.VerticalOffset;
+
+                GameObject instance;
+                if (prefab != null)
+                {
+                    instance = UnityEngine.Object.Instantiate(prefab, instances);
+                }
+                else
+                {
+                    instance = new GameObject();
+                    instance.SetActive(false);
+                    instance.transform.SetParent(instances, false);
+                    instance.AddComponent<SceneryAssetInstance>().identifier = assetIdentifier;
+                }
+                instance.name = id + ":" + index.ToString("D4");
+                instance.transform.localPosition = position;
+                instance.transform.localRotation = rotation * Quaternion.Euler(definition.RotationOffset);
+                instance.transform.localScale = definition.InstanceScale == default
+                    ? Vector3.one
+                    : definition.InstanceScale;
+                instance.SetActive(true);
+            }
+
+            FuseLog.Info(
+                $"FUSE built object-line spliney '{id}' with {placements.Count} instance(s) "
+                + $"at {definition.Spacing:0.##} m spacing.");
+        }
+
+        private static bool TrySnapObjectLineToTerrain(Vector3 position, out Vector3 snapped)
+        {
+            var hits = Physics.RaycastAll(
+                    position + Vector3.up * 500f,
+                    Vector3.down,
+                    1500f)
+                .OrderBy(hit => hit.distance);
+            foreach (var hit in hits)
+            {
+                if (hit.collider == null)
+                    continue;
+                var layerName = LayerMask.LayerToName(hit.collider.gameObject.layer) ?? string.Empty;
+                if (layerName.IndexOf("terrain", StringComparison.OrdinalIgnoreCase) < 0
+                    && layerName.IndexOf("ground", StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    continue;
+                }
+                snapped = hit.point;
+                return true;
+            }
+            snapped = position;
+            return false;
+        }
+
         private static SplineProfile ResolveSplineProfile(string profileName, SplineyKind kind)
         {
             return ResolveNamedObject(
@@ -638,6 +816,26 @@ namespace FUSE.Runtime.API
             return _fallbackTrestleRoot;
         }
 
+        private static Transform GetObjectLineRoot()
+        {
+            var existing = GameObject.Find("World/FUSE Object Lines");
+            if (existing != null)
+                return existing.transform;
+            var world = GameObject.Find("World");
+            if (world != null)
+            {
+                var root = new GameObject("FUSE Object Lines");
+                root.transform.SetParent(world.transform, false);
+                return root.transform;
+            }
+            if (_fallbackObjectLineRoot == null)
+            {
+                _fallbackObjectLineRoot = new GameObject("FUSE Object Lines").transform;
+                UnityEngine.Object.DontDestroyOnLoad(_fallbackObjectLineRoot.gameObject);
+            }
+            return _fallbackObjectLineRoot;
+        }
+
         private static Vector3 AveragePosition(IReadOnlyList<FuseSplineyPoint> points)
         {
             var center = Vector3.zero;
@@ -651,6 +849,13 @@ namespace FUSE.Runtime.API
 
         private static SplineyKind ParseKind(string value)
         {
+            if (string.Equals(value, "objectLine", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "object-line", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "fence", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "retainingWall", StringComparison.OrdinalIgnoreCase))
+            {
+                return SplineyKind.ObjectLine;
+            }
             if (string.Equals(value, "trestle", StringComparison.OrdinalIgnoreCase))
             {
                 return SplineyKind.Trestle;
@@ -755,7 +960,8 @@ namespace FUSE.Runtime.API
             River,
             TerrainRoad,
             Waterfall,
-            Trestle
+            Trestle,
+            ObjectLine
         }
     }
 

--- a/FUSE/Runtime/API/TrackAPI.Areas.cs
+++ b/FUSE/Runtime/API/TrackAPI.Areas.cs
@@ -309,7 +309,9 @@ namespace FUSE.Runtime.API
 
         private static void ApplyAreaDefinition(Area area, FuseArea definition)
         {
-            var displayName = string.IsNullOrWhiteSpace(definition.Name) ? area.identifier : definition.Name;
+            var displayName = string.IsNullOrWhiteSpace(definition.Name)
+                ? (string.IsNullOrWhiteSpace(area.name) ? area.identifier : area.name)
+                : definition.Name;
             area.name = displayName;
             area.gameObject.name = displayName;
             if (definition.Position.HasValue)

--- a/FUSE/Runtime/API/TrackAPI.Graph.cs
+++ b/FUSE/Runtime/API/TrackAPI.Graph.cs
@@ -412,6 +412,7 @@ namespace FUSE.Runtime.API
             Location? bestLower = null;
             var bestLength = float.PositiveInfinity;
             var bestFacing = string.Empty;
+            var validCandidateCount = 0;
 
             for (var trial = 1; trial <= 3; trial++)
             {
@@ -433,7 +434,13 @@ namespace FUSE.Runtime.API
                     var points = span.GetPoints();
                     var length = span.Length;
                     if (points == null || points.Count < 2 ||
-                        length <= SpanDistanceTolerance || length >= bestLength)
+                        length <= SpanDistanceTolerance)
+                    {
+                        continue;
+                    }
+
+                    validCandidateCount++;
+                    if (length >= bestLength)
                     {
                         continue;
                     }
@@ -451,10 +458,17 @@ namespace FUSE.Runtime.API
                 }
             }
 
-            if (!bestUpper.HasValue || !bestLower.HasValue)
+            if (!bestUpper.HasValue || !bestLower.HasValue || validCandidateCount != 1)
             {
                 span.upper = originalUpper;
                 span.lower = originalLower;
+                if (validCandidateCount > 1)
+                {
+                    FuseLog.Warning(
+                        $"FUSE refused to auto-repair track span '{spanId}' because {validCandidateCount} endpoint-facing " +
+                        "combinations resolved through the switch graph. Choosing the shortest route is ambiguous and can bind " +
+                        "an industry track to a neighboring track; correct the authored endpoint directions instead.");
+                }
                 return false;
             }
 
@@ -567,6 +581,7 @@ namespace FUSE.Runtime.API
             var id = span.id ?? string.Empty;
             var displayName = span.name ?? string.Empty;
             UnregisterSpanWithGraph(Graph.Shared, id);
+            span.id = CreateRetiredSpanId(id);
             RemoveRuntimeObject(span);
             if (!string.IsNullOrWhiteSpace(id))
             {

--- a/FUSE/Runtime/API/TrackAPI.Helpers.cs
+++ b/FUSE/Runtime/API/TrackAPI.Helpers.cs
@@ -46,6 +46,7 @@ namespace FUSE.Runtime.API
                 Position = definition.Position,
                 Rotation = definition.Rotation,
                 FlipSwitchStand = definition.FlipSwitchStand,
+                IsDiamond = definition.IsDiamond,
                 GroupId = definition.GroupId,
                 Tags = definition.Tags?.ToArray()
             };
@@ -69,8 +70,12 @@ namespace FUSE.Runtime.API
                 GroupId = definition.GroupId,
                 Tags = definition.Tags?.ToArray(),
                 Gauge = definition.Gauge,
+                BridgeSupportsSteel = definition.BridgeSupportsSteel,
+                Yard = definition.Yard,
                 Partial = definition.Partial,
                 PreserveStyle = definition.PreserveStyle,
+                PreserveBridgeSupportsSteel = definition.PreserveBridgeSupportsSteel,
+                PreserveYard = definition.PreserveYard,
                 PreserveTrackClass = definition.PreserveTrackClass,
                 PreserveSpeedLimit = definition.PreserveSpeedLimit,
                 PreservePriority = definition.PreservePriority,

--- a/FUSE/Runtime/API/TrackAPI.Nodes.cs
+++ b/FUSE/Runtime/API/TrackAPI.Nodes.cs
@@ -9,6 +9,7 @@ using FUSE.Authoring.Data;
 using FUSE.Authoring.Data.Common;
 using FUSE.Runtime.Events;
 using FUSE.Infrastructure;
+using FUSE.Compatibility;
 using Track;
 using Track.Signals;
 using UnityEngine;
@@ -49,6 +50,7 @@ namespace FUSE.Runtime.API
             }
 
             var node = AddNode(id, definition.Position, definition.Rotation, definition.FlipSwitchStand, definition.GroupId);
+            RailroaderTrackContract.SetNodeIsDiamond(node, definition.IsDiamond);
             FuseApiPersistence.RecordDefinition(FuseDefinitionKind.TrackNode, id, definition);
             return node;
         }
@@ -78,6 +80,7 @@ namespace FUSE.Runtime.API
             }
 
             UpdateNode(id, definition.Position, definition.Rotation, definition.FlipSwitchStand);
+            RailroaderTrackContract.SetNodeIsDiamond(RequireNode(id), definition.IsDiamond);
             FuseApiPersistence.RecordDefinition(FuseDefinitionKind.TrackNode, id, definition);
         }
 
@@ -126,6 +129,7 @@ namespace FUSE.Runtime.API
             definition.Position = node.transform.localPosition;
             definition.Rotation = node.transform.localEulerAngles;
             definition.FlipSwitchStand = node.flipSwitchStand;
+            definition.IsDiamond = RailroaderTrackContract.GetNodeIsDiamond(node);
             return definition;
         }
     }

--- a/FUSE/Runtime/API/TrackAPI.Segments.cs
+++ b/FUSE/Runtime/API/TrackAPI.Segments.cs
@@ -9,6 +9,7 @@ using FUSE.Authoring.Data;
 using FUSE.Authoring.Data.Common;
 using FUSE.Runtime.Events;
 using FUSE.Infrastructure;
+using FUSE.Compatibility;
 using Track;
 using Track.Signals;
 using UnityEngine;
@@ -63,6 +64,11 @@ namespace FUSE.Runtime.API
                 definition.GroupId,
                 ParseTrackClass(definition.TrackClass),
                 definition.Priority);
+            RailroaderTrackContract.ApplyStructure(
+                segment,
+                definition.Style,
+                definition.BridgeSupportsSteel,
+                definition.Yard);
             FuseApiPersistence.RecordDefinition(FuseDefinitionKind.TrackSegment, id, definition);
             return segment;
         }
@@ -110,6 +116,11 @@ namespace FUSE.Runtime.API
                 ParseTrackClass(definition.TrackClass),
                 definition.Priority,
                 definition.GroupId);
+            RailroaderTrackContract.ApplyStructure(
+                RequireSegment(id),
+                definition.Style,
+                definition.BridgeSupportsSteel,
+                definition.Yard);
             FuseApiPersistence.RecordDefinition(FuseDefinitionKind.TrackSegment, id, definition);
         }
 
@@ -154,7 +165,9 @@ namespace FUSE.Runtime.API
             definition = definition ?? new FuseSegment();
             definition.StartNodeId = segment.a != null ? segment.a.id : null;
             definition.EndNodeId = segment.b != null ? segment.b.id : null;
-            definition.Style = segment.style.ToString();
+            definition.Style = RailroaderTrackContract.GetStyleName(segment);
+            definition.BridgeSupportsSteel = RailroaderTrackContract.GetBridgeSupportsSteel(segment);
+            definition.Yard = RailroaderTrackContract.GetYard(segment);
             definition.TrackClass = segment.trackClass == TrackClass.Mainline ? "main" : segment.trackClass.ToString();
             definition.SpeedLimit = segment.speedLimit;
             definition.Priority = segment.priority;

--- a/FUSE/Runtime/API/TrackAPI.Spans.cs
+++ b/FUSE/Runtime/API/TrackAPI.Spans.cs
@@ -46,6 +46,10 @@ namespace FUSE.Runtime.API
             }
             catch
             {
+                // Unity destruction is deferred. Do not leave a failed temporary
+                // object discoverable under the requested id for the remainder
+                // of this frame, or a later retry can be mistaken for a duplicate.
+                span.id = CreateRetiredSpanId(id);
                 RemoveRuntimeObject(span);
                 throw;
             }
@@ -121,11 +125,55 @@ namespace FUSE.Runtime.API
         {
             var span = RequireSpan(id);
             UnregisterSpanWithGraph(Graph.Shared, id);
+            // Retire the identity before scheduling Unity destruction. A package
+            // can legitimately recreate this id in the same apply pass.
+            span.id = CreateRetiredSpanId(id);
             RemoveRuntimeObject(span);
             FuseSpanRuntimeIndex.Instance.Remove(id);
             FuseRuntimeDefinitionCache.Remove(FuseDefinitionKind.TrackSpan, id);
             FuseEvents.RaiseSpanRemoved(id);
             RequestRebuild();
+        }
+
+        /// <summary>
+        /// Recreates a span whose endpoint topology changed without exposing two
+        /// live scene objects under the same identifier. Existing industry and
+        /// interchange components are rebound to the replacement instance before
+        /// Unity retires the old component at the end of the frame.
+        /// </summary>
+        public static TrackSpan ReplaceSpan(string id, FuseSpan definition)
+        {
+            RequireId(id, nameof(id));
+            if (definition == null)
+            {
+                throw new ArgumentNullException(nameof(definition));
+            }
+
+            var graph = RequireGraph();
+            var previousSpan = RequireSpan(id);
+            UnregisterSpanWithGraph(graph, id);
+            FuseSpanRuntimeIndex.Instance.Remove(id);
+            previousSpan.id = CreateRetiredSpanId(id);
+
+            TrackSpan replacementSpan;
+            try
+            {
+                replacementSpan = AddSpan(id, definition);
+            }
+            catch
+            {
+                // The previous component has not been destroyed yet, so a failed
+                // replacement can be rolled back without losing the working span.
+                previousSpan.id = id;
+                FuseSpanRuntimeIndex.Instance.Set(id, previousSpan);
+                RegisterSpanWithGraph(graph, previousSpan);
+                throw;
+            }
+
+            IndustryAPI.ReplaceTrackSpanReferences(previousSpan, replacementSpan, "TrackAPI.ReplaceSpan");
+            RemoveRuntimeObject(previousSpan);
+            FuseLog.Info($"FUSE atomically replaced track span id='{id}' and rebound its runtime consumers.");
+            return replacementSpan;
         }
 
         public static TrackSpan GetSpan(string id)
@@ -169,6 +217,31 @@ namespace FUSE.Runtime.API
         {
             return UnityEngine.Object.FindObjectsOfType<TrackSpan>(true)
                 .Where(span => span != null && !string.IsNullOrWhiteSpace(span.id));
+        }
+
+        /// <summary>
+        /// Returns only spans owned by the live graph dictionary. Scene-wide
+        /// searches also find prefab/template components and objects waiting for
+        /// Unity's deferred destruction; those are useful to compatibility code
+        /// but are not broken runtime track and must not become audit findings.
+        /// </summary>
+        internal static IEnumerable<TrackSpan> GetRegisteredSpansForDiagnostics()
+        {
+            var graph = Graph.Shared;
+            var spans = graph != null
+                ? GraphSpansField?.GetValue(graph) as Dictionary<string, TrackSpan>
+                : null;
+            if (spans != null)
+            {
+                return spans.Values
+                    .Where(span => span != null && !string.IsNullOrWhiteSpace(span.id))
+                    .Distinct()
+                    .ToArray();
+            }
+
+            return GetAllSpans()
+                .Where(span => graph != null && ReferenceEquals(graph.SpanForId(span.id), span))
+                .ToArray();
         }
 
         private static TrackSpan[] GetRegisteredGraphSpans()
@@ -268,9 +341,28 @@ namespace FUSE.Runtime.API
 
             FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.TrackSpan, span.id, out FuseSpan definition);
             definition = definition ?? new FuseSpan();
-            definition.Upper = span.upper.HasValue ? ToDefinition(span.upper.Value) : null;
-            definition.Lower = span.lower.HasValue ? ToDefinition(span.lower.Value) : null;
+
+            // Railroader's TrackSpan location getters can temporarily return
+            // null when Graph.TryResolveLocation cannot resolve an otherwise
+            // valid serialized endpoint. Keep the authored/cache endpoint in
+            // that case. The audit can then distinguish a genuinely missing
+            // endpoint from an endpoint whose referenced segment was removed.
+            if (span.upper.HasValue)
+            {
+                definition.Upper = ToDefinition(span.upper.Value);
+            }
+
+            if (span.lower.HasValue)
+            {
+                definition.Lower = ToDefinition(span.lower.Value);
+            }
+
             return definition;
+        }
+
+        private static string CreateRetiredSpanId(string id)
+        {
+            return $"__FUSE_RETIRED_SPAN__{id ?? string.Empty}__{Guid.NewGuid():N}";
         }
     }
 }

--- a/FUSE/Runtime/API/WaterSurfaceAPI.cs
+++ b/FUSE/Runtime/API/WaterSurfaceAPI.cs
@@ -1,0 +1,371 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Authoring.Data;
+using FUSE.Infrastructure;
+using FUSE.Runtime.Cache;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace FUSE.Runtime.API
+{
+    /// <summary>
+    /// Creates FUSE-owned lake polygons from native world data. The runtime
+    /// uses Railroader's public LakePolygon contract and loaded water assets;
+    /// it does not embed or duplicate game implementation code.
+    /// </summary>
+    public static class WaterSurfaceAPI
+    {
+        private static Transform _fallbackRoot;
+        private static Material _fallbackMaterial;
+
+        public static GameObject AddWaterSurface(string id, FuseWaterSurface definition)
+        {
+            RequireId(id);
+            if (definition == null)
+                throw new ArgumentNullException(nameof(definition));
+            if (GetWaterSurface(id) != null)
+                throw new InvalidOperationException($"Water surface '{id}' already exists.");
+
+            var root = new GameObject(id);
+            try
+            {
+                ApplyDefinition(root, id, definition);
+                FuseWaterSurfaceRuntimeIndex.Instance.Set(id, root);
+                FuseApiPersistence.RecordDefinition(FuseDefinitionKind.WaterSurface, id, definition);
+                return root;
+            }
+            catch
+            {
+                root.SetActive(false);
+                ReleaseGeneratedMesh(root);
+                UnityEngine.Object.Destroy(root);
+                throw;
+            }
+        }
+
+        public static void UpdateWaterSurface(string id, FuseWaterSurface definition)
+        {
+            var root = RequireWaterSurface(id);
+            if (definition == null)
+                throw new ArgumentNullException(nameof(definition));
+
+            ApplyDefinition(root, id, definition);
+            FuseWaterSurfaceRuntimeIndex.Instance.Set(id, root);
+            FuseApiPersistence.RecordDefinition(FuseDefinitionKind.WaterSurface, id, definition);
+        }
+
+        public static GameObject GetWaterSurface(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                return null;
+            if (FuseWaterSurfaceRuntimeIndex.Instance.TryGetValue(id, out var cached))
+                return cached as GameObject;
+            if (FuseCacheRegistry.IsReady)
+                return null;
+
+            return UnityEngine.Object.FindObjectsOfType<FuseWaterSurfaceMarker>(true)
+                .FirstOrDefault(marker => string.Equals(marker.Id, id, StringComparison.OrdinalIgnoreCase))
+                ?.gameObject;
+        }
+
+        public static IEnumerable<GameObject> GetAllWaterSurfaces()
+        {
+            return UnityEngine.Object.FindObjectsOfType<FuseWaterSurfaceMarker>(true)
+                .Where(marker => marker != null)
+                .Select(marker => marker.gameObject);
+        }
+
+        public static FuseWaterSurface GetWaterSurfaceDefinition(string id)
+        {
+            return GetDefinition(GetWaterSurface(id));
+        }
+
+        public static FuseWaterSurface GetDefinition(GameObject root)
+        {
+            if (root == null)
+                return null;
+            var marker = root.GetComponent<FuseWaterSurfaceMarker>();
+            var id = marker != null ? marker.Id : root.name;
+            FuseRuntimeDefinitionCache.TryGet(
+                FuseDefinitionKind.WaterSurface,
+                id,
+                out FuseWaterSurface definition);
+            definition = definition ?? new FuseWaterSurface();
+
+            var lake = root.GetComponent<LakePolygon>();
+            if (lake != null)
+            {
+                definition.Points = (lake.points ?? new List<Vector3>())
+                    .Select(root.transform.TransformPoint)
+                    .ToArray();
+                definition.LockHeight = lake.lockHeight;
+                definition.SnapToTerrain = lake.snapToTerrain;
+                definition.EnableCollider = root.GetComponent<MeshCollider>() != null;
+                definition.UvScale = lake.uvScale;
+                definition.TriangleDensity = lake.traingleDensity;
+                definition.MaximumTriangleArea = lake.maximumTriangleSize;
+                definition.YOffset = lake.yOffset;
+            }
+
+            if (marker != null)
+            {
+                definition.SourceLakePath = marker.SourceLakePath;
+                definition.MaterialName = marker.MaterialName;
+            }
+            return definition;
+        }
+
+        public static void RemoveWaterSurface(string id)
+        {
+            if (!TryRemoveWaterSurface(id))
+                throw new InvalidOperationException($"Water surface '{id}' was not found.");
+        }
+
+        public static bool TryRemoveWaterSurface(string id)
+        {
+            var root = GetWaterSurface(id);
+            if (root == null)
+            {
+                FuseLog.Warning($"FUSE world removal skipped missing water surface '{id}'.");
+                return false;
+            }
+
+            root.SetActive(false);
+            ReleaseGeneratedMesh(root);
+            UnityEngine.Object.Destroy(root);
+            FuseWaterSurfaceRuntimeIndex.Instance.Remove(id);
+            FuseRuntimeDefinitionCache.Remove(FuseDefinitionKind.WaterSurface, id);
+            FuseLog.Info($"FUSE removed water surface '{id}'.");
+            return true;
+        }
+
+        private static void ApplyDefinition(GameObject root, string id, FuseWaterSurface definition)
+        {
+            var points = definition.Points ?? Array.Empty<Vector3>();
+            if (points.Length < 3)
+                throw new InvalidOperationException($"Water surface '{id}' requires at least three boundary points.");
+            if (definition.TriangleDensity <= 0f || definition.TriangleDensity > 1f)
+                throw new InvalidOperationException($"Water surface '{id}' triangleDensity must be greater than 0 and at most 1.");
+            if (definition.MaximumTriangleArea <= 0f)
+                throw new InvalidOperationException($"Water surface '{id}' maximumTriangleArea must be greater than 0.");
+
+            var source = ResolveSourceLake(definition.SourceLakePath);
+            var material = ResolveMaterial(source, definition.MaterialName);
+            root.SetActive(false);
+            try
+            {
+                root.name = id;
+                root.transform.SetParent(GetWaterRoot(), false);
+                root.transform.localPosition = Vector3.zero;
+                root.transform.localRotation = Quaternion.identity;
+                root.transform.localScale = Vector3.one;
+                var waterLayer = LayerMask.NameToLayer("Water");
+                if (waterLayer >= 0)
+                    root.layer = waterLayer;
+
+                var lake = root.GetComponent<LakePolygon>() ?? root.AddComponent<LakePolygon>();
+                var renderer = root.GetComponent<MeshRenderer>() ?? root.AddComponent<MeshRenderer>();
+                renderer.sharedMaterial = material;
+
+                ApplySourceLakeProfile(source, lake);
+                lake.points = points.ToList();
+                lake.lockHeight = definition.LockHeight;
+                lake.snapToTerrain = definition.SnapToTerrain;
+                lake.uvScale = definition.UvScale;
+                lake.traingleDensity = definition.TriangleDensity;
+                lake.maximumTriangleSize = definition.MaximumTriangleArea;
+                lake.yOffset = definition.YOffset;
+
+                var collider = root.GetComponent<MeshCollider>();
+                if (definition.EnableCollider && collider == null)
+                    collider = root.AddComponent<MeshCollider>();
+                else if (!definition.EnableCollider && collider != null)
+                    UnityEngine.Object.Destroy(collider);
+
+                var previousMesh = root.GetComponent<MeshFilter>()?.sharedMesh;
+                // A source lake's painted per-vertex flow map belongs to its old
+                // triangulation. Generate a fresh automatic map for this polygon
+                // while retaining the source profile's flow speed and noise.
+                lake.overrideFlowMap = false;
+                lake.colorsFlowMap.Clear();
+                lake.GeneratePolygon(false);
+                if (collider != null)
+                    collider.sharedMesh = root.GetComponent<MeshFilter>()?.sharedMesh;
+                ReleaseReplacedMesh(previousMesh, lake.currentMesh);
+
+                var marker = root.GetComponent<FuseWaterSurfaceMarker>()
+                             ?? root.AddComponent<FuseWaterSurfaceMarker>();
+                marker.Id = id;
+                marker.SourceLakePath = definition.SourceLakePath;
+                marker.MaterialName = definition.MaterialName;
+            }
+            finally
+            {
+                root.SetActive(true);
+            }
+        }
+
+        private static void ApplySourceLakeProfile(LakePolygon source, LakePolygon target)
+        {
+            if (ReferenceEquals(target, null))
+                throw new ArgumentNullException(nameof(target));
+
+            if (ReferenceEquals(source, null))
+            {
+                target.currentProfile = null;
+                target.receiveShadows = false;
+                target.shadowCastingMode = ShadowCastingMode.Off;
+                return;
+            }
+
+            // These are public LakePolygon rendering/profile controls. Copying
+            // them preserves the loaded map's water appearance without copying
+            // the game's mesh-generation implementation or terrain mutations.
+            target.currentProfile = source.currentProfile;
+            target.distSmooth = source.distSmooth;
+            target.terrainSmoothMultiplier = source.terrainSmoothMultiplier;
+            target.overrideLakeRender = source.overrideLakeRender;
+            target.receiveShadows = source.receiveShadows;
+            target.shadowCastingMode = source.shadowCastingMode;
+            target.automaticFlowMapScale = source.automaticFlowMapScale;
+            target.noiseflowMap = source.noiseflowMap;
+            target.noiseMultiplierflowMap = source.noiseMultiplierflowMap;
+            target.noiseSizeXflowMap = source.noiseSizeXflowMap;
+            target.noiseSizeZflowMap = source.noiseSizeZflowMap;
+            target.floatSpeed = source.floatSpeed;
+            target.flowSpeed = source.flowSpeed;
+            target.flowDirection = source.flowDirection;
+            target.normalFromRaycast = source.normalFromRaycast;
+            target.snapMask = source.snapMask;
+        }
+
+        private static void ReleaseReplacedMesh(Mesh previous, Mesh current)
+        {
+            if (previous != null && previous != current)
+                UnityEngine.Object.Destroy(previous);
+        }
+
+        private static void ReleaseGeneratedMesh(GameObject root)
+        {
+            if (root == null)
+                return;
+
+            var lake = root.GetComponent<LakePolygon>();
+            var filter = root.GetComponent<MeshFilter>();
+            var collider = root.GetComponent<MeshCollider>();
+            var mesh = lake?.currentMesh ?? filter?.sharedMesh;
+            if (collider != null && collider.sharedMesh == mesh)
+                collider.sharedMesh = null;
+            if (filter != null && filter.sharedMesh == mesh)
+                filter.sharedMesh = null;
+            if (lake != null)
+            {
+                lake.currentMesh = null;
+                lake.meshfilter = null;
+            }
+            if (mesh != null)
+                UnityEngine.Object.Destroy(mesh);
+        }
+
+        private static LakePolygon ResolveSourceLake(string path)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                var sourceObject = FusePrefabResolver.ResolveScenePath(path.Trim());
+                var source = sourceObject != null
+                    ? sourceObject.GetComponent<LakePolygon>()
+                      ?? sourceObject.GetComponentInChildren<LakePolygon>(true)
+                    : null;
+                if (source == null)
+                    throw new InvalidOperationException($"Source lake path '{path}' was not found or has no LakePolygon component.");
+                return source;
+            }
+
+            return Resources.FindObjectsOfTypeAll<LakePolygon>()
+                .FirstOrDefault(candidate => candidate != null
+                    && candidate.GetComponent<FuseWaterSurfaceMarker>() == null
+                    && candidate.GetComponent<MeshRenderer>()?.sharedMaterial != null);
+        }
+
+        private static Material ResolveMaterial(LakePolygon source, string materialName)
+        {
+            if (!string.IsNullOrWhiteSpace(materialName))
+            {
+                var material = Resources.FindObjectsOfTypeAll<Material>()
+                    .FirstOrDefault(candidate => candidate != null
+                        && string.Equals(candidate.name, materialName.Trim(), StringComparison.OrdinalIgnoreCase));
+                if (material == null)
+                    throw new InvalidOperationException($"Water material '{materialName}' was not found among loaded game assets.");
+                return material;
+            }
+
+            var sourceMaterial = source?.GetComponent<MeshRenderer>()?.sharedMaterial;
+            if (sourceMaterial != null)
+                return sourceMaterial;
+
+            var loadedWater = Resources.FindObjectsOfTypeAll<Material>()
+                .FirstOrDefault(candidate => candidate != null
+                    && (candidate.name.IndexOf("lake", StringComparison.OrdinalIgnoreCase) >= 0
+                        || candidate.name.IndexOf("water", StringComparison.OrdinalIgnoreCase) >= 0));
+            if (loadedWater != null)
+                return loadedWater;
+
+            if (_fallbackMaterial == null)
+            {
+                var shader = Shader.Find("Universal Render Pipeline/Lit") ?? Shader.Find("Standard");
+                if (shader == null)
+                    throw new InvalidOperationException("No loaded lake material or fallback render shader was available.");
+                _fallbackMaterial = new Material(shader)
+                {
+                    name = "FUSE Fallback Water",
+                    color = new Color(0.08f, 0.32f, 0.48f, 0.82f),
+                    hideFlags = HideFlags.HideAndDontSave,
+                };
+                FuseLog.Warning("FUSE could not find a stock lake material; using the simple fallback water material.");
+            }
+            return _fallbackMaterial;
+        }
+
+        private static Transform GetWaterRoot()
+        {
+            var existing = GameObject.Find("World/Water Surfaces");
+            if (existing != null)
+                return existing.transform;
+            var world = GameObject.Find("World");
+            if (world != null)
+            {
+                var root = new GameObject("Water Surfaces");
+                root.transform.SetParent(world.transform, false);
+                return root.transform;
+            }
+            if (_fallbackRoot == null)
+            {
+                _fallbackRoot = new GameObject("FUSE Water Surfaces").transform;
+                UnityEngine.Object.DontDestroyOnLoad(_fallbackRoot.gameObject);
+            }
+            return _fallbackRoot;
+        }
+
+        private static GameObject RequireWaterSurface(string id)
+        {
+            var root = GetWaterSurface(id);
+            if (root == null)
+                throw new InvalidOperationException($"Water surface '{id}' was not found.");
+            return root;
+        }
+
+        private static void RequireId(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentException("ID is required.", nameof(id));
+        }
+    }
+
+    public sealed class FuseWaterSurfaceMarker : MonoBehaviour
+    {
+        public string Id;
+        public string SourceLakePath;
+        public string MaterialName;
+    }
+}

--- a/FUSE/Runtime/Cache/FuseCacheRegistry.cs
+++ b/FUSE/Runtime/Cache/FuseCacheRegistry.cs
@@ -41,6 +41,7 @@ namespace FUSE.Runtime.Cache
             Register(new FuseStationRuntimeIndex());
             Register(new FuseSceneryRuntimeIndex());
             Register(new FuseSplineyRuntimeIndex());
+            Register(new FuseWaterSurfaceRuntimeIndex());
             Register(new FuseMapLabelRuntimeIndex());
         }
 
@@ -70,6 +71,7 @@ namespace FUSE.Runtime.Cache
             FuseStationRuntimeIndex.Instance.Rebuild();
             FuseSceneryRuntimeIndex.Instance.Rebuild();
             FuseSplineyRuntimeIndex.Instance.Rebuild();
+            FuseWaterSurfaceRuntimeIndex.Instance.Rebuild();
             FuseMapLabelRuntimeIndex.Instance.Rebuild();
             // Full rebuilds mark session boundaries (map load, manual reload) where
             // SceneryAssetManager.Shared and its catalog may have been replaced
@@ -80,7 +82,7 @@ namespace FUSE.Runtime.Cache
             _fullRebuildCount++;
             FusePerformanceMetrics.RecordCount("cache full rebuilds", _fullRebuildCount);
             FuseLog.Info(
-                $"FUSE cache full rebuild #{_fullRebuildCount} (16 indexes) elapsedMs={stopwatch.ElapsedMilliseconds}.");
+                $"FUSE cache full rebuild #{_fullRebuildCount} (17 indexes) elapsedMs={stopwatch.ElapsedMilliseconds}.");
         }
 
         /// <summary>
@@ -128,6 +130,7 @@ namespace FUSE.Runtime.Cache
             FuseStationRuntimeIndex.Instance.Clear();
             FuseSceneryRuntimeIndex.Instance.Clear();
             FuseSplineyRuntimeIndex.Instance.Clear();
+            FuseWaterSurfaceRuntimeIndex.Instance.Clear();
             FuseMapLabelRuntimeIndex.Instance.Clear();
             _isReady = false;
         }

--- a/FUSE/Runtime/Cache/FuseRuntimeCaches.cs
+++ b/FUSE/Runtime/Cache/FuseRuntimeCaches.cs
@@ -243,6 +243,19 @@ namespace FUSE.Runtime.Cache
         }
     }
 
+    public sealed class FuseWaterSurfaceRuntimeIndex : FuseRuntimeIndex<FuseWaterSurfaceRuntimeIndex>
+    {
+        public override void Rebuild()
+        {
+            Clear();
+            foreach (var marker in Object.FindObjectsOfType<FUSE.Runtime.API.FuseWaterSurfaceMarker>(true)
+                         .Where(marker => marker != null && !string.IsNullOrWhiteSpace(marker.Id)))
+            {
+                Set(marker.Id, marker.gameObject);
+            }
+        }
+    }
+
     public sealed class FuseMapLabelRuntimeIndex : FuseRuntimeIndex<FuseMapLabelRuntimeIndex>
     {
         public override void Rebuild()

--- a/FUSE/Runtime/Events/FuseOutboundRoutingEvents.cs
+++ b/FUSE/Runtime/Events/FuseOutboundRoutingEvents.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Infrastructure;
+using Model.Ops;
+
+namespace FUSE.Runtime.Events
+{
+    public sealed class FuseOutboundRoutingCandidate
+    {
+        public FuseOutboundRoutingCandidate(
+            IndustryComponent component,
+            float weight,
+            float? proposedPayment = null,
+            int? proposedGraceDays = null)
+        {
+            Component = component ?? throw new ArgumentNullException(nameof(component));
+            Weight = weight;
+            ProposedPayment = proposedPayment;
+            ProposedGraceDays = proposedGraceDays;
+        }
+
+        public IndustryComponent Component { get; }
+        public float Weight { get; set; }
+        public float? ProposedPayment { get; set; }
+        public int? ProposedGraceDays { get; set; }
+    }
+
+    public sealed class FuseOutboundRoutingContext
+    {
+        internal FuseOutboundRoutingContext(
+            IOpsCar car,
+            OpsCarPosition origin,
+            bool loaded,
+            IList<FuseOutboundRoutingCandidate> candidates)
+        {
+            Car = car;
+            Origin = origin;
+            IsLoaded = loaded;
+            Candidates = candidates;
+        }
+
+        public IOpsCar Car { get; }
+        public OpsCarPosition Origin { get; }
+        public bool IsLoaded { get; }
+        public IList<FuseOutboundRoutingCandidate> Candidates { get; }
+    }
+
+    public static class FuseOutboundRoutingEvents
+    {
+        public static event Action<FuseOutboundRoutingContext> Preparing;
+
+        internal static void RaisePreparing(FuseOutboundRoutingContext context)
+        {
+            var handlers = Preparing;
+            if (handlers == null)
+            {
+                return;
+            }
+
+            foreach (Action<FuseOutboundRoutingContext> handler in handlers.GetInvocationList())
+            {
+                try
+                {
+                    handler(context);
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        "FUSE contained an outbound-routing extension error; " +
+                        $"other extensions and base routing remain available: {ex.GetBaseException().Message}");
+                }
+            }
+        }
+    }
+}

--- a/FUSE/Runtime/Lifecycle/FuseRuntimePump.cs
+++ b/FUSE/Runtime/Lifecycle/FuseRuntimePump.cs
@@ -16,7 +16,9 @@ namespace FUSE.Runtime.Lifecycle
     /// zero records, toasts, or quarantines, while the enqueue-side counters
     /// kept climbing). Queue-consuming work now lives here, on a host created
     /// unconditionally at plugin load, so a UI refactor can never silently
-    /// starve it again. Cost when idle: two lock-free queue-empty snapshots.
+    /// starve it again. Every driven subsystem has a constant-time idle guard;
+    /// the pump does not enumerate packages, scene objects, or asset stores while
+    /// no work is pending.
     /// </summary>
     internal static class FuseRuntimePump
     {
@@ -83,6 +85,11 @@ namespace FUSE.Runtime.Lifecycle
                 // discovery and Harmony mutation are coalesced and replayed here.
                 FUSE.Patches.FuseThirdPartyGuardInstaller.DrainPending();
 
+                // RailLoader plugins that implement IUpdateHandler expect their
+                // callback every Unity frame. Hosting only OnEnable made those
+                // plugins appear loaded while their runtime behavior stayed inert.
+                FUSE.Loading.FuseLegacyAssemblyHost.UpdateHostedPlugins();
+
                 // TimeSync Mod's ten-minute System.Threading.Timer callback
                 // arrives on a worker thread. Replay it here before it can
                 // touch StateManager and the Unity-backed in-game console.
@@ -113,6 +120,13 @@ namespace FUSE.Runtime.Lifecycle
                 // teleport. Finish only a bounded number of car bodies,
                 // trucks, unique materials, and load models per frame.
                 FUSE.Patches.FuseCarModelCompletionScheduler.Update();
+
+                // EquipmentWindow synchronously enumerates every mounted
+                // Definitions.json the first time it opens. Warm one cold
+                // store per frame so legacy container edit patches (notably
+                // Lego's large definition set) cannot produce a multi-second
+                // buy-menu stall.
+                FUSE.Patches.FuseEquipmentCatalogWarmup.Update();
             }
         }
     }

--- a/FUSE/Runtime/Lifecycle/FuseUnusedAssetReclaimer.cs
+++ b/FUSE/Runtime/Lifecycle/FuseUnusedAssetReclaimer.cs
@@ -75,6 +75,15 @@ namespace FUSE.Runtime.Lifecycle
                 return;
             }
 
+            // This method is driven every Unity frame. Texture.currentTextureMemory
+            // crosses into Unity's native runtime, but it cannot influence the
+            // decision when there are no evicted requests waiting to be reclaimed.
+            // Keep the overwhelmingly common idle path entirely managed and cheap.
+            if (pending <= 0)
+            {
+                return;
+            }
+
             var textureCurrentBytes = ToSignedBytes(Texture.currentTextureMemory);
             if (!HasEnoughPressureToSweep(pending, textureCurrentBytes) ||
                 Time.realtimeSinceStartup - _lastPendingChangeRealtime < QuietSeconds ||

--- a/FUSE/Runtime/Registry/FuseRegistry.cs
+++ b/FUSE/Runtime/Registry/FuseRegistry.cs
@@ -296,7 +296,62 @@ namespace FUSE.Runtime.Registry
             }
         }
 
+        /// <summary>
+        /// Records a conflict discovered while constructing a merged final
+        /// state, before either package can create a normal runtime claim. This
+        /// is used for delete-vs-definition collisions where the later delete
+        /// removes the earlier package from the plan entirely.
+        /// </summary>
+        internal static void RecordPlannedConflict(
+            FuseClaimKind kind,
+            string id,
+            string ownerPackageId,
+            string attemptedPackageId,
+            string resolution)
+        {
+            if (string.IsNullOrWhiteSpace(id) ||
+                string.IsNullOrWhiteSpace(ownerPackageId) ||
+                string.IsNullOrWhiteSpace(attemptedPackageId) ||
+                string.Equals(ownerPackageId, attemptedPackageId, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            lock (Sync)
+            {
+                if (ConflictHistory.Any(existing =>
+                    existing.Kind == kind &&
+                    string.Equals(existing.Id, id, StringComparison.OrdinalIgnoreCase) &&
+                    ((string.Equals(existing.OwnerPackageId, ownerPackageId, StringComparison.OrdinalIgnoreCase) &&
+                      string.Equals(existing.AttemptedPackageId, attemptedPackageId, StringComparison.OrdinalIgnoreCase)) ||
+                     (string.Equals(existing.OwnerPackageId, attemptedPackageId, StringComparison.OrdinalIgnoreCase) &&
+                      string.Equals(existing.AttemptedPackageId, ownerPackageId, StringComparison.OrdinalIgnoreCase)))))
+                {
+                    return;
+                }
+
+                RecordConflictLocked(
+                    kind,
+                    id,
+                    ownerPackageId,
+                    attemptedPackageId,
+                    string.IsNullOrWhiteSpace(resolution)
+                        ? "merged plan collision"
+                        : resolution);
+            }
+        }
+
         private static void RecordConflictLocked(FuseClaimKind kind, string id, string owner, string attempted)
+        {
+            RecordConflictLocked(kind, id, owner, attempted, "claim skipped; existing owner retained");
+        }
+
+        private static void RecordConflictLocked(
+            FuseClaimKind kind,
+            string id,
+            string owner,
+            string attempted,
+            string resolution)
         {
             ConflictHistory.Add(new FuseRegistryConflict
             {
@@ -305,7 +360,7 @@ namespace FUSE.Runtime.Registry
                 Id = id,
                 OwnerPackageId = owner,
                 AttemptedPackageId = attempted,
-                Resolution = "claim skipped; existing owner retained",
+                Resolution = resolution,
                 AtUtc = DateTime.UtcNow
             });
 
@@ -317,7 +372,7 @@ namespace FUSE.Runtime.Registry
             FuseLog.Warning(
                 $"FUSE registry conflict package='{attempted}' operation='claim runtime object' " +
                 $"target='{kind}' kind='{kind}' id='{id}' owner='{owner}' " +
-                "resolution='claim skipped; existing owner retained'.");
+                $"resolution='{resolution}'.");
         }
 
         private static string MakeKey(FuseClaimKind kind, string id)

--- a/FUSE/Runtime/Registry/FuseRegistryConflict.cs
+++ b/FUSE/Runtime/Registry/FuseRegistryConflict.cs
@@ -4,7 +4,8 @@ namespace FUSE.Runtime.Registry
 {
     /// <summary>
     /// A recorded attempt by a package to claim a resource that is already
-    /// owned exclusively by another package.
+    /// owned by another package. Some records are blocking exclusive claims;
+    /// others describe an allowed shared merge that authors still need to see.
     /// </summary>
     public sealed class FuseRegistryConflict
     {
@@ -15,6 +16,24 @@ namespace FUSE.Runtime.Registry
         public string AttemptedPackageId { get; internal set; }
         public string Resolution { get; internal set; }
         public DateTime AtUtc { get; internal set; }
+
+        /// <summary>
+        /// True when the record documents a successful cumulative merge rather
+        /// than one package losing ownership or having an operation skipped.
+        /// These records remain useful to authors, but are not load-health
+        /// failures and must not inflate the user-facing conflict count.
+        /// </summary>
+        public bool IsCooperativeMerge =>
+            Contains("shared industry destination overlap") ||
+            Contains("definitions merged into the same runtime location") ||
+            Contains("shared industry component removal overlap") ||
+            Contains("shared merge");
+
+        private bool Contains(string value)
+        {
+            return !string.IsNullOrWhiteSpace(Resolution) &&
+                   Resolution.IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
 
         public override string ToString()
         {

--- a/docs/AUTHORING_RECIPES.md
+++ b/docs/AUTHORING_RECIPES.md
@@ -1,0 +1,195 @@
+# FUSE Authoring Recipes
+
+This page answers the common “how do I do this?” questions. The
+[JSON schema reference](../schemas/FUSE_JSON_SCHEMA.md) remains the field-by-field
+contract.
+
+## Start A Package
+
+The easiest route is Tile Editor → **New Mod**. For hand-authored native data,
+create one package folder containing `Info.json` and one or more
+`*.fuse.json` files. Point `FuseDataFiles` at every fragment:
+
+```json
+{
+  "Id": "Author.Route",
+  "DisplayName": "Author Route",
+  "Author": "Author",
+  "Version": "1.0.0",
+  "ManagerVersion": "0.27.10",
+  "Requirements": ["FUSE"],
+  "LoadAfter": ["FUSE"],
+  "FuseDataFiles": ["track.fuse.json", "industry.fuse.json"]
+}
+```
+
+Use `FuseRequires` for a hard data-package dependency. Use `FuseLoadAfter` or
+`FuseLoadBefore` only for ordering. A missing hard dependency faults/skips the
+affected package and appears in `/fuse.report`; it must not break unrelated
+packages or game menus.
+
+## Move Or Replace Track
+
+1. Open the package in Tile Editor and connect to the game.
+2. Press `F9`, open **Geo**, then select the node or segment in the world.
+3. Use the node/segment transform controls. The relationship list shows every
+   segment using a selected node and both endpoints of a selected segment.
+4. Save and force a track reload if the live preview ever differs from the
+   selected JSON. The editor now rebuilds affected track objects after topology
+   changes so stale copies do not accumulate.
+5. Reopen the package and verify the same IDs and geometry before release.
+
+Do not create a second segment with the same ID to replace the first one. FUSE
+uses atomic replacement for existing span/segment IDs so industries keep their
+references, but duplicate definitions inside one package are still authoring
+errors.
+
+## Remove A Base-Game Industry
+
+Use the exact runtime industry ID, not its company-window display name:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "id": "Author.Route.industry-removals",
+  "name": "Industry removals",
+  "modVersion": "1.0.0",
+  "operations": {
+    "removals": {
+      "industries": ["exact-runtime-industry-id"]
+    }
+  }
+}
+```
+
+Run `/fuse.dumpgraph` and `/fuse.dumpruntimegraph` to find and compare IDs. The
+Tile Editor Operations page can discover/select industries, but manual JSON is
+still the safest way to remove a stock industry when the editor cannot identify
+an unambiguous owning layer.
+
+## Add Freight Loading Or Unloading
+
+A rail industry component changes freight on cars spotted over a TrackSpan. It
+does **not** place a visible coal chute, water column, or fuel stand.
+
+1. Create/select a town and industry in Tile Editor → `F9` → **Operations**.
+2. Create a whole, partial, or multi-segment TrackSpan from selected track.
+3. Add a `loader`, `unloader`, `formulaic`, `teamTrack`, `interchange`, or other
+   component to the industry.
+4. Select the span and load ID, then configure capacity/rates.
+5. Verify `/fuse.operations` and the company window in a new sandbox save.
+
+## Place A Visible Service Loader
+
+Choose the implementation that matches the asset:
+
+- An existing vanilla-style loader prefab that already contains Railroader's
+  loader components can use native `operations.loaders`.
+- A custom coal/water/diesel/bunker-C/wood facility should be placed through
+  `world.scenery`, then bound with `ToolshedServiceFacilities.json`. Toolshed owns
+  its outlet, animation, transfer, storage, and interaction behavior.
+
+Do not split one custom facility between a scenery clone and an unrelated
+operations loader. That creates the “tank in one place, loading point in another”
+failure. The visible object and its service points must share the same placed
+root/transform contract.
+
+## Move A Base-Game Object Or Town Sign
+
+Open `F9` → **Objects**, disable Track Geometry if it blocks selection, then click
+the object. Save its move/rotate/scale/visibility override as a scene clone or
+mandela entry. Thin signs have a screen-space picking halo, and shared town/map
+roots are blocked so one click cannot move an entire scene hierarchy.
+
+## Edit Roads And Other Mandelas
+
+Use **Spliney** for roads, rivers, bridges, and trestles. Base-game spline control
+points are editable; the first change writes a same-name override into the active
+layer. A legacy scene path such as `World/Roads Sylva/Chipper Curve` remains a
+scene path—it is not an asset identifier.
+
+Use **Objects/Mandela** for individual scene objects and **Scenery** for asset-pack
+models. They have different ownership and runtime rebuild paths.
+
+## Build A Fence, Retaining Wall, Or Other Repeated Object Line
+
+Use a native `world.splineys` entry with `type: "objectLine"`. This samples a
+path at uniform spacing and places rigid modules; it does not stretch a fence
+panel or retaining-wall block into a distorted mesh.
+
+```json
+{
+  "world": {
+    "splineys": {
+      "yard:fence:north": {
+        "type": "objectLine",
+        "assetIdentifier": "your-pack:fence-panel",
+        "spacing": 3.0,
+        "instanceScale": { "x": 1, "y": 1, "z": 1 },
+        "rotationOffset": { "x": 0, "y": 90, "z": 0 },
+        "lateralOffset": 0,
+        "verticalOffset": 0,
+        "snapToTerrain": true,
+        "alignToSlope": false,
+        "placeAtEnd": true,
+        "maximumInstances": 1024,
+        "points": [
+          { "position": { "x": 10, "y": 2, "z": 15 } },
+          { "position": { "x": 55, "y": 3, "z": 22 } }
+        ]
+      }
+    }
+  }
+}
+```
+
+Choose exactly one source: `assetIdentifier` is portable and recommended;
+`prefab` accepts a safe FUSE prefab/scene-path URI for advanced stock-object
+cloning. The Tile Editor exposes this as **Geo → Spliney → Fence / Wall** and
+rebuilds the repeated modules while its point handles remain editable. This is
+native FUSE only; the legacy RailLoader spline schema has no equivalent.
+
+## Conditional Legacy Mixins
+
+Converted conditional fragments use `mixinto.requires`:
+
+```json
+{
+  "mixinto": {
+    "target": "game-graph",
+    "sourceFile": "OptionalYard.json",
+    "requires": [
+      { "id": "Author.BaseYard", "notBefore": "1.2.0" }
+    ]
+  }
+}
+```
+
+When the dependency is missing or outside the allowed range, FUSE skips this
+fragment and reports the package, folder, source file, dependency ID, and action.
+`loadAfter` is ordering and must not be flattened into a hard requirement.
+
+## Package Options And Modular Mods
+
+Top-level `settings` creates controls in FUSE's per-mod settings page. Native
+code can read them through `FuseModSettingsAPI`. The current v1 data schema does
+not yet make arbitrary JSON sections conditional on a setting, so do not imply
+that a slider automatically enables track/spans. Until a declarative condition
+format is released, use separate optional data packages/fragments with explicit
+dependencies, or a small independently authored code component that reads the
+setting and applies supported API operations.
+
+## Diagnose Bad JSON
+
+Run `/fuse.report` for a readable report or `/fuse.report json` for structured
+output. A definition failure includes:
+
+- package ID
+- absolute package folder and source file
+- JSON path
+- line and column when Newtonsoft can provide them
+- validation code/message
+- suggested action
+
+FUSE isolates the bad definition and continues loading unrelated packages. Fix
+the first syntax error first; later errors can be consequences of that one.

--- a/docs/BASE_GAME_MAP_AUTHORING_AUDIT.md
+++ b/docs/BASE_GAME_MAP_AUTHORING_AUDIT.md
@@ -1,0 +1,83 @@
+# Railroader base-game map-authoring audit
+
+This audit compares the observable Railroader map contract in the decompiled
+2026.1 source with FUSE native schema, FUSE runtime behavior, and both Tile
+Editor surfaces. Decompiled code is used only to identify public data shapes,
+identifiers, initialization order, and observable behavior; no implementation
+code is copied.
+
+The installed game on the audit machine still exposes the earlier Unity
+`TrackSegment.Style` contract. The 2026.1 source changes track objects and uses
+combinable structure flags. Compatibility therefore has two distinct gates:
+
+1. Native documents must retain every known field now.
+2. A FUSE/editor binary compiled for a released game generation must pass its
+   own live acceptance run. A source audit is not evidence that an unreleased
+   binary contract already works in game.
+
+## Coverage matrix
+
+| Base-game concern | Observable contract | FUSE/editor coverage | Remaining acceptance |
+|---|---|---|---|
+| Map identity and launch | `MapDefinition` supplies map data, terrain tile sets, layers, and attribution; a session selects one registered map | Native `map` declaration, registered-map browser, launch command, map identity/start-state authoring, standalone-map golden fixture | Launch the generated fixture, save, reload, and reopen it in both editors |
+| Layering | Base data plus JSON merge-patch layers; tombstones remove inherited values | FUSE owns its canonical native document and explicit removals; legacy mixintos convert at the boundary; native modular feature rules conditionally apply authored objects | Mixed native/legacy live reload and one full generated-map round trip |
+| Folders | Map folders group objects/spawns and folder enabled state gates them | FUSE feature groups provide stronger package-owned conditional gating; editor retains unknown official-map fields when editing | Add an official-map import crosswalk so folder names/enabled state are visible instead of opaque retained data |
+| Map objects | Registered DTO kinds include scenery, circle/rectangle/curve masks, and built-ins | Native scenery, masks, labels, scene clones, telegraph, water, splineys, and object lines; selectable base objects and town signs | Dense-scene object picking and stock-object move/remove live pass |
+| Built-in car loader | Built-in id + track anchor + parameters, including infinite or industry supply | Native operations loaders plus Toolshed custom service bindings, track/span snap, offsets, source industry and load points | Live loading/unloading, storage, payment, and custom-model pass |
+| Built-in spline loft | Ordered control points, point width/rotation, width/Y offsets, end extension, cap falloff, and generated mesh; used by road/river content | Deformable road/river splineys plus rigid repeated-object lines for fences, walls, guardrails, and pipes | Profile/material family inventory, cap/falloff UI acceptance, and in-game save/reload |
+| Terrain tiles | Height, splat, vegetation, statistics, streaming and map tile-set ownership | Tile import/download workflow, sculpt/paint, categorical vegetation masks, atomic save/backup, statistics rebuild, cache invalidation, terrain registration | Seam/falloff/undo fidelity and live paint-save-reload across adjacent tiles |
+| Water | Lake polygons/flat water surfaces reuse game material/profile data; rivers can also be spline-driven | Native water surfaces with CRUD, stock replacement, point editing, schema, validation, diagnostics; river spline authoring | Reflection/collider/material behavior and save/reload in game |
+| Track nodes | Position, rotation, switch-stand flip, and diamond-crossing state | Native position/rotation/flip plus additive `isDiamond`; converter and editor preserve the field | Diamond routing/rendering in the game build that exposes it |
+| Track segments | Endpoints, group, priority, speed, class, style or newer bridge/steel/tunnel/yard flags | Existing `style` stays canonical for released builds; additive steel-support and independent-yard metadata preserve the newer contract; gauge metadata, groups, grade labels, validation | Compile/run against the released flags-era assembly; live bridges, tunnels, yards, and DKW/crossing geometry |
+| Turntables | Transform, radius, subdivisions, node ids, default stop and bridge group | Native turntable authoring and editor workflow | Custom model/track alignment, roundhouse, save/reload live pass |
+| Track spans and areas | Locations anchor by segment/end/distance; areas group spans and UI/operations identity | Native spans/areas, normalization, node/segment relationships, orphan validation, legacy repair/rebinding | Sylva/Kater base-span cases and delivery/highlight/payment agreement |
+| Industry operations | Areas, industries, loads, contracts, components, storage, loaders/unloaders, teams, interchange, passenger/timetable services | Native models, editors, schema, pre-publish cross-file validation, package-local fault reporting | Every component kind, EOD processing, contract changes and company-window live pass |
+| Passenger service | Stops, span membership, agents/timetables and neighboring-stop caches | Native passenger/station models, invalid-span sanitation, editor workflows and validation | Neighbor reconciliation, timetable/UI, save/reload and modded-map live pass |
+| Interchanges | Industry/service components, track/span routing and exchange behavior | Native interchange editor/runtime models and compatibility shims | Multi-interchange ordering, inbound/outbound/EOD and legacy interchange corpus |
+| Signals and CTC | Signals, heads/aspects, blocks, routes, switch locks, interlockings and CTC panel components | Portable signal/CTC schema and runtime, editor placement/routes/blocks/dispatcher panel, cross-file validation | Native FUSE ownership, broader signal/custom-asset families, and a complete live territory |
+| Progression | Map features, milestones, gating, industry/track availability and starting state | Native progression, transfer diagnostics, feature options and start-equipment scoping | Fresh career/sandbox reload behavior and complete generated-map progression pass |
+| Starting equipment | Session setup places starting cuts and tutorial owns early UI flow | Package/map-scoped equipment pool; tutorial wait; cancellation retains queued cuts; successful placement requires full car count | Unrelated-new-save test and tutorial/Escape/cancel/resume/place live pass |
+| Spawns/portals | Spawn DTOs and map bootstrap locations; interchange/portal concepts participate in session creation | Native spawn/start-point and interchange authoring in the complete-map fixture | Multiple spawn choices and portal/interchange launch behavior in game |
+| Save identity | Stable object ids, graph ids, KVO/save identities and post-load binding are required | Stable native ids, duplicate/collision validation, atomic writes, backups, undo/redo, runtime definition cache | Generated map save, reload, edit, re-export and second reload |
+| Runtime caches | Terrain, graph, scenery, operations and UI caches have subsystem-specific invalidation/rebuild order | Targeted track rebuild, terrain invalidation, scenery/asset indexes, operations refresh, live diagnostics and test bridge | Every-tab live acceptance using the newest deployed DLL |
+| Multiplayer authority | Several operations/signals/session changes are authority-sensitive | Signal/CTC portable model includes multiplayer state; most authoring runs on local editor/session | Host/client ownership and synchronization pass |
+
+## Canonical FUSE track additions from this audit
+
+The following properties are additive and do not change existing native
+documents:
+
+- `tracks.nodes.<id>.isDiamond`
+- `tracks.segments.<id>.bridgeSupportsSteel`
+- `tracks.segments.<id>.yard`
+- the corresponding `preserveBridgeSupportsSteel` and `preserveYard` controls
+  for partial legacy overlays
+
+Legacy numeric flags are decoded at conversion time. Existing `style` values
+remain valid and continue to drive the installed released game. Editors update
+copies of node/segment objects so unknown companion and future fields survive
+ordinary position/property edits.
+
+## What a from-scratch map must prove
+
+A map-authoring release is accepted only when one fixture completes this whole
+sequence without hand-editing:
+
+1. Create map identity, attribution and coordinate/tile set.
+2. Acquire/import adjacent terrain tiles and preserve source/licensing data.
+3. Sculpt terrain, paint texture/vegetation, add/edit water, then save/reload.
+4. Lay main, branch, yard, bridge/tunnel, turnout, crossing, span, group,
+   turntable and interchange track; inspect grades and node relationships.
+5. Add roads/rivers plus rigid fence/wall/guardrail/pipe object lines.
+6. Add scenery, masks, labels, town signs, loaders and custom Toolshed models.
+7. Configure areas, loads, industries, contracts, storage, delivery/payment,
+   passenger service, interchange service and progression.
+8. Build a working signal territory and CTC panel with routes/interlockings.
+9. Configure spawn/start state and package-scoped starting equipment.
+10. Validate, export, install, launch, operate, save, reload, reopen in the
+    editor, change content, re-export and reload again.
+11. Repeat from the published wiki using a clean installation.
+
+Automated fixtures currently prove document creation, validation, export and
+reopen. The live stages remain deliberately separate so a green unit test can
+never be mistaken for rendered/operational proof.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+- Installer 0.7.0 repairs UMM startup order for installed code mods that
+  reference FUSE-replaced RailLoader/Strange Customs assemblies. It inspects
+  DLL metadata without loading code, backs up each manifest, and adds FUSE to
+  `Requirements`/`LoadAfter`, fixing Alina Utilities failing before FUSE's
+  assembly resolver could run.
+
+- Completed the author-help catalog for native feature rules, rigid object-line
+  splineys, and water surfaces. Every validation code emitted by either
+  validator now has a title, cause, concrete fix, and example, enforced by the
+  Core coverage gate; two obsolete mixinto help keys were removed.
+
+- Added native ForYourConvenience parity without shipping the old code:
+  dependency-scoped station-map actions, off-by-default caboose icons and
+  speed/load car-tag additions, persisted Legacy Gameplay toggles, and a
+  read-only **Tools > Industry Dashboard** built from the current operations
+  controller.
+
+- Added native, dependency-scoped replacements for AbsoluteMadness and
+  SomeKindOfMadness. Outbound industry routing remains disabled for normal
+  profiles, activates when an enabled package requests either retired id (or
+  through an explicit Legacy Gameplay setting), exposes a contained native
+  candidate event, and includes bounded capacity/payment/short-trip/origin and
+  order-shuffle controls.
+- Added a native Interchange2Interchange replacement with dependency-scoped
+  activation, contracted interchange visibility, daily cross-interchange cargo
+  orders, bounded cut sizes, and a persisted maximum-cars control.
+
+- Added native FallFromGrace parity: FUSE now owns the configurable grace-day transform, exposes its settings under **Settings > Legacy Gameplay**, and adds the due-time row to paid waybills without requiring the old DLL. Default settings leave the base-game calculation unchanged.
+- Added native C1CD parity: configurable interchange intervals, daily or overnight service windows, and continuous extra-service scheduling now live under **Settings > Legacy Gameplay**. Invalid intervals are bounded instead of allowing the legacy scheduling loop to hang.
+
+- Added the legacy `/cs-livery-refresh` command and a FUSE-owned
+  `/fuse.liveries` diagnostic report. Refresh now clears only FUSE's cached
+  livery textures and reapplies each live car's saved `cs.livery` selection.
+- Replaced the Strange Customs `FileCache` ABI stub with a FUSE-owned loose-file
+  cache for PNG/JPEG textures and WAV/OGG/MP3/AIFF clips. It coalesces audio
+  callbacks, invalidates changed files, contains callback failures, and cleans
+  up cached Unity objects when FUSE unloads.
+- Replaced the Strange Customs `FlowyThingBuilder` ABI stub with a native
+  adapter that converts legacy road/river data at the compatibility boundary
+  and creates or updates the live spline through `SplineyAPI`.
+- Wired RailLoader's `WillCopyDebugInformation` compatibility event into copied
+  FUSE health reports. Contributions are bounded and normalized, and listener
+  exceptions are isolated at the messenger-listener boundary.
+- Completed the ADRFDR data contract: `ADRFDR.Pay4Resource` now resolves to
+  FUSE's native pay-for-resource component and location pickers display its
+  custom "Acquire …" title through the compatibility interface.
+
+## Unreleased audit accuracy follow-up (2026-08-20)
+
+- Prevents the runtime definition cache from returning the stored `FuseSpan`
+  object by reference. Span endpoints are now deep-cloned, so diagnostics and
+  other read paths cannot mutate or erase the authored definition.
+- Preserves cached authored span endpoints when Railroader temporarily cannot
+  resolve a `TrackSpan` location. The audit now distinguishes that transient
+  runtime state from a genuinely missing endpoint and still reports referenced
+  segments that were actually removed.
+- Stops reporting an empty `Industry` container as a defect by itself. The game
+  legitimately uses componentless industries for base locations, passenger or
+  scenery-only places, fictional destinations, and disabled content.
+- Omits successful `shared-extension` registry merges from audit findings; they
+  remain available as informational records on the dedicated Mod Conflicts
+  page.
+
 All notable changes to FUSE are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and FUSE uses
 [semantic versioning](https://semver.org/) with the mod and the external editor
@@ -9,13 +72,97 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
 
 ### Added
 
+- Native `world.splineys` now supports `objectLine` definitions for fences,
+  retaining walls, guardrails, pipes, and other rigid repeating modules. FUSE
+  places a loaded scenery asset or safe prefab along a uniformly sampled path
+  with scale, rotation, lateral/vertical offset, terrain snap, slope alignment,
+  endpoint, and instance-cap controls. Live updates preserve editor helper
+  children, and failed creation cleans up its partial runtime root.
+
+- Installer 0.6 now preflights the complete selected batch before writing:
+  unsafe/case-colliding ZIP members, ambiguous nested manifests, duplicate
+  package ids and `.FUSE` aliases, UMM/FUSE/RailLoader requirements, version
+  bounds, forward references, and dependency-failure propagation. Explicit
+  FUSE replacement contracts satisfy only the legacy ids FUSE actually owns;
+  reports preserve every dependency and corrective failure message.
+
+- Package faults now carry package id/name, source root, relative and absolute
+  file names, JSON property/line/position, validation code, expected shape,
+  received value, and a concrete action. Native, manifest, and legacy-converter
+  failures share the format; health JSON and selected-mod **Copy Mod Info**
+  preserve the complete author-facing diagnostic without crowding Status.
+
+- Native package `featureRules` connect existing FUSE settings to exact authored
+  track, operations, world, progression, and audio objects. Boolean, choice,
+  and numeric comparisons are evaluated on map load without mutating source
+  definitions; validation, Mods-page state, schema examples, and Tile Editor
+  authoring make the reload-required behavior explicit.
+
+- Native `world.waterSurfaces` authoring and runtime support creates, updates,
+  removes, inspects, caches, and reports polygonal lake planes without depending
+  on Alina's map runtime. Authors can reuse a stock lake by scene path, select a
+  loaded material, or use FUSE's guarded fallback; schema and validation reject
+  underspecified or unsafe tessellation data before map apply.
+
+- The Mods page now groups packages by actual runtime state and distinguishes
+  disabled, skipped, missing-dependency, incompatible, invalid-data, partially
+  applied, loaded-awaiting-map, and successfully applied packages. Optional
+  conditional mixintos remain green with a note instead of being presented as
+  whole-mod failures; copied mod info includes the same state and reason.
+- Legacy top-level `ConflictsWith` checks now see enabled code-only and
+  asset-only packages in the Mods folder, as well as retired package ids
+  provided by FUSE compatibility. Disabled and active-profile-excluded mods no
+  longer satisfy conditional or top-level compatibility checks.
+- Successful shared industry destination/component merges are now displayed in
+  **Mod Conflicts** under an informational **Shared Extension Targets** section.
+  They no longer count as ownership conflicts or load-health failures; actual
+  skipped/replaced ownership and spatial warnings remain separate and visible.
+- Human and JSON load reports now distinguish package folders from resident and
+  applied definitions. Missing optional mixinto companions are listed as
+  inactive conditional fragments, while only actionable skips contribute to
+  unhealthy status; legacy JSON count aliases remain for report consumers.
+
+- **Tools > Mod Conflicts** groups runtime ownership records by package pair and
+  shows exactly which nodes, segments, spans, industries, scenery, or other
+  targets the two packages share, plus the resolution FUSE used. A full report
+  can be copied for authors. Conservative spatial track-layout warnings appear
+  on this page separately from proven ownership conflicts; they retain both
+  packages and do not inflate the main Status conflict count.
+
+- Reduced always-on runtime overhead for large legacy mod sets: hosted RailLoader
+  update callbacks are now discovered once when the plug-in is hosted instead of
+  rebuilding a dictionary snapshot and repeating interface reflection every Unity
+  frame. The unused-asset reclaimer also avoids querying Unity texture-memory
+  counters while no evictions are pending.
+
+- Asset overlap diagnostics now collapse hundreds of keys shared by the same
+  winner/overridden source set into one source group. The panel and clipboard
+  summary state whether definitions are identical or behaviorally different and
+  explain the impact, while the exported JSON retains every individual key.
+
+- FUSE now completes AssetLoader 1.0.1's data-loading contract without running
+  its DLL. Direct discovery includes package-root, child, catalog-only, and
+  normal bundled stores. Definitions-only immediate child folders used by
+  tender/rolling-stock swaps are routed to their exact existing store, while
+  native packages can declare nested overrides with `FuseDefinitionOverrides`.
+  Malformed overrides fall back to the original store definitions and appear in
+  the Assets report instead of breaking equipment/customization menus. The
+  installer backs up old AssetLoader folders/ZIPs, verifies the runtime DLL is
+  absent, and creates a data-only `AssetLoader` UMM alias requiring FUSE so old
+  manifest dependencies remain valid.
+
 - `FUSE-Installer.exe` now bundles the FUSE framework and installs it on a
   manual (double-click) run, so players can get FUSE running without unzipping
   anything. Dragging mod `.zip` files onto the exe still installs exactly those
   mods and leaves FUSE untouched. A no-argument run also still processes any
   loose zips beside the exe; pass `--no-fuse` to skip installing FUSE. The
-  release build bundles the core mod zip it just built and self-checks, via a
-  dry run, that a manual run will install FUSE.
+  release build bundles the core mod zip it just built and performs a real
+  install into a throwaway Railroader tree to prove a manual run writes
+  `Mods/FUSE/Info.json`. The build gate waits for PyInstaller's extracted GUI
+  child process, avoiding a false failure while the files are still being
+  written. A drag-and-drop GUI launch leaves the bundled framework unchecked so
+  its scope matches the documented "install the dropped archives" behavior;
+  `--with-fuse` opts it back in.
 - A pytest suite for the installer and its legacy JSON reader
   (`tools/tests/`), run in CI by a new Python Tests workflow.
 - FUSE checks GitHub on startup for a newer stable release and, if the running
@@ -42,6 +189,158 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
 
 ### Fixed
 
+- Both converter entry points now reject code-only, asset-only, map-tile, and
+  already-native packages with specific installer guidance instead of reporting
+  a successful zero-fragment conversion. Mixed packages can still convert their
+  recognized top-level RailLoader JSON while keeping DLL behavior explicitly
+  unsupported. Failed reports are stored under `_conversion-reports` rather
+  than creating a report-only `.FUSE` package. Batch detection includes
+  manifest/code packages and no longer mistakes nested schema examples inside a
+  compiled mod for route content.
+
+- World labels no longer render over the pause menu or normal game windows.
+  The debug overlay pauses its IMGUI rendering while the game is paused or any
+  managed game window is shown, then resumes without rebuilding user settings.
+
+- Legacy package ordering now resolves object- or string-form `requires` and
+  `loadAfter` identifiers through the same `.FUSE` alias rules before building
+  the topological order. Conditional mixinto requirements both control whether
+  each fragment applies and add an optional package-order edge when their
+  dependency is present; a missing optional layer does not fault the package.
+  When a resolved later package explicitly requires or
+  loads after a base package, its intentional overrides are no longer presented
+  as mods fighting; unrelated packages remain conflict records. The Dependency
+  Graph labels retired runtime dependencies such as Strange Customs, Alina's
+  Map Mod, AssetLoader, and RailLoader services as `PROVIDED BY FUSE`, while
+  content packs such as Alina's SW expansion remain real dependencies.
+  Hosted legacy code plugins now also initialize in resolved
+  `requires`/`loadAfter`/`loadBefore` order rather than alphabetical Mods-folder
+  order. Cycles retain every plugin in deterministic order and emit one
+  actionable warning.
+
+- Legacy `conflictsWith` declarations are no longer discarded. Complete-package
+  conflicts retain inclusive version bounds in `FuseConflictsWith` and prevent
+  only the declaring package from loading; conditional mixinto conflicts skip
+  only that fragment. Tools > Mod Conflicts shows these separately as
+  author-declared incompatibilities instead of mixing them into detected runtime
+  ownership collisions. Hosted legacy mod definitions also expose their real
+  requires/load-order/conflict metadata to old plug-ins.
+
+- The merged graph planner now records definition-versus-definition ownership
+  collisions for nodes, segments, spans, and turntables, not only removals that
+  displaced earlier definitions. This makes competing route layouts visible
+  even when the last package wins a shared identifier. Independent layouts
+  using different IDs are covered by a non-blocking nearby-node advisory.
+
+- Passenger stops no longer throw during activation when another route package
+  removed a segment referenced by one of their child spans. FUSE sanitizes the
+  invalid span endpoints so Railroader's nullable checks skip that track. The
+  Strange Customs span facade likewise omits invalid endpoints, preventing
+  Signals Everywhere serialization from failing after graph collisions.
+
+- Duplicate automatic-waybill destinations are collapsed by their semantic
+  component type, area, display name, and track spans before the base-game
+  picker is built. Multiple live component instances can no longer produce the
+  same Whittier destination several times in the car Operations menu.
+
+- Legacy JSON control-character repair is still reported with the exact source
+  file, but the same warning is emitted only once per file and session instead
+  of repeating on each conversion pass.
+
+- A stale, partially bound Alina Utilities assembly can no longer make the
+  legacy host record a package error before UMM recovery activates the working
+  entry. Unloadable compiler-generated types are skipped locally, and the
+  recovered UMM plug-in remains the sole active instance.
+
+- If an older dual-entry Alina Utilities install still leaves a legacy
+  singleton alive without its RailLoader context, FUSE now connects that
+  instance to Alina Utilities' UMM settings object. This prevents its tile
+  distance, damage, and main-menu hooks from throwing while leaving the
+  separately installed utility mod in control of its original features.
+
+- Legacy Alina map packages no longer materialize the editor-only
+  `TurntableMeasurementTool` scenery helper in gameplay. This removes the
+  bright yellow measurement overlay that covered Stryker's Bryson turntable;
+  native FUSE scenery identifiers are unchanged.
+
+- Synthetic legacy map-tile definitions are no longer sent through the
+  game-graph patch expander, removing the misleading “source JSON could not be
+  resolved” warning emitted once per Alina map expansion.
+
+- Corrected the public schema's track gauge contract: `gauge` belongs to track
+  segments (matching the runtime model, converter, editor, and documentation),
+  not nodes. The schema now accepts the native editor's explicit
+  `DualGauge_L`, `DualGauge_R`, and `DualGauge_T` transition values and includes
+  the documented reserved `fuse://` URI scheme.
+
+- Legacy area objects used only as namespaces around `industries` no longer
+  become track-area updates with an invented `(0,0,0)` position or identifier
+  display name. ARC Whittier/KWIX-style packages can patch the base Whittier
+  industries without moving the live area/operations hierarchy away from its
+  tracks. Explicit authored area position, radius, color, order, spans, and
+  group metadata still convert normally. (#210, #239)
+
+- Confusing Supplements' `IndustryComponents.Empty` now has a complete
+  FUSE-owned behavior: it remains a visible span-bound track marker, accepts
+  every automatic destination class, and performs no service or ordering work.
+  Output-track warnings such as "KEEP CLEAR" no longer degrade into a stock
+  loader with a null load that repeatedly throws during `Industry.Tick`.
+
+- Alina's bright-yellow `TurntableMeasurementTool` is treated as an editor-only
+  authoring helper and is not instantiated in a playable map. Stryker's Bryson
+  keeps its actual cloned turntable while the yellow measurement plate is
+  omitted. The separate `ALWHouses_CabooseHouse` message in that report is an
+  ALW asset-pack catalog entry whose prefab is absent from the bundle; FUSE
+  quarantines that asset without blaming or hiding the turntable. (#235)
+
+- The Diagnostics Report no longer labels Railroader's endpoint-less base-game
+  placeholder/progression spans as invalid mod track. Span validation now applies
+  only to spans owned by a FUSE-hosted package. An actual package-owned malformed
+  span still names its owner, while a span removed by a competing route overhaul
+  is presented as a package collision with compatibility guidance instead of a
+  false base-track failure.
+
+- Legacy Strange Customs scenery is no longer discarded merely because its
+  identifier was absent from FUSE's mounted asset-pack index. Legacy-hosted
+  packages receive RailLoader-compatible guarded runtime resolution, with the
+  first attempted placement logged per identifier and real failures quarantined.
+  Native FUSE packages remain strictly validated so bad JSON cannot destabilize
+  unrelated content or game menus.
+
+- The Assets Report now distinguishes identical duplicate definitions from
+  conflicting definitions and shows package-relative source paths. Two installed
+  copies such as `RTM Objects pack` and `RTM_Objects_pack` can therefore be told
+  apart instead of appearing as a nonsensical self-override.
+
+- Live Diagnostics auto-refresh now preserves the right-hand detail/log scroll
+  position, including the bottom position, instead of snapping the page back to
+  the top once per second. The menu now identifies the detail pane when a page
+  also contains a separate navigation `ScrollRect`.
+
+- Opening the Equipment Purchase window no longer performs every cold asset-pack
+  `Definitions.json` load in one frame. FUSE warms one prefab store per frame and
+  caches the filtered car catalog for the active `PrefabStore`, avoiding the
+  multi-second buy-menu lock seen with large Lego/custom-equipment installations.
+
+- Runtime ownership collisions are now recorded when a later package removes a
+  node, segment, or span defined by an earlier package. These removal-versus-
+  definition collisions previously disappeared while FUSE built the merged plan,
+  leaving `/fuse.conflicts` at zero even when route overhauls were deleting one
+  another's graph. Package faults now also retain the source folder and definition
+  file in the report.
+
+- Asset-pack component kinds registered after a store was first inspected now
+  invalidate only the affected cold store and reload its untouched definitions
+  without re-running old-loader mutation postfixes. Toolshed storage/load-point
+  definitions on the ALW tank loader are therefore retained even when Toolshed
+  initializes after FUSE asset discovery; the visible tank and functional loader
+  no longer split into unrelated objects.
+
+- Legacy-install detection and the installer cleanup list now include
+  `Railloader.Injector.dll`. It is the managed legacy loader and Harmony owner,
+  not a harmless native bootstrap file, so leaving it in `Managed` could run the
+  old and FUSE loading pipelines together.
+
 - Updating FUSE through Unity Mod Manager failed with "Error when unpacking"
   and installed nothing, for every release from 1.0.0 through 1.0.2. The
   published zips stored entry names with backslashes, because
@@ -61,6 +360,36 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
   (a locked file, a bad path, a full disk) no longer leaves a half-written mod
   folder behind, and a failed `--replace` reinstall leaves the existing install
   untouched.
+
+- The standalone converter now keeps legacy hard `Requirements` as native FUSE
+  requirements and normalizes object-form `LoadAfter` entries to their ids.
+  Requirements for the loader systems FUSE itself replaces (Alina's Map Mod and
+  editor, RailLoader Injector/Interchange, and other core compatibility layers)
+  are removed instead of becoming impossible hard dependencies. (#240)
+
+- A concurrently installed legacy `AssetLoader` no longer patches the game's
+  prefab stores after FUSE has mounted and quarantined the same asset packs.
+  FUSE detects that exact legacy assembly and removes only its Harmony owner;
+  asset-pack problems remain isolated and the locomotive customization/buy-menu
+  path no longer receives a second set of stores. (#238)
+
+- Replacing a named TrackSpan now atomically rebinds every live industry and
+  interchange component from the old Unity component to the replacement before
+  the old object is retired. ARC Whittier-style base-track replacements no
+  longer leave Whittier Saw Mill without its customer/components or collapse
+  multiple unloading positions onto the surviving span. Strange Customs array-
+  wrapped additions such as Sylva Industries Boosted's
+  `trackSpans: [{ "$add": "Piei" }]` retain the vanilla R2 span and append R3,
+  restoring highlighting, delivery credit, and EOD payment on both tracks.
+  (#236, #239)
+
+- The Appalachian Railway starter-equipment placement pool is now activated
+  only by that package's Whittier start definition. It waits until the tutorial
+  overlay is out of the way, keeps an item queued when placement is cancelled
+  with Escape, and removes it only after `LastPlacedTrain` confirms that the
+  complete expected cut spawned. This also contains the current game's
+  false-success callback when `PlaceTrain` catches a failure. Other new games
+  no longer inherit the pool.
 
 - Legacy map mods collapsed onto the world origin on comma-decimal locales
   (pt-BR, de-DE, fr-FR, ...): spaghetti track on the map, "zero length" track
@@ -100,12 +429,12 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
   after it stopped resolving and buildings went missing across the map. Such a
   store is now quarantined by itself, its path is logged once, and later packs
   resolve normally; the bad file itself is still the mod author's to fix. (#196)
-- The Status page's "Mod Health" row flagged a mod as needing review after a
-  single one-off third-party exception (for example another mod's
-  first-frame-after-load `NullReferenceException`), contradicting the health
-  report, which only counts a mod as a problem once it recurs (3+ episodes or
-  10+ occurrences). Both surfaces now share that one threshold; anything
-  below it is listed as informational. (#208)
+- Runtime guards and observed Unity/third-party exceptions no longer make the
+  Status page or readiness summary look unhealthy. They remain captured in the
+  structured health report and now have a dedicated **Tools > Live
+  Diagnostics** page with level/text filtering, copy/export actions, a bounded
+  in-memory view, optional auto-refresh, and an optional RailLoader-style live
+  Windows console that mirrors `FUSE.log`. (#208)
 - A single unloadable type in some other assembly (typically a stray, real
   `Railloader.dll` still being loaded from a mod folder) aborted FUSE's scan for
   legacy `ISplineyBuilder` implementations, so every queued builder task —

--- a/docs/CHOOSING_A_WORKFLOW.md
+++ b/docs/CHOOSING_A_WORKFLOW.md
@@ -1,0 +1,51 @@
+# Install, Convert, Or Author?
+
+These are three different jobs. Choose the row that matches what you are trying
+to do before downloading a tool.
+
+| Goal | Use | What happens |
+| --- | --- | --- |
+| Play with one or many downloaded mods | `FUSE-Installer.exe` | Inspects each archive and installs native FUSE, UMM, or supported RailLoader packages. It does not rewrite the mod. |
+| Keep using an existing legacy data mod | Install it normally | FUSE can host supported RailLoader/Strange Customs data and compatibility APIs in memory. Conversion is optional while the package works correctly. |
+| Turn legacy JSON into native FUSE JSON | FUSE Converter | Converts route, graph, scenery, operations, and supported audio JSON, then writes a conversion report. |
+| Install an asset pack or Alina map-tile package | `FUSE-Installer.exe` | Installs the original package so FUSE can load it directly; these packages are not converter inputs. |
+| Convert a DLL/code mod | Do **not** use the converter | A converter cannot translate compiled program logic. Install the original package for FUSE compatibility hosting, or port its behavior as new independently written code. |
+| Build or edit a map visually | Railroader Tile Editor | Authors track, scenery, roads, operations, signals, and related JSON. Players do not need the Editor. |
+| Hand-author a native package | FUSE schema + author guide | Create `Info.json` and one or more `*.fuse.json` files. |
+| Add working coal/water/diesel/bunker-C/wood service | Toolshed authoring guide | FUSE places the world/operations data; Toolshed owns the service-facility behavior. |
+| Render narrow or dual gauge | FUSE Narrow Gauge | Optional runtime companion. It is not part of the Editor and is not required by ordinary FUSE packages. |
+
+## What The Converter Does Not Do
+
+The converter reads data. It does not decompile, translate, patch, or rebuild a
+`.dll`, `.pdb`, executable, Harmony patch, UMM entry point, or arbitrary C# mod.
+If a package contains code and data, only the recognized data can be converted.
+The report lists code binaries as manual/unsupported work so they cannot be
+mistaken for converted behavior.
+
+FUSE's compatibility host is a separate runtime feature. It independently
+implements supported legacy contracts so an installed legacy code mod can call
+familiar APIs. That is why installing an old package and converting its JSON are
+not the same operation.
+
+## Recommended Release Shape
+
+For players, distribute one FUSE Suite download/installer with clearly marked
+components:
+
+- FUSE Core — required
+- Toolshed — optional gameplay companion
+- FUSE Narrow Gauge — optional gauge renderer
+- Tile Editor — optional authoring tool; never required to play a FUSE map
+
+Keep those as separate assemblies and projects. A bug in an authoring tool or
+optional gameplay feature should not prevent FUSE Core from loading a save or
+opening a game menu.
+
+## Next
+
+- Players: [Getting Started](GETTING_STARTED.md)
+- Existing mods: [Migrating From Legacy Mods](MIGRATION_FROM_LEGACY.md)
+- Conversion: [FUSE Converter](FUSE_CONVERTER.md)
+- Authors: [Package Author Guide](PACKAGE_AUTHOR_GUIDE.md)
+- Common tasks: [Authoring Recipes](AUTHORING_RECIPES.md)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -17,7 +17,8 @@ The `2025.1.x` line. FUSE logs its version report at startup in `FUSE.log`.
 ### Do I need Railloader as well?
 
 No. FUSE replaces it. Running both means two loaders are live at once, and FUSE
-warns when it finds a leftover `Railloader.dll` or `Railloader.Interchange.dll`.
+warns when it finds a leftover `Railloader.dll`, `Railloader.Injector.dll`, or
+`Railloader.Interchange.dll`.
 
 ### Is FUSE free and open source?
 
@@ -58,8 +59,11 @@ No. A package that faults is reported and skipped; unrelated packages still load
 
 ### Can I run my old mods?
 
-Data mods convert. Run them through the converter to produce a `*.FUSE` package —
-see [MIGRATION_FROM_LEGACY.md](MIGRATION_FROM_LEGACY.md).
+RailLoader JSON data mods can convert. Run them through the converter to produce
+a `*.FUSE` package — see
+[MIGRATION_FROM_LEGACY.md](MIGRATION_FROM_LEGACY.md). Asset packs and Alina
+map-tile packages install directly because FUSE loads their supported legacy
+formats; converting them would only create a misleading empty wrapper.
 
 Script mods that ship `.dll` logic do not convert. Neither do rolling stock,
 locomotive, and car mods, except audio definitions FUSE can import.

--- a/docs/FUSE_CONVERTER.md
+++ b/docs/FUSE_CONVERTER.md
@@ -2,6 +2,11 @@
 
 Official drag-and-drop converter for legacy Railroader data mods.
 
+> **Data only:** this tool does not convert DLLs or code mods. It can convert
+> recognized JSON/data from a mixed package, but compiled behavior must remain an
+> installed compatibility-hosted mod or be independently reimplemented. Use
+> [Install, Convert, Or Author?](CHOOSING_A_WORKFLOW.md) if you are unsure.
+
 ## Download
 
 Prebuilt binaries are published on the GitHub Releases page rather than tracked in this repo:
@@ -21,10 +26,14 @@ Drag any of these onto `ConvertToFUSE.cmd` at the repo root:
 - a legacy route / track mod folder
 - a legacy route / track mod `.zip`
 - a legacy horn / whistle / bell folder or `.zip`
-- a legacy asset-pack folder or `.zip`
 - a single legacy JSON data file
 
 `ConvertToFUSE.cmd` launches the official FUSE converter.
+
+Drag asset packs, Alina map-tile packages, native FUSE packages, and compatible
+code mods onto `FUSE-Installer.exe` instead. The converter identifies those
+inputs and explains the correct install path; it does not make empty wrapper
+packages for them.
 
 The repository also includes the FUSE converter icon at:
 
@@ -72,7 +81,7 @@ dotnet run --project FUSE.ConverterCli -- "C:\Path\To\LegacyMod" --out "C:\Steam
 ```
 
 ```text
-fuse-convert <inputs...> [--out <dir>] [--kind auto|route|audio|asset] [--clean] [--batch]
+fuse-convert <inputs...> [--out <dir>] [--kind auto|route|audio] [--clean] [--batch]
              [--no-validate] [--strict] [--format console|json|markdown|all] [--quiet]
 ```
 
@@ -81,10 +90,10 @@ fuse-convert <inputs...> [--out <dir>] [--kind auto|route|audio|asset] [--clean]
 | `--out <dir>` | Output root; each mod converts into `<dir>\<ModFolder>.FUSE`. Default: `.\FUSEConverted`. |
 | `--kind <kind>` | Force a package kind instead of auto-detection. |
 | `--clean` | Replace an existing `.FUSE` output folder. |
-| `--batch` | Treat each input as a container and convert every recognized child folder. |
+| `--batch` | Treat each input as a container. Convert JSON packages and report the correct install guidance for code, asset, tile, or native packages. |
 | `--no-validate` | Skip validation (it is on by default). |
 | `--strict` | Validation warnings also fail the run (exit 2), not just errors. |
-| `--format <fmt>` | `console` (default) prints to stdout; `json` / `markdown` also write `conversion-report.json` / `conversion-report.md` into each output folder; `all` writes both. |
+| `--format <fmt>` | `console` (default) prints to stdout; `json` / `markdown` also write reports. Successful reports live in the output package; failed/unsupported reports live under `<out>\_conversion-reports`. |
 | `--quiet` | Suppress per-diagnostic output; print only summaries. |
 
 Exit codes (CI can gate conversion and validation separately):
@@ -146,7 +155,6 @@ Useful options:
 | `--clean` | Replace an existing generated `.FUSE` output folder under the output root. |
 | `--kind route` | Force route/track/data conversion. |
 | `--kind audio` | Force horn/whistle/bell conversion. |
-| `--kind asset` | Force asset-pack wrapper conversion. |
 | `--batch` | Recursively convert every recognized child mod, zip, or JSON in the input folder. |
 
 ## Outputs
@@ -155,7 +163,7 @@ Each converted package gets:
 
 - `Info.json`
 - one or more `*.fuse.json` files, or `audio.fuse.json`
-- copied audio files or asset pack folders when needed
+- copied audio files and asset folders carried by a converted route package when needed
 - `conversion-report.json`
 - `conversion-report.md`
 
@@ -174,8 +182,12 @@ The report is the important bit. It records:
 | Track / route JSON folders | One FUSE data file per source JSON, preserving file-per-concern structure. |
 | Single route JSON file | One standalone FUSE package fragment. |
 | Horn / whistle / bell packs | FUSE audio package with copied audio files. |
-| Strange Customs asset packs | FUSE asset wrapper with `FuseAssetPacks` in `Info.json`. |
 | Zip files | Extracted to a temporary folder, detected, converted, then cleaned up. |
+
+Asset-pack-only, Alina map-tile, native FUSE, and compiled-code packages are not
+conversion inputs. Install the original package with the FUSE installer. A
+mixed legacy package may still convert its recognized top-level JSON data; its
+DLL behavior remains unconverted and is called out in the report.
 
 ## Known Lossy Areas
 
@@ -210,5 +222,9 @@ Current intentional unsupported/deferred areas:
 - arbitrary legacy script logic from `.dll` files
 - rolling stock/car/locomotive packages outside FUSE audio definitions
 - unknown custom component types when their owning assembly is not installed or not converted to a FUSE component package
+
+The presence of a `.dll` is never a successful code conversion. The report must
+keep that binary visible as manual/unsupported work even when the package's JSON
+converted successfully.
 
 Unsupported entries must remain visible in `conversion-report.json` and `conversion-report.md`. A clean conversion is allowed to have `info` entries, but a supported package should not rely on hidden unsupported runtime behavior.

--- a/docs/FUSE_INSTALLER.md
+++ b/docs/FUSE_INSTALLER.md
@@ -15,9 +15,9 @@ works two ways:
 
 A no-argument run also installs any loose `.zip` files sitting beside the exe (in
 addition to FUSE), so the "drop several zips in the folder and run once" workflow
-still works. FUSE is skipped by default if it is already installed; pass
-`--replace` to back up and reinstall it. Pass `--no-fuse` to process only the
-loose zips without (re)installing FUSE.
+still works. Existing mod folders are backed up and updated by default. Pass
+`--skip-existing` to leave them alone, or `--no-fuse` to process only the loose
+zips without installing the bundled FUSE package.
 
 ## Download
 
@@ -28,31 +28,127 @@ so building locally produces a private copy at `dist\FUSE-Installer.exe`.
 The installer inspects zip structure and manifest JSON only. It does not import,
 execute, or depend on any package code.
 
+When FUSE is installed, the installer also creates a data-only UMM entry with
+the historical id `AssetLoader`. This entry contains no DLL and runs no patches;
+it exists so older mod manifests that require `AssetLoader` still pass UMM's
+dependency check before their content is loaded through FUSE.
+
+UMM code mods are reflected before their entry method runs. The installer also
+checks each installed code DLL (without executing it) for references to the
+RailLoader Interchange/Injector or Strange Customs contracts that FUSE replaces.
+When found, it adds `FUSE` to that mod's `Requirements` and `LoadAfter` fields so
+FUSE's compatibility resolver is active before UMM reflects the DLL. The
+original `Info.json` is copied to a dated
+`Mods\ModBackups\FUSEInstaller\CompatibilityManifests-*` folder first. This is
+what allows separately installed UMM packages such as Alina Utilities to start
+with the old loader DLLs absent. RailLoader-hosted data/code packages such as
+Signals Everywhere follow the separate hosted-package path described below.
+
 ## Supported zips
 
 - UMM packages with `Info.json`.
 - FUSE data packages with `Info.json` and FUSE data markers such as
   `FuseDataFiles`, `FuseAssetPacks`, or a FUSE requirement.
-- Supported legacy data packages with `Definition.json` plus data JSON containing
-  world, track, operations, or progression entries.
+- RailLoader packages with `Definition.json`, including data packages and
+  code-only hosted plugins such as Signals Everywhere.
 - Multi-package zips laid out as `Mods/PackageA/...` and `Mods/PackageB/...`.
+
+Each archive is inspected and staged before anything replaces an installed mod.
+One bad archive does not stop the remaining archives. The final table lists every
+package as `INSTALLED`, `UPDATED`, `SKIPPED`, or `FAILED`.
+
+Before writing any package, installer 0.7 scans the complete batch and checks:
+
+- unsafe, absolute, parent-traversing, duplicate, or case-colliding ZIP paths;
+- ambiguous layouts where one package manifest contains another package;
+- duplicate package ids across all selected ZIPs (including `.FUSE` aliases);
+- `Requirements`, `FuseRequires`, and RailLoader `requires`, including
+  `NotBefore`/`NotAfter` version bounds;
+- dependencies already installed or supplied later in the same batch; and
+- dependency failure propagation, so a package that fails preflight cannot
+  satisfy another package just by being present in the batch.
+
+Missing dependency results name the requester, dependency id, version bounds,
+and corrective action. FUSE satisfies only the legacy contracts it explicitly
+replaces (for example Alina's Map Mod, Strange Customs, Confusing Supplements,
+RailLoader Injector/Interchange, and AssetLoader); it does not broadly waive
+unrelated ZAMU or third-party requirements. Retired legacy version bounds are
+ignored only for those explicit FUSE replacement contracts. If an installed
+dependency has no readable version, the installer keeps the package eligible
+but records that the bound could not be verified.
 
 ## User flow
 
 To install FUSE:
 
-1. Put `FUSE-Installer.exe` in the base folder.
-2. Double-click it.
-3. FUSE is written to `Mods\FUSE`.
+1. Install Unity Mod Manager for Railroader.
+2. Double-click `FUSE-Installer.exe`. It searches registered Steam libraries for
+   Railroader; use **Browse** if you have more than one copy or a non-Steam
+   install.
+3. Leave **Install/update the bundled FUSE framework** checked.
+4. Add any mod zips you also want to install, then click **Install**.
+5. Read the package-by-package result list before closing the window.
 
-To install a mod:
+FUSE is written to `Mods\FUSE`.
 
-1. Drag its `.zip` onto `FUSE-Installer.exe` (or drop several at once).
-2. Each package is written to `Mods\<package id>`.
+To install mods:
 
-Existing folders are skipped by default. Run with `--replace` to move an existing
-folder into `Mods\ModBackups\FUSEInstaller\<timestamp>` before installing the new
-copy.
+1. Drag one or more `.zip` files onto `FUSE-Installer.exe`, or open the installer
+   and use **Add zips**.
+2. Confirm the detected Railroader folder and click **Install**.
+3. Each package is written to `Mods\<package id>`. Native FUSE, UMM, and hosted
+   RailLoader-format packages can be selected together.
+
+Existing folders are moved to
+`Mods\ModBackups\FUSEInstaller\<timestamp>` before the new copy is installed.
+Use `--skip-existing` only when you intentionally do not want updates.
+Every non-dry run writes a machine-readable result under
+`Mods\FUSEInstaller\Reports` so a failed package can be diagnosed without a
+screenshot of the installer window. The report's `compatibilityActions` list
+records each AssetLoader backup, alias installation, verification failure, or
+blocked migration with its source and destination paths. Each package record
+also preserves the dependency ids and version bounds used by preflight.
+
+## Removing the old loader safely
+
+Before installing, the tool checks the actual game folder, verifies Unity Mod
+Manager is present, and looks for known legacy loader files in
+`Railroader_Data\Managed`: `Railloader.dll`, `Railloader.Injector.dll`,
+`Railloader.Interchange.dll`, and `StrangeCustoms.dll`.
+
+If any are found, the installer stops and asks permission to move only those
+exact files into a dated backup under
+`Mods\ModBackups\FUSEInstaller\LegacyLoader-<timestamp>`. It does not silently
+delete or patch game files. For an unattended repair, pass
+`--repair-legacy-loader`.
+
+Steam's **Verify integrity of game files** is useful if a game-owned file was
+modified, but it may leave extra third-party DLLs behind. Verification therefore
+does not replace the installer's explicit legacy-file check.
+
+### Replacing AssetLoader
+
+FUSE owns all three behaviors exposed by AssetLoader 1.0.1: package-root and
+child `Catalog.json` store discovery, direct mod-folder store paths, and
+definitions-only child-folder overrides used by rolling-stock/tender swaps.
+
+During a FUSE install or update, the installer checks `Mods` for:
+
+- an old `AssetLoader` UMM folder or any immediate mod folder containing
+  `AssetLoader.dll`;
+- a loose `Mods\AssetLoader.dll`;
+- a loose `Mods\AssetLoader.zip`.
+
+With approval, those exact paths are moved to
+`Mods\ModBackups\FUSEInstaller\AssetLoader-<timestamp>`, then the installer
+creates `Mods\AssetLoader\Info.json` as the data-only dependency alias. It
+verifies that no old AssetLoader runtime remains. Use
+`--repair-asset-loader` for an unattended migration. Dragging the old
+AssetLoader ZIP onto the FUSE installer does not reinstall its DLL.
+
+Do not simply delete AssetLoader by hand while older packages still declare it
+as a UMM requirement. Either use the FUSE installer so the alias is created, or
+update those package manifests to require `FUSE` instead.
 
 ## Command examples
 
@@ -66,6 +162,13 @@ Install explicit zips:
 
 ```powershell
 .\FUSE-Installer.exe .\MyPackage.zip .\OtherPackage.zip
+```
+
+Force command-line mode (the published executable opens the graphical installer
+by default):
+
+```powershell
+.\FUSE-Installer.exe --cli .\MyPackage.zip .\OtherPackage.zip --with-fuse
 ```
 
 Inspect without writing:
@@ -115,5 +218,6 @@ powershell -ExecutionPolicy Bypass -File .\tools\build_installer_exe.ps1 -FusePa
 The release workflow does this automatically, passing the zip it just built. If
 you build without `-FusePayload`, the exe still installs mods from dragged zips,
 but a no-argument run has no FUSE to install and reports that instead. After a
-bundled build, the script runs a `--dry-run` self-check to confirm a manual run
-would install FUSE.
+bundled build, the script performs a real install into a throwaway fake game
+folder and confirms `Mods\FUSE\Info.json` was written. Installer tests also
+verify AssetLoader backup, DLL removal, and dependency-alias creation.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -23,13 +23,18 @@ operations matters there.
 3. Start Railroader.
 4. Check that FUSE appears in Unity Mod Manager's mod list and is enabled.
 
-`FUSE-Installer.exe` can do this for you: drop it and your mod zips in the game's
-base folder and run it. See [FUSE_INSTALLER.md](FUSE_INSTALLER.md).
+`FUSE-Installer.exe` can do this for you: put it beside `Railroader.exe`, then
+double-click it or drag one or more mod zips onto it. It validates the game/UMM
+install, backs up updates, reports each package separately, and detects leftover
+legacy loader DLLs. It also replaces the old AssetLoader runtime with a
+data-only dependency alias, so use the installer when migrating an existing
+AssetLoader-based setup. See [FUSE_INSTALLER.md](FUSE_INSTALLER.md).
 
 ## Install Packages
 
-FUSE packages are folders ending in `.FUSE` that go in `Railroader/Mods`
-alongside FUSE itself.
+Native FUSE, UMM, and hosted RailLoader packages all go in `Railroader/Mods`
+alongside FUSE itself. A native package does not have to use `.FUSE` in its
+folder name; its `Info.json` and declared data files identify it.
 
 1. Place each `*.FUSE` package folder in `Railroader/Mods`.
 2. Install any asset packs the package requires — route packages usually depend on
@@ -37,8 +42,8 @@ alongside FUSE itself.
 3. Start the game and load a map.
 
 FUSE respects UMM's enabled checkbox for any package folder UMM can see. Unchecking
-a converted route, audio, or asset package there marks it disabled in FUSE too, and
-its track and data files are not loaded.
+a converted route/audio package or a directly installed asset package there marks
+it disabled in FUSE too, and its track, data, or assets are not loaded.
 
 Converting a legacy mod into a `*.FUSE` package is the converter's job — see
 [FUSE_CONVERTER.md](FUSE_CONVERTER.md).
@@ -62,17 +67,24 @@ Then confirm your packages are actually present:
 
 Every package you installed should be listed and applied. A package that is
 missing here was never discovered — check that it is in `Railroader/Mods` and
-enabled in UMM. A package listed as faulted was found but failed to apply; check
-`FUSE.log` for the package id and phase.
+enabled in UMM. A package listed as faulted was found but isolated.
+`/fuse.report` names the package and source file; `/fuse.report json` includes
+structured paths and JSON locations for mod authors.
 
 ## The FUSE Menu
 
 The FUSE icon in the top bar opens the in-game menu.
 
 - **Status** — the latest load report.
-- **Tools** — the Object Inspector, dependency/asset/diagnostics reports, scenery
-  benchmarks, and Runtime Actions (`Reload Track/Data`, `Reload Terrain`,
-  `Rebuild Caches`).
+- **Tools** — the Object Inspector, dependency/asset reports, **Live
+  Diagnostics**, scenery benchmarks, and Runtime Actions (`Reload Track/Data`,
+  `Reload Terrain`, `Rebuild Caches`). Live Diagnostics can filter/copy the
+  recent FUSE log or open an optional continuously scrolling Windows console.
+
+Routine Unity exceptions and compatibility-guard counters belong under **Tools
+→ Live Diagnostics**. They do not by themselves make the Status page unhealthy;
+use the symptom and package/asset/graph findings to decide whether a report is
+actionable.
 
 Runtime Actions are recovery and testing tools. Check `FUSE.log` after using one.
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -49,7 +49,8 @@ Off by default. Enabling one is a testing decision — back up your save first. 
   `/fuse.conflicts` reports the collision.
 - **Legacy loaders, AMM, Strange Customs, and RailLoader can create duplicate
   objects** when used alongside converted packages for the same route. FUSE warns
-  when it finds a leftover `Railloader.dll` or `Railloader.Interchange.dll`.
+  when it finds a leftover `Railloader.dll`, `Railloader.Injector.dll`, or
+  `Railloader.Interchange.dll`.
 - **Custom industry components load only when the owning assembly is installed.**
   A package referencing a component type from an assembly you do not have reports
   the missing dependency rather than silently dropping the component.

--- a/docs/LEGACY_REPLACEMENT_PARITY.md
+++ b/docs/LEGACY_REPLACEMENT_PARITY.md
@@ -1,0 +1,157 @@
+# Legacy replacement parity audit
+
+This file is the release gate for claims that FUSE replaces an older loader or
+library. A package is not "replaced" merely because FUSE satisfies its dependency
+identifier, skips its DLL, or can deserialize some of its data. Every observable
+data contract and runtime behavior must have a FUSE-owned implementation, tests,
+and an in-game verification result.
+
+The decompiled projects are used only to identify wire formats and observable
+behavior. FUSE does not copy, ship, or execute their implementations.
+
+Status meanings:
+
+- **Verified**: FUSE-owned implementation, automated coverage, and in-game check.
+- **Implemented**: FUSE-owned implementation and automated coverage; in-game check pending.
+- **Partial**: useful support exists, but at least one listed behavior is absent or unverified.
+- **Missing**: no FUSE-owned equivalent exists.
+- **Hosted only**: FUSE can run the old code; this is not native replacement parity.
+- **N/A**: build-time dependency or retired UI that is intentionally superseded by a named native workflow.
+
+Do not move a row to Verified without recording the test and in-game fixture.
+
+## AssetLoader
+
+| Legacy contract | FUSE-owned implementation | Status | Release evidence still required |
+|---|---|---|---|
+| Register enabled UMM package roots/children containing `Catalog.json` (bundle optional) | Direct asset-pack registry | Implemented | Catalog-only and normal bundle in-game corpus; disabled-package behavior |
+| Resolve mod-folder base paths without copying to LocalLow | `fuseasset://` direct stores and runtime-store path patches | Implemented | In-game pack/bundle fixture on every supported install path |
+| Definitions-only child folder override keyed by store identifier | Native compatibility override registry plus `FuseDefinitionOverrides` | Implemented | Tender/rolling-stock swap in-game corpus; malformed and duplicate targets covered automatically |
+| Legos/other `ContainerSerialization.Deserialize` edits | One cold native deserialize per direct store | Implemented | Full LLW/customization/save-reload in-game fixture |
+| Historical UMM dependency id `AssetLoader` when old DLL is absent | Installer-generated data-only UMM alias requiring FUSE | Implemented | Real UMM startup with an old dependent package and no AssetLoader DLL |
+| Coexistence with old AssetLoader | Runtime disables only the old Harmony owner; installer moves the old runtime to backup and supplies a data-only dependency alias | Implemented | Test manual coexistence in both load orders plus installer migration to a real no-DLL setup |
+
+
+## Confusing Supplements
+
+| Legacy contract | FUSE-owned implementation | Status | Release evidence still required |
+|---|---|---|---|
+| `ConfusingSupplements.Bodygroups` asset component, `cs.bodygroups.*` save keys, model-path switching, Customize UI | `FuseConfusingSupplementsBodygroups*` | Implemented | Asset-pack fixture with multiple groups; save/reload and multiplayer permission check |
+| `ConfusingSupplements.LabelPrinter` asset component and `cs.labelprinter.*` text dictionaries | `FuseConfusingSupplementsLabelPrinter*` | Implemented | Road-number and lettering templates; save/reload; malformed group/name fixture |
+| `ConfusingSupplements.Refiller` rolling-stock transfer component | `FuseConfusingSupplementsRefiller*` | Implemented | Coupled diesel/steam/tender transfer fixture; host/client behavior; air connection changes |
+| `ConfusingSupplements.DestinationSign` model, decal, picker cycling, culling | `FuseConfusingSupplementsDestinationSign*` | Implemented | Real destination-sign prefab fixture; culling and destroy/reload check |
+| `CS.LiverySwap`, `livery:<carId>` directory mixintos, `cs.livery` save key, Customize UI | `FuseConfusingSupplementsLivery*` | Implemented | Multi-car isolation, repeated switching, texture cleanup, save/reload fixture |
+| Captive conversion loader/unloader | `FuseCaptiveConversionIndustryComponents` and component type normalization | Implemented | In-game production/storage/payment golden fixture |
+| Pay-for-resource loader | `FusePay4ResourceIndustryComponent` | Implemented | In-game hours, rate, cost, book reason, and EOD golden fixture |
+| Empty placeholder component, visible track marker, all auto-destination classes, inert service/order behavior | `FuseLegacyPlaceholderIndustryComponent` plus `IndustryAPI` legacy-empty handling | Implemented | In-game output-track highlighting/destination fixture and neighboring component ordering |
+| `/cs-livery-refresh` and texture inspection diagnostics | `/cs-livery-refresh` and `/fuse.liveries` | Implemented | In-game texture edit/refresh and report fixture |
+
+Automated coverage: `FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs`,
+`FUSE.Tests/Data/FuseIndustryComponentTypesTests.cs`,
+`FUSE.Tests/API/FuseLegacyPlaceholderIndustryComponentTests.cs`, and the legacy
+industry converter tests.
+
+## RailLoader.Interchange public contract
+
+| Contract | FUSE surface | Status | Known gap |
+|---|---|---|---|
+| `PluginBase`, `SingletonPluginBase`, enable/disable lifecycle | `RailloaderLegacySupport` + `FuseLegacyAssemblyHost` | Partial | Constructor/lifecycle matrix is not yet tested against every ZAMU/third-party assembly |
+| `IModDefinition`, `IMod`, `ModReference`, version ranges | Compatibility models and manifest discovery | Partial | Full version-bound/load-order golden set pending |
+| `IModdingContext.Mods`, `Requires`, `LoadAfter`, `LoadBefore`, `ConflictsWith` | Legacy manifest discovery and requirement resolver | Partial | Top-level conflict ids/bounds, conditional eligibility/ordering, and intentional-layer classification are covered; full hosted/version-bound in-game corpus remains open |
+| File/directory/managed-object mixintos | Legacy host mixinto enumeration | Partial | Native/runtime-converted file mixintos preserve conditional requires/conflicts; managed-object and some hosted conditional shapes are not proven |
+| Console command registration | Reflection bridge to game console | Partial | Command availability timing and command exception containment matrix pending |
+| Settings load/save | FUSE legacy settings bridge | Implemented | Cross-version/in-game save fixture pending |
+| JSON subtype and component-builder registration | `FuseLegacyTypeRegistry` | Implemented | Late-registration direct-store fixture pending |
+| `IUIHelper` windows and panel population | `FuseLegacyUIHelper` | Partial | All overloads, resize, callbacks, and disposal need in-game verification |
+| `IModTabHandler` | Hosted-plugin Mods UI integration | Partial | Rebuild/disposal and one-bad-tab containment fixture pending |
+| `IUpdateHandler` | Hosted plugin update dispatch | Implemented | Per-frame fault isolation/in-game fixture pending |
+| `WillCopyDebugInformation` event | Guarded event dispatch appended to copied `/fuse.report` health output | Implemented | Real hosted subscriber contribution and one-bad-listener in-game fixture |
+| `UIPanelBuilderCompatibility` helpers | Compatibility extensions | Partial | Every original overload/arity needs a reflection test |
+
+## RailLoader.Injector
+
+| Injector responsibility | FUSE replacement | Status |
+|---|---|---|
+| Locate and parse legacy `Definition.json` packages | `FuseDataPackageDiscovery`, legacy converter, legacy assembly host | Partial |
+| Dependency ordering, enable/disable, faults, conflicts | resolver, load report, package fault registry | Partial |
+| Mixinto parsing including conditional requires/conflicts | legacy converter/host | Partial (data/runtime conversion implemented; hosted managed-object matrix pending) |
+| Load old code mods without the injector assembly | assembly resolver and host | Partial |
+| Register component builders and JSON discriminators | `FuseLegacyTypeRegistry` | Implemented |
+| Console, mod settings, mod tabs, update handlers | legacy host/UI bridge | Partial |
+| Loader status/settings window | FUSE Status/Mods/Settings tools | Partial |
+| Live logging console | FUSE Live Diagnostics/live console | Implemented |
+| Bulletin/update system | FUSE version check only | Partial |
+| Drag-and-drop package installation | FUSE installer | Partial |
+| Legacy patch-file detection/removal guidance | installer/install detector | Partial |
+
+## Strange Customs
+
+| Capability | FUSE replacement | Status | Known gap |
+|---|---|---|---|
+| Track node/segment/span patching and removals | legacy converter + `TrackAPI` apply planner | Partial | Conditional mixinto eligibility/order is covered; base-span ownership and destructive-edit in-game fixtures remain |
+| Industries, loads, areas, operations components | legacy converter + native operations APIs | Partial | Complete custom component matrix and live payment/service fixtures |
+| Scenery and mandelas/scene transforms | legacy converter + `SceneryAPI`/`SceneCloneAPI` | Partial | Road mandelas and several clone/path edge cases still reported |
+| Roads/rivers/generic splineys | legacy converter + `SplineyAPI` + plugin host | Partial | Every handler/profile/end-style and hosted builder fixture |
+| Auto trestles | world conversion/runtime bridge | Partial | Geometry golden fixture |
+| Custom horns, whistles, and bells | FUSE audio API/patches | Partial | Full Strange Customs profile/keyframe compatibility matrix |
+| Conditional visual controls/sliders | FUSE visual-condition patches | Partial | All condition combinations and save keys need fixtures |
+| Direct asset-pack mounting and clone mixintos | direct-store registry/container mixinto registry | Partial | Duplicate-provider and late-registration stress fixtures |
+| `FileCache` loose audio/texture runtime service | FUSE-owned timestamp-invalidating texture/audio cache with contained completion callbacks | Implemented | Real loose WAV/OGG/PNG package, edit-on-disk refresh, and unload fixture |
+| `FlowyThingBuilder` ABI runtime build | Legacy DTO adapter backed by native `SplineyAPI` add/update | Implemented | Hosted plugin direct-build road/river fixture and parent-transform check |
+| Graph-change events for hosted plugins | spliney plugin host and compatibility messages | Partial | Event ordering, mutation merge, and repeat-load fixtures |
+| Legacy patch editor/undo/save API | ABI no-ops | N/A | Superseded by Tile Editor; editor parity is gated separately below |
+| Reload/verify/dump commands | FUSE commands cover only some functions | Partial | Explicit command mapping and docs |
+
+## Alina's Map Mod
+
+| Capability | FUSE replacement | Status | Known gap |
+|---|---|---|---|
+| Nodes, segments, spans, groups, removals | legacy converter + `TrackAPI` | Partial | Full Alina fixture matrix and same-area competing packages |
+| Scenery, map labels, map masks, map features | legacy converter + native world/progression APIs | Partial | Curve-mask and label edge fixtures |
+| Areas, industries, loads, components | legacy converter + native operations APIs | Partial | Component ordering/replacement and disabled-industry fixtures |
+| Loaders | legacy converter + loader API | Partial | Custom loader and track-snap authoring are editor gaps |
+| Passenger stops and station agents | native passenger/station APIs | Partial | Complete timetable/neighbor/area golden fixture |
+| Progressions, sections, delivery phases | native progression API | Partial | Full Alina progression corpus run |
+| Turntables | `TurntableAPI` | Partial | Custom visual/controller and save fixture |
+| Telegraph poles | `MapAPI` | Partial | Add/move/remove fixture |
+| Early map-load application | early loader/lifecycle | Partial | Every supported scene/load entry point |
+| Query tooltip extensions and validation window | FUSE diagnostics/inspector | Partial | One-to-one author-facing error coverage |
+| Alina map editor | Tile Editor | N/A | Tile Editor completion gate below |
+
+## Other ZAMU packages
+
+These packages are not currently in FUSE's suppressed-package set. Most can be
+hosted as old code mods, but hosted execution is not a native replacement.
+
+| Package | Observable behavior inventory | Native FUSE status |
+|---|---|---|
+| AbsoluteMadness | outbound empty/loaded routing overrides; settings tab | Implemented: dependency-scoped native routing, industry capacity weighting, payment/grace calculation, and persisted settings; in-game route-generation fixture pending |
+| ADRFDR | pay-for-resource industry component and picker title | Implemented: `ADRFDR.Pay4Resource` normalizes to the FUSE component and the picker honors `ICustomIndustryTitle`; in-game payment/title fixture pending |
+| C1CD | configurable interchange service interval, hours, continuous delivery | Implemented: native bounded scheduling policy, overnight/daytime service windows, continuous extra-service scheduling, and persisted UI; in-game service-cycle fixture pending |
+| CommandLine | third-party command-line parser dependency | N/A: load packaged dependency for hosted mods; no gameplay replacement |
+| DediSevi | dedicated-server startup, RCON, player list, autosave, instant load, terrain/camera/UI suppression | Missing |
+| FallFromGrace | grace-day calculation and inspector display | Implemented: native identity-safe grace transform, persisted compatibility settings, and due-time inspector row; in-game calculation/inspector fixture pending |
+| ForYourConvenience | caboose map icons, clickable stations, live car tags, industry dashboard/settings | Implemented: dependency-scoped station-map actions, opt-in caboose icons and speed/load tag lines, persisted settings, and native read-only Industry Dashboard; in-game icon/click/tag/dashboard fixture pending |
+| Interchange2Interchange | interchange contracts and car routing between interchanges | Implemented: dependency-scoped contracted interchanges, bounded daily cross-interchange orders, cargo discovery, inspector visibility, and persisted maximum-cut setting; in-game EOD/service fixture pending |
+| SanityInitiative | unit/UI/auto-engineer/equipment/roster/placer/daily-report fixes | Missing |
+| SerialTrafficControl | serial/TCP CTC protocol bridge and settings | Missing |
+| SomeKindOfMadness | outbound routing hooks, target overrides, shuffle/prevent-blocking behavior/settings | Implemented: native candidate event, configurable chance/fill/payment/short-trip/origin behavior, safe order shuffling, and dependency-scoped activation; in-game route-generation and extension-event fixture pending |
+
+## Tile Editor completion gate
+
+The editor's canonical output is native FUSE schema. A visible export-mode
+switch may select RailLoader legacy schema, but controls that cannot be expressed
+faithfully must be disabled with a reason; native schema must never be reduced to
+fit legacy limitations.
+
+Completion requires a documented end-to-end fixture that starts with no map and:
+
+1. acquires/imports terrain tiles and defines a new map;
+2. sculpts terrain and paints vegetation, saves, reloads, and compares the result;
+3. lays track, switches, spans, groups, grades, and interchanges;
+4. places scenery, town labels/signs, roads/water, loaders, and custom loaders;
+5. creates industries, operations, passenger stops, station agents, and progressions;
+6. creates signals, routes, CTC logic, and a working CTC panel;
+7. authors package feature/options groups for modular configurations;
+8. launches the generated map under FUSE and validates save/reload behavior;
+9. repeats the workflow from the published editor wiki without undocumented steps.

--- a/docs/MASTER_WORK_CHECKLIST.md
+++ b/docs/MASTER_WORK_CHECKLIST.md
@@ -1,0 +1,499 @@
+# FUSE ecosystem master work checklist
+
+This is the durable intake list for the FUSE, Tile Editor, Toolshed, and Narrow
+Gauge workstreams. It records reports and requested outcomes; an item being
+listed does not mean the report has been confirmed as a FUSE bug.
+
+Status key: **Open**, **Investigating**, **Implemented**, **Needs in-game test**,
+**External/content issue**, **Complete**.
+
+## Current automated release gate (2026-08-20)
+
+- FUSE net48 suite: **2,205 passed, 9 opt-in real-pack fixtures skipped, 0 failed**.
+- FUSE Core/schema/help suite: **122 passed, 0 failed**.
+- External editor UI suite: **96 passed, 0 failed**.
+- Tile Editor desktop suite: **126 passed, 0 failed**.
+- Installer/tools suite: **79 passed, 0 failed**.
+- FUSE editor bridge, Toolshed, Narrow Gauge, and Railroad Operations validation
+  harness all build/validate successfully; companion-mod builds were run with
+  deployment disabled.
+- Release ZIP validation passed. The bundled `FUSE-Installer.exe` and
+  `FUSE-Converter.exe` build and pass their smoke checks; the installer also
+  completes a throwaway self-install with the DLL-free AssetLoader dependency
+  alias and no obsolete AssetLoader runtime.
+- Slopwatch: **0 findings**. Most remaining unchecked acceptance boxes require a
+  fresh Railroader session or external wiki/release publication. The parity
+  matrix separately identifies the hosted/version-bound compatibility cases
+  that still need broader fixtures; neither category is represented as
+  automated proof.
+
+The detailed legacy behavior release gate lives in
+[`LEGACY_REPLACEMENT_PARITY.md`](LEGACY_REPLACEMENT_PARITY.md). A legacy package
+is not considered replaced just because its dependency is satisfied or its DLL
+is suppressed.
+
+## Non-negotiable compatibility rules
+
+- [x] Keep native FUSE schema canonical and regression-tested.
+- [x] Parse legacy formats only at an isolated compatibility boundary and adapt
+  them into FUSE-owned models/runtime behavior.
+- [x] Do not copy implementation code from decompiled projects. Use observable
+  contracts, identifiers, file formats, and behavior only.
+- [x] Do not claim replacement parity until automated and in-game fixtures pass.
+- [x] A bad package must fail locally, identify the package/folder/file/location,
+  explain the JSON/schema/dependency problem, and leave game menus usable.
+- [x] Separate genuine package/load failures from ordinary Unity/runtime
+  diagnostics so normal exceptions do not alarm users.
+
+## Live GitHub issue intake (2026-08-19)
+
+- [x] #240 Convertor error — converter fix and regression fixture implemented;
+  issue remains open pending release/user confirmation.
+- [x] #239 Whittier Sawmill Trackmod Issue (ARC Whittier) — span rebinding,
+  array-wrapped additions, and industry-only area-wrapper fixes implemented;
+  needs in-game confirmation with ARC Whittier.
+- [x] #238 Not able to customize locomotives — AssetLoader replacement and
+  malformed-store containment implemented. The supplied log also identified a
+  partially-bound Alina Utilities singleton breaking map/camera updates; FUSE
+  now reconnects that instance to its working UMM settings without replacing
+  the mod. Needs the restarted in-game equipment/camera corpus.
+- [x] #236 Multiple unloading areas — real DW5 and Sylva patch shapes covered by
+  converter tests; needs in-game delivery/EOD confirmation.
+- [x] #235 Stryker's Bryson Turntable is yellow/other issues — the supplied log
+  confirms the actual turntable was cloned, sanitized, and applied; the
+  editor-only yellow measurement plate is now filtered. ALW CabooseHouse is a
+  confirmed bad external asset bundle entry. Visual in-game confirmation remains.
+- [ ] #221 FPS drop — logs do not contain a captured frame profile and frame-spike
+  diagnostics were disabled, so a sustained-FPS root cause is not proven. Two
+  always-on costs were removed (legacy update callback reflection/snapshots and
+  zero-work Unity texture-memory polling); needs an in-game before/after capture.
+- [x] #220 Legacy in-game road is not altered — in-place base-road patch and
+  converter fixture implemented; needs in-game confirmation.
+- [x] #210 Whittier Industries assets load but track/location tags do not —
+  root-level spans and industry namespace wrappers fixed in tests; needs
+  in-game confirmation.
+- [x] #206 Issues With Mods — supplied logs show 36 packages/56 definitions
+  applied with zero FUSE faults. Optional mixins were correctly skipped; BRSS
+  threw its own exception, while malformed k50parts/ALW catalogs and missing
+  bundle entries are content faults. Current guarded asset resolution and
+  quarantine paths need in-game confirmation with the same corpus.
+- [x] #198 RMROC451's Tweaks and Things — the real RMROC451 archive now passes
+  the opt-in assembly-load, Interchange-shim, and Harmony-target compatibility
+  fixture against the installed game; needs in-game behavior confirmation.
+- [x] #186 Cross-platform ZIP path separators — archive builder and package
+  validation gate implemented; issue remains open pending release confirmation.
+- [ ] #21 Custom CTC Signaling — portable signal/CTC runtime, editor authoring,
+  authoritative schemas, automatic runtime dependency declaration, and
+  cross-file pre-publish validation are implemented. Native FUSE ownership and
+  an end-to-end in-game territory acceptance run remain open.
+- [ ] Recheck recently closed reports #232, #230, #224, #223, #222, #219,
+  #208, #207, #202, #201, #199, and #196 against the regression suite rather
+  than assuming closure proves the current build.
+
+## FUSE runtime and compatibility reports
+
+- [x] Complete AssetLoader replacement implementation: catalog/bundle stores,
+  catalog-plus-definitions stores without a local bundle, and legacy
+  definitions-only store overrides (including tender/rolling-stock swaps).
+- [x] AssetLoader-dependent packages have an explicit migration/dependency
+  path when the old DLL is absent; merely disabling the old Harmony patches
+  while retaining its assembly is not full replacement. The installer writes a
+  data-only `AssetLoader` UMM alias that requires FUSE.
+- [x] Update the installer to
+  detect old `AssetLoader` folders, ZIPs, DLLs, and active patches; present a
+  clear migration result; and verify the old runtime is no longer installed.
+  Removal/quarantine must be scoped and recoverable, and legacy UMM dependency
+  declarations must remain satisfiable through a FUSE-owned compatibility path.
+  (Offline files are handled by the installer; any still-loaded Harmony owner is
+  handled by FUSE's runtime replacement guard.)
+- [ ] Verify locomotives, rolling stock, tender swaps, native customization
+  controls, Legos library clones, save-car restoration, and the buy menu both
+  with and without the old AssetLoader installed.
+- [ ] Company window/menu lockout: reproduce with malformed and conflicting
+  packages; verify package-local containment and usable buy/company menus.
+- [x] Buy menu freezes for roughly seven seconds: cold prefab stores now warm
+  incrementally and the filtered equipment catalog is cached. Large real-world
+  equipment sets still need an in-game timing comparison.
+- [x] Converter failures: it only converts supported RailLoader JSON,
+  rejects code/native/asset-only/map-tile packages with the correct installer
+  guidance, and provides file/line/path/actionable diagnostics. The C# and
+  Python entry points share this policy; failed reports are written outside the
+  proposed `.FUSE` package so a report-only directory cannot be installed by
+  mistake. A real EFA corpus pass converted 38 JSON packages, produced 93
+  explicit unsupported/failure reports, wrote every report, and produced zero
+  successful output folders without a native fragment.
+- [ ] Conditional `mixInto` patches and `LoadAfter` dependencies (ARC Sylva
+  Terminal and related OttoSeer packages): object-form ids, hard-requirement
+  eligibility, conditional fragment requirements, optional ordering edges,
+  alias matching, and topological ordering are implemented and
+  regression-tested in the runtime and both converters. Hosted legacy code
+  plugins now use the same requires/loadAfter/loadBefore topological order
+  instead of Mods-folder enumeration order, with deterministic cycle fallback.
+  Declared
+  base/extension layering is excluded from Mod Conflicts. Needs an in-game pass
+  with ARC/OttoSeer/Katers packages before acceptance.
+- [ ] Base spans edited by legacy mods must remain renderable/owned correctly;
+  recover missing Sylva interchange tracks including
+  `SInterchange_Track_4` through `_9`.
+- [x] Diagnostics no longer flag unowned base-game placeholder/progression spans
+  as invalid mod content. Audit reads preserve authored FUSE span endpoints when
+  Railroader temporarily cannot resolve a runtime location, and report a true
+  orphan only when the referenced segment is actually gone. Componentless base,
+  passenger/scenery-only, fictional, and disabled location containers are not
+  treated as broken industries; malformed FUSE-owned spans remain actionable.
+- [x] Legacy base-road point replacements preserve and update the scene road in
+  place; broader road/river handler coverage remains in the parity matrix.
+- [ ] DKW nodes/segments that are valid must render; authoring geometry that is
+  too tight must produce an actionable warning rather than a false runtime bug.
+- [x] Preserve the flags-era graph fields found in the 2026.1 base-game audit:
+  diamond nodes, steel bridge supports, and independent yard designation.
+  Native schema/runtime conversion, partial-patch merging, removal snapshots,
+  desktop editor round-trip, and schema tests are implemented without changing
+  the released four-way `style` contract. A flags-era game build still requires
+  its own compile/live acceptance run.
+- [ ] Bjorn/ARC Whittier Sawmill track grouping: S01 cars must not resolve onto
+  S03 tracks; verify 1.0.3/1.0.4 behavior difference.
+- [ ] Sylva Industries Boosted: R2/R3 highlighting, car recognition, delivery
+  greying, and payment must all agree with the configured spans.
+- [ ] Kater interchange packages: preserve/merge referenced base-game spans.
+- [x] East Whittier overlapping/stranded track diagnosis: the supplied profile
+  simultaneously applied East Whittier Crossover, East Whittier Yard Revamp,
+  and AMW East Whittier. These are independent track layouts, not one malformed
+  switch. FUSE now reports cross-package same-ID replacements and separately
+  shows conservative spatial-layout warnings without auto-disabling either mod.
+  The older "PAC-MAN" gap still needs a one-layout-at-a-time in-game retest.
+- [x] Missing-mod visibility: the Mods page now groups and labels disabled,
+  skipped, dependency-missing, invalid, incompatible, partially applied,
+  loaded-but-awaiting-map, and successfully applied packages. Optional mixinto
+  omissions remain a successful apply with an explanatory note rather than a
+  whole-package failure, and the exact state is included by **Copy Mod Info**.
+- [ ] Legacy conflicts: preserve `ConflictsWith`, plus report actual runtime
+  ownership collisions without treating intentional same-package aliases or
+  declared `requires`/`loadAfter` extension layers as user-facing failures.
+  Ownership/layer classification is implemented. Top-level and conditional
+  `ConflictsWith` ids/version bounds are now preserved by both converters and
+  runtime conversion; matching top-level declarations skip the declaring
+  package, conditional declarations skip only their fragment, and Tools > Mod
+  Conflicts labels them as author-declared incompatibilities. Top-level checks
+  now include enabled code-only and asset-only mod manifests plus FUSE runtime
+  replacements, while ignoring disabled/profile-excluded packages. Successful
+  shared industry merges (including the Andrews Coal Power + Tuckasegee Steel
+  Works Kirkland targets from the 2026-08-20 run) are now informational
+  extension layers and do not inflate conflicts/load health. The incompatible-
+  mod in-game corpus remains open.
+- [ ] Test deliberately incompatible track mods that move/delete/claim the same
+  nodes, spans, industries, and scenery; conflict handling must remain
+  deterministic and menus must remain usable. The 2026-08-20 mixed-pack run
+  kept the game/report UI alive with 114 resident definitions and correctly
+  attributed the Bryson delete-vs-definition damage to
+  `jclass.Collie Bryson Removal` versus `StrykerBryson` (1 contained package
+  fault, 11 post-bind graph issues). Seven absent-companion mixintos remained
+  optional inactive fragments. Retest the revised status/conflict counts and
+  the affected in-game menus before closing this stress item.
+- [x] Add **Tools > Mod Conflicts**, grouped by package pair, with object kinds,
+  exact identifiers, resolution behavior, spatial-advisory separation, refresh,
+  and a complete clipboard report. Definition-versus-definition replacement is
+  now recorded in addition to delete-versus-definition conflicts.
+- [x] Asset duplicate reports collapse keys by winner/overridden source set,
+  distinguish identical copies from different definitions, identify the winner,
+  show example keys and impact, and retain every key in the exported report.
+- [ ] Strange Customs asset/audio/animation behavior and third-party rolling
+  stock visuals (including Freeman/Salty reports) need package-specific fixtures.
+- [ ] CLB, LEGO, Joo200, Signals Everywhere, and Alina Utilities must load and
+  operate correctly. A recovered Alina Utilities entry no longer also produces
+  a false legacy-host mod error, and a partially-bound legacy singleton is
+  repaired from the mod's UMM settings so its map-distance/camera patches do not
+  throw every frame. Actual in-game behavior still needs the restarted corpus
+  pass. Griz and Competition are explicitly not replacement gates.
+- [ ] Appy Railway starter equipment pool applies only when its package/map
+  requests it; do not affect unrelated new saves. Definition/setup scoping and
+  regression tests are implemented; the exact installed-game setup coroutine
+  contract has been rechecked with ILSpy. Needs one unrelated-new-save in-game
+  acceptance pass.
+- [ ] Appy starter placement must survive the tutorial and Escape key without
+  consuming/loss of unplaced equipment. Presentation waits for the tutorial,
+  cancellation retains the queued cut, and the queue now consumes a cut only
+  when `TrainController.LastPlacedTrain` confirms the full expected car count;
+  this also guards the current game's false-success callback after a caught
+  placement exception. Needs an in-game cancel/resume/place pass.
+- [x] Live diagnostics auto-refresh preserves the detail/log scroll position,
+  including bottom-follow behavior, instead of selecting the navigation list.
+- [x] World debug labels no longer render above pause/modal/game windows; they
+  resume automatically after the blocking UI closes.
+- [x] Provide a live console/log view comparable to RailLoader's console, with
+  pause/filter/copy/open-folder controls, without putting normal exceptions on
+  the primary Status page.
+- [ ] Validate GP38/Unity errors and mark harmless third-party/engine diagnostics
+  as such instead of load faults.
+- [x] Automatic-waybill location picker removes semantic duplicates caused by
+  multiple runtime component instances without deleting the underlying
+  operations data.
+- [x] Invalid track spans are removed from passenger-stop activation inputs
+  before base-game `PassengerStop.OnEnable` can dereference a removed segment.
+  Strange Customs/Signals Everywhere span serialization also omits invalid
+  endpoints instead of throwing through the graph rebuild.
+- [x] Repaired legacy JSON control-byte warnings are emitted once per source
+  file/session instead of repeating for every conversion pass.
+
+## Legacy replacement audit
+
+- [ ] Complete every row in `LEGACY_REPLACEMENT_PARITY.md` for:
+  - [ ] Alina's Map Mod (Alina Utilities remains an allowed separate dependency).
+  - [ ] RailLoader.Injector.
+  - [ ] RailLoader.Interchange.
+  - [ ] Strange Customs.
+  - [ ] Modular Scenery/asset loading responsibilities.
+  - [ ] Confusing Supplements, including body component groups, label printer,
+    refiller, destination sign, livery swap, and industry components.
+  - [x] AbsoluteMadness (native dependency-scoped routing; in-game fixture remains in the parity row).
+  - [x] ADRFDR (native component/title contract; in-game fixture remains in the parity row).
+  - [x] C1CD (native service scheduling/settings; in-game fixture remains in the parity row).
+  - [ ] CommandLine contract where required by hosted compatibility.
+  - [ ] DediSevi.
+  - [x] FallFromGrace (native grace transform/inspector row; in-game fixture remains in the parity row).
+  - [x] ForYourConvenience (native dashboard, station actions, and optional map/tag additions; in-game fixture remains in the parity row).
+  - [x] Interchange2Interchange (native bounded cross-interchange ordering; in-game fixture remains in the parity row).
+  - [ ] SanityInitiative.
+  - [ ] SerialTrafficControl.
+  - [x] SomeKindOfMadness (native configurable routing/event contract; in-game fixture remains in the parity row).
+- [ ] Verify replacement against real mods in `C:\Railroader mods`,
+  `E:\Backup mods`, Nexus samples, and the decompiled contract inventory under
+  `C:\Hrogers_Railroader_mods_Projects\Decompiled DLLs Not BASE GAME`.
+- [ ] Verify behavior with old DLLs absent; separately verify safe hosted-mode
+  behavior during migration where native parity is not yet complete.
+
+## Installer and user setup
+
+- [x] One clear FUSE installation path that places UMM/FUSE files correctly.
+  The bundled installer installs FUSE on a normal launch and installs only the
+  dropped packages during drag-and-drop use.
+- [x] Multi-file drag-and-drop installer for native FUSE, RailLoader data mods,
+  and UMM mods; recursively inspect ZIP layout rather than guessing by name.
+- [x] Per-package success/failure/skip result and a final batch summary, plus a
+  machine-readable report retaining source root, errors, requirements, and
+  compatibility actions.
+- [x] Detect unsafe archives, ambiguous/nested manifests, duplicate and
+  case-colliding archive members, duplicate/aliased package ids, version
+  conflicts, missing or failed dependencies, and unsupported/unmanifested
+  packages without partial corruption. Healthy packages are staged and swapped
+  atomically; existing installs survive extraction or swap failure.
+- [x] Locate Steam installations robustly, including non-default libraries.
+- [x] Detect old RailLoader-patched game files and provide safe verification or
+  Steam file-verification guidance; do not blindly overwrite game binaries.
+- [x] Explain prerequisites, exact install folders, first launch, upgrading,
+  removal, logs, and recovery in plain language.
+- [x] Repair startup order for separately installed UMM code mods that reference
+  FUSE-replaced RailLoader/Strange Customs assemblies. Installer 0.7.0 scans
+  assembly metadata without executing it, backs up the original manifest, and
+  adds FUSE to `Requirements`/`LoadAfter` while preserving the manifest's
+  existing string/object/list shapes. The installed Alina Utilities manifest
+  was repaired and its original retained under
+  `Mods\ModBackups\FUSEInstaller\CompatibilityManifests-*`.
+- [ ] Verify UMM drag-and-drop behavior and the previously reported 1.0.2 install
+  failure.
+
+## Error reporting and author support
+
+- [x] Every JSON error report includes package id/name, source root, relative and
+  absolute file path, line/column when available, JSON property path, validation
+  code, expected shape/type, received value, and a concrete fix hint. Native,
+  manifest, and legacy-conversion parse paths feed the same structured fault.
+- [x] Every validation code emitted by the game and shared Core validators has a
+  catalogued title, cause, concrete repair, and example. Coverage now includes
+  native modular feature rules, rigid object-line splineys, and water surfaces;
+  the dedicated catalog-coverage suite prevents new cryptic codes or stale help
+  entries.
+- [x] Missing dependency reports name the missing id, required version/range,
+  requester, and where to obtain/enable it when known. Installer batch preflight
+  also distinguishes FUSE-provided legacy contracts from unrelated dependencies
+  and propagates a failed provider to its dependents before any writes.
+- [x] Provide a complete package-scoped export suitable for a mod author, while
+  keeping the Status page concise and actionable. **Copy Mod Info** now includes
+  the full structured diagnostic block for only the selected package; the full
+  health JSON carries the same fields.
+- [x] Distinguish package fault, conflict, warning, suppression, orphan, broken
+  asset, graph issue, and benign runtime diagnostic. Status remains load-health
+  focused; conflicts, audits, assets, and live/third-party diagnostics have
+  separate Tools pages and structured report sections.
+- [ ] Verify health/audit/debug bundle output against Cowboy's and the local
+  stress-test reports.
+
+## Tile Editor — correctness and usability
+
+- [x] Canonical new projects/output use native FUSE schema. Native scenery now
+  writes `world.scenery.<id>.assetIdentifier`; earlier misplaced root scenery is
+  migrated collision-safely. Full-map in-game acceptance remains open below.
+- [x] Visible FUSE Native / RailLoader Legacy export switch.
+- [x] Grey out controls that legacy schema cannot express and show why; never
+  reduce native FUSE capabilities to legacy limitations. The editor identifies
+  limited legacy mode and disables native industry removals, station agents,
+  custom Toolshed bindings, and visible water-surface authoring while retaining
+  the supported RailLoader forms for track, passenger stops, loader builders,
+  roads, and scenery.
+- [x] Fix selection obstruction/priority (track geometry must not hide town signs
+  or intended selectable objects). Track render geometry is filtered; needs
+  in-game object-picking confirmation.
+- [x] Fix stale/accumulating track previews without requiring a full track reload.
+  Targeted rebuild is implemented; needs multi-mod in-game confirmation.
+- [x] Show node-to-segment and segment-to-node relationships and warn about
+  duplicates/covered track.
+- [x] Fix vegetation painting save/reload reversion. Categorical mask persistence
+  and FUSE tile override registration are implemented. Both editor surfaces now
+  describe the 0–7 values truthfully as full-to-clear density levels with
+  approximate percentages/examples, desktop save defensively recalculates tile
+  statistics and clears all render caches, and the in-game save invalidates or
+  rebuilds Railroader's terrain cache. The every-tab live save audit remains
+  open.
+- [x] Fix striped/weird-line terrain deformation artifacts. Interpolated brush
+  sampling is implemented; broader falloff/seam/undo fidelity testing remains
+  part of the whole-map acceptance test.
+- [ ] Complete road/river/spline/mandela authoring and runtime application.
+- [x] Toggle grade labels above track segments.
+- [x] Turnout geometry guidance including minimum practical radii/tightness.
+- [x] Add/move/remove base-game objects including town signs; selection needs
+  in-game confirmation around dense track geometry.
+- [x] Add/edit/remove base-game industries with explicit native operations.
+- [ ] Make industries, areas, loads, components, storage, contracts, delivery,
+  payment, and progression setup understandable and validated. The desktop Mod
+  panel now exposes a copyable pre-publish validator and clean ZIP export;
+  native area/span/load/industry/station/loader/passenger relationships are
+  checked, with dependency-provided add-on references reported as warnings and
+  missing standalone-map references as errors. In-game workflow/behavior
+  acceptance remains open.
+- [ ] Complete passenger stops, station agents, timetable/neighbor relationships,
+  and map/company window integration.
+- [ ] Complete interchange creation, tracks, routing, and service settings.
+- [ ] Complete signals, signal movement, heads/aspects, routes, blocks, logic,
+  complete CTC systems, and CTC panel authoring/runtime wiring. The editor and
+  Railroad Operations now cover base semaphore placement/track locking,
+  multi-head aspects, diamond interlockings, ABS/manual/CTC blocks, power-switch
+  control points, routes, dispatcher UI, multiplayer state, schema files, and
+  full graph/cross-file validation. FUSE-native section ownership, broader
+  signal families/custom assets, and whole-territory in-game acceptance remain.
+- [x] Loader placement can snap to a selected track/span and then adjust lateral,
+  longitudinal, vertical, and rotational offsets manually.
+- [x] Support custom loader models/load points/service definitions. Native FUSE
+  scenery and Toolshed binding are one undoable/save-safe editor action.
+- [x] Import/discover Toolshed-authored custom loaders as a placeable catalog and
+  emit matching native scenery and service-binding data. Industry/load/span
+  operation components remain explicit author choices rather than guessed data.
+- [x] Use
+  `C:\Hrogers_Railroader_mods_Projects\Toolshed\FuseServiceFacilityTest.zip`
+  as the first Toolshed integration fixture (bunker-C tank loader, wood shed,
+  source industry, span binding, authored load points). The editor presets and
+  field contract match the fixture; in-game transfer/storage behavior still
+  needs confirmation with Toolshed installed.
+- [x] Native per-mod feature/options schema and runtime UI for modular packages:
+  booleans/choices/sliders conditionally enable exact authored track, spans,
+  scenery, operations, world, progression, and audio objects. The source
+  definition remains intact, changes are clearly reload-required, FUSE's Mods
+  page reports the active/disabled feature set, and the Editor Options workspace
+  authors and validates the rules. RailLoader mode stays visibly disabled
+  because it has no equivalent contract.
+- [ ] Every tab needs a capability, validation, save/reload, undo/redo, runtime,
+  and documentation audit; Signals and Operations are partial implementations,
+  not empty stubs.
+
+## Tile Editor — whole-map workflow acceptance test
+
+The automated desktop golden test `tests/test_complete_map_workflow.py` now
+creates a native standalone map, imports a tile, authors track/turnout/spans,
+operations, passenger and interchange content, scenery/road/town sign/water,
+modular options, progression, signals/CTC, and a Toolshed binding, then saves,
+reopens, validates against FUSE's authoritative schema, exports a ZIP, and
+checks its contents. The boxes below intentionally remain open until the same
+fixture installs, launches, saves, reloads, and is visually/operationally
+verified in Railroader.
+
+- [ ] Download/acquire terrain tiles with licensing/source metadata.
+- [ ] Create a new map coordinate/tile set from scratch.
+- [ ] Add tiles to an existing map safely.
+- [ ] Sculpt terrain; paint vegetation; save/reload exactly. Both editors now
+  use named 0–7 full-to-clear density levels (not misleading fixed biomes),
+  categorical mask writes, atomic tile saves, backup retention, dirty ownership,
+  render-stat/cache refresh, and Railroader cache invalidation/rebuild; the live
+  paint/save/reload acceptance run remains open.
+- [ ] Create water surfaces and edit/remove existing water/lake planes. Native
+  `world.waterSurfaces`, runtime CRUD/cache/diagnostics, Editor creation and
+  point editing, stock-lake replacement, desktop validation, and schema docs are
+  implemented; in-game material, collider, save/reload, and replacement
+  acceptance remains open.
+- [ ] Lay track, switches, crossings, spans, groups, grades, bridges/trestles,
+  turntables, and yards.
+- [ ] Draw fences, retaining walls, guardrails, pipes, and similar repeated
+  objects. Native `objectLine` schema/runtime/editor support, uniform spacing,
+  terrain snap, offsets, scaling, rotation, endpoint placement, safety caps,
+  undo/save, documentation, and legacy-mode gating are implemented; asset and
+  scene-prefab in-game round-trip acceptance remains open.
+- [ ] Add scenery, roads, labels, town signs, loaders, service facilities,
+  interchanges, industries, passenger facilities, progression, signals, and CTC.
+- [ ] Configure map identity/start state/start equipment correctly.
+- [ ] Export, validate, install, launch, save, reload, and edit the generated map.
+  Desktop Validate/Export ZIP is implemented; install/launch and full generated-
+  map round-trip acceptance remain open.
+- [ ] A new author can repeat the complete workflow from the wiki alone.
+
+## Railroader base-game audit for map completeness
+
+The subsystem-by-subsystem source crosswalk and acceptance boundary are now
+documented in [`BASE_GAME_MAP_AUTHORING_AUDIT.md`](BASE_GAME_MAP_AUTHORING_AUDIT.md).
+
+- [x] Inventory map bootstrap/session creation, coordinate spaces, terrain tiles,
+  texture/vegetation layers, and streaming/culling.
+- [x] Inventory water/lake/river surfaces, materials, reflection/collider behavior,
+  persistence, editing, and creation requirements. The current `LakePolygon`
+  creation contract and source-material/profile reuse are covered by native
+  schema/runtime/editor support; reflection behavior and full in-game persistence
+  acceptance still require golden-master testing.
+- [x] Inventory track graph, render geometry, switches, crossings, bridges,
+  turntables, signals, blocks/routes, CTC, speed limits, grades, and validation.
+- [x] Inventory scenery, buildings, roads, spline systems, signs, labels, map
+  masks/features, telegraph, portals/interchanges, and service points. Rigid
+  repeated-object lines are now covered separately from deformable road/river
+  meshes; remaining spline/profile families still need the full base audit.
+- [x] Inventory areas/towns, industries, loads, contracts, storage, loaders,
+  passenger stops, agents/timetables, progression/milestones, and starting state.
+- [x] Inventory save identifiers, initialization order, cache rebuilds, teardown,
+  multiplayer authority, and UI views required for each authored subsystem.
+- [x] Compare every discovered subsystem with FUSE native schema, runtime APIs,
+  Tile Editor UI, validation, serialization, tests, and wiki coverage.
+
+## Documentation and wikis
+
+- [x] Rewrite the local FUSE install, getting started, troubleshooting, migration,
+  converter scope, package authoring, schema, operations, diagnostics, and
+  command documentation.
+- [ ] Complete FUSE wiki and sync published pages.
+- [x] Complete the local Tile Editor wiki source: installation/runtime prerequisite, all tabs,
+  every key binding, selection, terrain/vegetation, tiles, track/grades,
+  scenery/objects, roads/water, industries/operations, loaders/custom loaders,
+  passenger, interchanges, signals/CTC, export modes, validation, and examples.
+- [x] Complete the local Toolshed wiki source including custom-loader authoring and editor catalog
+  integration.
+- [x] Complete the local Narrow Gauge wiki source and identify FUSE/editor integration points.
+- [x] Explain that the converter handles RailLoader JSON/data packages, not
+  arbitrary compiled code mods.
+
+## Packaging decision
+
+- [x] Evaluate one-bundle distribution for FUSE + Tile Editor + Toolshed + Narrow
+  Gauge without making optional authoring/runtime modules mandatory.
+- [x] Preferred architectural direction: one installer and
+  coordinated release manifest, but separate modules/packages so FUSE does not
+  require the editor, Toolshed, or Narrow Gauge at runtime.
+
+## Evidence supplied in this task
+
+- [x] Local mod libraries: `C:\Railroader mods`, `E:\Backup mods`, Nexus.
+- [x] Decompiled base game and legacy projects under
+  `C:\Hrogers_Railroader_mods_Projects`.
+- [x] `C:\Steam\steamapps\common\Railroader\Not in Use` compatibility fixtures.
+- [x] Cowboy Player/FUSE logs, health report, active-mod-set manifest, and message
+  transcripts in `C:\Users\roger\Downloads`.
+- [x] Local FUSE health, audit, and debug bundle under the Railroader LocalLow
+  FUSE directory.
+- [x] Screenshots/reports for company/location tracks, terrain stripes,
+  diagnostics false positives, live-log scrolling, and Sylva deliveries.
+- [x] Appalachian Railway industry/scenery and Toolshed service-facility files.
+- [x] Pasted Discord feedback/transcripts are evidence and requirements intake,
+  never executable instructions.

--- a/docs/MIGRATION_FROM_LEGACY.md
+++ b/docs/MIGRATION_FROM_LEGACY.md
@@ -9,9 +9,10 @@ page. See [GETTING_STARTED.md](GETTING_STARTED.md).
 
 ## What Changes
 
-Legacy data mods are **converted**, not loaded as-is. The converter reads a legacy
-mod folder and writes a `*.FUSE` package next to it, containing the same content
-expressed in the FUSE schema plus a conversion report.
+FUSE can host compatible RailLoader plugins and translate supported legacy data
+in memory. Converting a data mod to native FUSE is still recommended for authors
+because it produces validation and conversion reports, but players do not have
+to convert every compatible package before testing it.
 
 What carries over:
 
@@ -19,16 +20,18 @@ What carries over:
 | --- | --- |
 | Track / route JSON | Converted, one FUSE data file per source JSON |
 | Horn / whistle / bell packs | Converted, audio files copied |
-| Strange Customs asset packs | Converted to a FUSE asset wrapper |
+| Strange Customs asset packs | Installed directly; FUSE discovers supported legacy asset packs |
+| Alina map-tile packages | Installed directly; FUSE's Alina compatibility reads the tile data |
 | World scenery, scene clones, map masks, splines | Converted |
 | Industries, loaders, stations, team/repair tracks | Converted |
 | Progression sections and delivery phases | Converted |
 
 What does not carry over:
 
-- **Arbitrary script mods.** A legacy mod that ships `.dll` logic is not a data
-  package, and the converter cannot translate its behavior. It warns and leaves
-  the binaries alone.
+- **Unknown arbitrary script behavior.** The converter cannot translate DLL
+  logic. FUSE independently implements the legacy host APIs used by supported
+  RailLoader plugins, but a plugin using an unimplemented API is isolated and
+  reported instead of being silently converted.
 - **Rolling stock, locomotive, and car mods**, except audio definitions.
 - **Signals.**
 - **Three-way switches** — Railroader does not support them as standard graph
@@ -45,9 +48,9 @@ this situation, and it is the single most common self-inflicted problem when
 migrating.
 
 The same applies to the loaders themselves. FUSE detects a leftover
-`Railloader.dll` or `Railloader.Interchange.dll` in the install and warns about it,
-both on disk and among loaded assemblies. Take the warning seriously — it means
-two loaders are live at once.
+`Railloader.dll`, `Railloader.Injector.dll`, or `Railloader.Interchange.dll` in
+the install and warns about it, both on disk and among loaded assemblies. Take
+the warning seriously — it means two loaders are live at once.
 
 Loading both is supported only as a deliberate conflict test.
 
@@ -62,7 +65,9 @@ the step people skip and regret.
 
 List your legacy mods and sort them into three groups:
 
-- **Data mods** (routes, scenery, industries, audio, asset packs) — these convert.
+- **Convertible data mods** (routes, scenery, industries, supported audio JSON) — these convert.
+- **Direct-install data** (asset packs and Alina map tiles) — install the original
+  package through the FUSE installer; do not run it through the converter.
 - **Script mods** (`.dll` logic) — these do not convert; check whether a FUSE-native
   equivalent exists.
 - **Rolling stock** — out of scope except audio.
@@ -87,6 +92,8 @@ fuse-convert "C:\Path\To\LegacyMod" --out "C:\Steam\steamapps\common\Railroader\
 ### 4. Read the conversion report
 
 Every converted package gets `conversion-report.json` and `conversion-report.md`.
+Failed or direct-install inputs write their reports under the output root's
+`_conversion-reports` folder so the report cannot be mistaken for a package.
 **Read them.** The converter classifies each source concept rather than silently
 dropping it:
 
@@ -144,13 +151,14 @@ The legacy loader. FUSE reads Railloader's package metadata directly, including
 `RailLoadPriority`, `RailLoadAfter`, and `RailLoadBefore` for load ordering, so
 ordering relationships you already established carry across.
 
-Remove `Railloader.dll` and `Railloader.Interchange.dll` once you have migrated —
+Remove `Railloader.dll`, `Railloader.Injector.dll`, and
+`Railloader.Interchange.dll` once you have migrated —
 FUSE warns while they remain.
 
 ### Strange Customs
 
-Asset packs convert to a FUSE asset wrapper with `FuseAssetPacks` declared in
-`Info.json`. Mixin files convert through the `mixinto` mechanism; a missing mixinto
+Asset packs install directly and remain available to native or converted route
+packages. Mixin files convert through the `mixinto` mechanism; a missing mixinto
 requirement skips only that fragment rather than faulting the whole stack.
 
 ### ConfusingSupplements / For Your Convenience

--- a/docs/PACKAGE_AUTHOR_GUIDE.md
+++ b/docs/PACKAGE_AUTHOR_GUIDE.md
@@ -23,16 +23,39 @@ Every file should include:
 - Do not rename an id just to change display text.
 - Keep display names in `name`; keep identity in `id`.
 
+## Player-Selectable Features
+
+Use top-level `settings` plus `featureRules` when one package should offer
+optional track, scenery, industries, loaders, or other authored sections. The
+Tile Editor's **Options** workspace creates on/off, choice, and slider settings,
+lets you select the exact objects controlled by each option, and writes both
+dictionaries together.
+
+Feature settings must be marked `reloadRequired`; the Editor does this
+automatically. A false rule omits only the targets listed by that rule from the
+runtime definition. It does not delete those objects from the package file.
+Every target must be authored in the same definition, and an industry-component
+target uses `industryId/componentId`. See the schema guide for the full target
+list and JSON example.
+
+RailLoader output has no equivalent contract. The Editor therefore disables
+this workspace in legacy mode instead of creating a lossy or misleading export.
+
 ## Dependencies
 
 Use package metadata for required package ordering and dependencies:
 
-- `RailLoadPriority`
-- `RailLoadAfter`
-- `RailLoadBefore`
-- normal UMM `Requirements` when the mod itself requires FUSE or another mod
+- `FuseLoadPriority`
+- `FuseRequires` for hard FUSE data-package dependencies
+- `FuseLoadAfter`
+- `FuseLoadBefore`
+- `FuseConflictsWith` for explicit package incompatibilities, with optional
+  `NotBefore`/`NotAfter` bounds
+- normal UMM `Requirements`/`LoadAfter` when a UMM code mod requires FUSE or another UMM mod
 
-Use `mixinto` when converting legacy conditional mixin files. Missing mixinto requirements should skip only that fragment, not the whole stack.
+Use `mixinto` when converting legacy conditional mixin files. Missing mixinto
+requirements or matching `mixinto.conflictsWith` references skip only that
+fragment, not the whole stack.
 
 ## Optional References
 
@@ -84,6 +107,38 @@ for a map that intentionally overlays custom terrain on Bushnell/Whittier.
 
 Asset pack objects should keep their real asset identifiers. Do not alias to unrelated assets if the correct pack exists.
 
+### Asset stores and definition overrides
+
+Declare normal asset-pack roots with `FuseAssetPacks`. A runtime store is
+identified by `Catalog.json`; `Bundle` is optional for a definitions-only
+catalog whose assets are supplied by another store. FUSE reports an actual
+missing bundle if an asset from that store is requested.
+
+For the old AssetLoader pattern where a `Definitions.json` file replaces the
+definitions of an existing store (rolling-stock and tender swaps), prefer an
+explicit native manifest entry:
+
+```json
+{
+  "Requirements": ["FUSE"],
+  "FuseDefinitionOverrides": [
+    {
+      "StoreIdentifier": "fm-flatcar03",
+      "Path": "DefinitionOverrides/fm-flatcar03/Definitions.json"
+    }
+  ]
+}
+```
+
+The path must stay inside the package. An object entry names the exact existing
+store id; a string path infers the id from its parent folder. FUSE also detects
+AssetLoader's legacy immediate-child convention automatically, but native
+packages should be explicit. If two packages target the same exact store, FUSE
+chooses deterministically and reports both source files.
+
+New packages should require `FUSE`, not `AssetLoader`. The installer's data-only
+`AssetLoader` alias exists only for old manifests.
+
 ## Diagnostics
 
 Use these commands while authoring:
@@ -100,3 +155,10 @@ Use these commands while authoring:
 - `/fuse.dumpmandelas`
 
 Warnings should name package id, operation, object id, and field whenever possible.
+
+Malformed JSON and validation faults are isolated to the affected definition.
+`/fuse.report` and `/fuse.report json` include the absolute folder/file, JSON
+path, line/column when available, and a suggested action. Treat a report with a
+faulted package as an authoring failure even if unrelated packages still work.
+
+For task-based examples, see [Authoring Recipes](AUTHORING_RECIPES.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ New to FUSE, or installing it on a fresh setup.
 | Doc | What it covers |
 | --- | --- |
 | [Getting Started](GETTING_STARTED.md) | Install FUSE and your first packages, verify the load, update, uninstall |
+| [Install, Convert, Or Author?](CHOOSING_A_WORKFLOW.md) | Pick the right installer, converter, editor, or runtime companion |
 | [FAQ](FAQ.md) | Common questions — legacy mods, multiplayer, saves, performance |
 | [Settings](SETTINGS.md) | All 29 settings, their defaults, and where they live |
 | [Console Commands](CONSOLE_COMMANDS.md) | Every `/fuse.*` command |
@@ -27,6 +28,7 @@ Building or converting FUSE packages.
 | Doc | What it covers |
 | --- | --- |
 | [Package Author Guide](PACKAGE_AUTHOR_GUIDE.md) | The authoring contract — ids, dependencies, optional references |
+| [Authoring Recipes](AUTHORING_RECIPES.md) | Move track, remove industries, place loaders, edit roads/signs, diagnose JSON |
 | [JSON Schema Reference](../schemas/FUSE_JSON_SCHEMA.md) | The full data contract |
 | [Converter](FUSE_CONVERTER.md) | Drag-and-drop, batch, and `fuse-convert` CLI conversion |
 | [External Editor](EXTERNAL_EDITOR.md) | The standalone desktop editor |
@@ -69,6 +71,9 @@ conflicts is a clean load.
 
 **A package isn't loading.** `/fuse.loaded` — not listed means undiscovered,
 listed as faulted means it failed to apply.
+
+**Can the converter convert a DLL/code mod?** No. It converts recognized JSON
+and package data only. See [Install, Convert, Or Author?](CHOOSING_A_WORKFLOW.md).
 
 **Filing a bug?** Attach `FUSE.log`, `Player.log`, `/fuse.report json` output, and
 the package's `conversion-report.json`.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -30,9 +30,29 @@ Also include console output or screenshots for:
 
 ## Common Symptoms
 
+### I Want A Live Debug Console
+
+Open **FUSE → Tools → Live Diagnostics → Open Live Console**. On Windows this
+opens a continuously scrolling mirror of `FUSE.log` for a second monitor. Stop
+it from the same page before exiting; the console's Close command is disabled so
+closing that optional diagnostics window cannot terminate Railroader. On other
+platforms, use the filtered in-game viewer or tail `FUSE.log` with a text tool.
+
+The compatibility-guard and observed-exception lists on this page are evidence,
+not automatic bug verdicts. Include them when they repeat alongside a visible
+problem.
+
 ### Faulted Package
 
 Run `/fuse.loaded` and `/fuse.report`. Check `FUSE.log` for the package id and phase. Package failures should not prevent unrelated packages from loading.
+
+For an author-ready report, open **FUSE → Mods**, select the affected package,
+and use **Copy Mod Info**. Its actionable diagnostic names the package and
+source root, shows both relative and absolute filenames, includes JSON
+property/line/position and validation code when available, contrasts the
+expected shape with the received value, and ends with the concrete correction.
+This package-scoped copy is usually easier to send to an author than the full
+health report.
 
 ### Unknown Scenery Asset
 
@@ -45,6 +65,16 @@ Check whether it is a regular asset pack item or a scene clone. For scene clones
 ### Bad Track, Missing Span, Or Broken Segment
 
 Run `/fuse.dumpgraph` and `/fuse.dumpruntimegraph`. The files are written to the main Railroader folder as `FUSE-original-graph.json` and `FUSE-runtime-graph.json`.
+
+Open **FUSE → Tools → Mod Conflicts** before assuming one track mod is broken.
+The page groups conflicts by the two packages involved and lists the exact
+objects and winning/merge behavior. "Potential track-layout overlap" is an
+advisory: FUSE found multiple nearby authored nodes but kept both packages
+because an intentional connection can look similar. If the map contains
+overlapping switches, floating rails, or dead stubs, temporarily enable only one
+primary layout for that area and retest. For example, East Whittier Yard Revamp
+and AMW East Whittier are alternative yard layouts; add East Whittier Crossover
+only when its author declares it compatible with the chosen layout.
 
 ### Company Window Or Location List Looks Wrong
 

--- a/schemas/FUSE_JSON_SCHEMA.md
+++ b/schemas/FUSE_JSON_SCHEMA.md
@@ -3,7 +3,7 @@
 This folder defines the JSON side of the FUSE mod format.
 
 - `fuse-mod.schema.json` is the authoritative JSON Schema for hand-authored and editor-exported `.json` files.
-- `fuse-mod.example.json` is a compact example that exercises track, spans, areas, industry ordering, built-in and custom industry components, loaders, turntables, roundhouses, stations, scenery, spawn points, span-anchored scenery, splineys, telegraph poles, labels, speed signs, masks, suppressions, map tiles, scene clones, world removals, progression data, audio definitions, mixinto metadata, package settings, and editor state.
+- `fuse-mod.example.json` is a compact example that exercises track, spans, areas, industry ordering, built-in and custom industry components, loaders, turntables, roundhouses, stations, scenery, spawn points, span-anchored scenery, splineys, water surfaces, telegraph poles, labels, speed signs, masks, suppressions, map tiles, scene clones, world removals, progression data, audio definitions, mixinto metadata, package settings, and editor state.
 - `umm-info.schema.json` documents the Unity Mod Manager `Info.json` shape FUSE expects for API mods, data packages, and asset-pack packages.
 - `umm-info.example.json` is a data-only map package manifest that depends on `FUSE`.
 
@@ -15,7 +15,7 @@ Top-level object groups:
 
 - `tracks`: nodes, segments, spans, areas, and optional removals for deleting base-game track objects.
 - `operations`: loads, industries, loaders, turntables, and passenger stations.
-- `world`: scenery, spawn points, splineys, telegraph poles, map labels, map masks, map tile overlays, scene clones, and optional removals for base scene objects.
+- `world`: scenery, spawn points, splineys, polygonal water surfaces, telegraph poles, map labels, map masks, map tile overlays, scene clones, and optional removals for base scene objects.
 - `progression`: progression trees and map features.
 
 Map declarations are complete replacement worlds by default. `map.suppressBaseWorld`
@@ -27,7 +27,7 @@ uses custom terrain as an overlay on the stock world.
 - `editor`: optional editor-only state that FUSE can ignore at runtime.
 - `extensions`: optional namespaced third-party data.
 
-`mixinto` is optional metadata for converted RailLoader/Strange Customs conditional mixin files. The converted file remains a normal FUSE fragment, but FUSE checks `mixinto.requires[]` immediately before runtime apply. If any required mod is missing, older than `notBefore`, or newer than `notAfter`, that fragment is skipped without faulting the rest of the package.
+`mixinto` is optional metadata for converted RailLoader/Strange Customs conditional mixin files. The converted file remains a normal FUSE fragment, but FUSE checks `mixinto.requires[]` and `mixinto.conflictsWith[]` immediately before runtime apply. A missing/out-of-range requirement or a matching conflict skips that fragment without faulting the rest of the package.
 
 ```json
 {
@@ -36,6 +36,9 @@ uses custom terrain as an overlay on the stock world.
     "sourceFile": "CNRI_FoxysLimestonePatch.json",
     "requires": [
       { "id": "CaptainFoxy.NantahalaLime", "notBefore": "1.1" }
+    ],
+    "conflictsWith": [
+      { "id": "Some.Incompatible.Route", "notAfter": "3.0" }
     ]
   }
 }
@@ -65,6 +68,46 @@ Enum `values` are treated as exact strings. FUSE does not normalize or rename se
   }
 }
 ```
+
+Native modular packages can connect a setting to authored content with a
+top-level `featureRules` dictionary. When a rule does not match, FUSE omits
+only its named targets from the runtime copy of the definition. The source JSON
+stays intact, so changing the option and reloading restores the objects.
+
+```json
+{
+  "settings": {
+    "enableExtraYard": {
+      "type": "bool",
+      "label": "Extra Yard Tracks",
+      "scope": "profile",
+      "default": true,
+      "reloadRequired": true
+    }
+  },
+  "featureRules": {
+    "extraYard": {
+      "setting": "enableExtraYard",
+      "operator": "equals",
+      "value": true,
+      "targets": {
+        "trackNodes": ["yard:n:4", "yard:n:5"],
+        "trackSegments": ["yard:s:extra"],
+        "trackSpans": ["yard:span:extra"],
+        "scenery": ["yard:prop:bumper"]
+      }
+    }
+  }
+}
+```
+
+Operators are `equals`, `notEquals`, `greaterThan`,
+`greaterThanOrEqual`, `lessThan`, and `lessThanOrEqual`; ordering operators
+require a number setting. Target keys cover track, operations, world,
+progression, and audio dictionaries. Industry components use
+`industryId/componentId`. Every target must be authored in the same definition,
+which prevents an option from accidentally deleting base-game or dependency
+objects. Rules are native FUSE data and are not projected into RailLoader JSON.
 
 All editable game objects are stored in dictionaries keyed by object ID. The ID is not repeated inside the object body. This keeps editor updates simple: replacing `tracks.nodes["murphy:n:001"]` updates exactly one object without array searches or ID duplication.
 
@@ -100,11 +143,12 @@ The shipped examples cover the public authoring cases:
 | Audio pack | `fuse-mod.example.json` | `audio.whistles`, `audio.horns`, and `audio.bells`. |
 | Industry component pack | `fuse-mod.example.json` | Built-in component types plus a fully-qualified custom component type with `fields`. |
 | Load component pack | `fuse-mod.example.json` | `operations.loads.*.fields` can carry reflection-bound custom load data. |
-| Package settings | `fuse-mod.example.json` | Top-level `settings` with bool, enum, color, user/profile/server scope, and reload metadata. |
-| Mixinto | `fuse-mod.example.json` | `mixinto.target`, `mixinto.sourceFile`, and conditional `requires`. |
+| Package settings | `fuse-mod.example.json` | Top-level `settings` with bool, enum, color, user/profile/server scope, reload metadata, and object-level `featureRules`. |
+| Mixinto | `fuse-mod.example.json` | `mixinto.target`, `mixinto.sourceFile`, conditional `requires`, and conditional `conflictsWith`. |
 | Progression section | `fuse-mod.example.json` | Root `progression.sections[]`, delivery phases, unlock features, and interchange transfers. |
 | Map mask | `fuse-mod.example.json` | `world.mapMasks` for terrain/object mask authoring. |
 | Scene clone | `fuse-mod.example.json` | `world.sceneClones` for base-game object cloning/retargeting. |
+| Water surface | `fuse-mod.example.json` | `world.waterSurfaces` for FUSE-owned lake planes and optional stock-lake material reuse. |
 | Span-anchored scenery | `fuse-mod.example.json` | `world.scenery.*.anchorSpanIds`. |
 | Signals | Not included | Signals are deferred and should not be treated as supported yet. |
 
@@ -279,7 +323,11 @@ Track segments may also set optional companion-mod gauge metadata:
 }
 ```
 
-FUSE stores `gauge` for mods such as NarrowGaugeMod; base Railroader track geometry remains unchanged unless a companion mod acts on it.
+FUSE stores `gauge` for mods such as NarrowGaugeMod; base Railroader track
+geometry remains unchanged unless a companion mod acts on it. Native values are
+`Standard`, `Narrow`, `DualGauge`, `DualGauge_L`, `DualGauge_R`, and
+`DualGauge_T`; the additional legacy aliases accepted by the schema are read
+compatibility values, not recommended new output.
 
 Asset and prefab references are URI strings:
 
@@ -316,6 +364,13 @@ Spliney `type` describes the physical spline family, not its material flavor:
 - `road`: normal road spline. Use `style`/`profile` for dirt versus pavement.
 - `terrainRoad`: terrain-carved road spline. Use `style`/`profile` for dirt versus pavement.
 - `trestle`: auto-generated trestle spline.
+- `objectLine`: repeats a scenery asset or safe scene-path prefab along a
+  piecewise path. Use this for fence panels, retaining-wall sections,
+  guardrails, hedges, and other rigid modules that must not be stretched into
+  a road/river mesh. Set exactly one of `assetIdentifier` or `prefab`, then use
+  `spacing`, `instanceScale`, `rotationOffset`, lateral/vertical offsets,
+  optional terrain snapping/slope alignment, and the bounded
+  `maximumInstances` safety limit.
 
 Converted Strange Customs `FlowyThingBuilder` data must inspect `style` and `profile`; entries with `style: "River"` or river profiles should be emitted as `type: "river"`, not as roads.
 When converting `FlowyThingBuilder` entries, preserve the legacy default `offsetY: -0.1` if the source omits it; the field keeps road and river surfaces at the same vertical bias Strange Customs used.
@@ -392,6 +447,7 @@ FUSE treats these as overlays on top of the base game's `StreamingAssets/Maps/<d
 - `tracks.areas` are applied at runtime and are used as preferred parents for FUSE-created industries. Area and industry `order` values are also used when rebuilding company-window location ordering.
 - `operations.loads` are applied at runtime by creating or updating `CarPrototypeLibrary.instance.opsLoads` entries. Use `units`, `density`, `unitWeightInPounds`, `importable`, `payPerQuantity`, and `costPerUnit` when the custom load needs full behavior parity with legacy mod data. Custom load mods may use `fields` for reflection-bound field/property values on the runtime `Load` object.
 - `world.mapMasks` are applied at runtime using the default behavior above.
+- `world.waterSurfaces` creates editable polygonal lake planes. Supply at least three world-space points; `sourceLakePath` reuses a specific stock lake's material/profile, while `materialName` selects a loaded material explicitly. `lockHeight`, `snapToTerrain`, `uvScale`, `triangleDensity`, `maximumTriangleArea`, `yOffset`, and `enableCollider` control generation. This native-only contract is intentionally not projected into RailLoader JSON.
 - `world.telegraphPoles` are applied at runtime by generating pole instances along the provided point path at the requested spacing.
 - `world.telegraphPoleMovements` are applied at runtime by translating existing base-game telegraph pole graph nodes by index. FUSE forces the telegraph manager to refresh when possible.
 - `world.spawnPoints` are applied at runtime by creating or updating `Character.SpawnPoint` components under a FUSE-owned world root.
@@ -453,3 +509,58 @@ Asset-pack-only packages can expose existing Railroader `AssetPack` runtime stor
   "FuseAssetPacks": ["SCAssetPacks"]
 }
 ```
+
+Track nodes and segments also preserve the newer graph structure metadata while
+remaining compatible with released Railroader builds that expose the older
+four-way style enum:
+
+```json
+{
+  "tracks": {
+    "nodes": {
+      "murphy:n:diamond-west": {
+        "position": { "x": 10, "y": 2, "z": 20 },
+        "rotation": { "x": 0, "y": 90, "z": 0 },
+        "isDiamond": true
+      }
+    },
+    "segments": {
+      "murphy:s:steel-yard-bridge": {
+        "startNodeId": "murphy:n:001",
+        "endNodeId": "murphy:n:002",
+        "style": "bridge",
+        "bridgeSupportsSteel": true,
+        "yard": true
+      }
+    }
+  }
+}
+```
+
+`isDiamond` marks a graph crossing node. `bridgeSupportsSteel` selects the
+steel-support bridge variant, and `yard` is independent of bridge/tunnel
+structure on game builds that expose combinable flags. Existing `style` values
+(`standard`, `bridge`, `tunnel`, `yard`) remain valid. Partial legacy overlays
+can set `preserveBridgeSupportsSteel` and `preserveYard` just as they already use
+`preserveStyle`.
+
+`Catalog.json` identifies a runtime store. A local `Bundle` is not required for
+a definitions-only catalog whose asset references resolve to another store.
+
+Use `FuseDefinitionOverrides` when a package intentionally supplies
+`Definitions.json` for an existing store without supplying a new catalog/bundle:
+
+```json
+{
+  "Requirements": ["FUSE"],
+  "FuseDefinitionOverrides": [
+    {
+      "StoreIdentifier": "fm-flatcar03",
+      "Path": "DefinitionOverrides/fm-flatcar03/Definitions.json"
+    }
+  ]
+}
+```
+
+Paths are package-relative and cannot escape the package directory. A string
+entry is also accepted and infers `StoreIdentifier` from its parent folder.

--- a/schemas/fuse-mod.example.json
+++ b/schemas/fuse-mod.example.json
@@ -24,7 +24,8 @@
       "label": "Depot Props",
       "description": "Show optional detail props around the depot.",
       "scope": "user",
-      "default": true
+      "default": true,
+      "reloadRequired": true
     },
     "yardDetailLevel": {
       "type": "enum",
@@ -45,6 +46,18 @@
       "scope": "server",
       "default": "#D6C89A",
       "advanced": true
+    }
+  },
+  "featureRules": {
+    "optionalDepotProps": {
+      "setting": "enableDepotProps",
+      "operator": "equals",
+      "value": true,
+      "targets": {
+        "scenery": [
+          "murphy:scenery:depot"
+        ]
+      }
     }
   },
   "tracks": {
@@ -661,6 +674,40 @@
           }
         ]
       },
+      "murphy:fence:001": {
+        "type": "objectLine",
+        "assetIdentifier": "example-pack:fence-panel",
+        "spacing": 3,
+        "instanceScale": {
+          "x": 1,
+          "y": 1,
+          "z": 1
+        },
+        "rotationOffset": {
+          "x": 0,
+          "y": 90,
+          "z": 0
+        },
+        "snapToTerrain": true,
+        "placeAtEnd": true,
+        "maximumInstances": 256,
+        "points": [
+          {
+            "position": {
+              "x": 10,
+              "y": 1,
+              "z": 24
+            }
+          },
+          {
+            "position": {
+              "x": 52,
+              "y": 2,
+              "z": 27
+            }
+          }
+        ]
+      },
       "murphy:waterfall:001": {
         "type": "waterfall",
         "profile": "default",
@@ -680,6 +727,39 @@
             }
           }
         ]
+      }
+    },
+    "waterSurfaces": {
+      "murphy:lake:millpond": {
+        "points": [
+          {
+            "x": 92,
+            "y": 1.5,
+            "z": -42
+          },
+          {
+            "x": 132,
+            "y": 1.5,
+            "z": -38
+          },
+          {
+            "x": 128,
+            "y": 1.5,
+            "z": -12
+          },
+          {
+            "x": 88,
+            "y": 1.5,
+            "z": -16
+          }
+        ],
+        "lockHeight": true,
+        "snapToTerrain": false,
+        "enableCollider": false,
+        "uvScale": 1,
+        "triangleDensity": 0.2,
+        "maximumTriangleArea": 50,
+        "yOffset": 0
       }
     },
     "telegraphPoles": {

--- a/schemas/fuse-mod.schema.json
+++ b/schemas/fuse-mod.schema.json
@@ -91,6 +91,10 @@
             "$ref": "#/$defs/settings",
             "description": "Package-declared FUSE settings. Runtime values are stored outside the mod folder and scoped by user, profile, or server profile."
         },
+        "featureRules": {
+            "$ref": "#/$defs/featureRules",
+            "description": "Native FUSE rules that include authored objects only when a package setting matches. Rules are evaluated on map/package load."
+        },
         "editor": {
             "$ref": "#/$defs/editor"
         },
@@ -113,7 +117,7 @@
         "uri": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^(vanilla|path|scenery|asset|rail|file|empty)://.*$"
+            "pattern": "^(vanilla|path|scenery|asset|rail|file|empty|fuse)://.*$"
         },
         "vec3": {
             "type": "object",
@@ -185,6 +189,14 @@
                         "$ref": "#/$defs/modRequirement"
                     },
                     "default": []
+                },
+                "conflictsWith": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/modRequirement"
+                    },
+                    "default": [],
+                    "description": "Legacy conditional incompatibilities. The fragment is skipped when any matching package/version is enabled; the rest of the package remains active."
                 }
             }
         },
@@ -294,6 +306,82 @@
                 }
             }
         },
+        "featureRules": {
+            "type": "object",
+            "description": "Dictionary of stable feature-rule ids. A false rule omits all named targets until the next map/package reload.",
+            "propertyNames": {
+                "$ref": "#/$defs/id"
+            },
+            "additionalProperties": {
+                "$ref": "#/$defs/featureRule"
+            }
+        },
+        "featureRule": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "setting",
+                "value",
+                "targets"
+            ],
+            "properties": {
+                "setting": {
+                    "$ref": "#/$defs/id",
+                    "description": "Id of a setting declared by this package. The setting should set reloadRequired=true."
+                },
+                "operator": {
+                    "type": "string",
+                    "enum": [
+                        "equals",
+                        "notEquals",
+                        "greaterThan",
+                        "greaterThanOrEqual",
+                        "lessThan",
+                        "lessThanOrEqual"
+                    ],
+                    "default": "equals"
+                },
+                "value": {
+                    "description": "Comparison value. Its JSON type should match the referenced setting."
+                },
+                "targets": {
+                    "$ref": "#/$defs/featureTargets"
+                }
+            }
+        },
+        "featureTargets": {
+            "type": "object",
+            "additionalProperties": false,
+            "minProperties": 1,
+            "properties": {
+                "trackNodes": { "$ref": "#/$defs/stringArray" },
+                "trackSegments": { "$ref": "#/$defs/stringArray" },
+                "trackSpans": { "$ref": "#/$defs/stringArray" },
+                "trackAreas": { "$ref": "#/$defs/stringArray" },
+                "loads": { "$ref": "#/$defs/stringArray" },
+                "industries": { "$ref": "#/$defs/stringArray" },
+                "industryComponents": {
+                    "$ref": "#/$defs/stringArray",
+                    "description": "Industry/component references formatted as industryId/componentId."
+                },
+                "loaders": { "$ref": "#/$defs/stringArray" },
+                "turntables": { "$ref": "#/$defs/stringArray" },
+                "stations": { "$ref": "#/$defs/stringArray" },
+                "scenery": { "$ref": "#/$defs/stringArray" },
+                "splineys": { "$ref": "#/$defs/stringArray" },
+                "waterSurfaces": { "$ref": "#/$defs/stringArray" },
+                "telegraphPoles": { "$ref": "#/$defs/stringArray" },
+                "mapLabels": { "$ref": "#/$defs/stringArray" },
+                "mapMasks": { "$ref": "#/$defs/stringArray" },
+                "mapTiles": { "$ref": "#/$defs/stringArray" },
+                "sceneClones": { "$ref": "#/$defs/stringArray" },
+                "progressions": { "$ref": "#/$defs/stringArray" },
+                "mapFeatures": { "$ref": "#/$defs/stringArray" },
+                "whistles": { "$ref": "#/$defs/stringArray" },
+                "horns": { "$ref": "#/$defs/stringArray" },
+                "bells": { "$ref": "#/$defs/stringArray" }
+            }
+        },
         "tracks": {
             "type": "object",
             "additionalProperties": false,
@@ -401,27 +489,16 @@
                     "type": "boolean",
                     "default": false
                 },
+                "isDiamond": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Marks this node as one half of a diamond crossing. FUSE preserves it on game versions that expose diamond-node routing."
+                },
                 "groupId": {
                     "$ref": "#/$defs/idRef"
                 },
                 "tags": {
                     "$ref": "#/$defs/stringArray"
-                },
-                "gauge": {
-                    "type": "string",
-                    "enum": [
-                        "Standard",
-                        "Narrow",
-                        "3ft",
-                        "3 ft",
-                        "ThreeFoot",
-                        "Three Foot",
-                        "DualGauge",
-                        "Dual",
-                        "Mixed",
-                        "MixedGauge"
-                    ],
-                    "description": "Optional NarrowGaugeMod metadata. FUSE stores the value for companion mods; Railroader's base graph still uses the normal track geometry."
                 }
             }
         },
@@ -463,6 +540,35 @@
                 "tags": {
                     "$ref": "#/$defs/stringArray"
                 },
+                "gauge": {
+                    "type": "string",
+                    "enum": [
+                        "Standard",
+                        "Narrow",
+                        "3ft",
+                        "3 ft",
+                        "ThreeFoot",
+                        "Three Foot",
+                        "DualGauge",
+                        "DualGauge_L",
+                        "DualGauge_R",
+                        "DualGauge_T",
+                        "Dual",
+                        "Mixed",
+                        "MixedGauge"
+                    ],
+                    "description": "Optional NarrowGaugeMod segment metadata. FUSE stores the value for companion mods; Railroader's base graph still uses the normal track geometry."
+                },
+                "bridgeSupportsSteel": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use steel bridge supports when style is bridge. Older Railroader builds that only expose the four-way style enum retain bridge style but cannot represent this extra distinction."
+                },
+                "yard": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Marks the segment as yard track independently of bridge/tunnel structure on Railroader builds that expose combinable track flags. The legacy style value 'yard' remains supported."
+                },
                 "partial": {
                     "type": "boolean",
                     "default": false,
@@ -472,6 +578,16 @@
                     "type": "boolean",
                     "default": false,
                     "description": "In a partial patch, keep the existing segment style instead of overwriting it."
+                },
+                "preserveBridgeSupportsSteel": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "In a partial patch, keep the existing bridge-support material flag."
+                },
+                "preserveYard": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "In a partial patch, keep the existing independent yard flag."
                 },
                 "preserveTrackClass": {
                     "type": "boolean",
@@ -1333,6 +1449,20 @@
                     ],
                     "default": {}
                 },
+                "waterSurfaces": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/dictionary"
+                        },
+                        {
+                            "additionalProperties": {
+                                "$ref": "#/$defs/waterSurface"
+                            }
+                        }
+                    ],
+                    "description": "FUSE-owned lake polygons built from world-space boundary points and loaded Railroader water assets.",
+                    "default": {}
+                },
                 "telegraphPoles": {
                     "allOf": [
                         {
@@ -1435,6 +1565,7 @@
                     "default": {
                         "scenery": [],
                         "splineys": [],
+                        "waterSurfaces": [],
                         "telegraphPoles": [],
                         "mapLabels": [],
                         "mapMasks": [],
@@ -1452,6 +1583,9 @@
                     "$ref": "#/$defs/worldRemovalArray"
                 },
                 "splineys": {
+                    "$ref": "#/$defs/worldRemovalArray"
+                },
+                "waterSurfaces": {
                     "$ref": "#/$defs/worldRemovalArray"
                 },
                 "telegraphPoles": {
@@ -1570,7 +1704,8 @@
                         "road",
                         "terrainRoad",
                         "trestle",
-                        "waterfall"
+                        "waterfall",
+                        "objectLine"
                     ]
                 },
                 "profile": {
@@ -1589,6 +1724,55 @@
                 },
                 "tailStyle": {
                     "type": "string"
+                },
+                "assetIdentifier": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Scenery asset repeated by an objectLine spline. Mutually exclusive with prefab."
+                },
+                "prefab": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Prefab URI such as path://scene/World/... repeated by an objectLine spline. Mutually exclusive with assetIdentifier."
+                },
+                "spacing": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "default": 5
+                },
+                "instanceScale": {
+                    "$ref": "#/$defs/vec3",
+                    "default": { "x": 1, "y": 1, "z": 1 }
+                },
+                "rotationOffset": {
+                    "$ref": "#/$defs/vec3",
+                    "default": { "x": 0, "y": 0, "z": 0 }
+                },
+                "lateralOffset": {
+                    "type": "number",
+                    "default": 0
+                },
+                "verticalOffset": {
+                    "type": "number",
+                    "default": 0
+                },
+                "snapToTerrain": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "alignToSlope": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "placeAtEnd": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "maximumInstances": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 4096,
+                    "default": 1024
                 },
                 "points": {
                     "type": "array",
@@ -1620,6 +1804,64 @@
                 "width": {
                     "type": "number",
                     "exclusiveMinimum": 0
+                }
+            }
+        },
+        "waterSurface": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "points"
+            ],
+            "properties": {
+                "points": {
+                    "type": "array",
+                    "minItems": 3,
+                    "items": {
+                        "$ref": "#/$defs/vec3"
+                    }
+                },
+                "sourceLakePath": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Optional scene path whose LakePolygon profile/material should be reused."
+                },
+                "materialName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Optional exact loaded material name. When omitted, FUSE uses the source or a loaded stock water material."
+                },
+                "lockHeight": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "snapToTerrain": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "enableCollider": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "uvScale": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "default": 1
+                },
+                "triangleDensity": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "maximum": 1,
+                    "default": 0.2
+                },
+                "maximumTriangleArea": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "default": 50
+                },
+                "yOffset": {
+                    "type": "number",
+                    "default": 0
                 }
             }
         },

--- a/schemas/umm-info.example.json
+++ b/schemas/umm-info.example.json
@@ -17,6 +17,7 @@
   ],
   "FuseLoadPriority": 100,
   "FuseLoadAfter": [],
+  "FuseConflictsWith": [],
   "FuseLoadBefore": [],
   "FuseDataFiles": [
     "track.fuse.json",
@@ -26,5 +27,11 @@
   ],
   "FuseAssetPacks": [
     "SCAssetPacks"
+  ],
+  "FuseDefinitionOverrides": [
+    {
+      "StoreIdentifier": "example-existing-store",
+      "Path": "DefinitionOverrides/example-existing-store/Definitions.json"
+    }
   ]
 }

--- a/schemas/umm-info.schema.json
+++ b/schemas/umm-info.schema.json
@@ -77,6 +77,14 @@
       "default": 0,
       "description": "FUSE-specific package ordering priority. Lower values load earlier; ties fall back to dependency order, then package id."
     },
+    "FuseRequires": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/dependency"
+      },
+      "default": [],
+      "description": "FUSE data package ids that must be installed and enabled for this package to apply."
+    },
     "FuseLoadAfter": {
       "type": "array",
       "items": {
@@ -92,6 +100,14 @@
       },
       "default": [],
       "description": "FUSE-specific data package ids that must load after this package."
+    },
+    "FuseConflictsWith": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/dependency"
+      },
+      "default": [],
+      "description": "Package ids and optional version bounds that this complete data package declares incompatible. Matching enabled packages prevent this package from loading and are shown as author-declared incompatibilities."
     },
     "FuseDataFile": {
       "type": "string",
@@ -123,6 +139,33 @@
         }
       ],
       "description": "FUSE-specific relative folder or folders containing Railroader AssetPack Runtime stores, for example SCAssetPacks."
+    },
+    "FuseDefinitionOverrides": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/definitionOverride"
+        },
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/definitionOverride"
+              },
+              {
+                "type": "string",
+                "minLength": 1
+              }
+            ]
+          },
+          "default": []
+        }
+      ],
+      "description": "FUSE-owned replacement for AssetLoader definitions-only store routing. Paths are relative to this package. String entries infer the target store identifier from the parent folder; object entries can name it explicitly."
     },
     "Settings": {
       "type": "object",
@@ -197,10 +240,31 @@
             },
             "NotBefore": {
               "type": "string"
+            },
+            "NotAfter": {
+              "type": "string"
             }
           }
         }
       ]
+    },
+    "definitionOverride": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Path"
+      ],
+      "properties": {
+        "StoreIdentifier": {
+          "$ref": "#/$defs/id",
+          "description": "Exact existing AssetPackRuntimeStore identifier whose Definitions.json is replaced. If omitted, FUSE uses the definition file's parent folder name."
+        },
+        "Path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Package-relative Definitions.json path, or a package-relative folder containing Definitions.json."
+        }
+      }
     }
   }
 }

--- a/scripts/Sync-Wiki.ps1
+++ b/scripts/Sync-Wiki.ps1
@@ -42,6 +42,7 @@ $blobBase = 'https://github.com/F-U-S-E-E/FuseDevelopmentGroup/blob/main'
 # docs/ file -> wiki page name. Order drives the sidebar.
 $pageMap = [ordered]@{
     'GETTING_STARTED.md'      = 'Getting-Started'
+    'CHOOSING_A_WORKFLOW.md'  = 'Install-Convert-Or-Author'
     'FAQ.md'                  = 'FAQ'
     'MIGRATION_FROM_LEGACY.md' = 'Migrating-From-Legacy-Mods'
     'SETTINGS.md'             = 'Settings'
@@ -51,13 +52,15 @@ $pageMap = [ordered]@{
     'FUSE_INSTALLER.md'       = 'Installer'
     'FUSE_CONVERTER.md'       = 'Converter'
     'PACKAGE_AUTHOR_GUIDE.md' = 'Package-Author-Guide'
+    'AUTHORING_RECIPES.md'    = 'Authoring-Recipes'
     'EXTERNAL_EDITOR.md'      = 'External-Editor'
+    'BASE_GAME_MAP_AUTHORING_AUDIT.md' = 'Map-Authoring-Coverage'
 }
 
 # Sidebar grouping.
 $sections = [ordered]@{
-    'Players'         = @('Getting-Started', 'FAQ', 'Migrating-From-Legacy-Mods', 'Settings', 'Console-Commands', 'Troubleshooting', 'Known-Issues', 'Installer')
-    'Package Authors' = @('Converter', 'Package-Author-Guide', 'External-Editor')
+    'Players'         = @('Getting-Started', 'Install-Convert-Or-Author', 'FAQ', 'Migrating-From-Legacy-Mods', 'Settings', 'Console-Commands', 'Troubleshooting', 'Known-Issues', 'Installer')
+    'Package Authors' = @('Converter', 'Package-Author-Guide', 'Authoring-Recipes', 'External-Editor', 'Map-Authoring-Coverage')
 }
 
 function Convert-Links {
@@ -147,6 +150,9 @@ and Alina's Map Mod packages.
 
 **New here?** Start with [Getting Started](Getting-Started).
 
+**Not sure whether to install, convert, or edit a mod?** Use
+[Install, Convert, Or Author](Install-Convert-Or-Author).
+
 **Coming from Railloader or another legacy stack?** Read
 [Migrating From Legacy Mods](Migrating-From-Legacy-Mods) before installing
 anything.
@@ -154,6 +160,7 @@ anything.
 ## Players
 
 - [Getting Started](Getting-Started) — install, verify, update, uninstall
+- [Install, Convert, Or Author](Install-Convert-Or-Author) — choose the correct tool
 - [FAQ](FAQ) — legacy mods, multiplayer, saves, performance
 - [Settings](Settings) — every setting and its default
 - [Console Commands](Console-Commands) — every ``/fuse.*`` command
@@ -165,7 +172,9 @@ anything.
 
 - [Converter](Converter) — converting legacy mods
 - [Package Author Guide](Package-Author-Guide) — the authoring contract
+- [Authoring Recipes](Authoring-Recipes) — common map, industry, loader, and JSON tasks
 - [External Editor](External-Editor) — the standalone desktop editor
+- [Map Authoring Coverage](Map-Authoring-Coverage) — base-game subsystem crosswalk and live acceptance boundary
 - [JSON Schema Reference]($blobBase/schemas/FUSE_JSON_SCHEMA.md) — the data contract
 
 ## Offline manuals

--- a/tools/build_installer_exe.ps1
+++ b/tools/build_installer_exe.ps1
@@ -84,6 +84,7 @@ $args = @(
     '--clean',
     '--noconfirm',
     '--onefile',
+    '--windowed',
     '--name', 'FUSE-Installer',
     '--icon', $IconPath,
     '--distpath', $OutputDir,
@@ -137,10 +138,14 @@ if (-not (Test-Path -LiteralPath $exePath)) {
 }
 
 Write-Host "Smoke check: running '$exePath --help'..."
-$smokeOutput = & $exePath --help 2>&1
-$smokeExit = $LASTEXITCODE
+$smokeProcess = Start-Process `
+    -FilePath $exePath `
+    -ArgumentList @('--help') `
+    -WindowStyle Hidden `
+    -Wait `
+    -PassThru
+$smokeExit = $smokeProcess.ExitCode
 if ($smokeExit -ne 0) {
-    Write-Host $smokeOutput
     throw "Smoke check failed (exit=$smokeExit)."
 }
 
@@ -152,25 +157,49 @@ if (-not [string]::IsNullOrWhiteSpace($BundledFuse)) {
     Write-Host "Self-check: installing bundled FUSE into a throwaway dir..."
     $ProbeDir = Join-Path $WorkDir 'selfcheck'
     if (Test-Path $ProbeDir) { Remove-Item $ProbeDir -Recurse -Force }
-    New-Item -ItemType Directory -Force -Path $ProbeDir | Out-Null
-    $selfOutput = & $exePath --no-pause --game-dir $ProbeDir 2>&1
-    $selfExit = $LASTEXITCODE
-    Write-Host $selfOutput
+    $ProbeUmmDir = Join-Path $ProbeDir 'Railroader_Data\Managed\UnityModManager'
+    New-Item -ItemType Directory -Force -Path $ProbeUmmDir | Out-Null
+    New-Item -ItemType File -Force -Path (Join-Path $ProbeDir 'Railroader.exe') | Out-Null
+    New-Item -ItemType File -Force -Path (Join-Path $ProbeUmmDir 'UnityModManager.dll') | Out-Null
+    # PyInstaller's windowed one-file launcher can return control to a PowerShell
+    # invocation before its extracted child process has finished. Start-Process
+    # -Wait follows the GUI process tree, so the assertions below cannot race the
+    # actual install (the old direct '& $exePath' check intermittently reported
+    # a missing Info.json while the child was still writing it).
+    $quotedProbeDir = '"' + $ProbeDir + '"'
+    $selfProcess = Start-Process `
+        -FilePath $exePath `
+        -ArgumentList @('--cli', '--no-pause', '--game-dir', $quotedProbeDir) `
+        -WindowStyle Hidden `
+        -Wait `
+        -PassThru
+    $selfExit = $selfProcess.ExitCode
     if ($selfExit -ne 0) {
         throw "Self-check failed (exit=$selfExit): bundled FUSE install did not succeed."
-    }
-    # Match the inspected package id, not just the word FUSE (which also appears
-    # in the static "bundled FUSE:" / "FUSE:" output labels), so a non-FUSE
-    # payload can't silently pass the self-check.
-    if ("$selfOutput" -notmatch 'id=FUSE(\s|$)') {
-        throw "Self-check failed: bundled package is not FUSE (id=FUSE missing from install output)."
     }
     # Confirm extraction actually wrote the mod to disk.
     $installedInfo = Join-Path $ProbeDir 'Mods\FUSE\Info.json'
     if (-not (Test-Path -LiteralPath $installedInfo -PathType Leaf)) {
         throw "Self-check failed: expected $installedInfo after installing bundled FUSE."
     }
-    Write-Host "Self-check passed: a manual run installs FUSE to Mods\FUSE."
+    $installedManifest = Get-Content -LiteralPath $installedInfo -Raw | ConvertFrom-Json
+    $installedId = if ($null -ne $installedManifest.Id) { [string]$installedManifest.Id } else { [string]$installedManifest.id }
+    if ($installedId -ne 'FUSE') {
+        throw "Self-check failed: bundled package id is '$installedId', expected 'FUSE'."
+    }
+    $assetLoaderInfo = Join-Path $ProbeDir 'Mods\AssetLoader\Info.json'
+    if (-not (Test-Path -LiteralPath $assetLoaderInfo -PathType Leaf)) {
+        throw "Self-check failed: expected FUSE's data-only AssetLoader alias at $assetLoaderInfo."
+    }
+    $assetLoaderManifest = Get-Content -LiteralPath $assetLoaderInfo -Raw | ConvertFrom-Json
+    if ([string]$assetLoaderManifest.FuseProvidedCompatibility -ne 'FUSE.AssetLoaderCompatibility') {
+        throw "Self-check failed: the AssetLoader alias is missing FUSE's compatibility marker."
+    }
+    $assetLoaderDll = Join-Path $ProbeDir 'Mods\AssetLoader\AssetLoader.dll'
+    if (Test-Path -LiteralPath $assetLoaderDll) {
+        throw "Self-check failed: old AssetLoader runtime DLL remains installed at $assetLoaderDll."
+    }
+    Write-Host "Self-check passed: FUSE and its DLL-free AssetLoader dependency alias were installed."
 }
 
 Write-Host "Built: $exePath"

--- a/tools/fuse_convert.py
+++ b/tools/fuse_convert.py
@@ -310,12 +310,32 @@ CORE_LEGACY_REQUIREMENTS = {
     "railroader",
     "railloader",
     "rail-loader",
+    "railloader.injector",
+    "railloader.interchange",
+    "assetloader",
+    "alinanova21.alinasmapmod",
+    "alinasmapmod",
+    "alinamapmod",
+    "alinanova21.mapeditor",
+    "mapeditor",
+    "mmapeditor",
     "zamu.strangecustoms",
     "strangecustoms",
     "zamu.confusingsupplements",
     "confusingsupplements",
+    "zamu.foryourconvenience",
+    "foryourconvenience",
     "fuse",
 }
+
+
+def is_core_legacy_requirement(package_id: object) -> bool:
+    value = str(package_id or "").strip()
+    lowered = value.lower()
+    while lowered.endswith(".fuse") or lowered.endswith(".rail"):
+        value = value[:-5]
+        lowered = value.lower()
+    return lowered in CORE_LEGACY_REQUIREMENTS
 
 
 def extract_file_reference(value):
@@ -327,10 +347,12 @@ def extract_file_reference(value):
     return match.group(1).strip().strip("\"'")
 
 
-def convert_requirement(item):
+def convert_requirement(item, *, filter_replacement_capabilities=True):
     if isinstance(item, str):
         requirement_id = item.strip()
-        if not requirement_id or requirement_id.lower() in CORE_LEGACY_REQUIREMENTS:
+        if not requirement_id or (
+            filter_replacement_capabilities and is_core_legacy_requirement(requirement_id)
+        ):
             return None
         return {"id": requirement_id}
 
@@ -338,7 +360,9 @@ def convert_requirement(item):
         return None
 
     requirement_id = str(item.get("id") or item.get("Id") or "").strip()
-    if not requirement_id or requirement_id.lower() in CORE_LEGACY_REQUIREMENTS:
+    if not requirement_id or (
+        filter_replacement_capabilities and is_core_legacy_requirement(requirement_id)
+    ):
         return None
 
     result = {
@@ -361,11 +385,23 @@ def convert_requirements(value):
     return result
 
 
+def convert_conflict_references(value):
+    if not isinstance(value, list):
+        return []
+
+    result = []
+    for item in value:
+        converted = convert_requirement(item, filter_replacement_capabilities=False)
+        if converted:
+            result.append(converted)
+    return result
+
+
 def fuse_package_id(requirement_id):
     text = str(requirement_id or "").strip()
     if not text:
         return None
-    if text.lower() in CORE_LEGACY_REQUIREMENTS:
+    if is_core_legacy_requirement(text):
         return None
     if text.lower().endswith(".fuse"):
         return text
@@ -373,12 +409,18 @@ def fuse_package_id(requirement_id):
 
 
 def legacy_load_after(mod_folder):
+    required, load_after = legacy_dependencies(mod_folder)
+    return _dedupe_dependency_ids(required + load_after)
+
+
+def legacy_dependencies(mod_folder):
     path = mod_folder / "Definition.json"
     if not path.exists():
-        return []
+        return [], []
 
     definition = load_json(path)
-    result = []
+    required = []
+    ordered_after = []
 
     requirements = (
         definition.get("requires")
@@ -390,20 +432,73 @@ def legacy_load_after(mod_folder):
     for requirement in convert_requirements(requirements):
         package_id = fuse_package_id(requirement.get("id"))
         if package_id:
-            result.append(package_id)
+            required.append(package_id)
 
     load_after = definition.get("loadAfter") or definition.get("LoadAfter") or []
     if isinstance(load_after, str):
         load_after = [load_after]
     if isinstance(load_after, list):
         for item in load_after:
-            package_id = fuse_package_id(item)
+            item_id = item
+            if isinstance(item, dict):
+                item_id = item.get("id") or item.get("Id")
+            package_id = fuse_package_id(item_id)
             if package_id:
-                result.append(package_id)
+                ordered_after.append(package_id)
 
+    mixintos = definition.get("mixintos") or definition.get("Mixintos")
+    for requirement_id in _mixinto_requirement_ids(mixintos):
+        package_id = fuse_package_id(requirement_id)
+        if package_id:
+            ordered_after.append(package_id)
+
+    return _dedupe_dependency_ids(required), _dedupe_dependency_ids(ordered_after)
+
+
+def legacy_conflicts_with(mod_folder):
+    path = mod_folder / "Definition.json"
+    if not path.exists():
+        return []
+
+    definition = load_json(path)
+    conflicts = definition.get("conflictsWith") or definition.get("ConflictsWith") or []
+    return [
+        clean(
+            {
+                "Id": reference.get("id"),
+                "NotBefore": reference.get("notBefore"),
+                "NotAfter": reference.get("notAfter"),
+            }
+        )
+        for reference in convert_conflict_references(conflicts)
+    ]
+
+
+def _mixinto_requirement_ids(value):
+    if isinstance(value, list):
+        for item in value:
+            yield from _mixinto_requirement_ids(item)
+        return
+
+    if not isinstance(value, dict):
+        return
+
+    requirements = value.get("requires") or value.get("Requires") or []
+    for requirement in convert_requirements(requirements):
+        requirement_id = requirement.get("id")
+        if requirement_id:
+            yield requirement_id
+
+    for key, child in value.items():
+        if key.lower() == "requires":
+            continue
+        yield from _mixinto_requirement_ids(child)
+
+
+def _dedupe_dependency_ids(values):
     seen = set()
     ordered = []
-    for item in result:
+    for item in values:
         key = item.lower()
         if key not in seen:
             seen.add(key)
@@ -420,7 +515,7 @@ def mixinto_metadata(mod_folder):
     metadata = {}
     ordered_files = []
 
-    def record(target, reference, requirements):
+    def record(target, reference, requirements, conflicts_with):
         referenced_file = extract_file_reference(reference)
         if not referenced_file:
             return
@@ -433,11 +528,12 @@ def mixinto_metadata(mod_folder):
             "target": str(target or "").strip(),
             "sourceFile": source_file,
             "requires": requirements or [],
+            "conflictsWith": conflicts_with or [],
         })
 
     def visit_target(target, value):
         if isinstance(value, str):
-            record(target, value, [])
+            record(target, value, [], [])
             return
 
         if isinstance(value, list):
@@ -449,8 +545,11 @@ def mixinto_metadata(mod_folder):
             return
 
         requirements = convert_requirements(value.get("requires") or value.get("Requires"))
+        conflicts_with = convert_conflict_references(
+            value.get("conflictsWith") or value.get("ConflictsWith")
+        )
         reference = value.get("mixinto") or value.get("Mixinto")
-        record(target, reference, requirements)
+        record(target, reference, requirements, conflicts_with)
 
     mixintos = definition.get("mixintos") or definition.get("Mixintos") or {}
     if isinstance(mixintos, dict):
@@ -2226,7 +2325,8 @@ def _emit_track_group_coverage_warning(declared_initial_groups: set[str]) -> Non
 
 def convert_mod(mod_folder, out_folder):
     mod_id, mod_name, version, author = meta(mod_folder)
-    load_after = legacy_load_after(mod_folder)
+    required, load_after = legacy_dependencies(mod_folder)
+    conflicts_with = legacy_conflicts_with(mod_folder)
     mixinto_sources, mixinto_order = mixinto_metadata(mod_folder)
     mixinto_order_index = {name: index for index, name in enumerate(mixinto_order)}
     source_files = sorted(
@@ -2302,7 +2402,10 @@ def convert_mod(mod_folder, out_folder):
         "Version": version,
         "ManagerVersion": "0.27.10",
         "Requirements": ["FUSE"],
-        "LoadAfter": ["FUSE"] + load_after,
+        "LoadAfter": ["FUSE"],
+        "FuseRequires": required,
+        "FuseLoadAfter": load_after,
+        "FuseConflictsWith": conflicts_with,
         "FuseDataFiles": rail_data_files,
     }
     save_json(out_folder / "Info.json", info)

--- a/tools/fuse_converter.py
+++ b/tools/fuse_converter.py
@@ -34,7 +34,7 @@ import convert_fuse_audio  # noqa: E402
 import legacy_json  # noqa: E402
 
 
-TOOL_VERSION = "0.2.0"
+TOOL_VERSION = "0.2.1"
 DEFAULT_STEAM_MODS = Path(r"C:\Steam\steamapps\common\Railroader\Mods")
 DEFAULT_MANAGER_VERSION = "0.27.10"
 JSON_MANIFEST_NAMES = {"definition.json", "info.json"}
@@ -541,6 +541,24 @@ def has_direct_asset_pack_sources(source: Path) -> bool:
     return has_direct_asset_pack_children(source)
 
 
+def has_direct_native_fuse_data(source: Path) -> bool:
+    if not source.is_dir():
+        return False
+    try:
+        return any(path.is_file() and path.name.lower().endswith(".fuse.json") for path in source.iterdir())
+    except OSError:
+        return False
+
+
+def has_direct_compiled_plugin(source: Path) -> bool:
+    if not source.is_dir():
+        return False
+    try:
+        return any(path.is_file() and path.suffix.lower() == ".dll" for path in source.iterdir())
+    except OSError:
+        return False
+
+
 def detect_direct_kind(source: Path, requested: str) -> str:
     if source.is_file():
         if source.suffix.lower() == ".zip":
@@ -562,17 +580,21 @@ def detect_direct_kind(source: Path, requested: str) -> str:
     direct_assets = has_direct_asset_pack_sources(source)
     direct_json = has_direct_convertible_json(source)
 
+    if has_direct_native_fuse_data(source):
+        return "native"
+
     if requested == "route":
         return "route" if direct_route or direct_tiles or direct_json else "unknown"
     if requested == "audio":
         return "audio" if direct_audio or direct_json else "unknown"
-    if requested == "asset":
-        return "asset" if direct_assets else "unknown"
-
     if direct_audio and not direct_route:
         return "audio"
-    if direct_route or direct_tiles:
+    if direct_route:
         return "route"
+    if has_direct_compiled_plugin(source):
+        return "code"
+    if direct_tiles:
+        return "map_tile"
     if direct_assets:
         return "asset"
     return "unknown"
@@ -597,12 +619,23 @@ def detect_kind(source: Path, requested: str) -> str:
     if requested != "auto":
         return requested
 
+    if source.is_dir() and has_direct_native_fuse_data(source):
+        return "native"
+    if (
+        source.is_dir()
+        and has_direct_compiled_plugin(source)
+        and not detects_direct_route_data(source)
+        and not detects_direct_audio(source)
+    ):
+        return "code"
     if detects_audio(source) and not detects_route_data(source):
         return "audio"
     if detects_route_data(source):
         return "route"
+    if source.is_dir() and has_direct_compiled_plugin(source):
+        return "code"
     if find_map_tile_sources(source):
-        return "route"
+        return "map_tile"
     if find_asset_pack_sources(source):
         return "asset"
     if is_json_file(source):
@@ -647,7 +680,8 @@ def update_info_json(output: Path, update: dict[str, Any]) -> None:
 
 def write_reports(report: ConversionReport) -> None:
     report.finish()
-    write_json(report.output / "conversion-report.json", report.to_dict())
+    report_folder = report_output_folder(report)
+    write_json(report_folder / "conversion-report.json", report.to_dict())
 
     lines = [
         f"# FUSE Conversion Report - {report.output.name}",
@@ -696,7 +730,13 @@ def write_reports(report: ConversionReport) -> None:
         )
     if not report.entries:
         lines.append("| OK |  |  | No warnings or errors. |")
-    write_text(report.output / "conversion-report.md", "\n".join(lines) + "\n")
+    write_text(report_folder / "conversion-report.md", "\n".join(lines) + "\n")
+
+
+def report_output_folder(report: ConversionReport) -> Path:
+    if report.status != "failed":
+        return report.output
+    return report.output.parent / "_conversion-reports" / report.output.name
 
 
 def write_batch_reports(source_root: Path, out_root: Path, reports: list[ConversionReport]) -> None:
@@ -717,8 +757,9 @@ def write_batch_reports(source_root: Path, out_root: Path, reports: list[Convers
 
         report_name = slug(report.package_id or report.output.name or f"report-{index}", f"report-{index}")
         report_stem = f"{index:03d}-{report_name}"
-        json_source = report.output / "conversion-report.json"
-        md_source = report.output / "conversion-report.md"
+        source_report_folder = report_output_folder(report)
+        json_source = source_report_folder / "conversion-report.json"
+        md_source = source_report_folder / "conversion-report.md"
         json_dest = audit_dir / f"{report_stem}.json"
         md_dest = audit_dir / f"{report_stem}.md"
         if json_source.exists():
@@ -1199,7 +1240,6 @@ def convert_input(input_path: Path, out_root: Path, kind: str, clean_output: boo
         output = out_root / output_name_for(original)
         report = ConversionReport(original, output, "unknown", status="failed")
         report.add("ERROR", "Input path does not exist.", original)
-        output.mkdir(parents=True, exist_ok=True)
         write_reports(report)
         return report
 
@@ -1225,13 +1265,38 @@ def convert_input(input_path: Path, out_root: Path, kind: str, clean_output: boo
             elif detected == "audio":
                 convert_audio(working_source, output, clean_output, report)
             elif detected == "asset":
-                convert_asset(working_source, output, clean_output, report)
+                report.add(
+                    "ERROR",
+                    "Asset-pack-only package detected. FUSE loads supported asset packs directly; install this package with the FUSE installer instead of converting it.",
+                    working_source,
+                    "unsupported-asset-package",
+                )
+            elif detected == "map_tile":
+                report.add(
+                    "ERROR",
+                    "Legacy map-tile package detected. FUSE's Alina compatibility loads supported tile data directly; install this package with the FUSE installer instead of converting it.",
+                    working_source,
+                    "unsupported-map-tile-package",
+                )
+            elif detected == "native":
+                report.add(
+                    "ERROR",
+                    "This package already contains FUSE-native data. No conversion is needed; install the original package with the FUSE installer.",
+                    working_source,
+                    "unsupported-already-native",
+                )
+            elif detected == "code":
+                report.add(
+                    "ERROR",
+                    "Compiled code mod detected. The converter only translates RailLoader JSON data and cannot reproduce DLL behavior; install a compatible code mod directly or ask its author for a FUSE-native version.",
+                    working_source,
+                    "unsupported-code-package",
+                )
             else:
-                raise RuntimeError("could not detect package type; use --kind route, --kind audio, or --kind asset")
+                raise RuntimeError("no convertible RailLoader JSON data detected; use the FUSE installer for code, asset, map-tile, or native packages")
 
             scan_legacy_warnings(working_source, report)
         except Exception as exc:
-            output.mkdir(parents=True, exist_ok=True)
             report.add("ERROR", str(exc), working_source, detected)
 
         write_reports(report)
@@ -1347,14 +1412,14 @@ def print_summary(report: ConversionReport) -> None:
         print(f"  counts: {counts}")
     if report.warnings or report.errors:
         print(f"  warnings={report.warnings} errors={report.errors}")
-    print(f"  report: {report.output / 'conversion-report.md'}")
+    print(f"  report: {report_output_folder(report) / 'conversion-report.md'}")
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Convert legacy Railroader mods to FUSE packages.")
     parser.add_argument("inputs", nargs="+", help="Legacy folder, zip file, or JSON file. Drag-and-drop works on Windows.")
     parser.add_argument("--out", default=None, help="Output root. Default is Railroader Mods if found, or FUSEConverted for --batch.")
-    parser.add_argument("--kind", choices=("auto", "route", "audio", "asset"), default="auto", help="Force a package type.")
+    parser.add_argument("--kind", choices=("auto", "route", "audio"), default="auto", help="Force a JSON package type.")
     parser.add_argument("--clean", action="store_true", help="Replace existing .FUSE output folders under the output root.")
     parser.add_argument("--batch", action="store_true", help="Treat each input folder as a container and recursively convert every recognized child mod, zip, or JSON in it.")
     args = parser.parse_args()

--- a/tools/fuse_installer.py
+++ b/tools/fuse_installer.py
@@ -9,6 +9,8 @@ executes package code.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
 import os
 import re
@@ -28,9 +30,39 @@ if str(SCRIPT_DIR) not in sys.path:
 import legacy_json  # noqa: E402
 
 
-TOOL_VERSION = "0.2.0"
+TOOL_VERSION = "0.7.0"
 BUNDLED_FUSE_NAME = "bundled_fuse.zip"
 MANIFEST_NAMES = {"info.json", "definition.json"}
+LEGACY_MANAGED_FILES = (
+    "Railloader.dll",
+    "Railloader.Injector.dll",
+    "Railloader.Interchange.dll",
+    "StrangeCustoms.dll",
+)
+ASSETLOADER_ID = "AssetLoader"
+ASSETLOADER_DLL = "AssetLoader.dll"
+ASSETLOADER_COMPATIBILITY_MARKER = "FUSE.AssetLoaderCompatibility"
+ASSETLOADER_COMPATIBILITY_MANIFEST = {
+    "Id": ASSETLOADER_ID,
+    "DisplayName": "AssetLoader Compatibility (provided by FUSE)",
+    "Author": "FUSE",
+    "Version": "1.0.1",
+    "ManagerVersion": "0.27.10",
+    "Requirements": ["FUSE"],
+    "LoadAfter": ["FUSE"],
+    "ContentType": "Compatibility",
+    "FuseProvidedCompatibility": ASSETLOADER_COMPATIBILITY_MARKER,
+}
+# UMM reflects a code mod's assembly before calling its entry point. If that
+# assembly references a loader contract FUSE replaces, FUSE must already be
+# loaded so its AssemblyResolve bridge can provide the compatibility types.
+# Detect the actual metadata reference in the DLL instead of maintaining a
+# brittle list of third-party package names.
+FUSE_LEGACY_STARTUP_ASSEMBLY_REFERENCES = (
+    b"Railloader.Interchange",
+    b"Railloader.Injector",
+    b"StrangeCustoms",
+)
 LEGACY_DATA_KEYS = {
     "tracks",
     "loads",
@@ -57,6 +89,26 @@ WINDOWS_RESERVED_NAMES = {
     *(f"lpt{index}" for index in range(1, 10)),
 }
 
+# Keep this explicit and narrow, matching FuseReplacementCapabilityCatalog.
+# These are compatibility contracts FUSE actually provides; unrelated Zamu/Joo
+# package ids must still be installed normally.
+FUSE_REPLACEMENT_IDS = {
+    "fuse", "railroader", "railloader", "rail-loader",
+    "railloader.injector", "railloader.interchange", "assetloader",
+    "alinanova21.alinasmapmod", "alinasmapmod", "alinamapmod",
+    "alinanova21.mapeditor", "mapeditor", "mmapeditor",
+    "zamu.confusingsupplements", "zamu.foryourconvenience",
+    "zamu.strangecustoms", "strangecustoms", "confusingsupplements",
+    "foryourconvenience",
+}
+
+
+@dataclass(frozen=True)
+class PackageRequirement:
+    package_id: str
+    not_before: str = ""
+    not_after: str = ""
+
 
 @dataclass
 class ZipPackage:
@@ -70,6 +122,8 @@ class ZipPackage:
     manifest_member: str
     member_count: int
     notes: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    requirements: list[PackageRequirement] = field(default_factory=list)
 
     @property
     def root_label(self) -> str:
@@ -83,6 +137,32 @@ class InstallResult:
     destination: Path
     message: str = ""
     backup: Path | None = None
+
+
+@dataclass
+class CompatibilityAction:
+    component: str
+    status: str
+    message: str
+    source: Path | None = None
+    destination: Path | None = None
+
+
+def package_id_aliases(package_id: str) -> tuple[str, ...]:
+    normalized = (package_id or "").strip().lower()
+    if not normalized:
+        return ()
+    aliases = [normalized]
+    if normalized.endswith(".fuse") or normalized.endswith(".rail"):
+        aliases.append(normalized[:-5])
+    return tuple(dict.fromkeys(aliases))
+
+
+def replacement_id_key(package_id: str) -> str:
+    normalized = (package_id or "").strip().lower()
+    while normalized.endswith(".fuse") or normalized.endswith(".rail"):
+        normalized = normalized[:-5]
+    return "railloader" if normalized == "rail-loader" else normalized
 
 
 def normalize_zip_parts(name: str) -> tuple[str, ...] | None:
@@ -136,7 +216,10 @@ def find_member(
     root: tuple[str, ...],
     file_name: str,
 ) -> zipfile.ZipInfo | None:
-    expected = path_key(root + (file_name,))
+    file_parts = normalize_zip_parts(file_name)
+    if file_parts is None:
+        return None
+    expected = path_key(root + file_parts)
     for info, parts in files.items():
         if path_key(parts) == expected:
             return info
@@ -167,6 +250,64 @@ def candidate_roots(files: dict[zipfile.ZipInfo, tuple[str, ...]]) -> list[tuple
     return selected
 
 
+def archive_layout_errors(
+    archive: zipfile.ZipFile,
+    files: dict[zipfile.ZipInfo, tuple[str, ...]],
+) -> list[str]:
+    errors: list[str] = []
+    unsafe_members = [
+        info.filename
+        for info in archive.infolist()
+        if not info.is_dir()
+        and not info.filename.replace("\\", "/").startswith("__MACOSX/")
+        and normalize_zip_parts(info.filename) is None
+    ]
+    if unsafe_members:
+        preview = ", ".join(repr(name) for name in unsafe_members[:5])
+        suffix = f" (+{len(unsafe_members) - 5} more)" if len(unsafe_members) > 5 else ""
+        errors.append(
+            "Archive contains unsafe member path(s) that cannot be installed: "
+            f"{preview}{suffix}. Rebuild the ZIP without absolute paths, '..', drive prefixes, or invalid Windows characters."
+        )
+
+    by_path: dict[tuple[str, ...], list[str]] = {}
+    for info, parts in files.items():
+        by_path.setdefault(path_key(parts), []).append(info.filename)
+    duplicate_paths = [names for names in by_path.values() if len(names) > 1]
+    if duplicate_paths:
+        preview = "; ".join(" / ".join(names) for names in duplicate_paths[:5])
+        suffix = f" (+{len(duplicate_paths) - 5} more)" if len(duplicate_paths) > 5 else ""
+        errors.append(
+            "Archive contains duplicate or case-colliding member path(s): "
+            f"{preview}{suffix}. Keep one file for each destination path."
+        )
+
+    manifest_roots = sorted(
+        {
+            path_key(parts[:-1]): parts[:-1]
+            for parts in files.values()
+            if parts[-1].lower() in MANIFEST_NAMES
+        }.values(),
+        key=lambda item: (len(item), path_key(item)),
+    )
+    nested_pairs: list[tuple[tuple[str, ...], tuple[str, ...]]] = []
+    for index, parent in enumerate(manifest_roots):
+        for child in manifest_roots[index + 1:]:
+            if len(child) > len(parent) and starts_with(path_key(child), path_key(parent)):
+                nested_pairs.append((parent, child))
+    if nested_pairs:
+        preview = "; ".join(
+            f"{'/'.join(parent) or '.'} contains {'/'.join(child)}"
+            for parent, child in nested_pairs[:5]
+        )
+        suffix = f" (+{len(nested_pairs) - 5} more)" if len(nested_pairs) > 5 else ""
+        errors.append(
+            "Archive layout is ambiguous because one package manifest contains another package manifest: "
+            f"{preview}{suffix}. Put sibling packages under separate folders such as Mods/PackageA and Mods/PackageB."
+        )
+    return errors
+
+
 def read_zip_text(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> str:
     if info.file_size > MAX_JSON_BYTES:
         raise ValueError(f"JSON file is too large to inspect safely: {info.filename}")
@@ -178,7 +319,17 @@ def read_zip_text(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> str:
 
 
 def read_zip_json(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> Any:
-    return legacy_json.loads(read_zip_text(archive, info))
+    # Comments and trailing commas remain tolerated for old RailLoader files,
+    # but the installer must not silently invent missing closing braces. A mod
+    # author needs the real file/line failure before the package reaches game.
+    return legacy_json.loads(read_zip_text(archive, info), repair=False)
+
+
+def describe_json_error(member_name: str, exc: Exception) -> str:
+    line = getattr(exc, "lineno", 0)
+    column = getattr(exc, "colno", 0)
+    location = f" line {line}, column {column}" if line else ""
+    return f"{member_name}{location}: {exc}"
 
 
 def string_field(data: dict[str, Any] | None, *names: str) -> str:
@@ -235,6 +386,62 @@ def looks_like_legacy_data(archive: zipfile.ZipFile, files: dict[zipfile.ZipInfo
     return False
 
 
+def is_railloader_manifest(data: dict[str, Any]) -> bool:
+    """Recognize both data-only and code-only RailLoader packages.
+
+    Code-only packages commonly contain only Definition.json, an ``assemblies``
+    list, and DLLs. Requiring a data JSON file made the installer reject exactly
+    the hosted compatibility packages FUSE is intended to run.
+    """
+    if not isinstance(data, dict):
+        return False
+    package_id = string_field(data, "id", "Id")
+    if not package_id:
+        return False
+    return any(
+        key in data
+        for key in (
+            "manifestVersion",
+            "ManifestVersion",
+            "assemblies",
+            "Assemblies",
+            "mixintos",
+            "Mixintos",
+            "requires",
+            "Requires",
+        )
+    )
+
+
+def parse_requirements(*values: Any) -> list[PackageRequirement]:
+    result: list[PackageRequirement] = []
+    seen: set[tuple[str, str, str]] = set()
+    for value in values:
+        entries = value if isinstance(value, list) else [value] if value else []
+        for entry in entries:
+            if isinstance(entry, str):
+                requirement = PackageRequirement(entry.strip())
+            elif isinstance(entry, dict):
+                requirement = PackageRequirement(
+                    string_field(entry, "Id", "id"),
+                    string_field(entry, "NotBefore", "notBefore", "MinimumVersion", "minimumVersion"),
+                    string_field(entry, "NotAfter", "notAfter", "MaximumVersion", "maximumVersion"),
+                )
+            else:
+                continue
+            if not requirement.package_id:
+                continue
+            key = (
+                requirement.package_id.lower(),
+                requirement.not_before,
+                requirement.not_after,
+            )
+            if key not in seen:
+                seen.add(key)
+                result.append(requirement)
+    return result
+
+
 def ensure_fuse_id(value: str) -> str:
     text = (value or "").strip() or "LegacyDataPackage"
     return text if text.lower().endswith(".fuse") else f"{text}.FUSE"
@@ -262,6 +469,7 @@ def package_from_root(
     info_data: dict[str, Any] = {}
     definition_data: dict[str, Any] = {}
     notes: list[str] = []
+    errors: list[str] = []
 
     if info_member is not None:
         try:
@@ -271,7 +479,7 @@ def package_from_root(
             else:
                 notes.append("Info.json was not an object.")
         except Exception as exc:
-            notes.append(f"Info.json could not be parsed: {exc}")
+            errors.append("Info.json could not be parsed: " + describe_json_error(info_member.filename, exc))
 
     if definition_member is not None:
         try:
@@ -281,7 +489,7 @@ def package_from_root(
             else:
                 notes.append("Definition.json was not an object.")
         except Exception as exc:
-            notes.append(f"Definition.json could not be parsed: {exc}")
+            errors.append("Definition.json could not be parsed: " + describe_json_error(definition_member.filename, exc))
 
     source_folder = root[-1] if root and root[-1].lower() != "mods" else zip_path.stem
     member_count = sum(1 for parts in files.values() if starts_with(parts, root))
@@ -290,7 +498,11 @@ def package_from_root(
         package_id = string_field(info_data, "Id", "id") or safe_folder_name(source_folder)
         display_name = string_field(info_data, "DisplayName", "Name", "name") or package_id
         version = string_field(info_data, "Version", "version")
-        kind = "fuse-data" if has_fuse_data_marker(info_data) else "umm"
+        kind = "invalid" if errors else ("fuse-data" if has_fuse_data_marker(info_data) else "umm")
+        if not errors and kind == "fuse-data":
+            errors.extend(validate_fuse_data_members(archive, files, root, info_data))
+            if errors:
+                kind = "invalid"
         install_name = safe_folder_name(package_id, safe_folder_name(source_folder))
         return ZipPackage(
             zip_path=zip_path,
@@ -303,27 +515,124 @@ def package_from_root(
             manifest_member=info_member.filename,
             member_count=member_count,
             notes=notes,
+            errors=errors,
+            requirements=parse_requirements(
+                info_data.get("Requirements"),
+                info_data.get("requirements"),
+                info_data.get("FuseRequires"),
+            ),
         )
 
-    if definition_member is not None and looks_like_legacy_data(archive, files, root):
+    if definition_member is not None and (
+        errors or
+        is_railloader_manifest(definition_data) or
+        looks_like_legacy_data(archive, files, root)
+    ):
         legacy_id = string_field(definition_data, "id", "Id") or safe_folder_name(source_folder)
-        package_id = ensure_fuse_id(legacy_id)
         display_name = string_field(definition_data, "name", "DisplayName", "Name") or legacy_id
         version = string_field(definition_data, "version", "Version")
+        has_legacy_data = looks_like_legacy_data(archive, files, root)
+        if has_legacy_data:
+            notes.append("RailLoader data will be converted in memory and applied by FUSE.")
+        if definition_data.get("assemblies") or definition_data.get("Assemblies"):
+            notes.append("RailLoader plugin assemblies will be hosted by FUSE compatibility.")
+        if not errors:
+            errors.extend(validate_railloader_data_members(archive, files, root))
         return ZipPackage(
             zip_path=zip_path,
             root=root,
-            kind="legacy-data",
-            package_id=package_id,
+            kind="invalid" if errors else "railloader",
+            package_id=legacy_id,
             display_name=display_name,
             version=version,
-            install_name=safe_folder_name(package_id, safe_folder_name(source_folder)),
+            install_name=safe_folder_name(legacy_id, safe_folder_name(source_folder)),
             manifest_member=definition_member.filename,
             member_count=member_count,
             notes=notes,
+            errors=errors,
+            requirements=parse_requirements(
+                definition_data.get("requires"),
+                definition_data.get("Requires"),
+            ),
         )
 
     return None
+
+
+def data_file_names(info: dict[str, Any]) -> tuple[list[str], list[str]]:
+    value = info.get("FuseDataFiles", info.get("FuseDataFile"))
+    if value is None:
+        return [], []
+    values = [value] if isinstance(value, str) else value if isinstance(value, list) else []
+    errors: list[str] = []
+    if not values:
+        errors.append("Info.json FuseDataFile/FuseDataFiles must be a file name or a non-empty list of file names.")
+        return [], errors
+    names: list[str] = []
+    for index, item in enumerate(values):
+        if not isinstance(item, str) or not item.strip():
+            errors.append(f"Info.json FuseDataFiles[{index}] must be a non-empty string.")
+            continue
+        parts = normalize_zip_parts(item.strip())
+        if parts is None:
+            errors.append(f"Info.json FuseDataFiles[{index}] contains an unsafe path: {item!r}.")
+            continue
+        names.append("/".join(parts))
+    return names, errors
+
+
+def validate_json_member(archive: zipfile.ZipFile, member: zipfile.ZipInfo) -> list[str]:
+    try:
+        value = read_zip_json(archive, member)
+    except Exception as exc:
+        return ["JSON could not be parsed: " + describe_json_error(member.filename, exc)]
+    if not isinstance(value, dict):
+        return [f"{member.filename}: FUSE/RailLoader data JSON must contain an object at the root."]
+    return []
+
+
+def validate_fuse_data_members(
+    archive: zipfile.ZipFile,
+    files: dict[zipfile.ZipInfo, tuple[str, ...]],
+    root: tuple[str, ...],
+    info: dict[str, Any],
+) -> list[str]:
+    names, errors = data_file_names(info)
+    members: list[zipfile.ZipInfo] = []
+    if names:
+        for name in names:
+            member = find_member(files, root, name)
+            if member is None:
+                errors.append(f"Info.json declares missing FuseDataFile '{name}' in package root '{'/'.join(root) or '.'}'.")
+            else:
+                members.append(member)
+    else:
+        members.extend(
+            member
+            for member, parts in files.items()
+            if starts_with(parts, root)
+            and len(parts) == len(root) + 1
+            and parts[-1].lower().endswith(".fuse.json")
+        )
+    for member in dict.fromkeys(members):
+        errors.extend(validate_json_member(archive, member))
+    return errors
+
+
+def validate_railloader_data_members(
+    archive: zipfile.ZipFile,
+    files: dict[zipfile.ZipInfo, tuple[str, ...]],
+    root: tuple[str, ...],
+) -> list[str]:
+    errors: list[str] = []
+    for member, parts in files.items():
+        if not starts_with(parts, root) or len(parts) != len(root) + 1:
+            continue
+        name = parts[-1].lower()
+        if not name.endswith(".json") or name in MANIFEST_NAMES or name.endswith("report.json"):
+            continue
+        errors.extend(validate_json_member(archive, member))
+    return errors
 
 
 def inspect_zip(zip_path: Path) -> tuple[list[ZipPackage], list[str]]:
@@ -332,6 +641,7 @@ def inspect_zip(zip_path: Path) -> tuple[list[ZipPackage], list[str]]:
     try:
         with zipfile.ZipFile(zip_path, "r") as archive:
             files = zip_file_parts(archive)
+            layout_errors = archive_layout_errors(archive, files)
             roots = candidate_roots(files)
             for root in roots:
                 package = package_from_root(zip_path, archive, files, root)
@@ -339,7 +649,12 @@ def inspect_zip(zip_path: Path) -> tuple[list[ZipPackage], list[str]]:
                     label = "/".join(root) if root else "."
                     warnings.append(f"{zip_path.name}: unsupported package root '{label}'.")
                     continue
+                package.errors.extend(layout_errors)
+                if layout_errors:
+                    package.kind = "invalid"
                 packages.append(package)
+            if layout_errors and not packages:
+                warnings.extend(f"{zip_path.name}: {error}" for error in layout_errors)
     except zipfile.BadZipFile as exc:
         warnings.append(f"{zip_path.name}: not a readable zip file: {exc}")
     except OSError as exc:
@@ -387,6 +702,8 @@ def unique_path(path: Path) -> Path:
 
 
 def install_package(package: ZipPackage, mods_dir: Path, replace: bool, dry_run: bool) -> InstallResult:
+    if package.errors:
+        raise ValueError("; ".join(package.errors))
     destination = mods_dir / package.install_name
     backup: Path | None = None
 
@@ -434,13 +751,623 @@ def install_package(package: ZipPackage, mods_dir: Path, replace: bool, dry_run:
             backup = None
         raise
 
-    return InstallResult(package, "installed", destination, "", backup)
+    status = "updated" if backup is not None else "installed"
+    return InstallResult(package, status, destination, "", backup)
+
+
+def validate_game_dir(game_dir: Path) -> list[str]:
+    errors: list[str] = []
+    if not (game_dir / "Railroader.exe").is_file():
+        errors.append(f"Railroader.exe was not found in {game_dir}")
+
+    managed = game_dir / "Railroader_Data" / "Managed"
+    if not managed.is_dir():
+        errors.append(f"Railroader_Data\\Managed was not found in {game_dir}")
+    return errors
+
+
+def unity_mod_manager_installed(game_dir: Path) -> bool:
+    managed = game_dir / "Railroader_Data" / "Managed"
+    candidates = (
+        managed / "UnityModManager" / "UnityModManager.dll",
+        managed / "UnityModManager" / "UnityModManagerNet.dll",
+        managed / "UnityModManager.dll",
+        managed / "UnityModManagerNet.dll",
+    )
+    return any(candidate.is_file() for candidate in candidates)
+
+
+def find_legacy_managed_files(game_dir: Path) -> list[Path]:
+    managed = game_dir / "Railroader_Data" / "Managed"
+    if not managed.is_dir():
+        return []
+    by_name = {item.name.lower(): item for item in managed.iterdir() if item.is_file()}
+    return [
+        by_name[name.lower()]
+        for name in LEGACY_MANAGED_FILES
+        if name.lower() in by_name
+    ]
+
+
+def backup_legacy_managed_files(files: Iterable[Path], mods_dir: Path, dry_run: bool) -> list[tuple[Path, Path]]:
+    existing = [Path(path).resolve() for path in files if Path(path).is_file()]
+    if not existing:
+        return []
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_root = mods_dir / "ModBackups" / "FUSEInstaller" / f"LegacyLoader-{timestamp}" / "Managed"
+    moved: list[tuple[Path, Path]] = []
+    for source in existing:
+        destination = unique_path(backup_root / source.name)
+        moved.append((source, destination))
+        if dry_run:
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(source), str(destination))
+    return moved
+
+
+def read_loose_info_json(folder: Path) -> dict[str, Any] | None:
+    """Read a UMM manifest for install-state checks without executing code."""
+    for name in ("Info.json", "info.json"):
+        path = folder / name
+        if not path.is_file():
+            continue
+        try:
+            value = legacy_json.loads(path.read_text(encoding="utf-8-sig"), repair=False)
+            return value if isinstance(value, dict) else None
+        except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+            return None
+    return None
+
+
+def find_loose_info_path(folder: Path) -> Path | None:
+    """Return the existing UMM manifest path without changing its casing."""
+    for name in ("Info.json", "info.json"):
+        path = folder / name
+        if path.is_file():
+            return path
+    return None
+
+
+def manifest_contains_dependency(value: Any, package_id: str) -> bool:
+    expected = (package_id or "").strip().lower()
+    if not expected:
+        return False
+    if isinstance(value, str):
+        return value.strip().lower() == expected
+    if isinstance(value, dict):
+        actual = value.get("Id", value.get("id", ""))
+        return str(actual or "").strip().lower() == expected
+    if isinstance(value, list):
+        return any(manifest_contains_dependency(item, package_id) for item in value)
+    return False
+
+
+def append_manifest_dependency(manifest: dict[str, Any], field_name: str, package_id: str) -> bool:
+    current = manifest.get(field_name)
+    if manifest_contains_dependency(current, package_id):
+        return False
+    if current is None:
+        manifest[field_name] = [package_id]
+    elif isinstance(current, list):
+        current.append(package_id)
+    else:
+        manifest[field_name] = [current, package_id]
+    return True
+
+
+def references_fuse_replaced_startup_assembly(assembly_path: Path) -> bool:
+    """Inspect CLR metadata strings without importing or executing the DLL."""
+    try:
+        data = assembly_path.read_bytes()
+    except OSError:
+        return False
+    return any(reference in data for reference in FUSE_LEGACY_STARTUP_ASSEMBLY_REFERENCES)
+
+
+def find_legacy_umm_startup_dependency_manifests(mods_dir: Path) -> list[tuple[Path, Path, dict[str, Any]]]:
+    """Find code mods that need FUSE loaded before UMM reflects their DLL."""
+    if not mods_dir.is_dir():
+        return []
+
+    candidates: list[tuple[Path, Path, dict[str, Any]]] = []
+    for folder in sorted(mods_dir.iterdir(), key=lambda item: item.name.lower()):
+        if not folder.is_dir() or folder.name.lower() in {"fuse", "fuseinstaller", "modbackups"}:
+            continue
+        info_path = find_loose_info_path(folder)
+        manifest = read_loose_info_json(folder)
+        if info_path is None or manifest is None:
+            continue
+        if str(manifest.get("Id", manifest.get("id", ""))).strip().lower() == "fuse":
+            continue
+        assembly_name = str(manifest.get("AssemblyName", manifest.get("assemblyName", "")) or "").strip()
+        if not assembly_name:
+            continue
+        assembly_path = folder / assembly_name
+        if not assembly_path.is_file() or not references_fuse_replaced_startup_assembly(assembly_path):
+            continue
+        if (
+            manifest_contains_dependency(manifest.get("Requirements"), "FUSE")
+            and manifest_contains_dependency(manifest.get("LoadAfter"), "FUSE")
+        ):
+            continue
+        candidates.append((folder, info_path, manifest))
+    return candidates
+
+
+def repair_legacy_umm_startup_dependencies(mods_dir: Path, dry_run: bool) -> list[CompatibilityAction]:
+    """Make legacy code mods load after FUSE, with recoverable manifest backups."""
+    candidates = find_legacy_umm_startup_dependency_manifests(mods_dir)
+    if not candidates:
+        return []
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_root = mods_dir / "ModBackups" / "FUSEInstaller" / f"CompatibilityManifests-{timestamp}"
+    actions: list[CompatibilityAction] = []
+    for folder, info_path, manifest in candidates:
+        package_id = str(manifest.get("Id", manifest.get("id", folder.name)) or folder.name)
+        backup_path = unique_path(backup_root / folder.name / info_path.name)
+        try:
+            append_manifest_dependency(manifest, "Requirements", "FUSE")
+            append_manifest_dependency(manifest, "LoadAfter", "FUSE")
+            if not dry_run:
+                backup_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(info_path, backup_path)
+                temporary_path = info_path.with_name(info_path.name + ".fuse-installer-new")
+                temporary_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+                os.replace(temporary_path, info_path)
+            actions.append(CompatibilityAction(
+                component=package_id,
+                status="planned" if dry_run else "updated",
+                message=(
+                    "Would add FUSE to UMM Requirements/LoadAfter so FUSE's legacy API bridge is active "
+                    "before this assembly is reflected."
+                    if dry_run else
+                    "Added FUSE to UMM Requirements/LoadAfter so FUSE's legacy API bridge is active "
+                    "before this assembly is reflected; the original manifest was backed up."
+                ),
+                source=info_path,
+                destination=backup_path,
+            ))
+        except Exception as exc:
+            actions.append(CompatibilityAction(
+                component=package_id,
+                status="failed",
+                message=f"Could not repair legacy UMM startup order: {exc}",
+                source=info_path,
+                destination=backup_path,
+            ))
+    return actions
+
+
+def folder_contains_file_named(folder: Path, filename: str) -> bool:
+    if not folder.is_dir():
+        return False
+    expected = filename.lower()
+    try:
+        return any(item.is_file() and item.name.lower() == expected for item in folder.iterdir())
+    except OSError:
+        return False
+
+
+def is_fuse_assetloader_compatibility(folder: Path) -> bool:
+    info = read_loose_info_json(folder)
+    if not info:
+        return False
+    marker = info.get("FuseProvidedCompatibility")
+    package_id = info.get("Id", info.get("id"))
+    return (
+        str(package_id or "").lower() == ASSETLOADER_ID.lower()
+        and marker == ASSETLOADER_COMPATIBILITY_MARKER
+        and not folder_contains_file_named(folder, ASSETLOADER_DLL)
+    )
+
+
+def find_fuse_assetloader_compatibility(mods_dir: Path) -> Path | None:
+    if not mods_dir.is_dir():
+        return None
+    for child in sorted(mods_dir.iterdir(), key=lambda item: item.name.lower()):
+        if child.is_dir() and is_fuse_assetloader_compatibility(child):
+            return child
+    return None
+
+
+def find_installed_mod_by_id(mods_dir: Path, package_id: str) -> Path | None:
+    if not mods_dir.is_dir() or not package_id:
+        return None
+    for child in sorted(mods_dir.iterdir(), key=lambda item: item.name.lower()):
+        if not child.is_dir():
+            continue
+        info = read_loose_info_json(child)
+        installed_id = str((info or {}).get("Id", (info or {}).get("id", "")))
+        if installed_id.lower() == package_id.lower():
+            return child
+    return None
+
+
+def read_installed_package_versions(mods_dir: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not mods_dir.is_dir():
+        return result
+    for child in sorted(mods_dir.iterdir(), key=lambda item: item.name.lower()):
+        if not child.is_dir():
+            continue
+        manifest = read_loose_info_json(child)
+        if manifest is None:
+            definition = child / "Definition.json"
+            if definition.is_file():
+                try:
+                    value = legacy_json.loads(
+                        definition.read_text(encoding="utf-8-sig"),
+                        repair=False,
+                    )
+                    manifest = value if isinstance(value, dict) else None
+                except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+                    manifest = None
+        package_id = string_field(manifest, "Id", "id")
+        if package_id:
+            version = string_field(manifest, "Version", "version")
+            for alias in package_id_aliases(package_id):
+                result.setdefault(alias, version)
+        result.setdefault(child.name.lower(), string_field(manifest, "Version", "version"))
+    return result
+
+
+def version_numbers(value: str) -> tuple[int, ...] | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    matches = re.findall(r"\d+", text)
+    return tuple(int(item) for item in matches) if matches else None
+
+
+def compare_versions(left: str, right: str) -> int | None:
+    first = version_numbers(left)
+    second = version_numbers(right)
+    if first is None or second is None:
+        return None
+    width = max(len(first), len(second))
+    first += (0,) * (width - len(first))
+    second += (0,) * (width - len(second))
+    return (first > second) - (first < second)
+
+
+def validate_batch_dependencies(
+    packages: Iterable[ZipPackage],
+    mods_dir: Path,
+    fuse_available: bool,
+) -> None:
+    package_list = list(packages)
+    by_id: dict[str, list[ZipPackage]] = {}
+    for package in package_list:
+        for alias in package_id_aliases(package.package_id):
+            by_id.setdefault(alias, []).append(package)
+    duplicate_groups: dict[str, list[ZipPackage]] = {}
+    for package in package_list:
+        aliases = package_id_aliases(package.package_id)
+        duplicate_key = aliases[-1] if aliases else package.package_id.lower()
+        duplicate_groups.setdefault(duplicate_key, []).append(package)
+    for package_id, duplicates in duplicate_groups.items():
+        if len(duplicates) <= 1:
+            continue
+        sources = ", ".join(
+            f"{item.zip_path.name}:{item.root_label}" for item in duplicates
+        )
+        for package in duplicates:
+            package.errors.append(
+                f"Duplicate package id '{package.package_id}' appears more than once in this batch ({sources}). "
+                "Remove the duplicate archive/root so installation order cannot overwrite it."
+            )
+
+    installed = read_installed_package_versions(mods_dir)
+    installed_fuse_available = fuse_available or "fuse" in installed
+
+    # Repeat until stable so a package whose own preflight failed cannot satisfy
+    # another package merely because both happened to be present in the batch.
+    # Existing installed providers remain valid fallbacks when an update ZIP is
+    # bad, and forward references within a healthy batch are supported.
+    changed = True
+    while changed:
+        changed = False
+        fuse_provider_available = installed_fuse_available or any(
+            "fuse" in package_id_aliases(candidate.package_id)
+            and not candidate.errors
+            for candidate in package_list
+        )
+        for package in package_list:
+            if package.errors:
+                continue
+            for requirement in package.requirements:
+                required_id = requirement.package_id.lower()
+                replacement_id = replacement_id_key(requirement.package_id)
+                if fuse_provider_available and replacement_id in FUSE_REPLACEMENT_IDS:
+                    continue
+
+                provider_versions: list[str] = []
+                if required_id in installed:
+                    provider_versions.append(installed[required_id])
+                provider_versions.extend(
+                    candidate.version
+                    for candidate in by_id.get(required_id, [])
+                    if not candidate.errors
+                    and candidate.package_id.lower() != ASSETLOADER_ID.lower()
+                )
+                if not provider_versions:
+                    bounds = requirement_bounds(requirement)
+                    batch_provider_failed = required_id in by_id
+                    if batch_provider_failed:
+                        message = (
+                            f"Dependency '{requirement.package_id}'{bounds} required by "
+                            f"'{package.package_id}' is in this batch but failed preflight. "
+                            "Fix or remove the failed dependency package, then retry the batch."
+                        )
+                    else:
+                        message = (
+                            f"Missing dependency '{requirement.package_id}'{bounds} required by "
+                            f"'{package.package_id}'. {dependency_install_hint(requirement.package_id)}"
+                        )
+                    package.errors.append(message)
+                    changed = True
+                    break
+
+                if not requirement.not_before and not requirement.not_after:
+                    continue
+                if any(version_numbers(version) is None for version in provider_versions):
+                    note = (
+                        f"Dependency '{requirement.package_id}' is present but has no readable version; "
+                        f"the installer could not verify {requirement_bounds(requirement).strip()}."
+                    )
+                    if note not in package.notes:
+                        package.notes.append(note)
+                    continue
+                if any(
+                    requirement_version_matches(version, requirement)
+                    for version in provider_versions
+                ):
+                    continue
+
+                available_versions = ", ".join(sorted(set(provider_versions)))
+                package.errors.append(
+                    f"Dependency version conflict for '{requirement.package_id}': "
+                    f"'{package.package_id}' requires{requirement_bounds(requirement)}, "
+                    f"but available version(s) are {available_versions}."
+                )
+                changed = True
+                break
+
+
+def requirement_version_matches(version: str, requirement: PackageRequirement) -> bool:
+    if requirement.not_before:
+        comparison = compare_versions(version, requirement.not_before)
+        if comparison is not None and comparison < 0:
+            return False
+    if requirement.not_after:
+        comparison = compare_versions(version, requirement.not_after)
+        if comparison is not None and comparison > 0:
+            return False
+    return True
+
+
+def dependency_install_hint(package_id: str) -> str:
+    if replacement_id_key(package_id) in FUSE_REPLACEMENT_IDS:
+        return (
+            "Install or update FUSE (or include FUSE in this batch); FUSE provides this "
+            "legacy dependency contract, so do not reinstall the replaced legacy DLL."
+        )
+    return "Install/enable that package in Mods, or include it in this batch."
+
+
+def requirement_bounds(requirement: PackageRequirement) -> str:
+    parts = []
+    if requirement.not_before:
+        parts.append("not before " + requirement.not_before)
+    if requirement.not_after:
+        parts.append("not after " + requirement.not_after)
+    return " (" + ", ".join(parts) + ")" if parts else ""
+
+
+def find_legacy_assetloader_paths(mods_dir: Path) -> list[Path]:
+    """Find old AssetLoader runtime files while excluding FUSE's data-only alias."""
+    if not mods_dir.is_dir():
+        return []
+
+    found: list[Path] = []
+    for child in sorted(mods_dir.iterdir(), key=lambda item: item.name.lower()):
+        if child.is_file():
+            lower_name = child.name.lower()
+            if lower_name == "assetloader.zip" or lower_name == "assetloader.dll":
+                found.append(child)
+            continue
+
+        if not child.is_dir() or is_fuse_assetloader_compatibility(child):
+            continue
+
+        info = read_loose_info_json(child)
+        package_id = str((info or {}).get("Id", (info or {}).get("id", "")))
+        has_runtime = folder_contains_file_named(child, ASSETLOADER_DLL)
+        if has_runtime or package_id.lower() == ASSETLOADER_ID.lower():
+            found.append(child)
+
+    return found
+
+
+def backup_legacy_assetloader_paths(
+    paths: Iterable[Path],
+    mods_dir: Path,
+    dry_run: bool,
+) -> list[tuple[Path, Path]]:
+    existing = [Path(path).resolve() for path in paths if Path(path).exists()]
+    if not existing:
+        return []
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_root = mods_dir / "ModBackups" / "FUSEInstaller" / f"AssetLoader-{timestamp}"
+    moved: list[tuple[Path, Path]] = []
+    for source in existing:
+        destination = unique_path(backup_root / source.name)
+        moved.append((source, destination))
+        if dry_run:
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(source), str(destination))
+    return moved
+
+
+def should_repair_assetloader(args: argparse.Namespace, paths: list[Path]) -> bool:
+    if not paths:
+        return True
+    if getattr(args, "repair_asset_loader", False) or getattr(args, "repair_legacy_loader", False):
+        return True
+    if args.dry_run or not sys.stdin.isatty():
+        return False
+
+    print("\nFUSE now replaces the old AssetLoader runtime. These paths remain installed:")
+    for path in paths:
+        print(f"  {path}")
+    print("They will be moved to a dated backup and replaced by a data-only dependency alias.")
+    try:
+        answer = input("Back up and replace old AssetLoader now? [Y/n]: ").strip().lower()
+    except EOFError:
+        return False
+    return answer in {"", "y", "yes"}
+
+
+def install_assetloader_compatibility_alias(mods_dir: Path, dry_run: bool) -> Path:
+    existing = find_fuse_assetloader_compatibility(mods_dir)
+    if existing is not None:
+        destination = existing
+    else:
+        preferred = mods_dir / ASSETLOADER_ID
+        destination = preferred if not preferred.exists() else mods_dir / ASSETLOADER_COMPATIBILITY_MARKER
+
+    if dry_run:
+        return destination
+
+    destination.mkdir(parents=True, exist_ok=True)
+    manifest_path = destination / "Info.json"
+    temporary_path = destination / "Info.json.fuse-installer-new"
+    temporary_path.write_text(
+        json.dumps(ASSETLOADER_COMPATIBILITY_MANIFEST, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary_path, manifest_path)
+    return destination
+
+
+def should_repair_legacy_files(args: argparse.Namespace, files: list[Path]) -> bool:
+    if not files:
+        return False
+    if args.repair_legacy_loader:
+        return True
+    if args.dry_run or not sys.stdin.isatty():
+        return False
+
+    print("\nFUSE cannot safely run while these old managed loader files remain:")
+    for path in files:
+        print(f"  {path}")
+    print("They will be moved to a dated backup, not deleted.")
+    try:
+        answer = input("Back up and remove the old loader files now? [Y/n]: ").strip().lower()
+    except EOFError:
+        return False
+    return answer in {"", "y", "yes"}
 
 
 def default_game_dir() -> Path:
-    if getattr(sys, "frozen", False):
-        return Path(sys.executable).resolve().parent
-    return Path.cwd().resolve()
+    start = Path(sys.executable).resolve().parent if getattr(sys, "frozen", False) else Path.cwd().resolve()
+    # FUSE-Complete keeps utilities under ``Tools``. Let that copy work when
+    # the complete archive itself was extracted into the Railroader folder.
+    for candidate in (start, start.parent):
+        if (candidate / "Railroader.exe").is_file():
+            return candidate
+    discovered = discover_game_dirs()
+    return discovered[0] if discovered else start
+
+
+def parse_steam_library_paths(text: str) -> list[Path]:
+    """Read Steam's old or current libraryfolders.vdf path entries."""
+    paths: list[Path] = []
+    seen: set[str] = set()
+    for match in re.finditer(r'"path"\s+"([^"]+)"', text or "", flags=re.IGNORECASE):
+        value = match.group(1).replace("\\\\", "\\").strip()
+        if not value:
+            continue
+        key = os.path.normcase(os.path.abspath(value))
+        if key in seen:
+            continue
+        seen.add(key)
+        paths.append(Path(value))
+    return paths
+
+
+def steam_roots() -> list[Path]:
+    candidates: list[Path] = []
+    if sys.platform.startswith("win"):
+        try:
+            import winreg
+
+            for hive, key_name, value_name in (
+                (winreg.HKEY_CURRENT_USER, r"Software\Valve\Steam", "SteamPath"),
+                (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\WOW6432Node\Valve\Steam", "InstallPath"),
+                (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Valve\Steam", "InstallPath"),
+            ):
+                try:
+                    with winreg.OpenKey(hive, key_name) as key:
+                        value, _kind = winreg.QueryValueEx(key, value_name)
+                        if value:
+                            candidates.append(Path(str(value)))
+                except OSError:
+                    continue
+        except (ImportError, OSError):
+            pass
+
+    for environment_name in ("ProgramFiles(x86)", "ProgramFiles"):
+        value = os.environ.get(environment_name, "").strip()
+        if value:
+            candidates.append(Path(value) / "Steam")
+    candidates.extend((Path(r"C:\Steam"), Path(r"D:\Steam"), Path(r"D:\SteamLibrary")))
+
+    roots: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.expanduser().resolve()
+        except OSError:
+            continue
+        key = os.path.normcase(str(resolved))
+        if key in seen or not resolved.exists():
+            continue
+        seen.add(key)
+        roots.append(resolved)
+    return roots
+
+
+def discover_game_dirs() -> list[Path]:
+    libraries: list[Path] = []
+    for root in steam_roots():
+        libraries.append(root)
+        vdf = root / "steamapps" / "libraryfolders.vdf"
+        try:
+            if vdf.is_file():
+                libraries.extend(parse_steam_library_paths(vdf.read_text(encoding="utf-8", errors="replace")))
+        except OSError:
+            continue
+
+    games: list[Path] = []
+    seen: set[str] = set()
+    for library in libraries:
+        candidate = library / "steamapps" / "common" / "Railroader"
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        key = os.path.normcase(str(resolved))
+        if key in seen or not (resolved / "Railroader.exe").is_file():
+            continue
+        seen.add(key)
+        games.append(resolved)
+    return games
 
 
 def resolve_bundled_fuse() -> Path | None:
@@ -497,6 +1424,9 @@ def print_package(package: ZipPackage) -> None:
     if package.notes:
         for note in package.notes:
             print(f"    note: {note}")
+    if package.errors:
+        for error in package.errors:
+            print(f"    error: {error}")
 
 
 def print_result(result: InstallResult) -> None:
@@ -511,6 +1441,85 @@ def print_result(result: InstallResult) -> None:
         print(f"  note: {result.message}")
 
 
+def write_install_report(
+    game_dir: Path,
+    mods_dir: Path,
+    targets: list[Path],
+    results: list[InstallResult],
+    scan_failures: int,
+    dry_run: bool,
+    compatibility_actions: list[CompatibilityAction] | None = None,
+) -> Path | None:
+    if dry_run:
+        return None
+    report_root = mods_dir / "FUSEInstaller" / "Reports"
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    report_path = unique_path(report_root / f"install-{timestamp}.json")
+    compatibility_actions = compatibility_actions or []
+    report = {
+        "installerVersion": TOOL_VERSION,
+        "generated": datetime.now().astimezone().isoformat(),
+        "dryRun": dry_run,
+        "gameDirectory": str(game_dir),
+        "modsDirectory": str(mods_dir),
+        "archives": [str(path) for path in targets],
+        "scanFailures": scan_failures,
+        "summary": {
+            "installed": sum(1 for item in results if item.status == "installed"),
+            "updated": sum(1 for item in results if item.status == "updated"),
+            "skipped": sum(1 for item in results if item.status == "skipped"),
+            "failed": (
+                scan_failures
+                + sum(1 for item in results if item.status == "failed")
+                + sum(1 for item in compatibility_actions if item.status == "failed")
+            ),
+        },
+        "packages": [
+            {
+                "status": item.status,
+                "kind": item.package.kind,
+                "id": item.package.package_id,
+                "name": item.package.display_name,
+                "version": item.package.version,
+                "sourceArchive": str(item.package.zip_path),
+                "sourceRoot": item.package.root_label,
+                "manifest": item.package.manifest_member,
+                "destination": str(item.destination),
+                "backup": str(item.backup) if item.backup else None,
+                "message": item.message,
+                "notes": list(item.package.notes),
+                "errors": list(item.package.errors),
+                "requirements": [
+                    {
+                        "id": requirement.package_id,
+                        "notBefore": requirement.not_before or None,
+                        "notAfter": requirement.not_after or None,
+                    }
+                    for requirement in item.package.requirements
+                ],
+            }
+            for item in results
+        ],
+        "compatibilityActions": [
+            {
+                "component": item.component,
+                "status": item.status,
+                "message": item.message,
+                "source": str(item.source) if item.source else None,
+                "destination": str(item.destination) if item.destination else None,
+            }
+            for item in compatibility_actions
+        ],
+    }
+    try:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        return report_path
+    except OSError as exc:
+        print(f"WARNING: could not write install report: {exc}")
+        return None
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
@@ -519,23 +1528,74 @@ def build_parser() -> argparse.ArgumentParser:
             "as arguments) to install those mods."
         ),
     )
-    parser.add_argument("zips", nargs="*", help="Zip files to install. Drag-and-drop works on Windows.")
+    parser.add_argument("zips", nargs="*", help="Zip files to install. Drag-and-drop accepts multiple files on Windows.")
     parser.add_argument("--game-dir", default=None, help="Base folder. Default is this exe's folder, or the current directory when run as a script.")
     parser.add_argument("--mods-dir", default=None, help="Mods folder. Default is <base folder>\\Mods.")
     parser.add_argument("--inbox", default=None, help="Folder to scan for zip files when no zip arguments are passed.")
-    parser.add_argument("--replace", action="store_true", help="Backup and replace existing mod folders.")
+    parser.add_argument("--replace", action="store_true", help="Backup and replace existing mod folders (this is now the default).")
+    parser.add_argument("--skip-existing", action="store_true", help="Leave existing mod folders unchanged instead of updating them.")
+    parser.add_argument("--repair-legacy-loader", action="store_true", help="Back up conflicting legacy loader DLLs from Railroader_Data\\Managed before installing.")
+    parser.add_argument("--repair-asset-loader", action="store_true", help="Back up the old Mods\\AssetLoader runtime and install FUSE's data-only AssetLoader dependency alias.")
+    parser.add_argument("--with-fuse", action="store_true", help="Install/update the bundled FUSE framework along with explicitly supplied mod zips.")
     parser.add_argument("--no-fuse", action="store_true", help="Do not install the bundled FUSE framework on a manual run; only process zip files.")
     parser.add_argument("--dry-run", action="store_true", help="Inspect zips and print planned installs without writing files.")
     parser.add_argument("--archive-zips", action="store_true", help="Move successfully processed zips to Mods\\FUSEInstaller\\InstalledZips.")
     parser.add_argument("--pause", action="store_true", help="Pause before closing.")
     parser.add_argument("--no-pause", action="store_true", help="Do not pause before closing, even when bundled as an exe.")
+    parser.add_argument("--cli", action="store_true", help="Use command-line mode instead of the graphical installer.")
+    parser.add_argument("--gui", action="store_true", help="Use the graphical installer when running the Python script.")
     parser.add_argument("--version", action="version", version=f"FUSE Installer {TOOL_VERSION}")
     return parser
+
+
+def should_preselect_bundled_fuse(args: argparse.Namespace, bundled_available: bool) -> bool:
+    """Return the GUI default while preserving drag-and-drop input scope.
+
+    A manual launch is the FUSE installation flow, so the bundled framework is
+    selected. Dragging explicit archives onto the executable processes only
+    those archives unless ``--with-fuse`` was explicitly supplied.
+    """
+    return bool(
+        bundled_available
+        and not args.no_fuse
+        and (not args.zips or args.with_fuse)
+    )
 
 
 def run(args: argparse.Namespace) -> int:
     game_dir = Path(args.game_dir).resolve() if args.game_dir else default_game_dir()
     mods_dir = Path(args.mods_dir).resolve() if args.mods_dir else (game_dir / "Mods").resolve()
+
+    preflight_errors = validate_game_dir(game_dir)
+    if not unity_mod_manager_installed(game_dir):
+        preflight_errors.append(
+            "Unity Mod Manager is not installed for this Railroader copy. "
+            "Install UMM first; FUSE itself is loaded by UMM."
+        )
+    if preflight_errors:
+        print(f"FUSE Installer {TOOL_VERSION}")
+        print("FAILED: Railroader installation preflight")
+        for error in preflight_errors:
+            print(f"  {error}")
+        print("  Put FUSE-Installer.exe beside Railroader.exe, or pass --game-dir to the correct folder.")
+        return 1
+
+    legacy_files = find_legacy_managed_files(game_dir)
+    if legacy_files:
+        if should_repair_legacy_files(args, legacy_files):
+            moved = backup_legacy_managed_files(legacy_files, mods_dir, args.dry_run)
+            verb = "Would move" if args.dry_run else "Moved"
+            for source, destination in moved:
+                print(f"{verb} legacy loader: {source} -> {destination}")
+            print("Legacy loader preflight: CLEAN")
+        else:
+            print(f"FUSE Installer {TOOL_VERSION}")
+            print("FAILED: conflicting legacy loader files were found:")
+            for path in legacy_files:
+                print(f"  {path}")
+            print("Run again and approve the backup prompt, or pass --repair-legacy-loader.")
+            print("Steam Verify can restore modified game files, but it may not remove extra DLLs; the files above must be moved too.")
+            return 1
 
     explicit = bool(args.zips)
     zips = find_input_zips(args, game_dir)
@@ -544,7 +1604,7 @@ def run(args: argparse.Namespace) -> int:
     # exe, alongside any loose zips found beside it. Dragging specific zips onto
     # the exe installs exactly those and never force-installs FUSE.
     bundle_on_disk = resolve_bundled_fuse()
-    bundled_fuse = bundle_on_disk if (not explicit and not args.no_fuse) else None
+    bundled_fuse = bundle_on_disk if ((not explicit or args.with_fuse) and not args.no_fuse) else None
 
     targets: list[Path] = []
     seen: set[Path] = set()
@@ -559,8 +1619,8 @@ def run(args: argparse.Namespace) -> int:
     print(f"mods: {mods_dir}")
     if args.dry_run:
         print("mode: dry run")
-    if args.replace:
-        print("replace: enabled")
+    replace_existing = not args.skip_existing or args.replace
+    print(f"existing mods: {'backup and update' if replace_existing else 'skip'}")
     if bundled_fuse is not None:
         print(f"bundled FUSE: {bundled_fuse.name}")
     print()
@@ -575,6 +1635,20 @@ def run(args: argparse.Namespace) -> int:
     if not args.dry_run:
         mods_dir.mkdir(parents=True, exist_ok=True)
 
+    scan_cache: dict[Path, tuple[list[ZipPackage], list[str]]] = {}
+    scanned_packages: list[ZipPackage] = []
+    for target in targets:
+        if not target.exists():
+            continue
+        scan_cache[target] = inspect_zip(target)
+        scanned_packages.extend(scan_cache[target][0])
+    fuse_available_for_dependencies = find_installed_mod_by_id(mods_dir, "FUSE") is not None
+    validate_batch_dependencies(
+        scanned_packages,
+        mods_dir,
+        fuse_available_for_dependencies,
+    )
+
     all_results: list[InstallResult] = []
     scan_failures = 0
     for zip_path in targets:
@@ -585,7 +1659,11 @@ def run(args: argparse.Namespace) -> int:
             scan_failures += 1
             continue
 
-        packages, warnings = inspect_zip(zip_path)
+        packages, warnings = (
+            scan_cache[zip_path]
+            if zip_path in scan_cache
+            else inspect_zip(zip_path)
+        )
         for warning in warnings:
             print(f"  warning: {warning}")
         if not packages:
@@ -594,8 +1672,28 @@ def run(args: argparse.Namespace) -> int:
 
         for package in packages:
             print_package(package)
+            if package.package_id.lower() == ASSETLOADER_ID.lower():
+                result = InstallResult(
+                    package,
+                    "skipped",
+                    mods_dir / package.install_name,
+                    "Old AssetLoader is replaced by FUSE; the installer will create a data-only dependency alias.",
+                )
+                all_results.append(result)
+                print_result(result)
+                continue
+            if package.errors:
+                result = InstallResult(
+                    package,
+                    "failed",
+                    mods_dir / package.install_name,
+                    "; ".join(package.errors),
+                )
+                all_results.append(result)
+                print_result(result)
+                continue
             try:
-                result = install_package(package, mods_dir, args.replace, args.dry_run)
+                result = install_package(package, mods_dir, replace_existing, args.dry_run)
                 all_results.append(result)
                 print_result(result)
             except Exception as exc:
@@ -605,19 +1703,367 @@ def run(args: argparse.Namespace) -> int:
         print()
 
         zip_results = [result for result in all_results if result.package.zip_path == zip_path]
+        assetloader_without_replacement = (
+            any(result.package.package_id.lower() == ASSETLOADER_ID.lower() for result in zip_results)
+            and find_installed_mod_by_id(mods_dir, "FUSE") is None
+            and not any(
+                result.package.package_id.lower() == "fuse" and result.status != "failed"
+                for result in all_results
+            )
+            and bundled_fuse is None
+        )
         # Never archive the bundled FUSE payload: it lives inside the PyInstaller
         # extraction dir, not beside the exe.
-        if args.archive_zips and zip_path != bundled_fuse and zip_results and not any(result.status == "failed" for result in zip_results):
+        if (
+            args.archive_zips
+            and zip_path != bundled_fuse
+            and zip_results
+            and not assetloader_without_replacement
+            and not any(result.status == "failed" for result in zip_results)
+        ):
             archived_to = archive_zip(zip_path, mods_dir, args.dry_run)
             verb = "Would archive" if args.dry_run else "Archived"
             print(f"{verb}: {zip_path} -> {archived_to}")
 
+    compatibility_actions: list[CompatibilityAction] = []
+    fuse_available = (
+        find_installed_mod_by_id(mods_dir, "FUSE") is not None
+        or any(
+            result.package.package_id.lower() == "fuse"
+            and result.status != "failed"
+            for result in all_results
+        )
+    )
+    assetloader_package_results = [
+        result
+        for result in all_results
+        if result.package.package_id.lower() == ASSETLOADER_ID.lower()
+    ]
+    if assetloader_package_results and not fuse_available:
+        for result in assetloader_package_results:
+            result.status = "failed"
+            result.message = (
+                "AssetLoader is replaced by FUSE, but FUSE is not installed. "
+                "Install FUSE first or include --with-fuse."
+            )
+        compatibility_actions.append(CompatibilityAction(
+            ASSETLOADER_ID,
+            "blocked",
+            "The old AssetLoader package was not installed because its replacement, FUSE, is unavailable.",
+        ))
+    if fuse_available:
+        legacy_assetloader_paths = find_legacy_assetloader_paths(mods_dir)
+        if legacy_assetloader_paths and not should_repair_assetloader(args, legacy_assetloader_paths):
+            print("FAILED: old AssetLoader runtime remains installed:")
+            for path in legacy_assetloader_paths:
+                print(f"  {path}")
+            print("Run again and approve migration, or pass --repair-asset-loader.")
+            compatibility_actions.append(CompatibilityAction(
+                ASSETLOADER_ID,
+                "failed",
+                "Old AssetLoader runtime remains installed; approve migration or pass --repair-asset-loader. "
+                "Paths: " + "; ".join(str(path) for path in legacy_assetloader_paths),
+            ))
+        else:
+            try:
+                moved = backup_legacy_assetloader_paths(
+                    legacy_assetloader_paths,
+                    mods_dir,
+                    args.dry_run,
+                )
+                verb = "Would move" if args.dry_run else "Moved"
+                for source, destination in moved:
+                    print(f"{verb} old AssetLoader: {source} -> {destination}")
+                    compatibility_actions.append(CompatibilityAction(
+                        ASSETLOADER_ID,
+                        "planned" if args.dry_run else "backed-up",
+                        "Old AssetLoader runtime was moved to a recoverable backup."
+                        if not args.dry_run else
+                        "Old AssetLoader runtime would be moved to a recoverable backup.",
+                        source,
+                        destination,
+                    ))
+
+                remaining = [] if args.dry_run else find_legacy_assetloader_paths(mods_dir)
+                if remaining:
+                    print("FAILED: AssetLoader cleanup verification found remaining runtime paths:")
+                    for path in remaining:
+                        print(f"  {path}")
+                    compatibility_actions.append(CompatibilityAction(
+                        ASSETLOADER_ID,
+                        "failed",
+                        "Cleanup verification found remaining AssetLoader runtime paths: "
+                        + "; ".join(str(path) for path in remaining),
+                    ))
+                else:
+                    alias_path = install_assetloader_compatibility_alias(mods_dir, args.dry_run)
+                    verb = "Would install" if args.dry_run else "Installed"
+                    print(f"{verb} FUSE AssetLoader dependency alias: {alias_path}")
+                    print("AssetLoader runtime verification: CLEAN")
+                    compatibility_actions.append(CompatibilityAction(
+                        ASSETLOADER_ID,
+                        "planned" if args.dry_run else "installed",
+                        "FUSE's data-only AssetLoader dependency alias is present; no AssetLoader DLL is installed."
+                        if not args.dry_run else
+                        "FUSE's data-only AssetLoader dependency alias would be installed.",
+                        destination=alias_path,
+                    ))
+            except Exception as exc:
+                print(f"FAILED: AssetLoader migration: {exc}")
+                compatibility_actions.append(CompatibilityAction(
+                    ASSETLOADER_ID,
+                    "failed",
+                    f"AssetLoader migration failed: {exc}",
+                ))
+
+        startup_actions = repair_legacy_umm_startup_dependencies(mods_dir, args.dry_run)
+        for action in startup_actions:
+            verb = "Would repair" if action.status == "planned" else (
+                "Repaired" if action.status == "updated" else "FAILED"
+            )
+            print(f"{verb} legacy startup order for {action.component}: {action.message}")
+        compatibility_actions.extend(startup_actions)
+
+    print("Install results:")
+    for result in all_results:
+        detail = result.message or str(result.destination)
+        print(f"  [{result.status.upper()}] {result.package.display_name} ({result.package.kind}) - {detail}")
+
     installed = sum(1 for result in all_results if result.status == "installed")
+    updated = sum(1 for result in all_results if result.status == "updated")
     skipped = sum(1 for result in all_results if result.status == "skipped")
     failed_results = sum(1 for result in all_results if result.status == "failed")
-    failures = scan_failures + failed_results
-    print(f"Summary: installed={installed} skipped={skipped} failed={failures}")
+    compatibility_failures = sum(1 for item in compatibility_actions if item.status == "failed")
+    failures = scan_failures + failed_results + compatibility_failures
+    print(f"Summary: installed={installed} updated={updated} skipped={skipped} failed={failures}")
+    report_path = write_install_report(
+        game_dir,
+        mods_dir,
+        targets,
+        all_results,
+        scan_failures,
+        args.dry_run,
+        compatibility_actions,
+    )
+    if report_path is not None:
+        print(f"Report: {report_path}")
     return 1 if failures else 0
+
+
+def run_gui(args: argparse.Namespace) -> int:
+    import tkinter as tk
+    from tkinter import filedialog, messagebox
+    from tkinter.scrolledtext import ScrolledText
+
+    root = tk.Tk()
+    root.title(f"FUSE Mod Installer {TOOL_VERSION}")
+    root.geometry("900x680")
+    root.minsize(760, 560)
+
+    game_var = tk.StringVar(value=str(Path(args.game_dir).resolve()) if args.game_dir else str(default_game_dir()))
+    bundled_fuse_available = resolve_bundled_fuse() is not None
+    install_fuse_var = tk.BooleanVar(
+        value=should_preselect_bundled_fuse(args, bundled_fuse_available))
+    update_var = tk.BooleanVar(value=not args.skip_existing)
+    archive_var = tk.BooleanVar(value=bool(args.archive_zips))
+    status_var = tk.StringVar(value="Ready. Select the Railroader folder and packages, then click Install.")
+
+    outer = tk.Frame(root, padx=16, pady=14)
+    outer.pack(fill="both", expand=True)
+
+    tk.Label(outer, text="FUSE Suite & Mod Installer", font=("Segoe UI", 17, "bold"), anchor="w").pack(fill="x")
+    tk.Label(
+        outer,
+        text="Installs Native FUSE, Unity Mod Manager, and hosted RailLoader-format mod packages. "
+             "Every package is inspected before an existing install is replaced.",
+        justify="left",
+        wraplength=840,
+        anchor="w",
+    ).pack(fill="x", pady=(2, 12))
+
+    game_row = tk.Frame(outer)
+    game_row.pack(fill="x", pady=(0, 10))
+    tk.Label(game_row, text="Railroader folder", width=18, anchor="w").pack(side="left")
+    tk.Entry(game_row, textvariable=game_var).pack(side="left", fill="x", expand=True, padx=(0, 6))
+
+    def browse_game() -> None:
+        selected = filedialog.askdirectory(title="Select the folder containing Railroader.exe", initialdir=game_var.get())
+        if selected:
+            game_var.set(selected)
+
+    tk.Button(game_row, text="Browse...", command=browse_game, width=11).pack(side="right")
+
+    package_frame = tk.LabelFrame(outer, text="Mod zip files", padx=8, pady=8)
+    package_frame.pack(fill="both", expand=False)
+    zip_list = tk.Listbox(package_frame, height=7, selectmode=tk.EXTENDED)
+    zip_list.pack(side="left", fill="both", expand=True)
+    for item in args.zips:
+        zip_list.insert(tk.END, str(Path(item).resolve()))
+
+    package_buttons = tk.Frame(package_frame)
+    package_buttons.pack(side="right", fill="y", padx=(8, 0))
+
+    def add_zips() -> None:
+        selected = filedialog.askopenfilenames(
+            title="Select one or more mod zip files",
+            filetypes=(("Zip packages", "*.zip"), ("All files", "*.*")),
+        )
+        existing = {zip_list.get(index) for index in range(zip_list.size())}
+        for item in selected:
+            resolved = str(Path(item).resolve())
+            if resolved not in existing:
+                zip_list.insert(tk.END, resolved)
+                existing.add(resolved)
+
+    def remove_zips() -> None:
+        for index in reversed(zip_list.curselection()):
+            zip_list.delete(index)
+
+    tk.Button(package_buttons, text="Add zips...", command=add_zips, width=13).pack(fill="x")
+    tk.Button(package_buttons, text="Remove", command=remove_zips, width=13).pack(fill="x", pady=(6, 0))
+
+    options = tk.Frame(outer)
+    options.pack(fill="x", pady=(10, 8))
+    fuse_check = tk.Checkbutton(
+        options,
+        text="Install/update the bundled FUSE framework",
+        variable=install_fuse_var,
+        state=(tk.NORMAL if bundled_fuse_available else tk.DISABLED),
+    )
+    fuse_check.pack(anchor="w")
+    tk.Checkbutton(options, text="Back up and update existing mod folders", variable=update_var).pack(anchor="w")
+    tk.Checkbutton(options, text="Archive successfully installed source zips", variable=archive_var).pack(anchor="w")
+
+    result_box = ScrolledText(outer, height=15, wrap="word", font=("Consolas", 9), state="disabled")
+    result_box.pack(fill="both", expand=True, pady=(6, 8))
+    result_box.tag_configure("success", foreground="#167a2f")
+    result_box.tag_configure("failure", foreground="#b42318")
+
+    status_label = tk.Label(outer, textvariable=status_var, anchor="w", justify="left", wraplength=840)
+    status_label.pack(fill="x")
+
+    action_row = tk.Frame(outer)
+    action_row.pack(fill="x", pady=(8, 0))
+
+    def set_result(text: str, success: bool) -> None:
+        result_box.configure(state="normal")
+        result_box.delete("1.0", tk.END)
+        result_box.insert(tk.END, text, "success" if success else "failure")
+        result_box.configure(state="disabled")
+        result_box.see(tk.END)
+
+    def copy_results() -> None:
+        root.clipboard_clear()
+        root.clipboard_append(result_box.get("1.0", tk.END).rstrip())
+        status_var.set("Copied the install results to the clipboard.")
+
+    def open_mods() -> None:
+        path = Path(game_var.get()).expanduser() / "Mods"
+        path.mkdir(parents=True, exist_ok=True)
+        try:
+            os.startfile(str(path))
+        except (AttributeError, OSError):
+            messagebox.showinfo("Mods folder", str(path))
+
+    def install() -> None:
+        game_dir = Path(game_var.get()).expanduser().resolve()
+        errors = validate_game_dir(game_dir)
+        if errors:
+            messagebox.showerror("Railroader folder not found", "\n".join(errors))
+            return
+        if not unity_mod_manager_installed(game_dir):
+            messagebox.showerror(
+                "Unity Mod Manager is required",
+                "Unity Mod Manager is not installed in this Railroader copy. Install UMM first, then run this installer again.",
+            )
+            return
+
+        selected_zips = [zip_list.get(index) for index in range(zip_list.size())]
+        if not selected_zips and not install_fuse_var.get():
+            messagebox.showinfo("Nothing selected", "Add one or more mod zips, or enable the bundled FUSE framework.")
+            return
+
+        legacy_files = find_legacy_managed_files(game_dir)
+        repair_legacy = False
+        if legacy_files:
+            listed = "\n".join(str(path) for path in legacy_files)
+            repair_legacy = messagebox.askyesno(
+                "Old RailLoader files found",
+                "These exact legacy loader files conflict with FUSE:\n\n" + listed +
+                "\n\nMove them to a dated backup and continue? Nothing will be deleted.",
+            )
+            if not repair_legacy:
+                status_var.set("Install cancelled: old managed RailLoader files must be backed up first.")
+                return
+
+        mods_dir = game_dir / "Mods"
+        legacy_assetloader_paths = find_legacy_assetloader_paths(mods_dir)
+        repair_asset_loader = False
+        fuse_will_be_available = (
+            install_fuse_var.get()
+            or find_installed_mod_by_id(mods_dir, "FUSE") is not None
+        )
+        if fuse_will_be_available and legacy_assetloader_paths:
+            listed = "\n".join(str(path) for path in legacy_assetloader_paths)
+            repair_asset_loader = messagebox.askyesno(
+                "Old AssetLoader runtime found",
+                "FUSE replaces the old AssetLoader runtime. These paths remain installed:\n\n" +
+                listed +
+                "\n\nMove them to a dated backup and install FUSE's data-only dependency alias? "
+                "Nothing will be deleted.",
+            )
+            if not repair_asset_loader:
+                status_var.set("Install cancelled: old AssetLoader must be migrated first.")
+                return
+
+        run_args = argparse.Namespace(**vars(args))
+        run_args.game_dir = str(game_dir)
+        run_args.mods_dir = None
+        run_args.zips = selected_zips
+        # Prevent the GUI's empty package list from implicitly installing every
+        # zip sitting beside Railroader.exe. Only listed files and the checked
+        # bundled framework are in scope.
+        run_args.inbox = str(game_dir / ".fuse-installer-no-inbox-scan")
+        run_args.with_fuse = install_fuse_var.get()
+        run_args.no_fuse = not install_fuse_var.get()
+        run_args.skip_existing = not update_var.get()
+        run_args.replace = update_var.get()
+        run_args.archive_zips = archive_var.get()
+        run_args.repair_legacy_loader = repair_legacy
+        run_args.repair_asset_loader = repair_asset_loader
+        run_args.no_pause = True
+        run_args.pause = False
+
+        status_var.set("Installing... Existing mods are backed up before replacement.")
+        root.update_idletasks()
+        output = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):
+                exit_code = run(run_args)
+        except Exception as exc:
+            exit_code = 1
+            output.write("\nUNEXPECTED INSTALLER ERROR: " + str(exc))
+
+        text = output.getvalue().strip()
+        success = exit_code == 0
+        set_result(text, success)
+        status_var.set(
+            "Install complete. Review the package-by-package results above."
+            if success else
+            "One or more packages failed. Successful packages were kept; failed packages did not replace existing installs."
+        )
+        if success:
+            messagebox.showinfo("FUSE install complete", "All selected packages installed successfully.")
+        else:
+            messagebox.showwarning("FUSE install finished with errors", "Review the failed package entries and report path in the installer window.")
+
+    tk.Button(action_row, text="Install", command=install, width=16).pack(side="left")
+    tk.Button(action_row, text="Open Mods Folder", command=open_mods, width=16).pack(side="left", padx=(8, 0))
+    tk.Button(action_row, text="Copy Results", command=copy_results, width=14).pack(side="left", padx=(8, 0))
+    tk.Button(action_row, text="Close", command=root.destroy, width=12).pack(side="right")
+
+    root.mainloop()
+    return 0
 
 
 def should_pause(args: argparse.Namespace) -> bool:
@@ -631,6 +2077,8 @@ def should_pause(args: argparse.Namespace) -> bool:
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
+    if args.gui or (getattr(sys, "frozen", False) and sys.platform.startswith("win") and not args.cli):
+        return run_gui(args)
     try:
         return run(args)
     finally:

--- a/tools/tests/test_fuse_convert_dependencies.py
+++ b/tools/tests/test_fuse_convert_dependencies.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+
+import fuse_convert
+
+
+def test_conditional_mixinto_requirement_adds_advisory_load_after(tmp_path):
+    (tmp_path / "Definition.json").write_text(
+        json.dumps(
+            {
+                "id": "Conditional.Mixinto",
+                "mixintos": {
+                    "game-graph": {
+                        "mixinto": "file(optional.json)",
+                        "requires": ["Optional.Base"],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    required, load_after = fuse_convert.legacy_dependencies(tmp_path)
+
+    assert required == []
+    assert load_after == ["Optional.Base.FUSE"]
+
+
+def test_nested_mixinto_arrays_preserve_order_and_deduplicate(tmp_path):
+    (tmp_path / "Definition.json").write_text(
+        json.dumps(
+            {
+                "mixintos": {
+                    "game-graph": [
+                        {
+                            "mixinto": "file(a.json)",
+                            "requires": ["Base.A", "Base.Shared"],
+                        },
+                        {
+                            "mixinto": "file(b.json)",
+                            "requires": ["base.shared", "Base.B"],
+                        },
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    required, load_after = fuse_convert.legacy_dependencies(tmp_path)
+
+    assert required == []
+    assert load_after == ["Base.A.FUSE", "Base.Shared.FUSE", "Base.B.FUSE"]
+
+
+def test_conflicts_with_is_preserved_in_manifest_and_conditional_mixinto(tmp_path):
+    (tmp_path / "Definition.json").write_text(
+        json.dumps(
+            {
+                "conflictsWith": [
+                    {"id": "Other.Route", "notBefore": "2.0", "notAfter": "3.0"},
+                    "Zamu.StrangeCustoms",
+                ],
+                "mixintos": {
+                    "game-graph": {
+                        "mixinto": "file(optional.json)",
+                        "conflictsWith": ["Conditional.Other"],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manifest_conflicts = fuse_convert.legacy_conflicts_with(tmp_path)
+    metadata, _ = fuse_convert.mixinto_metadata(tmp_path)
+
+    assert manifest_conflicts == [
+        {"Id": "Other.Route", "NotBefore": "2.0", "NotAfter": "3.0"},
+        {"Id": "Zamu.StrangeCustoms"},
+    ]
+    assert metadata["optional.json"]["conflictsWith"] == [
+        {"id": "Conditional.Other"}
+    ]

--- a/tools/tests/test_fuse_converter_classification.py
+++ b/tools/tests/test_fuse_converter_classification.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+
+import fuse_converter
+
+
+def make_asset_pack(folder):
+    folder.mkdir()
+    (folder / "bundle").write_bytes(b"asset")
+    (folder / "Catalog.json").write_text("{}", encoding="utf-8")
+    (folder / "Definitions.json").write_text("{}", encoding="utf-8")
+
+
+def test_asset_only_package_is_reported_for_install_without_fake_output(tmp_path):
+    source = tmp_path / "Assets"
+    make_asset_pack(source)
+    out_root = tmp_path / "out"
+
+    report = fuse_converter.convert_input(source, out_root, "auto", clean_output=True)
+
+    assert report.status == "failed"
+    assert report.detected_kind == "asset"
+    assert not report.output.exists()
+    report_file = out_root / "_conversion-reports" / "Assets.FUSE" / "conversion-report.json"
+    assert report_file.exists()
+    data = json.loads(report_file.read_text(encoding="utf-8"))
+    assert "install this package" in data["entries"][0]["message"]
+
+
+def test_map_tiles_and_code_are_not_reported_as_converted(tmp_path):
+    tiles = tmp_path / "Tiles"
+    tiles.mkdir()
+    (tiles / "tile.data").write_bytes(b"tile")
+    code = tmp_path / "Code"
+    code.mkdir()
+    (code / "Code.dll").write_bytes(b"assembly")
+    schemas = code / "schemas"
+    schemas.mkdir()
+    (schemas / "example.json").write_text(
+        json.dumps({"tracks": {"nodes": {}}}),
+        encoding="utf-8",
+    )
+
+    assert fuse_converter.detect_kind(tiles, "auto") == "map_tile"
+    assert fuse_converter.detect_kind(code, "auto") == "code"
+
+
+def test_mixed_code_and_route_json_converts_the_data_portion(tmp_path):
+    source = tmp_path / "Mixed"
+    source.mkdir()
+    (source / "Plugin.dll").write_bytes(b"assembly")
+    (source / "tracks.json").write_text(
+        json.dumps({"tracks": {"nodes": {"N1": {"position": {"x": 0, "y": 0, "z": 0}}}}}),
+        encoding="utf-8",
+    )
+
+    assert fuse_converter.detect_kind(source, "auto") == "route"

--- a/tools/tests/test_fuse_installer.py
+++ b/tools/tests/test_fuse_installer.py
@@ -7,6 +7,7 @@ FUSE while a drag-and-drop run installs only the dropped mods.
 
 from __future__ import annotations
 
+import argparse
 import json
 import zipfile
 from pathlib import Path
@@ -14,6 +15,28 @@ from pathlib import Path
 import pytest
 
 import fuse_installer as fi
+
+
+@pytest.mark.parametrize(
+    ("zips", "with_fuse", "no_fuse", "available", "expected"),
+    [
+        ([], False, False, True, True),
+        (["mod.zip"], False, False, True, False),
+        (["mod.zip"], True, False, True, True),
+        ([], False, True, True, False),
+        ([], False, False, False, False),
+    ],
+)
+def test_should_preselect_bundled_fuse_matches_launch_scope(
+    zips: list[str],
+    with_fuse: bool,
+    no_fuse: bool,
+    available: bool,
+    expected: bool,
+) -> None:
+    args = argparse.Namespace(zips=zips, with_fuse=with_fuse, no_fuse=no_fuse)
+
+    assert fi.should_preselect_bundled_fuse(args, available) is expected
 
 
 def make_zip(path: Path, files: dict[str, str | bytes]) -> Path:
@@ -92,6 +115,20 @@ def test_ensure_fuse_id_appends_suffix():
     assert fi.ensure_fuse_id("") == "LegacyDataPackage.FUSE"
 
 
+def test_parse_steam_library_paths_supports_current_vdf_format():
+    text = r'''
+    "libraryfolders"
+    {
+        "0" { "path" "C:\\Program Files (x86)\\Steam" }
+        "1" { "path" "E:\\Games\\SteamLibrary" }
+    }
+    '''
+    assert fi.parse_steam_library_paths(text) == [
+        Path(r"C:\Program Files (x86)\Steam"),
+        Path(r"E:\Games\SteamLibrary"),
+    ]
+
+
 # --------------------------------------------------------------------------- #
 # Root detection
 # --------------------------------------------------------------------------- #
@@ -155,8 +192,29 @@ def test_inspect_legacy_data_package(tmp_path):
     packages, _ = fi.inspect_zip(zip_path)
     assert len(packages) == 1
     pkg = packages[0]
-    assert pkg.kind == "legacy-data"
-    assert pkg.package_id == "OldPack.FUSE"
+    assert pkg.kind == "railloader"
+    assert pkg.package_id == "OldPack"
+
+
+def test_inspect_code_only_railloader_package(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {
+            "SignalsEverywhere/Definition.json": info(
+                manifestVersion=5,
+                id="Joo.SignalsEverywhere",
+                name="Signals Everywhere",
+                assemblies=["SignalsEverywhere"],
+            ),
+            "SignalsEverywhere/SignalsEverywhere.dll": b"binary",
+        },
+    )
+    packages, warnings = fi.inspect_zip(zip_path)
+    assert warnings == []
+    assert len(packages) == 1
+    assert packages[0].kind == "railloader"
+    assert packages[0].package_id == "Joo.SignalsEverywhere"
+    assert packages[0].install_name == "Joo.SignalsEverywhere"
 
 
 def test_inspect_unsupported_zip_warns(tmp_path):
@@ -164,6 +222,292 @@ def test_inspect_unsupported_zip_warns(tmp_path):
     packages, warnings = fi.inspect_zip(zip_path)
     assert packages == []
     assert warnings
+
+
+def test_inspect_malformed_manifest_reports_exact_member_and_location(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {
+            "Broken/Info.json": '{ "Id": "Broken", ',
+            "Broken/track.fuse.json": "{}",
+        },
+    )
+    packages, warnings = fi.inspect_zip(zip_path)
+    assert warnings == []
+    package = packages[0]
+    assert package.kind == "invalid"
+    assert package.errors
+    assert "Broken/Info.json" in package.errors[0]
+    assert "line 1" in package.errors[0]
+
+
+def test_inspect_rejects_unsafe_archive_member_even_with_valid_package(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "unsafe.zip",
+        {
+            "Good/Info.json": info(Id="Good"),
+            "../outside.dll": b"unsafe",
+        },
+    )
+
+    packages, warnings = fi.inspect_zip(zip_path)
+
+    assert warnings == []
+    assert packages[0].kind == "invalid"
+    assert "unsafe member path" in packages[0].errors[0]
+    assert "../outside.dll" in packages[0].errors[0]
+
+
+def test_inspect_rejects_case_colliding_archive_members(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "duplicate-members.zip",
+        {
+            "Good/Info.json": info(Id="Good"),
+            "Good/Data.json": "{}",
+            "Good/data.json": "{}",
+        },
+    )
+
+    packages, _ = fi.inspect_zip(zip_path)
+
+    assert packages[0].kind == "invalid"
+    assert "case-colliding" in packages[0].errors[0]
+
+
+def test_inspect_rejects_nested_manifest_layout_as_ambiguous(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "ambiguous.zip",
+        {
+            "Info.json": info(Id="Outer"),
+            "Nested/Info.json": info(Id="Inner"),
+        },
+    )
+
+    packages, _ = fi.inspect_zip(zip_path)
+
+    assert len(packages) == 1
+    assert packages[0].kind == "invalid"
+    assert "layout is ambiguous" in packages[0].errors[0]
+    assert "Nested" in packages[0].errors[0]
+
+
+def test_inspect_native_package_reports_missing_declared_file(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {"Broken/Info.json": info(Id="Broken", FuseDataFiles=["missing.fuse.json"])},
+    )
+    packages, _ = fi.inspect_zip(zip_path)
+    assert packages[0].kind == "invalid"
+    assert "missing.fuse.json" in packages[0].errors[0]
+
+
+def test_inspect_native_package_reports_malformed_data_file(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {
+            "Broken/Info.json": info(Id="Broken", FuseDataFiles=["data/track.fuse.json"]),
+            "Broken/data/track.fuse.json": '{ "tracks": }',
+        },
+    )
+    packages, _ = fi.inspect_zip(zip_path)
+    assert packages[0].kind == "invalid"
+    assert "Broken/data/track.fuse.json" in packages[0].errors[0]
+
+
+# --------------------------------------------------------------------------- #
+# Dependency and duplicate preflight
+# --------------------------------------------------------------------------- #
+
+def package(
+    tmp_path: Path,
+    package_id: str,
+    *,
+    version: str = "",
+    requirements: list[fi.PackageRequirement] | None = None,
+    zip_name: str | None = None,
+) -> fi.ZipPackage:
+    return fi.ZipPackage(
+        zip_path=tmp_path / (zip_name or f"{package_id}.zip"),
+        root=(package_id,),
+        kind="umm",
+        package_id=package_id,
+        display_name=package_id,
+        version=version,
+        install_name=package_id,
+        manifest_member=f"{package_id}/Info.json",
+        member_count=1,
+        requirements=requirements or [],
+    )
+
+
+def test_inspect_parses_umm_and_railloader_requirement_bounds(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "requirements.zip",
+        {
+            "Mods/Native/Info.json": info(
+                Id="Native",
+                Requirements=[{"Id": "FUSE", "NotBefore": "1.2.0"}],
+                FuseRequires=["Shared.Data"],
+            ),
+            "Mods/Legacy/Definition.json": info(
+                manifestVersion=7,
+                id="Legacy",
+                requires=[{"id": "Legacy.Base", "notAfter": "2.0.0"}],
+            ),
+        },
+    )
+
+    packages, warnings = fi.inspect_zip(zip_path)
+
+    assert warnings == []
+    by_id = {item.package_id: item for item in packages}
+    assert by_id["Native"].requirements == [
+        fi.PackageRequirement("FUSE", not_before="1.2.0"),
+        fi.PackageRequirement("Shared.Data"),
+    ]
+    assert by_id["Legacy"].requirements == [
+        fi.PackageRequirement("Legacy.Base", not_after="2.0.0")
+    ]
+
+
+def test_dependency_preflight_reports_missing_id_bounds_and_requester(tmp_path):
+    dependent = package(
+        tmp_path,
+        "Dependent",
+        requirements=[fi.PackageRequirement("Missing.Base", not_before="2.4")],
+    )
+
+    fi.validate_batch_dependencies([dependent], tmp_path / "Mods", fuse_available=False)
+
+    assert len(dependent.errors) == 1
+    assert "Missing.Base" in dependent.errors[0]
+    assert "not before 2.4" in dependent.errors[0]
+    assert "Dependent" in dependent.errors[0]
+
+
+def test_dependency_preflight_accepts_forward_reference_in_same_batch(tmp_path):
+    dependent = package(
+        tmp_path,
+        "Dependent",
+        requirements=[fi.PackageRequirement("Base", not_before="1.5")],
+    )
+    base = package(tmp_path, "Base.FUSE", version="2.0", zip_name="later.zip")
+
+    fi.validate_batch_dependencies([dependent, base], tmp_path / "Mods", fuse_available=False)
+
+    assert dependent.errors == []
+    assert base.errors == []
+
+
+def test_dependency_preflight_uses_installed_package_version(tmp_path):
+    mods = tmp_path / "Mods"
+    installed = mods / "Base"
+    installed.mkdir(parents=True)
+    (installed / "Info.json").write_text(
+        info(Id="Base", Version="2.3.0"),
+        encoding="utf-8",
+    )
+    dependent = package(
+        tmp_path,
+        "Dependent",
+        requirements=[fi.PackageRequirement("Base", not_before="2.0", not_after="3.0")],
+    )
+
+    fi.validate_batch_dependencies([dependent], mods, fuse_available=False)
+
+    assert dependent.errors == []
+
+
+@pytest.mark.parametrize(
+    ("available", "requirement"),
+    [
+        ("1.9", fi.PackageRequirement("Base", not_before="2.0")),
+        ("3.1", fi.PackageRequirement("Base", not_after="3.0")),
+    ],
+)
+def test_dependency_preflight_rejects_incompatible_versions(tmp_path, available, requirement):
+    base = package(tmp_path, "Base", version=available)
+    dependent = package(tmp_path, "Dependent", requirements=[requirement])
+
+    fi.validate_batch_dependencies([base, dependent], tmp_path / "Mods", fuse_available=False)
+
+    assert len(dependent.errors) == 1
+    assert "Dependency version conflict" in dependent.errors[0]
+    assert available in dependent.errors[0]
+
+
+def test_dependency_preflight_uses_only_explicit_fuse_replacements(tmp_path):
+    replaced = package(
+        tmp_path,
+        "ReplacedDependent",
+        requirements=[fi.PackageRequirement("Zamu.StrangeCustoms.FUSE", not_before="99.0")],
+    )
+    still_required = package(
+        tmp_path,
+        "HostedDependent",
+        requirements=[fi.PackageRequirement("Zamu.SomeKindOfMadness")],
+    )
+
+    fi.validate_batch_dependencies(
+        [replaced, still_required],
+        tmp_path / "Mods",
+        fuse_available=True,
+    )
+
+    assert replaced.errors == []
+    assert len(still_required.errors) == 1
+    assert "Zamu.SomeKindOfMadness" in still_required.errors[0]
+
+
+def test_dependency_preflight_rejects_duplicate_package_ids(tmp_path):
+    first = package(tmp_path, "Same.Id", zip_name="first.zip")
+    second = package(tmp_path, "Same.Id.FUSE", zip_name="second.zip")
+
+    fi.validate_batch_dependencies([first, second], tmp_path / "Mods", fuse_available=False)
+
+    assert "first.zip" in first.errors[0]
+    assert "second.zip" in first.errors[0]
+    assert len(second.errors) == 1
+
+
+def test_dependency_preflight_propagates_failed_batch_dependency(tmp_path):
+    top = package(
+        tmp_path,
+        "Top",
+        requirements=[fi.PackageRequirement("Middle")],
+    )
+    middle = package(
+        tmp_path,
+        "Middle",
+        requirements=[fi.PackageRequirement("Missing.Bottom")],
+    )
+
+    fi.validate_batch_dependencies([top, middle], tmp_path / "Mods", fuse_available=False)
+
+    assert "Missing.Bottom" in middle.errors[0]
+    assert "failed preflight" in top.errors[0]
+
+
+def test_failed_fuse_package_cannot_supply_replacement_dependency(tmp_path):
+    dependent = package(
+        tmp_path,
+        "Dependent",
+        requirements=[fi.PackageRequirement("Zamu.StrangeCustoms")],
+    )
+    broken_fuse = package(
+        tmp_path,
+        "FUSE",
+        requirements=[fi.PackageRequirement("Missing.Framework.Dependency")],
+    )
+
+    fi.validate_batch_dependencies(
+        [dependent, broken_fuse],
+        tmp_path / "Mods",
+        fuse_available=False,
+    )
+
+    assert "Missing.Framework.Dependency" in broken_fuse.errors[0]
+    assert "Install or update FUSE" in dependent.errors[0]
 
 
 # --------------------------------------------------------------------------- #
@@ -207,11 +551,137 @@ def test_replace_backs_up_then_installs(tmp_path):
         {"MyMod/Info.json": info(Id="MyMod"), "MyMod/new.txt": "new content"},
     )
     result = install_one(zip_path, mods, replace=True)
-    assert result.status == "installed"
     assert (dest / "new.txt").read_text() == "new content"
     assert not (dest / "old.txt").exists()  # replaced, not merged
     assert result.backup is not None
     assert (result.backup / "old.txt").read_text() == "old content"
+    assert result.status == "updated"
+
+
+def test_game_preflight_and_legacy_loader_detection(tmp_path):
+    game = tmp_path / "Railroader"
+    managed = game / "Railroader_Data" / "Managed"
+    umm = managed / "UnityModManager"
+    umm.mkdir(parents=True)
+    (game / "Railroader.exe").write_bytes(b"exe")
+    (umm / "UnityModManager.dll").write_bytes(b"umm")
+    conflicts = [managed / name for name in fi.LEGACY_MANAGED_FILES]
+    for conflict in conflicts:
+        conflict.write_bytes(b"old")
+
+    assert fi.validate_game_dir(game) == []
+    assert fi.unity_mod_manager_installed(game)
+    assert fi.find_legacy_managed_files(game) == conflicts
+
+    moved = fi.backup_legacy_managed_files(conflicts, game / "Mods", dry_run=False)
+    assert len(moved) == len(conflicts)
+    assert all(not conflict.exists() for conflict in conflicts)
+    assert all(destination.read_bytes() == b"old" for _, destination in moved)
+
+
+def test_assetloader_runtime_detection_backup_and_dependency_alias(tmp_path):
+    mods = tmp_path / "Mods"
+    old = mods / "AssetLoader"
+    old.mkdir(parents=True)
+    (old / "Info.json").write_text(info(Id="AssetLoader"), encoding="utf-8")
+    (old / "AssetLoader.dll").write_bytes(b"old-runtime")
+    old_zip = mods / "AssetLoader.zip"
+    old_zip.write_bytes(b"old-archive")
+
+    assert set(fi.find_legacy_assetloader_paths(mods)) == {old, old_zip}
+
+    moved = fi.backup_legacy_assetloader_paths(
+        fi.find_legacy_assetloader_paths(mods),
+        mods,
+        dry_run=False,
+    )
+    assert len(moved) == 2
+    assert not old.exists()
+    assert not old_zip.exists()
+
+    alias = fi.install_assetloader_compatibility_alias(mods, dry_run=False)
+    manifest = json.loads((alias / "Info.json").read_text(encoding="utf-8"))
+    assert manifest["Id"] == "AssetLoader"
+    assert manifest["Requirements"] == ["FUSE"]
+    assert manifest["FuseProvidedCompatibility"] == fi.ASSETLOADER_COMPATIBILITY_MARKER
+    assert not (alias / "AssetLoader.dll").exists()
+    assert fi.find_legacy_assetloader_paths(mods) == []
+    assert fi.find_fuse_assetloader_compatibility(mods) == alias
+
+
+def test_legacy_umm_startup_dependency_repair_backs_up_and_orders_after_fuse(tmp_path):
+    mods = tmp_path / "Mods"
+    alina = mods / "AlinasUtils"
+    alina.mkdir(parents=True)
+    original = {
+        "Id": "AlinaNova21.AlinasUtils",
+        "AssemblyName": "AlinasUtils.dll",
+        "EntryMethod": "AlinasUtils.UMM.Mod.Load",
+    }
+    (alina / "Info.json").write_text(json.dumps(original), encoding="utf-8")
+    (alina / "AlinasUtils.dll").write_bytes(
+        b"CLR metadata before Railloader.Interchange after"
+    )
+
+    actions = fi.repair_legacy_umm_startup_dependencies(mods, dry_run=False)
+
+    assert len(actions) == 1
+    assert actions[0].component == "AlinaNova21.AlinasUtils"
+    assert actions[0].status == "updated"
+    repaired = json.loads((alina / "Info.json").read_text(encoding="utf-8"))
+    assert repaired["Requirements"] == ["FUSE"]
+    assert repaired["LoadAfter"] == ["FUSE"]
+    assert actions[0].destination is not None
+    backup = json.loads(actions[0].destination.read_text(encoding="utf-8"))
+    assert backup == original
+
+
+def test_legacy_umm_startup_dependency_repair_preserves_existing_dependency_shapes(tmp_path):
+    mods = tmp_path / "Mods"
+    plugin = mods / "SignalsEverywhere"
+    plugin.mkdir(parents=True)
+    manifest = {
+        "Id": "Joo.SignalsEverywhere",
+        "AssemblyName": "SignalsEverywhere.dll",
+        "Requirements": [{"Id": "SomeLibrary"}],
+        "LoadAfter": "OtherMod",
+    }
+    (plugin / "info.json").write_text(json.dumps(manifest), encoding="utf-8")
+    (plugin / "SignalsEverywhere.dll").write_bytes(b"xxStrangeCustomsxx")
+
+    actions = fi.repair_legacy_umm_startup_dependencies(mods, dry_run=False)
+
+    assert len(actions) == 1
+    repaired = json.loads((plugin / "info.json").read_text(encoding="utf-8"))
+    assert repaired["Requirements"] == [{"Id": "SomeLibrary"}, "FUSE"]
+    assert repaired["LoadAfter"] == ["OtherMod", "FUSE"]
+
+
+def test_legacy_umm_startup_dependency_repair_skips_unrelated_and_already_ordered_mods(tmp_path):
+    mods = tmp_path / "Mods"
+    unrelated = mods / "Unrelated"
+    unrelated.mkdir(parents=True)
+    (unrelated / "Info.json").write_text(
+        info(Id="Unrelated", AssemblyName="Unrelated.dll"), encoding="utf-8"
+    )
+    (unrelated / "Unrelated.dll").write_bytes(b"ordinary code")
+
+    ready = mods / "Ready"
+    ready.mkdir(parents=True)
+    (ready / "Info.json").write_text(
+        info(
+            Id="Ready",
+            AssemblyName="Ready.dll",
+            Requirements=[{"Id": "FUSE"}],
+            LoadAfter=["FUSE"],
+        ),
+        encoding="utf-8",
+    )
+    (ready / "Ready.dll").write_bytes(b"Railloader.Interchange")
+
+    assert fi.find_legacy_umm_startup_dependency_manifests(mods) == []
+    assert fi.repair_legacy_umm_startup_dependencies(mods, dry_run=False) == []
+    assert not (mods / "ModBackups").exists()
 
 
 def test_install_name_colliding_with_staging_dir(tmp_path):
@@ -234,6 +704,64 @@ def test_dry_run_writes_nothing(tmp_path):
     result = install_one(zip_path, mods, dry_run=True)
     assert result.status == "installed"
     assert not mods.exists()
+
+
+def test_install_report_records_each_package_result(tmp_path):
+    game = tmp_path / "game"
+    mods = game / "Mods"
+    package = fi.ZipPackage(
+        zip_path=tmp_path / "one.zip",
+        root=("One",),
+        kind="umm",
+        package_id="One",
+        display_name="One Mod",
+        version="1.0",
+        install_name="One",
+        manifest_member="One/Info.json",
+        member_count=2,
+    )
+    result = fi.InstallResult(package, "installed", mods / "One")
+
+    path = fi.write_install_report(game, mods, [package.zip_path], [result], 0, dry_run=False)
+
+    assert path is not None and path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["summary"] == {"installed": 1, "updated": 0, "skipped": 0, "failed": 0}
+    assert data["packages"][0]["id"] == "One"
+    assert data["packages"][0]["status"] == "installed"
+    assert data["compatibilityActions"] == []
+
+
+def test_install_report_records_compatibility_failure(tmp_path):
+    game = tmp_path / "game"
+    mods = game / "Mods"
+    action = fi.CompatibilityAction(
+        component="AssetLoader",
+        status="failed",
+        message="Old runtime remains installed.",
+        source=mods / "AssetLoader",
+    )
+
+    path = fi.write_install_report(
+        game,
+        mods,
+        [],
+        [],
+        0,
+        dry_run=False,
+        compatibility_actions=[action],
+    )
+
+    assert path is not None and path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["summary"]["failed"] == 1
+    assert data["compatibilityActions"] == [{
+        "component": "AssetLoader",
+        "status": "failed",
+        "message": "Old runtime remains installed.",
+        "source": str(mods / "AssetLoader"),
+        "destination": None,
+    }]
 
 
 # --------------------------------------------------------------------------- #
@@ -319,24 +847,91 @@ def make_fuse_payload(tmp_path: Path) -> Path:
     )
 
 
+def make_game_dir(path: Path) -> Path:
+    managed = path / "Railroader_Data" / "Managed" / "UnityModManager"
+    managed.mkdir(parents=True)
+    (path / "Railroader.exe").write_bytes(b"exe")
+    (managed / "UnityModManager.dll").write_bytes(b"umm")
+    return path
+
+
 def run_installer(argv):
     args = fi.build_parser().parse_args(argv)
     return fi.run(args)
 
 
 def test_run_no_args_installs_bundled_fuse(tmp_path, monkeypatch):
-    game = tmp_path / "game"
-    game.mkdir()
+    game = make_game_dir(tmp_path / "game")
     monkeypatch.setenv("FUSE_INSTALLER_BUNDLED_ZIP", str(make_fuse_payload(tmp_path)))
 
     rc = run_installer(["--no-pause", "--game-dir", str(game)])
     assert rc == 0
     assert (game / "Mods" / "FUSE" / "FUSE.dll").exists()
+    alias = game / "Mods" / "AssetLoader" / "Info.json"
+    assert alias.exists()
+    assert json.loads(alias.read_text(encoding="utf-8"))["Requirements"] == ["FUSE"]
+
+
+def test_run_migrates_old_assetloader_when_fuse_is_installed(tmp_path, monkeypatch):
+    game = make_game_dir(tmp_path / "game")
+    old = game / "Mods" / "AssetLoader"
+    old.mkdir(parents=True)
+    (old / "Info.json").write_text(info(Id="AssetLoader"), encoding="utf-8")
+    (old / "AssetLoader.dll").write_bytes(b"old-runtime")
+    monkeypatch.setenv("FUSE_INSTALLER_BUNDLED_ZIP", str(make_fuse_payload(tmp_path)))
+
+    rc = run_installer([
+        "--no-pause",
+        "--repair-asset-loader",
+        "--game-dir",
+        str(game),
+    ])
+
+    assert rc == 0
+    assert (game / "Mods" / "FUSE" / "FUSE.dll").exists()
+    assert (game / "Mods" / "AssetLoader" / "Info.json").exists()
+    assert not (game / "Mods" / "AssetLoader" / "AssetLoader.dll").exists()
+    backups = list((game / "Mods" / "ModBackups" / "FUSEInstaller").rglob("AssetLoader.dll"))
+    assert len(backups) == 1
+    reports = list((game / "Mods" / "FUSEInstaller" / "Reports").glob("install-*.json"))
+    assert len(reports) == 1
+    report = json.loads(reports[0].read_text(encoding="utf-8"))
+    statuses = [item["status"] for item in report["compatibilityActions"]]
+    assert statuses == ["backed-up", "installed"]
+    assert report["summary"]["failed"] == 0
+
+
+def test_run_rejects_old_assetloader_package_when_fuse_is_unavailable(tmp_path, monkeypatch):
+    game = make_game_dir(tmp_path / "game")
+    monkeypatch.delenv("FUSE_INSTALLER_BUNDLED_ZIP", raising=False)
+    old_assetloader = make_zip(
+        tmp_path / "AssetLoader.zip",
+        {
+            "AssetLoader/Info.json": info(Id="AssetLoader"),
+            "AssetLoader/AssetLoader.dll": b"old-runtime",
+        },
+    )
+
+    rc = run_installer([
+        str(old_assetloader),
+        "--no-pause",
+        "--archive-zips",
+        "--game-dir",
+        str(game),
+    ])
+
+    assert rc == 1
+    assert old_assetloader.exists()
+    assert not (game / "Mods" / "AssetLoader").exists()
+    reports = list((game / "Mods" / "FUSEInstaller" / "Reports").glob("install-*.json"))
+    assert len(reports) == 1
+    report = json.loads(reports[0].read_text(encoding="utf-8"))
+    assert report["packages"][0]["status"] == "failed"
+    assert "FUSE is not installed" in report["packages"][0]["message"]
 
 
 def test_run_drag_zip_installs_only_that_mod(tmp_path, monkeypatch):
-    game = tmp_path / "game"
-    game.mkdir()
+    game = make_game_dir(tmp_path / "game")
     monkeypatch.setenv("FUSE_INSTALLER_BUNDLED_ZIP", str(make_fuse_payload(tmp_path)))
     mod = make_zip(tmp_path / "MyMod.zip", {"MyMod/Info.json": info(Id="MyMod")})
 
@@ -346,9 +941,28 @@ def test_run_drag_zip_installs_only_that_mod(tmp_path, monkeypatch):
     assert not (game / "Mods" / "FUSE").exists()  # drag-drop never force-installs FUSE
 
 
+def test_run_multi_package_zip_isolates_bad_json_and_installs_good_package(tmp_path, monkeypatch):
+    game = make_game_dir(tmp_path / "game")
+    monkeypatch.delenv("FUSE_INSTALLER_BUNDLED_ZIP", raising=False)
+    bundle = make_zip(
+        tmp_path / "Mods.zip",
+        {
+            "Mods/Good/Info.json": info(Id="Good"),
+            "Mods/Good/Good.dll": b"good",
+            "Mods/Bad/Info.json": '{ "Id": "Bad", ',
+            "Mods/Bad/bad.fuse.json": "{}",
+        },
+    )
+
+    rc = run_installer([str(bundle), "--no-pause", "--game-dir", str(game)])
+
+    assert rc == 1
+    assert (game / "Mods" / "Good" / "Good.dll").exists()
+    assert not (game / "Mods" / "Bad").exists()
+
+
 def test_run_no_fuse_flag_skips_bundled_fuse(tmp_path, monkeypatch):
-    game = tmp_path / "game"
-    game.mkdir()
+    game = make_game_dir(tmp_path / "game")
     monkeypatch.setenv("FUSE_INSTALLER_BUNDLED_ZIP", str(make_fuse_payload(tmp_path)))
 
     rc = run_installer(["--no-fuse", "--no-pause", "--game-dir", str(game)])


### PR DESCRIPTION
## Summary

This is the review checkpoint for the FUSE compatibility, diagnostics, installer/converter, native authoring, schema, and documentation overhaul.

Highlights:
- isolates malformed packages and reports package/file/JSON-path repair details without locking game menus
- expands RailLoader/Alina/Strange Customs/Confusing Supplements/AssetLoader compatibility
- respects legacy requires, loadAfter/loadBefore, conditional mixintos, and declared conflicts
- preserves and merges base-game track/spans while reporting destructive cross-mod conflicts
- adds live diagnostics, mod-conflict analysis, industry dashboard, feature options, water surfaces, and repeated-object lines
- revamps the multi-package installer and RailLoader-data converter
- adds the master checklist, parity matrix, authoring recipes, map audit, and wiki source

## Automated evidence

- FUSE net48: 2,205 passed, 9 opt-in real-pack fixtures skipped, 0 failed
- FUSE Core/schema/help: 122 passed, 0 failed
- External editor UI: 96 passed, 0 failed
- Tile Editor desktop: 126 passed, 0 failed
- Installer/tools: 79 passed, 0 failed
- Slopwatch: 0 findings
- Release ZIP validation passed
- FUSE-Installer.exe built and passed its throwaway self-install, including the DLL-free AssetLoader alias
- FUSE-Converter.exe built and passed its CLI smoke check

## Review / acceptance still required

This PR is intentionally a draft. The remaining unchecked items in `docs/MASTER_WORK_CHECKLIST.md` include fresh in-game verification for menus and buy timing, locomotives/customization/assets, ARC/Kater/Sylva track and delivery behavior, Appy starter placement, generated-map save/reload, terrain/vegetation, water/object lines, and a complete signal/CTC territory. Partial hosted/version-bound legacy cases remain explicitly identified in `docs/LEGACY_REPLACEMENT_PARITY.md`.

No DediSevi, SanityInitiative, or SerialTrafficControl parity claim is made.