### PR TITLE
Add legacy compatibility adapters and gameplay patches

### DIFF
--- a/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
+++ b/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
@@ -1,0 +1,193 @@
+using System.Collections.Generic;
+using FUSE.Compatibility;
+using FUSE.Interface.Console;
+using KeyValue.Runtime;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace FUSE.Tests.Compatibility
+{
+    public sealed class FuseConfusingSupplementsCompatibilityTests
+    {
+        [Fact]
+        public void BodygroupsComponent_UsesLegacyWireKindWithFuseOwnedType()
+        {
+            var component = new FuseConfusingSupplementsBodygroupsComponent();
+
+            Assert.Equal("ConfusingSupplements.Bodygroups", component.Kind);
+            Assert.Empty(component.Groups);
+            Assert.Contains(component.Kind, FuseConfusingSupplementsCompatibility.ImplementedComponentKinds);
+        }
+
+        [Fact]
+        public void BodygroupsBuilder_EmptySavedValueSelectsFirstDeclaredOption()
+        {
+            var options = new List<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>>
+            {
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "pilot",
+                    new FuseConfusingSupplementsBodygroupOption { Name = "Pilot" }),
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "snowplow",
+                    new FuseConfusingSupplementsBodygroupOption { Name = "Snowplow" })
+            };
+
+            var selected = FuseConfusingSupplementsBodygroupsBuilder.ReadSelectedOption(
+                Value.Null(),
+                options);
+
+            Assert.Equal("pilot", selected);
+            Assert.Equal(
+                "cs.bodygroups.pilot",
+                FuseConfusingSupplementsBodygroupsBuilder.SavedPropertyKey("pilot"));
+        }
+
+        [Fact]
+        public void BodygroupsBuilder_SavedValueWinsOverDefault()
+        {
+            var options = new List<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>>
+            {
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "pilot",
+                    new FuseConfusingSupplementsBodygroupOption()),
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "snowplow",
+                    new FuseConfusingSupplementsBodygroupOption())
+            };
+
+            var selected = FuseConfusingSupplementsBodygroupsBuilder.ReadSelectedOption(
+                Value.String("snowplow"),
+                options);
+
+            Assert.Equal("snowplow", selected);
+        }
+
+        [Fact]
+        public void BodygroupsBuilder_StaleSavedValueSelectsFirstDeclaredOption()
+        {
+            var options = new List<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>>
+            {
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "pilot",
+                    new FuseConfusingSupplementsBodygroupOption()),
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "snowplow",
+                    new FuseConfusingSupplementsBodygroupOption())
+            };
+
+            var selected = FuseConfusingSupplementsBodygroupsBuilder.ReadSelectedOption(
+                Value.String("removed-option"),
+                options);
+
+            Assert.Equal("pilot", selected);
+        }
+
+        [Fact]
+        public void ReplacementSurface_AccountsForEveryRegisteredRollingStockKind()
+        {
+            var expected = new[]
+            {
+                "ConfusingSupplements.Bodygroups",
+                "ConfusingSupplements.DestinationSign",
+                "ConfusingSupplements.LabelPrinter",
+                "CS.LiverySwap",
+                "ConfusingSupplements.Refiller"
+            };
+            var actual = FuseConfusingSupplementsCompatibility.ImplementedComponentKinds;
+
+            Assert.Equal(expected.Length, actual.Count);
+            Assert.All(expected, kind => Assert.Contains(kind, actual));
+            Assert.All(actual, kind => Assert.Contains(kind, expected));
+        }
+
+        [Theory]
+        [InlineData(-1, 3, false, 0)]
+        [InlineData(2, 3, false, -1)]
+        [InlineData(-1, 3, true, 2)]
+        [InlineData(0, 3, true, -1)]
+        [InlineData(0, 0, false, -1)]
+        public void DestinationSign_CyclesThroughHiddenAndNamedStates(
+            int current,
+            int count,
+            bool previous,
+            int expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseConfusingSupplementsDestinationSignPolicy.NextIndex(current, count, previous));
+        }
+
+        [Theory]
+        [InlineData("paint.PNG", true)]
+        [InlineData("paint.jpeg", true)]
+        [InlineData("paint.JPG", true)]
+        [InlineData("readme.txt", false)]
+        public void LiveryRegistry_AcceptsOnlySupportedTextureFiles(string path, bool expected)
+        {
+            Assert.Equal(expected, FuseConfusingSupplementsLiveryPolicy.IsTextureFile(path));
+        }
+
+        [Fact]
+        public void LiveryCompatibility_RegistersRefreshAndDiagnosticCommands()
+        {
+            var commandTypes = new[]
+            {
+                typeof(FuseLiveryRefreshCommand),
+                typeof(FuseLiveryRefreshAliasCommand),
+                typeof(FuseLiveryReportCommand)
+            };
+            var keywords = commandTypes.Select(commandType => CustomAttributeData
+                    .GetCustomAttributes(commandType)
+                    .Single(attribute =>
+                        attribute.AttributeType.FullName ==
+                        "UI.Console.ConsoleCommandAttribute")
+                    .ConstructorArguments[0]
+                    .Value as string)
+                .ToArray();
+
+            Assert.Contains("/cs-livery-refresh", keywords);
+            Assert.Contains("/fuse.livery.refresh", keywords);
+            Assert.Contains("/fuse.liveries", keywords);
+        }
+
+        [Theory]
+        [InlineData("diesel", "DIESEL", true)]
+        [InlineData("diesel", "coal", false)]
+        [InlineData(null, "diesel", false)]
+        [InlineData("diesel", null, false)]
+        [InlineData("", "diesel", false)]
+        [InlineData("diesel", "", false)]
+        public void RefillerCompatibility_MatchesLoadIdentifiersCaseInsensitively(
+            string sourceIdentifier,
+            string targetIdentifier,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseConfusingSupplementsRefillerPolicy.CanTargetReceiveFromSource(
+                    new[] { sourceIdentifier },
+                    new[] { targetIdentifier }));
+        }
+
+        [Fact]
+        public void RefillerTransferBudget_IsSharedAcrossTargetSlots()
+        {
+            var remainingTransfer = 10f;
+
+            var firstSlot = FuseConfusingSupplementsRefillerPolicy.Take(
+                ref remainingTransfer,
+                6f,
+                10f);
+            var secondSlot = FuseConfusingSupplementsRefillerPolicy.Take(
+                ref remainingTransfer,
+                8f,
+                10f);
+
+            Assert.Equal(6f, firstSlot);
+            Assert.Equal(4f, secondSlot);
+            Assert.Equal(0f, remainingTransfer);
+        }
+
+    }
+}

--- a/FUSE.Tests/Loading/FuseDirectStoreLegosLibraryReproTests.cs
+++ b/FUSE.Tests/Loading/FuseDirectStoreLegosLibraryReproTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using FUSE.Loading;
+using FUSE.Patches;
 using HarmonyLib;
 using Model.Definition;
 using Model.Definition.Data;
@@ -55,6 +56,34 @@ namespace FUSE.Tests.Loading
         {
             _h = harness;
             _out = output;
+        }
+
+        [Fact]
+        public void CompatibilityLatch_ReentersInstallerAfterSuccessfulUnpatch()
+        {
+            var installedField = typeof(FuseLegosLibraryCompatibility).GetField(
+                "_installed",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(installedField);
+            var original = (bool)installedField.GetValue(null);
+
+            try
+            {
+                installedField.SetValue(null, true);
+                Assert.Equal(
+                    "installed",
+                    FuseLegosLibraryCompatibility.EnsureInstalled(null));
+
+                FuseLegosLibraryCompatibility.ResetAfterSuccessfulUnpatch();
+
+                Assert.Equal(
+                    "unavailable (no harmony)",
+                    FuseLegosLibraryCompatibility.EnsureInstalled(null));
+            }
+            finally
+            {
+                installedField.SetValue(null, original);
+            }
         }
 
         // ------------------------------------------------------------------

--- a/FUSE.Tests/Patches/FuseAlinasUtilitiesCompatibilityTests.cs
+++ b/FUSE.Tests/Patches/FuseAlinasUtilitiesCompatibilityTests.cs
@@ -1,0 +1,70 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public class FuseAlinasUtilitiesCompatibilityTests
+    {
+        [Theory]
+        [InlineData("AlinasUtils", true)]
+        [InlineData("AlinasUtils1", true)]
+        [InlineData("alinasutils-recovered", true)]
+        [InlineData("Utilities", false)]
+        [InlineData("AlinasMapMod", false)]
+        [InlineData(null, false)]
+        public void AssemblyMatch_AcceptsRecoveredAlinasUtilitiesIdentities(
+            string assemblyName,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseAlinasUtilitiesCompatibility.IsTargetAssemblyName(assemblyName));
+        }
+
+        [Fact]
+        public void SettingsResolution_PreservesCurrentInstance()
+        {
+            var current = new object();
+            var umm = new object();
+
+            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettings(
+                current,
+                umm,
+                () => new object());
+
+            Assert.Same(current, resolved);
+        }
+
+        [Fact]
+        public void SettingsResolution_UsesUmmSettingsBeforeDefault()
+        {
+            var umm = new object();
+            var created = false;
+
+            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettings(
+                null,
+                umm,
+                () =>
+                {
+                    created = true;
+                    return new object();
+                });
+
+            Assert.Same(umm, resolved);
+            Assert.False(created);
+        }
+
+        [Fact]
+        public void SettingsResolution_CreatesDefaultAsLastResort()
+        {
+            var fallback = new object();
+
+            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettings(
+                null,
+                null,
+                () => fallback);
+
+            Assert.Same(fallback, resolved);
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseAssetLoaderReplacementCompatibilityTests.cs
+++ b/FUSE.Tests/Patches/FuseAssetLoaderReplacementCompatibilityTests.cs
@@ -1,0 +1,20 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public class FuseAssetLoaderReplacementCompatibilityTests
+    {
+        [Theory]
+        [InlineData("AssetLoader", true)]
+        [InlineData("assetloader", true)]
+        [InlineData("FUSE", false)]
+        [InlineData("SomeAssetPack", false)]
+        [InlineData(null, false)]
+        public void AssemblyMatch_IsExactAndCaseInsensitive(string assemblyName, bool expected)
+        {
+            Assert.Equal(expected,
+                FuseAssetLoaderReplacementCompatibility.IsTargetAssemblyName(assemblyName));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseCompanyStarterPlacementPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseCompanyStarterPlacementPatchTests.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseCompanyStarterPlacementPatchTests
+    {
+        [Fact]
+        public void StarterPool_RequiresAppalachianWhittierStartDefinition()
+        {
+            Assert.False(
+                FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
+                    "ewh-company",
+                    new[] { "FUSE", "Some.Other.Mod" }));
+            Assert.True(
+                FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
+                    "ewh-company",
+                    new[]
+                    {
+                        "FUSE",
+                        "KingG.Appalachian-Railway.start-whit",
+                    }));
+        }
+
+        [Fact]
+        public void StarterPool_DoesNotAffectOtherCompanyStarts()
+        {
+            var loaded = new[]
+            {
+                "KingG.Appalachian-Railway.start-whit",
+            };
+
+            Assert.False(
+                FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
+                    "ela-company",
+                    loaded));
+            Assert.False(
+                FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
+                    "",
+                    loaded));
+        }
+
+        [Theory]
+        [InlineData(false, false, false, 1)]
+        [InlineData(true, true, false, 1)]
+        [InlineData(true, false, true, 0)]
+        public void StarterPool_PreparesQueueOnlyForEligibleInactiveSetup(
+            bool shouldQueue,
+            bool presentationActive,
+            bool expectedPrepared,
+            int expectedRemaining)
+        {
+            var pending = new Queue<string>();
+            pending.Enqueue("retained-cut");
+
+            var prepared =
+                FuseCompanyStarterPlacementPatch.TryPrepareStarterQueue(
+                    pending,
+                    shouldQueue,
+                    presentationActive);
+
+            Assert.Equal(expectedPrepared, prepared);
+            Assert.Equal(expectedRemaining, pending.Count);
+        }
+
+        [Theory]
+        [InlineData(false, 3, 0, false)]
+        [InlineData(true, 3, 0, false)]
+        [InlineData(true, 3, 2, false)]
+        [InlineData(true, 3, 3, true)]
+        [InlineData(true, 0, 0, false)]
+        public void StarterPool_ConsumesCutOnlyAfterConfirmedCompletePlacement(
+            bool callbackReportedPlaced,
+            int expectedCarCount,
+            int placedCarCount,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseCompanyStarterPlacementPatch.WasPlacementCommitted(
+                    callbackReportedPlaced,
+                    expectedCarCount,
+                    placedCarCount));
+        }
+
+        [Theory]
+        [InlineData(false, 0, false, 1)]
+        [InlineData(true, 0, true, 0)]
+        [InlineData(true, 1, false, 1)]
+        public void StarterPool_DiscardsOnlySuccessfullyPreparedEmptyCuts(
+            bool preparationSucceeded,
+            int descriptorCount,
+            bool expectedConsumed,
+            int expectedRemaining)
+        {
+            var pending = new Queue<string>();
+            pending.Enqueue("retained-cut");
+
+            var consumed =
+                FuseCompanyStarterPlacementPatch.TryConsumeConfirmedEmpty(
+                    pending,
+                    preparationSucceeded,
+                    descriptorCount);
+
+            Assert.Equal(expectedConsumed, consumed);
+            Assert.Equal(expectedRemaining, pending.Count);
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseCustomIndustryTitlePatchTests.cs
+++ b/FUSE.Tests/Patches/FuseCustomIndustryTitlePatchTests.cs
@@ -1,0 +1,44 @@
+using FUSE.Patches;
+using StrangeCustoms.Tracks.Industries;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseCustomIndustryTitlePatchTests
+    {
+        [Fact]
+        public void TryGetCustomTitle_UsesLegacyCustomIndustryTitleContract()
+        {
+            var component = new FakeTitledComponent("Acquire coal at test depot");
+
+            var found = FuseCustomIndustryTitlePatch.TryGetCustomTitle(component, out var title);
+
+            Assert.True(found);
+            Assert.Equal("Acquire coal at test depot", title);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void TryGetCustomTitle_RejectsMissingTitle(string value)
+        {
+            var component = new FakeTitledComponent(value);
+
+            var found = FuseCustomIndustryTitlePatch.TryGetCustomTitle(component, out var title);
+
+            Assert.False(found);
+            Assert.Equal(value, title);
+        }
+
+        private sealed class FakeTitledComponent : ICustomIndustryTitle
+        {
+            internal FakeTitledComponent(string title)
+            {
+                Title = title;
+            }
+
+            public string Title { get; }
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseFallFromGraceCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseFallFromGraceCompatibilityPatchTests.cs
@@ -1,0 +1,39 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseFallFromGraceCompatibilityPatchTests
+    {
+        [Theory]
+        [InlineData(0, 0, 1, 0, 0)]
+        [InlineData(2, 0, 2, 1, 5)]
+        [InlineData(0, 3, 1, 0, 3)]
+        [InlineData(2, 0, int.MaxValue, int.MaxValue, int.MaxValue)]
+        [InlineData(int.MaxValue, int.MinValue, -2, 0, int.MinValue)]
+        public void Grace_adjustment_is_identity_configurable_and_overflow_safe(
+            int baseDays,
+            int minimum,
+            int multiplier,
+            int added,
+            int expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseFallFromGraceCalculationPatch.AdjustGraceDays(baseDays, minimum, multiplier, added));
+        }
+
+        [Theory]
+        [InlineData("2 days", true, "2 days remaining")]
+        [InlineData("3 hours", false, "3 hours overdue")]
+        [InlineData(null, true, " remaining")]
+        public void Due_status_is_total_and_distinguishes_remaining_from_overdue(
+            string interval,
+            bool remaining,
+            string expected)
+        {
+            Assert.Equal(expected, FuseFallFromGraceInspectorPatch.FormatDueStatus(interval, remaining));
+        }
+
+    }
+}

--- a/FUSE.Tests/Patches/FuseForYourConvenienceCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseForYourConvenienceCompatibilityPatchTests.cs
@@ -1,0 +1,64 @@
+using FUSE.Patches;
+using HarmonyLib;
+using Model;
+using UI.Map;
+using UI.Tags;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseForYourConvenienceCompatibilityPatchTests
+    {
+        [Theory]
+        [InlineData(0f, "0.0 MPH")]
+        [InlineData(10f, "22.4 MPH")]
+        [InlineData(-10f, "22.4 MPH")]
+        public void Speed_is_displayed_as_absolute_mph(float metersPerSecond, string expected)
+        {
+            Assert.Equal(expected, FuseForYourConveniencePolicy.FormatSpeed(metersPerSecond));
+        }
+
+        [Theory]
+        [InlineData(5f, 10f, "Coal", "50% Coal")]
+        [InlineData(50f, 10f, "Coal", "100% Coal")]
+        [InlineData(5f, 0f, null, "0% Unknown load")]
+        public void Load_summary_is_bounded_and_handles_bad_capacity(
+            float quantity,
+            float capacity,
+            string description,
+            string expected)
+        {
+            Assert.Equal(expected,
+                FuseForYourConveniencePolicy.FormatLoad(quantity, capacity, description));
+        }
+
+        [Theory]
+        [InlineData("Whittier", "whittier", null, true)]
+        [InlineData("Whittier Station", "WHITTIER_AREA", null, true)]
+        [InlineData("Bryson Depot", null, "bryson-depot", true)]
+        [InlineData("Whittier Saw Mill", "whittier", null, false)]
+        [InlineData("Whittier Saw Mill", "bryson", "bryson-depot", false)]
+        [InlineData("R1", "r1", null, false)]
+        public void Station_actions_require_a_matching_named_icon(
+            string iconIdentity,
+            string areaId,
+            string passengerStopId,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseForYourConvenienceStationMapPatch.IsStationIdentityMatch(
+                    iconIdentity,
+                    areaId,
+                    passengerStopId));
+        }
+
+        [Fact]
+        public void Harmony_targets_match_the_installed_game_contract()
+        {
+            Assert.NotNull(AccessTools.Method(typeof(Car), nameof(Car.Setup)));
+            Assert.NotNull(AccessTools.Method(typeof(TagController), "UpdateTag"));
+            Assert.NotNull(AccessTools.Method(typeof(MapBuilder), nameof(MapBuilder.Rebuild)));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseLocationPickerDeduplicationPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseLocationPickerDeduplicationPatchTests.cs
@@ -1,0 +1,88 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseLocationPickerDeduplicationPatchTests
+    {
+        [Fact]
+        public void DeduplicateByKey_CollapsesEquivalentKeysAndPreservesOrder()
+        {
+            var source = new[] { "sawmill-mp1", "SAWMILL-MP1", "sawmill-mp2" };
+
+            var removed = FuseLocationPickerDeduplicationPatch.DeduplicateByKey(
+                source,
+                value => value,
+                out var result);
+
+            Assert.Equal(1, removed);
+            Assert.Equal(new[] { "sawmill-mp1", "sawmill-mp2" }, result);
+        }
+
+        [Fact]
+        public void DeduplicateByKey_PreservesRowsWhoseIdentityCannotBeResolved()
+        {
+            var source = new[] { "broken-one", "broken-two" };
+
+            var removed = FuseLocationPickerDeduplicationPatch.DeduplicateByKey(
+                source,
+                _ => null,
+                out var result);
+
+            Assert.Equal(0, removed);
+            Assert.Equal(source, result);
+        }
+
+        [Fact]
+        public void DeduplicateByKey_PreservesSourceWhenKeySelectorIsNull()
+        {
+            var source = new[] { "sawmill-mp1", "sawmill-mp2" };
+
+            var removed = FuseLocationPickerDeduplicationPatch.DeduplicateByKey(
+                source,
+                null,
+                out var result);
+
+            Assert.Equal(0, removed);
+            Assert.Equal(source, result);
+        }
+
+        [Fact]
+        public void DeduplicateByKey_ReturnsEmptyResultForNullSource()
+        {
+            var removed = FuseLocationPickerDeduplicationPatch.DeduplicateByKey<string>(
+                null,
+                value => value,
+                out var result);
+
+            Assert.Equal(0, removed);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ResolveCanonicalByKey_ReturnsRetainedEquivalentInstance()
+        {
+            var retained = new Item("sawmill-mp1", 1);
+            var duplicate = new Item("SAWMILL-MP1", 2);
+
+            var selected = FuseLocationPickerDeduplicationPatch.ResolveCanonicalByKey(
+                duplicate,
+                new[] { retained },
+                item => item.Id);
+
+            Assert.Same(retained, selected);
+        }
+
+        private sealed class Item
+        {
+            internal Item(string id, int instance)
+            {
+                Id = id;
+                Instance = instance;
+            }
+
+            internal string Id { get; }
+            internal int Instance { get; }
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseMessengerIsolationPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseMessengerIsolationPatchTests.cs
@@ -6,6 +6,7 @@ using FUSE.Patches;
 using GalaSoft.MvvmLight.Helpers;
 using Game.Events;
 using HarmonyLib;
+using Railloader.Events;
 using Xunit;
 
 namespace FUSE.Tests.Patches
@@ -64,9 +65,10 @@ namespace FUSE.Tests.Patches
         }
 
         [Fact]
-        public void TargetMethods_CoverAllFourLifecycleEvents_WithBothDispatchEntries()
+        public void TargetMethods_CoverLifecycleAndLegacyDebugEvents_WithBothDispatchEntries()
         {
-            // Full expected surface: four lifecycle structs, two dispatch
+            // Full expected surface: four lifecycle structs plus the legacy
+            // debug-report contribution event, two dispatch
             // entries each. Compile-time typeofs again so any single
             // event going missing or changing shape raises an alarm here
             // instead of a runtime "stays unguarded" warning nobody reads.
@@ -75,7 +77,8 @@ namespace FUSE.Tests.Patches
                 typeof(MapWillLoadEvent),
                 typeof(MapDidLoadEvent),
                 typeof(MapWillUnloadEvent),
-                typeof(MapDidUnloadEvent)
+                typeof(MapDidUnloadEvent),
+                typeof(WillCopyDebugInformation)
             };
 
             var expected = new HashSet<MethodBase>();

--- a/FUSE.Tests/Patches/FuseOutboundIndustryRoutingPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseOutboundIndustryRoutingPatchTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseOutboundIndustryRoutingPatchTests
+    {
+        [Theory]
+        [InlineData(false, false, false, 0)]
+        [InlineData(false, true, false, 1)]
+        [InlineData(false, false, true, 2)]
+        [InlineData(false, true, true, 2)]
+        [InlineData(true, false, false, 2)]
+        public void ResolveMode_preserves_opt_in_and_legacy_precedence(
+            bool explicitOptIn,
+            bool absolute,
+            bool configurable,
+            int expected)
+        {
+            Assert.Equal(expected, (int)FuseOutboundIndustryRoutingPatch.ResolveMode(
+                explicitOptIn,
+                absolute,
+                configurable));
+        }
+
+        [Fact]
+        public void Shuffle_is_deterministic_with_a_supplied_random_source()
+        {
+            var first = new List<int> { 1, 2, 3, 4, 5 };
+            var second = new List<int> { 1, 2, 3, 4, 5 };
+
+            FuseOutboundIndustryBlockingPatch.Shuffle(first, new Random(19));
+            FuseOutboundIndustryBlockingPatch.Shuffle(second, new Random(19));
+
+            Assert.Equal(first, second);
+            Assert.NotEqual(new[] { 1, 2, 3, 4, 5 }, first);
+        }
+
+    }
+}

--- a/FUSE.UnityTests/Assets/Tests/LegacyRuntimeBehaviorTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/LegacyRuntimeBehaviorTests.cs
@@ -1,11 +1,23 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using FUSE.Authoring.Data;
+using FUSE.Compatibility;
+using FUSE.Patches;
 using FUSE.Runtime.API;
+using Game.Messages;
+using Game.Progression;
+using HarmonyLib;
+using KeyValue.Runtime;
 using Model.Ops;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Track;
+using UI.Builder;
+using UI.CarInspector;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -171,6 +183,377 @@ namespace FUSE.UnityTests
             Assert.That(target.shadowCastingMode, Is.EqualTo(ShadowCastingMode.Off));
         }
 
+        [Test]
+        public void StrangeCustomsFileCache_NormalizesPathsAndTracksEntryState()
+        {
+            var relative = Path.Combine("fixtures", "audio.wav");
+            var normalized = StrangeCustoms.FileCache.NormalizePath(relative);
+            var equivalent = StrangeCustoms.FileCache.NormalizePath(
+                Path.Combine("fixtures", ".", "audio.wav"));
+
+            Assert.That(Path.IsPathRooted(normalized), Is.True);
+            Assert.That(equivalent, Is.EqualTo(normalized));
+
+            var entry = new StrangeCustoms.FileCache.CacheEntry<string>(relative);
+            string observed = null;
+            entry.Register(value => observed = value);
+            entry.Set("loaded");
+
+            Assert.That(entry.IsValid, Is.True);
+            Assert.That(entry.IsLoading, Is.False);
+            Assert.That(entry.Value, Is.EqualTo("loaded"));
+            Assert.That(observed, Is.EqualTo("loaded"));
+
+            entry.Invalidate();
+            Assert.That(entry.IsValid, Is.False);
+            Assert.That(entry.Value, Is.Null);
+        }
+
+        [Test]
+        public void StrangeCustomsFlowyBuilder_AdaptsLegacyDataToNativeSpliney()
+        {
+            var definition = StrangeCustoms.FlowyThingBuilder.ConvertDefinition(
+                JObject.Parse(@"{
+                    'handler': 'StrangeCustoms.FlowyThingBuilder',
+                    'style': 'River',
+                    'profile': 'River profile',
+                    'points': [
+                        { 'position': { 'x': 1, 'y': 2, 'z': 3 }, 'width': 4 },
+                        { 'position': { 'x': 5, 'y': 6, 'z': 7 }, 'width': 8 }
+                    ]
+                }"));
+
+            Assert.That(definition.Type, Is.EqualTo("river"));
+            Assert.That(definition.Profile, Is.EqualTo("River profile"));
+            Assert.That(definition.OffsetY, Is.EqualTo(-0.1f));
+            Assert.That(definition.Points.Length, Is.EqualTo(2));
+            Assert.That(definition.Points[0].Width, Is.EqualTo(4f));
+            Assert.That(definition.Points[1].Position.z, Is.EqualTo(7f));
+        }
+
+        [Test]
+        public void LabelPrinter_SavedPropertyIdTrimsGroupThenNameFallback()
+        {
+            var grouped = new FuseConfusingSupplementsLabelPrinterComponent
+            {
+                Name = "Visible Name",
+                Group = " shared-label "
+            };
+            var ungrouped = new FuseConfusingSupplementsLabelPrinterComponent
+            {
+                Name = " road-name ",
+                Group = "   "
+            };
+
+            Assert.That(grouped.SavedPropertyId, Is.EqualTo("shared-label"));
+            Assert.That(ungrouped.SavedPropertyId, Is.EqualTo("road-name"));
+            Assert.That(
+                FuseConfusingSupplementsLabelPrinterBuilder.SavedPropertyKey(ungrouped.SavedPropertyId),
+                Is.EqualTo("cs.labelprinter.road-name"));
+            Assert.That(FuseConfusingSupplementsLabelPrinterBuilder.ReadText(Value.Null()), Is.Empty);
+        }
+
+        [Test]
+        public void LabelPrinter_UpdatedTextPreservesDictionaryFields()
+        {
+            var current = Value.Dictionary(new Dictionary<string, Value>
+            {
+                ["text"] = Value.String("Old text"),
+                ["font"] = Value.String("Railroad Roman")
+            });
+
+            var updated = FuseConfusingSupplementsLabelPrinterBuilder.UpdatedTextValue(current, "New text");
+            var runtime = PropertyValueConverter.SnapshotToRuntime(updated);
+
+            Assert.That(FuseConfusingSupplementsLabelPrinterBuilder.ReadText(runtime), Is.EqualTo("New text"));
+            Assert.That(runtime.DictionaryValue["font"].StringValue, Is.EqualTo("Railroad Roman"));
+        }
+
+        [Test]
+        public void LiveryController_BlankOrMissingSelectionRestoresOriginalTexture()
+        {
+            var controller = CreateLiveryController(
+                out var material,
+                out var originalTexture,
+                out var replacementTexture);
+
+            try
+            {
+                material.mainTexture = replacementTexture;
+                controller.ApplySavedSelection(Value.Null());
+                Assert.That(material.mainTexture, Is.SameAs(originalTexture));
+
+                material.mainTexture = replacementTexture;
+                controller.ApplySavedSelection(Value.String("removed-livery"));
+                Assert.That(material.mainTexture, Is.SameAs(originalTexture));
+            }
+            finally
+            {
+                FuseConfusingSupplementsLiveryRegistry.Shutdown();
+                UnityEngine.Object.DestroyImmediate(originalTexture);
+                UnityEngine.Object.DestroyImmediate(replacementTexture);
+                UnityEngine.Object.DestroyImmediate(material);
+            }
+        }
+
+        [Test]
+        public void LiveryRegistry_RefreshLiveCarsRestoresOriginalBeforeClearingCache()
+        {
+            CreateLiveryController(
+                out var material,
+                out var originalTexture,
+                out var replacementTexture);
+
+            try
+            {
+                material.mainTexture = replacementTexture;
+                AddCachedLiveryTexture("refresh-test", replacementTexture);
+
+                var refreshed = FuseConfusingSupplementsLiveryRegistry.RefreshLiveCars();
+
+                Assert.That(refreshed, Is.GreaterThanOrEqualTo(1));
+                Assert.That(material.mainTexture, Is.SameAs(originalTexture));
+                Assert.That(FuseConfusingSupplementsLiveryRegistry.CachedTextureCount, Is.Zero);
+            }
+            finally
+            {
+                FuseConfusingSupplementsLiveryRegistry.Shutdown();
+                UnityEngine.Object.DestroyImmediate(originalTexture);
+                if (replacementTexture != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(replacementTexture);
+                }
+
+                UnityEngine.Object.DestroyImmediate(material);
+            }
+        }
+
+        [Test]
+        public void LiveryController_OnDestroyDestroysEveryTrackedMaterialOnce()
+        {
+            var shader = Shader.Find("Unlit/Texture") ??
+                         Shader.Find("Sprites/Default") ??
+                         Shader.Find("Standard");
+            Assert.That(shader, Is.Not.Null);
+
+            var controllerObject = new GameObject("livery material cleanup fixture");
+            controllerObject.transform.SetParent(_root.transform, false);
+            var controller = controllerObject.AddComponent<FuseConfusingSupplementsLiveryController>();
+            var sourceTexture = new Texture2D(1, 1);
+            var sourceMaterial = new Material(shader);
+            sourceMaterial.mainTexture = sourceTexture;
+            try
+            {
+                var firstRendererObject = new GameObject("first livery renderer");
+                firstRendererObject.transform.SetParent(controllerObject.transform, false);
+                var firstRenderer = firstRendererObject.AddComponent<MeshRenderer>();
+                firstRenderer.sharedMaterial = sourceMaterial;
+
+                var secondRendererObject = new GameObject("second livery renderer");
+                secondRendererObject.transform.SetParent(controllerObject.transform, false);
+                var secondRenderer = secondRendererObject.AddComponent<MeshRenderer>();
+                secondRenderer.sharedMaterial = sourceMaterial;
+
+                controller.CaptureMaterials(controllerObject);
+                var capturedMaterials = new[]
+                {
+                    firstRenderer.material,
+                    secondRenderer.material
+                };
+
+                var ownedMaterialsField = typeof(FuseConfusingSupplementsLiveryController).GetField(
+                    "_ownedMaterials",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.That(ownedMaterialsField, Is.Not.Null);
+                var ownedMaterials = ownedMaterialsField.GetValue(controller) as ISet<Material>;
+                Assert.That(ownedMaterials, Is.Not.Null);
+                Assert.That(ownedMaterials.Count, Is.EqualTo(capturedMaterials.Distinct().Count()));
+
+                var materialSnapshotsField = typeof(FuseConfusingSupplementsLiveryController).GetField(
+                    "_materials",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.That(materialSnapshotsField, Is.Not.Null);
+                var materialSnapshots = materialSnapshotsField.GetValue(controller) as ICollection;
+                Assert.That(materialSnapshots, Is.Not.Null);
+                var initialSnapshotCount = materialSnapshots.Count;
+                Assert.That(initialSnapshotCount, Is.GreaterThan(0));
+
+                controller.CaptureMaterials(controllerObject);
+                Assert.That(ownedMaterials.Count, Is.EqualTo(capturedMaterials.Distinct().Count()));
+                Assert.That(materialSnapshots.Count, Is.EqualTo(initialSnapshotCount));
+
+                UnityEngine.Object.DestroyImmediate(controllerObject);
+
+                Assert.That(capturedMaterials.All(material => material == null), Is.True);
+                Assert.That(sourceMaterial == null, Is.False);
+            }
+            finally
+            {
+                if (controllerObject != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(controllerObject);
+                }
+
+                if (sourceMaterial != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(sourceMaterial);
+                }
+
+                if (sourceTexture != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(sourceTexture);
+                }
+            }
+        }
+
+        [Test]
+        public void LiveryRegistry_DestroyTextureUsesImmediateCleanupInEditMode()
+        {
+            Assert.That(Application.isPlaying, Is.False);
+            var texture = new Texture2D(1, 1);
+
+            FuseConfusingSupplementsLiveryRegistry.DestroyTexture(texture);
+
+            Assert.That(texture == null, Is.True);
+        }
+
+        [Test]
+        public void LiveryRegistry_FileIndexIsDeterministicAndClearedWithTextureCache()
+        {
+            var directory = Path.Combine(Path.GetTempPath(), "FUSE-livery-index-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+            try
+            {
+                var jpgPath = Path.Combine(directory, "boiler.jpg");
+                var pngPath = Path.Combine(directory, "boiler.png");
+                File.WriteAllBytes(pngPath, Array.Empty<byte>());
+                File.WriteAllBytes(jpgPath, Array.Empty<byte>());
+
+                var first = FuseConfusingSupplementsLiveryRegistry.GetTextureFiles(directory);
+                Assert.That(first["boiler"], Is.EqualTo(jpgPath));
+
+                var cabPath = Path.Combine(directory, "cab.png");
+                File.WriteAllBytes(cabPath, Array.Empty<byte>());
+                var cached = FuseConfusingSupplementsLiveryRegistry.GetTextureFiles(directory);
+                Assert.That(cached, Is.SameAs(first));
+                Assert.That(cached.ContainsKey("cab"), Is.False);
+
+                FuseConfusingSupplementsLiveryRegistry.Shutdown();
+                var refreshed = FuseConfusingSupplementsLiveryRegistry.GetTextureFiles(directory);
+                Assert.That(refreshed.ContainsKey("cab"), Is.True);
+            }
+            finally
+            {
+                FuseConfusingSupplementsLiveryRegistry.Shutdown();
+                Directory.Delete(directory, true);
+            }
+        }
+
+        [Test]
+        public void GracePatch_TargetsTheLocationOverload()
+        {
+            var expected = AccessTools.Method(
+                typeof(OpsController),
+                "CalculateGraceDays",
+                new[] { typeof(Location), typeof(Location) });
+            var declared = ResolveDeclaredHarmonyTarget(typeof(FuseFallFromGraceCalculationPatch));
+
+            Assert.That(expected, Is.Not.Null);
+            Assert.That(declared, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void InspectorPatch_TargetsTheWaybillPanelOverload()
+        {
+            var expected = AccessTools.Method(
+                typeof(CarInspector),
+                "PopulateWaybillPanel",
+                new[] { typeof(UIPanelBuilder), typeof(Waybill) });
+            var declared = ResolveDeclaredHarmonyTarget(typeof(FuseFallFromGraceInspectorPatch));
+
+            Assert.That(expected, Is.Not.Null);
+            Assert.That(declared, Is.EqualTo(expected));
+        }
+
+        private static MethodInfo ResolveDeclaredHarmonyTarget(Type patchType)
+        {
+            Type declaringType = null;
+            string methodName = null;
+            Type[] argumentTypes = null;
+            foreach (var patch in patchType.GetCustomAttributes(typeof(HarmonyPatch), false).Cast<HarmonyPatch>())
+            {
+                if (patch.info?.declaringType != null)
+                {
+                    declaringType = patch.info.declaringType;
+                }
+
+                if (!string.IsNullOrWhiteSpace(patch.info?.methodName))
+                {
+                    methodName = patch.info.methodName;
+                }
+
+                if (patch.info?.argumentTypes != null)
+                {
+                    argumentTypes = patch.info.argumentTypes;
+                }
+            }
+
+            Assert.That(declaringType, Is.Not.Null);
+            Assert.That(methodName, Is.Not.Null.And.Not.Empty);
+            return AccessTools.Method(declaringType, methodName, argumentTypes);
+        }
+
+        [TestCase(0f, 0)]
+        [TestCase(0.24f, 0)]
+        [TestCase(0.25f, 0)]
+        [TestCase(0.26f, 1)]
+        [TestCase(0.99f, 1)]
+        public void WeightedSelection_UsesRemainingCapacity(float sample, int expected)
+        {
+            Assert.That(
+                FuseOutboundIndustryRoutingPatch.SelectWeightedIndex(
+                    new[] { 1f, 3f },
+                    sample),
+                Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void WeightedSelection_HandlesEmptyAndZeroWeightSets()
+        {
+            Assert.That(
+                FuseOutboundIndustryRoutingPatch.SelectWeightedIndex(
+                    Array.Empty<float>(),
+                    0.5f),
+                Is.EqualTo(-1));
+            Assert.That(
+                FuseOutboundIndustryRoutingPatch.SelectWeightedIndex(
+                    new[] { 0f, 0f },
+                    0.75f),
+                Is.EqualTo(1));
+        }
+
+        [Test]
+        public void CompanyStarterQueue_SkipsNullPlacements()
+        {
+            var validPlacement = new SetupDescriptor.CarPlacement
+            {
+                carIdentifier = new[] { "starter-car" }
+            };
+            var setup = _root.AddComponent<SetupDescriptor>();
+            setup.identifier = "ewh-company";
+            setup.placements = new[] { null, validPlacement };
+            var queue = new Queue<SetupDescriptor.CarPlacement>();
+
+            var queued = FuseCompanyStarterPlacementPatch.QueueStarterPlacements(
+                setup,
+                queue);
+
+            Assert.That(queued, Is.EqualTo(1));
+            Assert.That(queue.Count, Is.EqualTo(1));
+            Assert.That(queue.Peek(), Is.SameAs(validPlacement));
+            Assert.That(setup.placements, Is.Empty);
+        }
+
         private static FuseSplineyPoint Point(float x, float z)
         {
             return new FuseSplineyPoint { Position = new Vector3(x, 0f, z) };
@@ -183,6 +566,78 @@ namespace FUSE.UnityTests
                 BindingFlags.NonPublic | BindingFlags.Static);
             Assert.That(method, Is.Not.Null);
             method.Invoke(null, new object[] { source, target });
+        }
+
+        private FuseConfusingSupplementsLiveryController CreateLiveryController(
+            out Material material,
+            out Texture2D originalTexture,
+            out Texture2D replacementTexture)
+        {
+            var shader = Shader.Find("Unlit/Texture") ??
+                         Shader.Find("Sprites/Default") ??
+                         Shader.Find("Standard");
+            Assert.That(shader, Is.Not.Null);
+
+            var carObject = new GameObject("livery controller fixture");
+            carObject.transform.SetParent(_root.transform, false);
+            var renderer = carObject.AddComponent<MeshRenderer>();
+            material = new Material(shader);
+            originalTexture = new Texture2D(1, 1) { name = "original" };
+            replacementTexture = new Texture2D(1, 1) { name = "replacement" };
+            material.mainTexture = originalTexture;
+            renderer.sharedMaterial = material;
+
+            var propertyIds = new List<int>();
+            material.GetTexturePropertyNameIDs(propertyIds);
+            var fixtureMaterial = material;
+            var fixtureOriginalTexture = originalTexture;
+            var propertyId = propertyIds.First(
+                id => fixtureMaterial.GetTexture(id) == fixtureOriginalTexture);
+
+            var controller = carObject.AddComponent<FuseConfusingSupplementsLiveryController>();
+            var controllerType = typeof(FuseConfusingSupplementsLiveryController);
+            var snapshotType = controllerType.GetNestedType("MaterialSnapshot", BindingFlags.NonPublic);
+            Assert.That(snapshotType, Is.Not.Null);
+            var constructor = snapshotType.GetConstructor(
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                null,
+                new[] { typeof(Material), typeof(int), typeof(Texture), typeof(string) },
+                null);
+            Assert.That(constructor, Is.Not.Null);
+
+            var materialsField = controllerType.GetField("_materials", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(materialsField, Is.Not.Null);
+            var snapshots = materialsField.GetValue(controller) as IList;
+            Assert.That(snapshots, Is.Not.Null);
+            snapshots.Add(constructor.Invoke(new object[]
+            {
+                material,
+                propertyId,
+                originalTexture,
+                originalTexture.name
+            }));
+
+            SetPrivateField(controller, "_carIdentifier", "fuse-unity-test-" + Guid.NewGuid());
+            SetPrivateField(controller, "_configured", true);
+            return controller;
+        }
+
+        private static void AddCachedLiveryTexture(string key, Texture2D texture)
+        {
+            var field = typeof(FuseConfusingSupplementsLiveryRegistry).GetField(
+                "Textures",
+                BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null);
+            var textures = field.GetValue(null) as IDictionary;
+            Assert.That(textures, Is.Not.Null);
+            textures[key] = texture;
+        }
+
+        private static void SetPrivateField(object target, string name, object value)
+        {
+            var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null);
+            field.SetValue(target, value);
         }
     }
 }

--- a/FUSE/Compatibility/FuseConfusingSupplementsBodygroups.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsBodygroups.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Infrastructure;
+using Game.Messages;
+using Game.State;
+using HarmonyLib;
+using KeyValue.Runtime;
+using Model;
+using Model.Definition;
+using Model.Definition.Data;
+using Railloader.Extensions;
+using UI.Builder;
+using UnityEngine;
+
+namespace FUSE.Compatibility
+{
+    /// <summary>
+    /// FUSE-owned implementation of the rolling-stock body-group component used by
+    /// legacy Confusing Supplements asset packs. The implementation deliberately
+    /// lives in FUSE's namespace: FUSE reproduces the data contract and behavior
+    /// without loading or redistributing the retired library assembly.
+    /// </summary>
+    internal sealed class FuseConfusingSupplementsBodygroupsComponent : Model.Definition.Component
+    {
+        internal const string ComponentKind = "ConfusingSupplements.Bodygroups";
+
+        public override string Kind => ComponentKind;
+
+        public Dictionary<string, FuseConfusingSupplementsBodygroup> Groups { get; set; } =
+            new Dictionary<string, FuseConfusingSupplementsBodygroup>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal sealed class FuseConfusingSupplementsBodygroup
+    {
+        public string Name { get; set; }
+
+        public Dictionary<string, FuseConfusingSupplementsBodygroupOption> Options { get; set; } =
+            new Dictionary<string, FuseConfusingSupplementsBodygroupOption>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal sealed class FuseConfusingSupplementsBodygroupOption
+    {
+        public string Name { get; set; }
+
+        public string[] Path { get; set; }
+    }
+
+    internal sealed class FuseConfusingSupplementsBodygroupsBuilder : ComponentBuilder<FuseConfusingSupplementsBodygroupsComponent>
+    {
+        internal const string SavedPropertyPrefix = "cs.bodygroups.";
+
+        internal static string SavedPropertyKey(string groupId)
+        {
+            return SavedPropertyPrefix + groupId;
+        }
+
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsBodygroupsComponent component)
+        {
+            var car = context.GameObject?.GetComponentInParent<Car>();
+            var modelRoot = car?.BodyTransform;
+            if (car == null || modelRoot == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not attach legacy bodygroups to '{context.ObjectName ?? "<unknown car>"}' " +
+                    "because its car body was unavailable.");
+                return;
+            }
+
+            foreach (var groupEntry in component?.Groups ??
+                         Enumerable.Empty<KeyValuePair<string, FuseConfusingSupplementsBodygroup>>())
+            {
+                var groupId = groupEntry.Key?.Trim();
+                var group = groupEntry.Value;
+                if (string.IsNullOrWhiteSpace(groupId) || group?.Options == null || group.Options.Count == 0)
+                {
+                    var rejectedGroupId = string.IsNullOrWhiteSpace(groupId) ? "<blank>" : groupId;
+                    FuseLog.Warning(
+                        $"FUSE ignored legacy bodygroup '{rejectedGroupId}' on " +
+                        $"'{context.ObjectName ?? "<unknown car>"}' because its id is blank or it has no options.");
+                    continue;
+                }
+
+                var propertyKey = SavedPropertyKey(groupId);
+                var options = group.Options.ToArray();
+                context.ObserveProperty(propertyKey, value =>
+                {
+                    var savedSelection = value.StringValue;
+                    var selectedOption = ReadSelectedOption(value, options);
+                    if (!string.IsNullOrWhiteSpace(savedSelection) &&
+                        !options.Any(option => string.Equals(
+                            option.Key,
+                            savedSelection,
+                            StringComparison.OrdinalIgnoreCase)))
+                    {
+                        FuseLog.Warning(
+                            $"FUSE legacy bodygroup '{groupId}' on " +
+                            $"'{context.ObjectName ?? "<unknown car>"}' no longer has saved option " +
+                            $"'{savedSelection}'; using '{selectedOption}' instead.");
+                    }
+
+                    ApplySelection(
+                        context.ObjectName,
+                        modelRoot,
+                        groupId,
+                        options,
+                        selectedOption);
+                });
+            }
+        }
+
+        internal static string ReadSelectedOption(
+            Value value,
+            IReadOnlyList<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>> options)
+        {
+            var selected = value.StringValue;
+            if (options == null || options.Count == 0)
+            {
+                return selected;
+            }
+
+            return string.IsNullOrWhiteSpace(selected) ||
+                   !options.Any(option => string.Equals(
+                       option.Key,
+                       selected,
+                       StringComparison.OrdinalIgnoreCase))
+                ? options[0].Key
+                : selected;
+        }
+
+        private static void ApplySelection(
+            string objectName,
+            Transform modelRoot,
+            string groupId,
+            IEnumerable<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>> options,
+            string selectedId)
+        {
+            foreach (var optionEntry in options)
+            {
+                var path = optionEntry.Value?.Path;
+                if (path == null || path.Length == 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var target = modelRoot.ResolveTransform(
+                        new TransformReference { Path = path },
+                        defaultReturnsReceiver: false);
+                    if (target == null)
+                    {
+                        FuseLog.Warning(
+                            $"FUSE legacy bodygroup '{groupId}' on '{objectName ?? "<unknown car>"}' " +
+                            $"could not resolve option '{optionEntry.Key}' path '{string.Join("/", path)}'.");
+                        continue;
+                    }
+
+                    target.gameObject.SetActive(
+                        string.Equals(optionEntry.Key, selectedId, StringComparison.OrdinalIgnoreCase));
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE contained a malformed legacy bodygroup path for '{objectName ?? "<unknown car>"}', " +
+                        $"group '{groupId}', option '{optionEntry.Key}': {ex.GetBaseException().Message}");
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(UI.CarCustomizeWindow.CarCustomizeWindow), "BuildColorTab")]
+    internal static class FuseConfusingSupplementsBodygroupsCustomizePatch
+    {
+        private static void Postfix(UIPanelBuilder builder, Car ____car)
+        {
+            if (____car?.Definition?.Components == null)
+            {
+                return;
+            }
+
+            var components = ____car.Definition.Components
+                .OfType<FuseConfusingSupplementsBodygroupsComponent>()
+                .Where(component => component.Groups != null && component.Groups.Count > 0)
+                .ToArray();
+            if (components.Length == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                builder.AddSection("Bodygroups", section =>
+                {
+                    foreach (var component in components)
+                    {
+                        AddGroups(section, ____car, component);
+                    }
+                }, 10f);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a legacy bodygroup Customize-window error; " +
+                    $"the rest of the window remains usable: {ex.GetBaseException().Message}");
+            }
+        }
+
+        private static void AddGroups(
+            UIPanelBuilder builder,
+            Car car,
+            FuseConfusingSupplementsBodygroupsComponent component)
+        {
+            foreach (var groupEntry in component.Groups)
+            {
+                var groupId = groupEntry.Key?.Trim();
+                var group = groupEntry.Value;
+                if (string.IsNullOrWhiteSpace(groupId) || group?.Options == null || group.Options.Count == 0)
+                {
+                    continue;
+                }
+
+                var optionEntries = group.Options.ToArray();
+                var optionIds = optionEntries.Select(entry => entry.Key).ToArray();
+                var optionNames = optionEntries
+                    .Select(entry => string.IsNullOrWhiteSpace(entry.Value?.Name) ? entry.Key : entry.Value.Name)
+                    .ToList();
+                var propertyKey = FuseConfusingSupplementsBodygroupsBuilder.SavedPropertyKey(groupId);
+                var current = car.KeyValueObject == null
+                    ? null
+                    : car.KeyValueObject[propertyKey].StringValue;
+                var selectedIndex = Array.FindIndex(
+                    optionIds,
+                    optionId => string.Equals(optionId, current, StringComparison.OrdinalIgnoreCase));
+                if (selectedIndex < 0)
+                {
+                    selectedIndex = 0;
+                }
+
+                var fieldName = string.IsNullOrWhiteSpace(group.Name) ? groupId : group.Name;
+                builder.AddField(fieldName, builder.AddDropdown(optionNames, selectedIndex, index =>
+                {
+                    if (index < 0 || index >= optionIds.Length)
+                    {
+                        return;
+                    }
+
+                    StateManager.ApplyLocal(new PropertyChange(
+                        car.id,
+                        propertyKey,
+                        new StringPropertyValue(optionIds[index])));
+                }));
+            }
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsCompatibility.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsCompatibility.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FUSE.Infrastructure;
+using Model;
+
+namespace FUSE.Compatibility
+{
+    /// <summary>
+    /// Owns the legacy component discriminator and saved-property contracts that
+    /// FUSE replaces when the retired Confusing Supplements package is suppressed.
+    /// </summary>
+    internal static class FuseConfusingSupplementsCompatibility
+    {
+        private static readonly object Gate = new object();
+        private static bool _initialized;
+
+        internal static IReadOnlyList<string> ImplementedComponentKinds { get; } = new[]
+        {
+            FuseConfusingSupplementsBodygroupsComponent.ComponentKind,
+            FuseConfusingSupplementsDestinationSignComponent.ComponentKind,
+            FuseConfusingSupplementsLabelPrinterComponent.ComponentKind,
+            FuseConfusingSupplementsLiveryComponent.ComponentKind,
+            FuseConfusingSupplementsRefillerComponent.ComponentKind
+        };
+
+        internal static void Initialize()
+        {
+            lock (Gate)
+            {
+                if (_initialized)
+                {
+                    return;
+                }
+
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsBodygroupsComponent),
+                    typeof(FuseConfusingSupplementsBodygroupsBuilder),
+                    FuseConfusingSupplementsBodygroupsComponent.ComponentKind);
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsDestinationSignComponent),
+                    typeof(FuseConfusingSupplementsDestinationSignBuilder),
+                    FuseConfusingSupplementsDestinationSignComponent.ComponentKind);
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsLabelPrinterComponent),
+                    typeof(FuseConfusingSupplementsLabelPrinterBuilder),
+                    FuseConfusingSupplementsLabelPrinterComponent.ComponentKind);
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsLiveryComponent),
+                    typeof(FuseConfusingSupplementsLiveryBuilder),
+                    FuseConfusingSupplementsLiveryComponent.ComponentKind);
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsRefillerComponent),
+                    typeof(FuseConfusingSupplementsRefillerBuilder),
+                    FuseConfusingSupplementsRefillerComponent.ComponentKind);
+                AppendTrainmasterPrefixes(
+                    FuseConfusingSupplementsBodygroupsBuilder.SavedPropertyPrefix,
+                    FuseConfusingSupplementsDestinationSignBuilder.SavedPropertyPrefix,
+                    FuseConfusingSupplementsLabelPrinterBuilder.SavedPropertyPrefix,
+                    FuseConfusingSupplementsLiveryBuilder.SavedPropertyKey);
+                _initialized = true;
+            }
+        }
+
+        internal static void Reset()
+        {
+            lock (Gate)
+            {
+                _initialized = false;
+            }
+        }
+
+        private static void RegisterComponent(Type componentType, Type builderType, string kind)
+        {
+            try
+            {
+                FuseLegacyTypeRegistry.RegisterComponent(componentType, builderType, kind);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not register its replacement for legacy component '{kind}': " +
+                    $"{ex.GetBaseException().GetType().Name}: {ex.GetBaseException().Message}");
+            }
+        }
+
+        private static void AppendTrainmasterPrefixes(params string[] requiredPrefixes)
+        {
+            try
+            {
+                var field = typeof(Car).GetField(
+                    "TrainmasterPrefixes",
+                    BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+                var current = field?.GetValue(null) as string[];
+                if (field == null || current == null)
+                {
+                    FuseLog.Warning(
+                        "FUSE could not extend the car property access list for legacy Confusing Supplements customization.");
+                    return;
+                }
+
+                var merged = current
+                    .Concat(requiredPrefixes ?? Array.Empty<string>())
+                    .Where(prefix => !string.IsNullOrWhiteSpace(prefix))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                if (!merged.SequenceEqual(current, StringComparer.OrdinalIgnoreCase))
+                {
+                    field.SetValue(null, merged);
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not extend the car property access list for legacy Confusing Supplements " +
+                    $"customization: {ex.GetBaseException().Message}");
+            }
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsDestinationSign.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsDestinationSign.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AssetPack.Runtime;
+using Effects.Decals;
+using FUSE.Infrastructure;
+using Game.Messages;
+using Game.State;
+using Helpers;
+using Helpers.Culling;
+using Model;
+using Model.Definition.Data;
+using Railloader.Extensions;
+using UnityEngine;
+using UnityEngine.Rendering.Universal;
+
+namespace FUSE.Compatibility
+{
+    internal sealed class FuseConfusingSupplementsDestinationSignComponent : Model.Definition.Component
+    {
+        internal const string ComponentKind = "ConfusingSupplements.DestinationSign";
+
+        public override string Kind => ComponentKind;
+
+        public AssetReference Model { get; set; } = new AssetReference();
+
+        public Vector3 Size { get; set; } = Vector3.one;
+
+        public List<string> Destinations { get; set; } = new List<string>();
+    }
+
+    internal sealed class FuseConfusingSupplementsDestinationSignBuilder : ComponentBuilder<FuseConfusingSupplementsDestinationSignComponent>
+    {
+        internal const string SavedPropertyPrefix = "cs.destinationsign.";
+
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsDestinationSignComponent component)
+        {
+            if (context.GameObject == null || component == null)
+            {
+                return;
+            }
+
+            var car = context.GameObject.GetComponentInParent<Car>();
+            var propertyId = string.IsNullOrWhiteSpace(component.Name)
+                ? component.Model?.AssetIdentifier
+                : component.Name;
+            var propertyKey = SavedPropertyPrefix +
+                              (string.IsNullOrWhiteSpace(propertyId) ? "default" : propertyId.Trim());
+            var controller = context.GameObject.AddComponent<FuseConfusingSupplementsDestinationSignController>();
+            controller.Configure(component, car, propertyKey);
+            context.ObserveProperty(propertyKey, controller.ApplySavedSelection);
+        }
+    }
+
+    internal static class FuseConfusingSupplementsDestinationSignPolicy
+    {
+        internal static int NextIndex(int current, int count, bool previous)
+        {
+            if (count <= 0)
+            {
+                return -1;
+            }
+
+            if (previous)
+            {
+                return current <= -1 ? count - 1 : current - 1;
+            }
+
+            return current >= count - 1 ? -1 : current + 1;
+        }
+    }
+
+    internal sealed class FuseConfusingSupplementsDestinationSignController : MonoBehaviour,
+        IPickable,
+        CullingManager.ICullingEventHandler
+    {
+        private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
+        private LoadedAssetReference<GameObject> _loadedModel;
+        private CullingManager.Token _cullingToken;
+        private DecalProjectorHelper _decal;
+        private GameObject _modelInstance;
+        private GameObject _sign;
+        private string[] _destinations = Array.Empty<string>();
+        private int _selectedIndex = -1;
+        private Car _car;
+        private string _propertyKey;
+
+        public float MaxPickDistance => _sign == null ? 0f : 5f;
+
+        public int Priority => 0;
+
+        public TooltipInfo TooltipInfo => new TooltipInfo("Change destination sign", "Primary: next; secondary: previous");
+
+        public PickableActivationFilter ActivationFilter => PickableActivationFilter.Any;
+
+        internal async void Configure(
+            FuseConfusingSupplementsDestinationSignComponent component,
+            Car car,
+            string propertyKey)
+        {
+            _car = car;
+            _propertyKey = propertyKey;
+            _destinations = (component?.Destinations ?? new List<string>())
+                .Where(destination => !string.IsNullOrWhiteSpace(destination))
+                .ToArray();
+            await ConfigureAsync(component);
+        }
+
+        internal void ApplySavedSelection(KeyValue.Runtime.Value value)
+        {
+            _selectedIndex = int.TryParse(
+                    value.StringValue,
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var selected)
+                ? Math.Max(-1, Math.Min(selected, _destinations.Length - 1))
+                : -1;
+            RefreshSign();
+        }
+
+        private async Task ConfigureAsync(FuseConfusingSupplementsDestinationSignComponent component)
+        {
+            var cancellationToken = _cancellation.Token;
+            try
+            {
+                if (component?.Model == null || component.Model.IsEmpty)
+                {
+                    throw new ArgumentException("Destination-sign model reference is empty.");
+                }
+
+                _loadedModel = await TrainController.Shared.PrefabStore.LoadAssetAsync<GameObject>(
+                    component.Model.AssetPackIdentifier,
+                    component.Model.AssetIdentifier,
+                    cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (_loadedModel?.Asset == null)
+                {
+                    throw new InvalidOperationException($"Destination-sign model '{component.Model.AssetIdentifier}' did not load.");
+                }
+
+                _modelInstance = UnityEngine.Object.Instantiate(_loadedModel.Asset, transform, false);
+                _modelInstance.name = "FUSE Destination Sign";
+                _modelInstance.transform.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
+                _sign = _modelInstance.GetComponentsInChildren<Transform>(true)
+                    .FirstOrDefault(child => string.Equals(child.name, "Sign", StringComparison.OrdinalIgnoreCase))
+                    ?.gameObject;
+                if (_sign == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Destination-sign model '{component.Model.AssetIdentifier}' has no child named 'Sign'.");
+                }
+
+                var projectorObject = new GameObject("FUSE Destination Text");
+                projectorObject.SetActive(false);
+                projectorObject.transform.SetParent(_sign.transform, false);
+                projectorObject.transform.SetLocalPositionAndRotation(
+                    Vector3.forward * 0.1f,
+                    Quaternion.Euler(0f, 180f, 0f));
+
+                var projector = projectorObject.AddComponent<DecalProjector>();
+                FuseConfusingSupplementsDecalProjector.Configure(projector, component.Size);
+
+                _decal = projectorObject.AddComponent<DecalProjectorHelper>();
+                _decal.decalRenderer = CanvasDecalRenderer.Shared;
+                _decal.templateName = "Tender";
+                _decal.text = string.Empty;
+                _decal.ForceColor(Color.black);
+                _decal.RenderDecal();
+                projectorObject.SetActive(true);
+
+                _cullingToken = CullingManager.Scenery?.AddSphere(transform, 10f, this);
+                _cullingToken?.RegisterFixedUpdate(transform);
+                RefreshSign();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                CleanupRuntimeObjects();
+                return;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not build a legacy destination sign: " +
+                    $"{ex.GetBaseException().GetType().Name}: {ex.GetBaseException().Message}");
+                CleanupRuntimeObjects();
+            }
+        }
+
+        public void Activate(PickableActivateEvent evt)
+        {
+            _selectedIndex = FuseConfusingSupplementsDestinationSignPolicy.NextIndex(
+                _selectedIndex,
+                _destinations.Length,
+                evt.Activation == PickableActivation.Secondary);
+            if (_car != null && !string.IsNullOrWhiteSpace(_propertyKey))
+            {
+                StateManager.ApplyLocal(new PropertyChange(
+                    _car.id,
+                    _propertyKey,
+                    new StringPropertyValue(_selectedIndex.ToString(CultureInfo.InvariantCulture))));
+            }
+            else
+            {
+                RefreshSign();
+            }
+        }
+
+        public void Deactivate()
+        {
+        }
+
+        private void RefreshSign()
+        {
+            if (_sign == null)
+            {
+                return;
+            }
+
+            if (_selectedIndex < 0 || _selectedIndex >= _destinations.Length || _decal == null)
+            {
+                _sign.SetActive(false);
+                return;
+            }
+
+            _decal.text = _destinations[_selectedIndex];
+            _decal.RenderDecal();
+            _sign.SetActive(true);
+        }
+
+        public void CullingSphereStateChanged(bool isVisible, int distanceBand)
+        {
+            if (_modelInstance != null)
+            {
+                _modelInstance.SetActive(isVisible && distanceBand < 1);
+            }
+        }
+
+        public void RequestUpdateCullingPosition()
+        {
+            _cullingToken?.UpdatePosition(transform);
+        }
+
+        private void OnDestroy()
+        {
+            _cancellation.Cancel();
+            _cancellation.Dispose();
+            CleanupRuntimeObjects();
+        }
+
+        private void CleanupRuntimeObjects()
+        {
+            _cullingToken?.Dispose();
+            _cullingToken = null;
+            _loadedModel?.Dispose();
+            _loadedModel = null;
+            if (_modelInstance != null)
+            {
+                UnityEngine.Object.Destroy(_modelInstance);
+                _modelInstance = null;
+            }
+
+            _sign = null;
+            _decal = null;
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Effects.Decals;
+using FUSE.Infrastructure;
+using Game.Messages;
+using Game.State;
+using HarmonyLib;
+using Helpers;
+using KeyValue.Runtime;
+using Model;
+using Model.Definition;
+using Model.Definition.Components;
+using Newtonsoft.Json;
+using Railloader.Extensions;
+using UI.Builder;
+using UnityEngine;
+using UnityEngine.Rendering.Universal;
+
+namespace FUSE.Compatibility
+{
+    internal sealed class FuseConfusingSupplementsLabelPrinterComponent : DecalComponent
+    {
+        internal const string ComponentKind = "ConfusingSupplements.LabelPrinter";
+
+        public override string Kind => ComponentKind;
+
+        public string Group { get; set; }
+
+        [JsonIgnore]
+        [DefinitionProperty(Hidden = true)]
+        public string SavedPropertyId => (string.IsNullOrWhiteSpace(Group) ? Name : Group)?.Trim();
+    }
+
+    internal sealed class FuseConfusingSupplementsLabelPrinterBuilder : ComponentBuilder<FuseConfusingSupplementsLabelPrinterComponent>
+    {
+        internal const string SavedPropertyPrefix = "cs.labelprinter.";
+        internal const string TextFieldName = "text";
+
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsLabelPrinterComponent component)
+        {
+            if (context.GameObject == null || component == null)
+            {
+                return;
+            }
+
+            var savedPropertyId = component.SavedPropertyId;
+            if (string.IsNullOrWhiteSpace(savedPropertyId))
+            {
+                FuseLog.Warning(
+                    $"FUSE ignored a legacy label-printer component on '{context.ObjectName ?? "<unknown car>"}' " +
+                    "because both name and group are empty.");
+                return;
+            }
+
+            if (!TryGetTemplateName(component.Content, out var templateName))
+            {
+                FuseLog.Warning(
+                    $"FUSE ignored legacy label-printer '{savedPropertyId}' on " +
+                    $"'{context.ObjectName ?? "<unknown car>"}' because decal content " +
+                    $"'{component.Content}' is unsupported.");
+                return;
+            }
+
+            var projector = context.GameObject.AddComponent<DecalProjector>();
+            FuseConfusingSupplementsDecalProjector.Configure(projector, component.Size);
+
+            var helper = context.GameObject.AddComponent<DecalProjectorHelper>();
+            helper.decalRenderer = CanvasDecalRenderer.Shared;
+            helper.templateName = templateName;
+            if (!string.IsNullOrWhiteSpace(component.ForceColor))
+            {
+                var color = ColorHelper.ColorFromHex(component.ForceColor);
+                if (color.HasValue)
+                {
+                    helper.ForceColor(color.Value);
+                }
+            }
+
+            context.ObserveProperty(SavedPropertyKey(savedPropertyId), value =>
+            {
+                helper.text = ReadText(value);
+                helper.RenderDecal();
+            });
+        }
+
+        internal static string ReadText(Value value)
+        {
+            if (value.Type == KeyValue.Runtime.ValueType.Dictionary)
+            {
+                var values = value.DictionaryValue;
+                return values != null && values.TryGetValue(TextFieldName, out var text)
+                    ? text.StringValue ?? string.Empty
+                    : string.Empty;
+            }
+
+            return value.StringValue ?? string.Empty;
+        }
+
+        internal static IPropertyValue UpdatedTextValue(Value current, string text)
+        {
+            var updatedText = new StringPropertyValue(text ?? string.Empty);
+            if (current.Type != KeyValue.Runtime.ValueType.Dictionary)
+            {
+                return updatedText;
+            }
+
+            var values = PropertyValueConverter.RuntimeToSnapshot(current.DictionaryValue);
+            values[TextFieldName] = updatedText;
+            return new DictionaryPropertyValue(values);
+        }
+
+        internal static string SavedPropertyKey(string savedPropertyId)
+        {
+            return SavedPropertyPrefix + savedPropertyId;
+        }
+
+        private static bool TryGetTemplateName(DecalContent content, out string templateName)
+        {
+            switch (content)
+            {
+                case DecalContent.RoadNumber:
+                    templateName = "Number";
+                    return true;
+                case DecalContent.Lettering:
+                    templateName = "Tender";
+                    return true;
+                default:
+                    templateName = null;
+                    return false;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(UI.CarCustomizeWindow.CarCustomizeWindow), "BuildColorTab")]
+    internal static class FuseConfusingSupplementsLabelPrinterCustomizePatch
+    {
+        private static void Postfix(UIPanelBuilder builder, Car ____car)
+        {
+            if (____car?.Definition?.Components == null)
+            {
+                return;
+            }
+
+            var labels = ____car.Definition.Components
+                .OfType<FuseConfusingSupplementsLabelPrinterComponent>()
+                .Where(component => !string.IsNullOrWhiteSpace(component.SavedPropertyId))
+                .GroupBy(component => component.SavedPropertyId, StringComparer.OrdinalIgnoreCase)
+                .Select(group => new
+                {
+                    Id = group.Key,
+                    Name = group.Select(component => component.Name)
+                        .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name)) ?? group.Key
+                })
+                .OrderBy(label => label.Name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (labels.Length == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                builder.AddSection("Labels", section =>
+                {
+                    foreach (var label in labels)
+                    {
+                        section.AddField(
+                            label.Name,
+                            section.AddInputField(
+                                GetText(____car, label.Id),
+                                text => SetText(____car, label.Id, text),
+                                null,
+                                100));
+                    }
+                }, 20f);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a legacy label-printer Customize-window error; " +
+                    $"the rest of the window remains usable: {ex.GetBaseException().Message}");
+            }
+        }
+
+        internal static string GetText(Car car, string savedPropertyId)
+        {
+            if (car?.KeyValueObject == null || string.IsNullOrWhiteSpace(savedPropertyId))
+            {
+                return string.Empty;
+            }
+
+            return FuseConfusingSupplementsLabelPrinterBuilder.ReadText(
+                car.KeyValueObject[FuseConfusingSupplementsLabelPrinterBuilder.SavedPropertyKey(savedPropertyId)]);
+        }
+
+        private static void SetText(Car car, string savedPropertyId, string text)
+        {
+            if (car?.KeyValueObject == null || string.IsNullOrWhiteSpace(savedPropertyId))
+            {
+                return;
+            }
+
+            var propertyKey = FuseConfusingSupplementsLabelPrinterBuilder.SavedPropertyKey(savedPropertyId);
+            StateManager.ApplyLocal(new PropertyChange(
+                car.id,
+                propertyKey,
+                FuseConfusingSupplementsLabelPrinterBuilder.UpdatedTextValue(
+                    car.KeyValueObject[propertyKey],
+                    text)));
+        }
+    }
+
+    internal static class FuseConfusingSupplementsDecalProjector
+    {
+        internal static void Configure(DecalProjector projector, Vector3 size)
+        {
+            projector.size = size;
+            projector.pivot = Vector3.zero;
+            projector.drawDistance = Mathf.Max(600f, Mathf.Max(size.x, size.y) * 100f);
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsLivery.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsLivery.cs
@@ -1,0 +1,698 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using Game.Messages;
+using Game.State;
+using HarmonyLib;
+using KeyValue.Runtime;
+using Model;
+using Railloader.Extensions;
+using UI.Builder;
+using UnityEngine;
+
+namespace FUSE.Compatibility
+{
+    internal sealed class FuseConfusingSupplementsLiveryComponent : Model.Definition.Component
+    {
+        internal const string ComponentKind = "CS.LiverySwap";
+
+        public override string Kind => ComponentKind;
+    }
+
+    internal sealed class FuseConfusingSupplementsLiveryBuilder : ComponentBuilder<FuseConfusingSupplementsLiveryComponent>
+    {
+        internal const string SavedPropertyKey = "cs.livery";
+
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsLiveryComponent component)
+        {
+            var car = context.GameObject?.GetComponentInParent<Car>();
+            if (car == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not attach legacy livery support to '{context.ObjectName ?? "<unknown car>"}' " +
+                    "because its car object was unavailable.");
+                return;
+            }
+
+            var controller = car.GetComponent<FuseConfusingSupplementsLiveryController>() ??
+                             car.gameObject.AddComponent<FuseConfusingSupplementsLiveryController>();
+            controller.Configure(car);
+            context.ObserveProperty(SavedPropertyKey, controller.ApplySavedSelection);
+        }
+    }
+
+    internal sealed class FuseConfusingSupplementsLiveryController : MonoBehaviour
+    {
+        private readonly List<MaterialSnapshot> _materials = new List<MaterialSnapshot>();
+        private readonly HashSet<Material> _ownedMaterials = new HashSet<Material>();
+        private Car _car;
+        private string _carIdentifier;
+        private bool _configured;
+
+        internal void Configure(Car car)
+        {
+            if (_configured || car == null)
+            {
+                return;
+            }
+
+            var definitionInfo = car.DefinitionInfo;
+            if (definitionInfo == null)
+            {
+                return;
+            }
+
+            _car = car;
+            _carIdentifier = definitionInfo.Identifier ?? string.Empty;
+            CaptureMaterials(car.gameObject);
+            _configured = true;
+        }
+
+        internal void ApplySavedSelection(Value value)
+        {
+            if (!_configured)
+            {
+                return;
+            }
+
+            var selected = value.StringValue;
+            RestoreOriginalTextures();
+            if (string.IsNullOrWhiteSpace(selected))
+            {
+                return;
+            }
+
+            var choice = FuseConfusingSupplementsLiveryRegistry.GetChoices(_carIdentifier)
+                .FirstOrDefault(candidate => string.Equals(candidate.Id, selected, StringComparison.OrdinalIgnoreCase));
+            if (choice == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not find legacy livery '{selected}' for rolling stock '{_carIdentifier}'. " +
+                    "The standard textures remain active.");
+                return;
+            }
+
+            ApplyDirectory(choice.DirectoryPath);
+        }
+
+        internal string CarIdentifier => _carIdentifier ?? string.Empty;
+
+        internal string SelectedLiveryId
+        {
+            get
+            {
+                if (!_configured || _car == null || _car.KeyValueObject == null)
+                {
+                    return string.Empty;
+                }
+
+                return _car.KeyValueObject[FuseConfusingSupplementsLiveryBuilder.SavedPropertyKey].StringValue ??
+                       string.Empty;
+            }
+        }
+
+        internal void RefreshFromSavedSelection()
+        {
+            if (!_configured)
+            {
+                return;
+            }
+
+            ApplySavedSelection(
+                _car == null || _car.KeyValueObject == null
+                    ? Value.Null()
+                    : _car.KeyValueObject[FuseConfusingSupplementsLiveryBuilder.SavedPropertyKey]);
+        }
+
+        internal void RestoreOriginalTexturesForRefresh()
+        {
+            if (_configured)
+            {
+                RestoreOriginalTextures();
+            }
+        }
+
+        internal void CaptureMaterials(GameObject carObject)
+        {
+            _materials.Clear();
+            var propertyIds = new List<int>();
+            foreach (var renderer in carObject.GetComponentsInChildren<Renderer>(true))
+            {
+                Material[] materials;
+                try
+                {
+                    // Renderer.materials creates per-renderer instances. This keeps a
+                    // livery chosen on one car from repainting every car that shares
+                    // the asset pack's source material.
+                    materials = renderer.materials;
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not isolate livery materials on '{_carIdentifier}': {ex.GetBaseException().Message}");
+                    continue;
+                }
+
+                foreach (var material in materials.Where(material => material != null))
+                {
+                    _ownedMaterials.Add(material);
+                    propertyIds.Clear();
+                    material.GetTexturePropertyNameIDs(propertyIds);
+                    foreach (var propertyId in propertyIds)
+                    {
+                        var texture = material.GetTexture(propertyId);
+                        if (texture == null)
+                        {
+                            continue;
+                        }
+
+                        _materials.Add(new MaterialSnapshot(
+                            material,
+                            propertyId,
+                            texture,
+                            texture.name ?? string.Empty));
+                    }
+                }
+            }
+        }
+
+        private void OnDestroy()
+        {
+            foreach (var material in _ownedMaterials)
+            {
+                if (material == null)
+                {
+                    continue;
+                }
+
+                if (Application.isPlaying)
+                {
+                    Destroy(material);
+                }
+                else
+                {
+                    DestroyImmediate(material);
+                }
+            }
+
+            _ownedMaterials.Clear();
+        }
+
+        private void RestoreOriginalTextures()
+        {
+            foreach (var snapshot in _materials)
+            {
+                if (snapshot.Material != null)
+                {
+                    snapshot.Material.SetTexture(snapshot.PropertyId, snapshot.OriginalTexture);
+                }
+            }
+        }
+
+        private void ApplyDirectory(string directoryPath)
+        {
+            var files = FuseConfusingSupplementsLiveryRegistry.GetTextureFiles(directoryPath);
+            if (files.Count == 0)
+            {
+                FuseLog.Warning(
+                    $"FUSE legacy livery folder '{directoryPath}' has no PNG or JPEG texture files.");
+                return;
+            }
+
+            var replacements = 0;
+            foreach (var snapshot in _materials)
+            {
+                if (snapshot.Material == null || string.IsNullOrWhiteSpace(snapshot.OriginalTextureName) ||
+                    !files.TryGetValue(snapshot.OriginalTextureName, out var texturePath))
+                {
+                    continue;
+                }
+
+                var texture = FuseConfusingSupplementsLiveryRegistry.LoadTexture(texturePath);
+                if (texture == null)
+                {
+                    continue;
+                }
+
+                snapshot.Material.SetTexture(snapshot.PropertyId, texture);
+                replacements++;
+            }
+
+            if (replacements == 0)
+            {
+                FuseLog.Warning(
+                    $"FUSE legacy livery folder '{directoryPath}' did not match any source texture names on " +
+                    $"rolling stock '{_carIdentifier}'.");
+            }
+        }
+
+        private sealed class MaterialSnapshot
+        {
+            internal MaterialSnapshot(
+                Material material,
+                int propertyId,
+                Texture originalTexture,
+                string originalTextureName)
+            {
+                Material = material;
+                PropertyId = propertyId;
+                OriginalTexture = originalTexture;
+                OriginalTextureName = originalTextureName;
+            }
+
+            internal Material Material { get; }
+            internal int PropertyId { get; }
+            internal Texture OriginalTexture { get; }
+            internal string OriginalTextureName { get; }
+        }
+    }
+
+    internal static class FuseConfusingSupplementsLiveryPolicy
+    {
+        internal static bool IsTextureFile(string path)
+        {
+            var extension = Path.GetExtension(path);
+            return string.Equals(extension, ".png", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(extension, ".jpg", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(extension, ".jpeg", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    internal static class FuseConfusingSupplementsLiveryRegistry
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<string, Texture2D> Textures =
+            new Dictionary<string, Texture2D>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, IReadOnlyList<FuseConfusingSupplementsLiveryChoice>> Choices =
+            new Dictionary<string, IReadOnlyList<FuseConfusingSupplementsLiveryChoice>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, IReadOnlyDictionary<string, string>> FileIndexes =
+            new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+
+        internal static int CachedTextureCount
+        {
+            get
+            {
+                lock (Gate)
+                {
+                    return Textures.Count;
+                }
+            }
+        }
+
+        internal static int RefreshLiveCars()
+        {
+            var controllers = Resources
+                .FindObjectsOfTypeAll<FuseConfusingSupplementsLiveryController>()
+                .Where(IsLiveController)
+                .ToArray();
+            foreach (var controller in controllers)
+            {
+                try
+                {
+                    controller.RestoreOriginalTexturesForRefresh();
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not restore standard textures on '{controller.CarIdentifier}': " +
+                        ex.GetBaseException().Message);
+                }
+            }
+
+            ClearTextureCache();
+            foreach (var controller in controllers)
+            {
+                try
+                {
+                    controller.RefreshFromSavedSelection();
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not refresh the legacy livery on '{controller.CarIdentifier}': " +
+                        ex.GetBaseException().Message);
+                }
+            }
+
+            return controllers.Length;
+        }
+
+        internal static string BuildDiagnosticReport()
+        {
+            var controllers = Resources
+                .FindObjectsOfTypeAll<FuseConfusingSupplementsLiveryController>()
+                .Where(IsLiveController)
+                .OrderBy(controller => controller.CarIdentifier, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(controller => controller.GetInstanceID())
+                .ToArray();
+            var report = new StringBuilder();
+            report.Append("FUSE livery diagnostics: cars=")
+                .Append(controllers.Length)
+                .Append(" cachedTextures=")
+                .Append(CachedTextureCount);
+
+            foreach (var controller in controllers)
+            {
+                var choices = GetChoices(controller.CarIdentifier);
+                report.AppendLine()
+                    .Append("- car=")
+                    .Append(string.IsNullOrWhiteSpace(controller.CarIdentifier)
+                        ? "<unknown>"
+                        : controller.CarIdentifier)
+                    .Append(" selected=")
+                    .Append(string.IsNullOrWhiteSpace(controller.SelectedLiveryId)
+                        ? "<standard>"
+                        : controller.SelectedLiveryId)
+                    .Append(" choices=")
+                    .Append(choices.Count);
+                if (choices.Count > 0)
+                {
+                    report.Append(" [")
+                        .Append(string.Join(", ", choices.Select(choice => choice.Id)))
+                        .Append(']');
+                }
+            }
+
+            return report.ToString();
+        }
+
+        internal static void Shutdown()
+        {
+            ClearTextureCache();
+        }
+
+        private static void ClearTextureCache()
+        {
+            Texture2D[] textures;
+            lock (Gate)
+            {
+                textures = Textures.Values.Where(texture => texture != null).ToArray();
+                Textures.Clear();
+                Choices.Clear();
+                FileIndexes.Clear();
+            }
+
+            foreach (var texture in textures)
+            {
+                DestroyTexture(texture);
+            }
+        }
+
+        internal static void DestroyTexture(Texture2D texture)
+        {
+            if (texture == null)
+            {
+                return;
+            }
+
+            if (Application.isPlaying)
+            {
+                UnityEngine.Object.Destroy(texture);
+            }
+            else
+            {
+                UnityEngine.Object.DestroyImmediate(texture);
+            }
+        }
+
+        private static bool IsLiveController(
+            FuseConfusingSupplementsLiveryController controller)
+        {
+            return controller != null
+                   && controller.gameObject != null
+                   && controller.gameObject.scene.IsValid();
+        }
+
+        internal static IReadOnlyList<FuseConfusingSupplementsLiveryChoice> GetChoices(string carIdentifier)
+        {
+            if (string.IsNullOrWhiteSpace(carIdentifier))
+            {
+                return Array.Empty<FuseConfusingSupplementsLiveryChoice>();
+            }
+
+            lock (Gate)
+            {
+                if (Choices.TryGetValue(carIdentifier, out var cached))
+                {
+                    return cached;
+                }
+            }
+
+            var choices = new Dictionary<string, FuseConfusingSupplementsLiveryChoice>(StringComparer.OrdinalIgnoreCase);
+            foreach (var mixinto in FuseLegacyAssemblyHost.EnumerateMixintos("livery:" + carIdentifier))
+            {
+                var path = mixinto.Mixinto;
+                if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+                {
+                    FuseLog.Warning(
+                        $"FUSE ignored legacy livery entry '{path ?? "<empty>"}' for '{carIdentifier}' " +
+                        "because it is not an existing directory.");
+                    continue;
+                }
+
+                var id = Path.GetFileName(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    continue;
+                }
+
+                if (choices.ContainsKey(id))
+                {
+                    FuseLog.Warning(
+                        $"FUSE found more than one legacy livery named '{id}' for '{carIdentifier}'. " +
+                        $"The first folder wins; ignored '{path}'.");
+                    continue;
+                }
+
+                choices[id] = new FuseConfusingSupplementsLiveryChoice(id, path);
+            }
+
+            var discovered = choices.Values.OrderBy(choice => choice.Id, StringComparer.OrdinalIgnoreCase).ToArray();
+            lock (Gate)
+            {
+                if (!Choices.TryGetValue(carIdentifier, out var cached))
+                {
+                    Choices[carIdentifier] = discovered;
+                    return discovered;
+                }
+
+                return cached;
+            }
+        }
+
+        internal static Dictionary<string, string> IndexTextureFiles(string directoryPath)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(directoryPath) || !Directory.Exists(directoryPath))
+            {
+                return result;
+            }
+
+            try
+            {
+                foreach (var path in Directory.EnumerateFiles(directoryPath))
+                {
+                    if (!FuseConfusingSupplementsLiveryPolicy.IsTextureFile(path))
+                    {
+                        continue;
+                    }
+
+                    var key = Path.GetFileNameWithoutExtension(path);
+                    if (result.TryGetValue(key, out var existing))
+                    {
+                        var winner = string.Compare(path, existing, StringComparison.OrdinalIgnoreCase) < 0
+                            ? path
+                            : existing;
+                        var ignored = string.Equals(winner, path, StringComparison.OrdinalIgnoreCase)
+                            ? existing
+                            : path;
+                        result[key] = winner;
+                        FuseLog.Warning(
+                            $"FUSE found more than one legacy livery texture named '{key}' in " +
+                            $"'{directoryPath}'. Alphabetical path precedence selected '{winner}' and ignored '{ignored}'.");
+                        continue;
+                    }
+
+                    result[key] = path;
+                }
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                LogTextureIndexFailure(directoryPath, ex);
+            }
+            catch (IOException ex)
+            {
+                LogTextureIndexFailure(directoryPath, ex);
+            }
+
+            return result;
+        }
+
+        internal static IReadOnlyDictionary<string, string> GetTextureFiles(string directoryPath)
+        {
+            if (string.IsNullOrWhiteSpace(directoryPath))
+            {
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            lock (Gate)
+            {
+                if (FileIndexes.TryGetValue(directoryPath, out var cached))
+                {
+                    return cached;
+                }
+            }
+
+            var discovered = IndexTextureFiles(directoryPath);
+            lock (Gate)
+            {
+                if (!FileIndexes.TryGetValue(directoryPath, out var cached))
+                {
+                    FileIndexes[directoryPath] = discovered;
+                    return discovered;
+                }
+
+                return cached;
+            }
+        }
+
+        private static void LogTextureIndexFailure(string directoryPath, Exception ex)
+        {
+            FuseLog.Warning(
+                $"FUSE could not index legacy livery textures in '{directoryPath}': " +
+                ex.GetBaseException().Message);
+        }
+
+        internal static Texture2D LoadTexture(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                return null;
+            }
+
+            lock (Gate)
+            {
+                if (Textures.TryGetValue(path, out var cached) && cached != null)
+                {
+                    return cached;
+                }
+            }
+
+            Texture2D texture = null;
+            try
+            {
+                texture = new Texture2D(2, 2, TextureFormat.RGBA32, true)
+                {
+                    name = Path.GetFileNameWithoutExtension(path)
+                };
+                if (!ImageConversion.LoadImage(texture, File.ReadAllBytes(path), true))
+                {
+                    DestroyTexture(texture);
+                    return null;
+                }
+            }
+            catch (Exception ex)
+            {
+                DestroyTexture(texture);
+
+                FuseLog.Warning(
+                    $"FUSE could not load legacy livery texture '{path}': {ex.GetBaseException().Message}");
+                return null;
+            }
+
+            lock (Gate)
+            {
+                if (Textures.TryGetValue(path, out var cached) && cached != null)
+                {
+                    DestroyTexture(texture);
+                    return cached;
+                }
+
+                Textures[path] = texture;
+                return texture;
+            }
+        }
+    }
+
+    internal sealed class FuseConfusingSupplementsLiveryChoice
+    {
+        internal FuseConfusingSupplementsLiveryChoice(string id, string directoryPath)
+        {
+            Id = id;
+            DirectoryPath = directoryPath;
+        }
+
+        internal string Id { get; }
+        internal string DirectoryPath { get; }
+    }
+
+    [HarmonyPatch(typeof(UI.CarCustomizeWindow.CarCustomizeWindow), "BuildColorTab")]
+    internal static class FuseConfusingSupplementsLiveryCustomizePatch
+    {
+        private static readonly string[] StandardLiveryIds = { string.Empty };
+        private static readonly string[] StandardLiveryNames = { "Standard" };
+
+        private static void Postfix(UIPanelBuilder builder, Car ____car)
+        {
+            if (____car?.Definition?.Components == null ||
+                !____car.Definition.Components.OfType<FuseConfusingSupplementsLiveryComponent>().Any())
+            {
+                return;
+            }
+
+            try
+            {
+                var choices = FuseConfusingSupplementsLiveryRegistry
+                    .GetChoices(____car.DefinitionInfo.Identifier)
+                    .ToArray();
+                builder.AddSection("Livery", section =>
+                {
+                    if (choices.Length == 0)
+                    {
+                        section.AddLabel(
+                            $"No compatible liveries found for {____car.DefinitionInfo.Identifier}.");
+                        return;
+                    }
+
+                    var ids = StandardLiveryIds.Concat(choices.Select(choice => choice.Id)).ToArray();
+                    var names = StandardLiveryNames.Concat(choices.Select(choice => choice.Id)).ToList();
+                    var current = ____car.KeyValueObject == null
+                        ? null
+                        : ____car.KeyValueObject[FuseConfusingSupplementsLiveryBuilder.SavedPropertyKey].StringValue;
+                    var selected = Array.FindIndex(
+                        ids,
+                        id => string.Equals(id, current, StringComparison.OrdinalIgnoreCase));
+                    if (selected < 0)
+                    {
+                        selected = 0;
+                    }
+
+                    section.AddField("Livery", section.AddDropdown(names, selected, index =>
+                    {
+                        if (____car.KeyValueObject == null || index < 0 || index >= ids.Length)
+                        {
+                            return;
+                        }
+
+                        StateManager.ApplyLocal(new PropertyChange(
+                            ____car.id,
+                            FuseConfusingSupplementsLiveryBuilder.SavedPropertyKey,
+                            new StringPropertyValue(ids[index] ?? string.Empty)));
+                    }));
+                }, 30f);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a legacy livery Customize-window error; " +
+                    $"the rest of the window remains usable: {ex.GetBaseException().Message}");
+            }
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsRefiller.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsRefiller.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Infrastructure;
+using Game.State;
+using Model;
+using Model.Definition;
+using Model.Definition.Data;
+using Model.Ops;
+using Model.Physics;
+using Railloader.Extensions;
+using UnityEngine;
+
+namespace FUSE.Compatibility
+{
+    internal sealed class FuseConfusingSupplementsRefillerComponent : Model.Definition.Component
+    {
+        internal const string ComponentKind = "ConfusingSupplements.Refiller";
+
+        public override string Kind => ComponentKind;
+
+        public int TransferRate { get; set; } = 36000;
+    }
+
+    internal sealed class FuseConfusingSupplementsRefillerBuilder : ComponentBuilder<FuseConfusingSupplementsRefillerComponent>
+    {
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsRefillerComponent component)
+        {
+            var car = context.GameObject?.GetComponentInParent<Car>();
+            if (car == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not attach a legacy refiller to '{context.ObjectName ?? "<unknown car>"}' " +
+                    "because its car object was unavailable.");
+                return;
+            }
+
+            var runtime = car.GetComponent<FuseConfusingSupplementsRefillerRuntime>() ??
+                          car.gameObject.AddComponent<FuseConfusingSupplementsRefillerRuntime>();
+            runtime.TransferPerSecond = Mathf.Max(0f, (component?.TransferRate ?? 0) / 3600f);
+        }
+    }
+
+    internal static class FuseConfusingSupplementsRefillerPolicy
+    {
+        internal static bool CanTargetReceiveFromSource(
+            IEnumerable<string> sourceLoadIdentifiers,
+            IEnumerable<string> targetLoadIdentifiers)
+        {
+            if (sourceLoadIdentifiers == null || targetLoadIdentifiers == null)
+            {
+                return false;
+            }
+
+            return targetLoadIdentifiers.Any(targetIdentifier =>
+                !string.IsNullOrWhiteSpace(targetIdentifier) &&
+                sourceLoadIdentifiers.Any(sourceIdentifier => string.Equals(
+                    sourceIdentifier,
+                    targetIdentifier,
+                    StringComparison.OrdinalIgnoreCase)));
+        }
+
+        internal static float Take(
+            ref float remainingTransfer,
+            float availableCapacity,
+            float availableSource)
+        {
+            var quantity = Math.Min(
+                Math.Max(0f, remainingTransfer),
+                Math.Min(Math.Max(0f, availableCapacity), Math.Max(0f, availableSource)));
+            remainingTransfer -= quantity;
+            return quantity;
+        }
+    }
+
+    internal sealed class FuseConfusingSupplementsRefillerRuntime : MonoBehaviour
+    {
+        internal float TransferPerSecond { get; set; }
+
+        private Car _source;
+        private float _nextUpdate;
+        private bool _faulted;
+
+        private void Awake()
+        {
+            _source = GetComponent<Car>();
+        }
+
+        private void Update()
+        {
+            if (_faulted || !StateManager.IsHost || _source == null || Time.time < _nextUpdate)
+            {
+                return;
+            }
+
+            _nextUpdate = Time.time + 1f;
+            try
+            {
+                var target = FindNearestCompatibleCar(_source, Car.LogicalEnd.A) ??
+                             FindNearestCompatibleCar(_source, Car.LogicalEnd.B);
+                if (target != null)
+                {
+                    TransferLoads(_source, target, TransferPerSecond);
+                }
+            }
+            catch (Exception ex)
+            {
+                _faulted = true;
+                FuseLog.Warning(
+                    $"FUSE contained a rolling-stock refiller error on '{_source.DisplayName ?? _source.id}': " +
+                    ex.GetBaseException().Message + ". This refiller is disabled until the car is rebuilt.");
+            }
+        }
+
+        private static bool CanTargetReceiveFromSource(CarDefinition source, CarDefinition target)
+        {
+            return FuseConfusingSupplementsRefillerPolicy.CanTargetReceiveFromSource(
+                source?.LoadSlots?.Select(slot => slot?.RequiredLoadIdentifier),
+                target?.LoadSlots?.Select(slot => slot?.RequiredLoadIdentifier));
+        }
+
+        private static Car FindNearestCompatibleCar(Car source, Car.LogicalEnd end)
+        {
+            var set = source.set;
+            var index = set?.IndexOfCar(source);
+            if (!index.HasValue)
+            {
+                return null;
+            }
+
+            var cursor = index.Value;
+            var stop = false;
+            while (!stop)
+            {
+                var candidate = set.NextCarConnected(
+                    ref cursor,
+                    end,
+                    IntegrationSet.EnumerationCondition.AirConnected,
+                    out stop);
+                if (candidate == null)
+                {
+                    break;
+                }
+
+                if (candidate == source)
+                {
+                    continue;
+                }
+
+                if (IsSupportedTarget(candidate) &&
+                    CanTargetReceiveFromSource(source.Definition, candidate.Definition))
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsSupportedTarget(Car car)
+        {
+            return car != null &&
+                   (car.Archetype == CarArchetype.LocomotiveDiesel ||
+                    car.Archetype == CarArchetype.LocomotiveSteam ||
+                    car.Archetype == CarArchetype.Tender);
+        }
+
+        private static void TransferLoads(Car source, Car target, float maximumTransfer)
+        {
+            if (maximumTransfer <= 0f || source?.Definition?.LoadSlots == null || target?.Definition?.LoadSlots == null)
+            {
+                return;
+            }
+
+            var remainingTransfer = maximumTransfer;
+            for (var targetIndex = 0; targetIndex < target.Definition.LoadSlots.Count; targetIndex++)
+            {
+                if (remainingTransfer <= 0f)
+                {
+                    break;
+                }
+
+                var targetSlot = target.Definition.LoadSlots[targetIndex];
+                var loadId = targetSlot?.RequiredLoadIdentifier;
+                if (string.IsNullOrWhiteSpace(loadId))
+                {
+                    continue;
+                }
+
+                var sourceIndex = source.Definition.LoadSlots.FindIndex(slot => string.Equals(
+                    slot?.RequiredLoadIdentifier,
+                    loadId,
+                    StringComparison.OrdinalIgnoreCase));
+                if (sourceIndex < 0)
+                {
+                    continue;
+                }
+
+                var sourceLoad = source.GetLoadInfo(sourceIndex);
+                if (!sourceLoad.HasValue || sourceLoad.Value.Quantity <= 0f)
+                {
+                    continue;
+                }
+
+                var targetLoad = target.GetLoadInfo(targetIndex);
+                var targetQuantity = targetLoad?.Quantity ?? 0f;
+                var quantity = FuseConfusingSupplementsRefillerPolicy.Take(
+                    ref remainingTransfer,
+                    targetSlot.MaximumCapacity - targetQuantity,
+                    sourceLoad.Value.Quantity);
+                if (quantity <= 0f)
+                {
+                    continue;
+                }
+
+                var remainingSource = sourceLoad.Value;
+                remainingSource.Quantity -= quantity;
+                target.SetLoadInfo(targetIndex, new CarLoadInfo(loadId, targetQuantity + quantity));
+                source.SetLoadInfo(sourceIndex, remainingSource);
+            }
+        }
+    }
+}

--- a/FUSE/FusePlugin.cs
+++ b/FUSE/FusePlugin.cs
@@ -65,7 +65,6 @@ namespace FUSE
             try
             {
                 FuseLegacySupportAssemblyShim.Initialize();
-                FuseLegacyUmmRecovery.RecoverFailedEntries();
                 WarnIfLegacyRailloaderInstallPresent();
                 LogStartupVersions(modEntry);
                 FuseSettings.Load(modEntry);
@@ -75,6 +74,8 @@ namespace FUSE
 
                 _harmony = new Harmony(HarmonyId);
                 FusePatchResilience.ApplyAll(_harmony, Assembly.GetExecutingAssembly());
+                FuseConfusingSupplementsCompatibility.Initialize();
+                StrangeCustoms.FileCache.EnsureInstance();
                 FuseNarrowGaugePerformanceCompatibility.Initialize(_harmony);
                 FuseEarlyLoader.SetPatchAvailable(FusePatchResilience.Applied.Any(patch =>
                     string.Equals(patch.TypeName, "FUSE.Patches.FuseEarlyLoaderSceneManagerPatch", StringComparison.Ordinal)));
@@ -218,14 +219,15 @@ namespace FUSE
 
         private static void Shutdown()
         {
-            FuseNarrowGaugePerformanceCompatibility.Shutdown();
-            FuseThirdPartyGuardInstaller.Shutdown();
+            RunShutdownStep("narrow-gauge compatibility", FuseNarrowGaugePerformanceCompatibility.Shutdown);
+            RunShutdownStep("third-party guards", FuseThirdPartyGuardInstaller.Shutdown);
 
             if (_harmony != null)
             {
                 try
                 {
                     _harmony.UnpatchAll(HarmonyId);
+                    FuseLegosLibraryCompatibility.ResetAfterSuccessfulUnpatch();
                 }
                 catch (Exception ex)
                 {
@@ -234,6 +236,9 @@ namespace FUSE
 
                 _harmony = null;
             }
+
+            RunShutdownStep("Confusing Supplements compatibility", FuseConfusingSupplementsCompatibility.Reset);
+            RunShutdownStep("legacy livery texture cache", FuseConfusingSupplementsLiveryRegistry.Shutdown);
 
             if (_lifecycle != null)
             {
@@ -249,43 +254,56 @@ namespace FUSE
                 _lifecycle = null;
             }
 
-            FuseSceneryLoadThrottlePatch.Shutdown();
-            FuseCullingManagerUpdateRacePatch.ResetStats();
-            FuseTrackRebuilderQueueProcessor.Shutdown();
-            FuseCarCullerPendingProcessor.Shutdown();
-            FuseCarModelCompletionScheduler.Shutdown();
-            FuseDeferredAssetReferenceReleaseQueue.Shutdown();
-            FuseSceneryLoadFailurePatch.Shutdown();
-            FuseModExceptionLogHook.Shutdown();
-            FuseLegacyAssemblyHost.Shutdown();
-            FuseLegacySupportAssemblyShim.Shutdown();
-            FuseLegacyUmmRecovery.Reset();
-            FuseRuntimeRebindService.Shutdown();
-            FuseVersionCheck.Shutdown();
-            FuseMenuWindow.Shutdown();
-            FuseTrackDebugOverlay.Shutdown();
-            FuseSceneryDebugOverlay.Shutdown();
-            FuseWorldLabelsOverlay.Shutdown();
-            FuseLoadingScreen.Shutdown();
-            FuseFrameSpikeDiagnostic.Shutdown();
-            FuseRuntimePump.Shutdown();
-            FuseNativeLeakDiagnostic.Shutdown();
-            FuseUnusedAssetReclaimer.Reset();
-            FuseConstrainedTextureMemoryPolicy.Restore();
+            RunShutdownStep("scenery load throttle", FuseSceneryLoadThrottlePatch.Shutdown);
+            RunShutdownStep("culling race statistics", FuseCullingManagerUpdateRacePatch.ResetStats);
+            RunShutdownStep("track rebuilder queue", FuseTrackRebuilderQueueProcessor.Shutdown);
+            RunShutdownStep("car culler queue", FuseCarCullerPendingProcessor.Shutdown);
+            RunShutdownStep("car model scheduler", FuseCarModelCompletionScheduler.Shutdown);
+            RunShutdownStep("deferred asset release queue", FuseDeferredAssetReferenceReleaseQueue.Shutdown);
+            RunShutdownStep("scenery load failure hook", FuseSceneryLoadFailurePatch.Shutdown);
+            RunShutdownStep("mod exception hook", FuseModExceptionLogHook.Shutdown);
+            RunShutdownStep("legacy assembly host", FuseLegacyAssemblyHost.Shutdown);
+            RunShutdownStep("legacy file cache", StrangeCustoms.FileCache.Shutdown);
+            RunShutdownStep("legacy support shim", FuseLegacySupportAssemblyShim.Shutdown);
+            RunShutdownStep("legacy UMM recovery", FuseLegacyUmmRecovery.Reset);
+            RunShutdownStep("runtime rebind service", FuseRuntimeRebindService.Shutdown);
+            RunShutdownStep("version check", FuseVersionCheck.Shutdown);
+            RunShutdownStep("menu window", FuseMenuWindow.Shutdown);
+            RunShutdownStep("track debug overlay", FuseTrackDebugOverlay.Shutdown);
+            RunShutdownStep("scenery debug overlay", FuseSceneryDebugOverlay.Shutdown);
+            RunShutdownStep("world labels overlay", FuseWorldLabelsOverlay.Shutdown);
+            RunShutdownStep("loading screen", FuseLoadingScreen.Shutdown);
+            RunShutdownStep("frame spike diagnostic", FuseFrameSpikeDiagnostic.Shutdown);
+            RunShutdownStep("runtime pump", FuseRuntimePump.Shutdown);
+            RunShutdownStep("native leak diagnostic", FuseNativeLeakDiagnostic.Shutdown);
+            RunShutdownStep("unused asset reclaimer", FuseUnusedAssetReclaimer.Reset);
+            RunShutdownStep("texture memory policy", FuseConstrainedTextureMemoryPolicy.Restore);
 
             if (_isLoaded && InGameEditorEnabled)
             {
-                FuseEditorBridge.NotifyFuseUnloaded();
+                RunShutdownStep("editor unload notification", FuseEditorBridge.NotifyFuseUnloaded);
             }
 
             if (_isLoaded)
             {
-                FuseEvents.RaiseFuseUnloaded();
+                RunShutdownStep("unload event", FuseEvents.RaiseFuseUnloaded);
                 FuseLog.Info("FUSE unloaded.");
             }
 
             _isLoaded = false;
             ModEntry = null;
+        }
+
+        private static void RunShutdownStep(string name, Action step)
+        {
+            try
+            {
+                step();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception($"FUSE failed while shutting down {name}", ex);
+            }
         }
     }
 }

--- a/FUSE/Info.json
+++ b/FUSE/Info.json
@@ -23,6 +23,24 @@
     "FrameSpikeThresholdMs": 100,
     "ForceConstrainedVramMode": false,
     "EnableNativeLeakStackTraces": false,
-    "EnableUpdateCheck": true
+    "EnableUpdateCheck": true,
+    "GraceMinimumDays": 0,
+    "GraceMultiplier": 1,
+    "GraceAddedDays": 0,
+    "InterchangeServiceIntervalMinutes": 150,
+    "InterchangeContinuousService": false,
+    "InterchangeNotBeforeHour": 0,
+    "InterchangeNotAfterHour": 24,
+    "EnableOutboundIndustryRerouting": false,
+    "OutboundIndustryRerouteChance": 0.25,
+    "OutboundIndustryFillFactor": 1,
+    "OutboundIndustryPaymentMultiplier": 1,
+    "OutboundIndustryAllowShortTrips": false,
+    "OutboundIndustryIgnoreOrigin": false,
+    "OutboundIndustryPreventBlocking": false,
+    "InterchangeToInterchangeMaximumCars": 30,
+    "ForYourConvenienceShowCabooseIcons": false,
+    "ForYourConvenienceShowCarTagMph": false,
+    "ForYourConvenienceShowCarTagLoads": false
   }
 }

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -86,6 +86,7 @@ namespace FUSE.Infrastructure
         public const bool DefaultOutboundIndustryIgnoreOrigin = false;
         public const bool DefaultOutboundIndustryPreventBlocking = false;
         public const int DefaultInterchangeToInterchangeMaximumCars = 30;
+        internal const int InterchangeToInterchangeMaximumCarsLimit = 200;
         public const bool DefaultForYourConvenienceShowCabooseIcons = false;
         public const bool DefaultForYourConvenienceShowCarTagMph = false;
         public const bool DefaultForYourConvenienceShowCarTagLoads = false;
@@ -356,7 +357,7 @@ namespace FUSE.Infrastructure
                     DefaultInterchangeNotAfterHour);
                 EnableOutboundIndustryRerouting =
                     ReadBool(settings, "EnableOutboundIndustryRerouting", DefaultEnableOutboundIndustryRerouting);
-                OutboundIndustryRerouteChance = Mathf.Clamp01(
+                OutboundIndustryRerouteChance = ClampOutboundIndustryRerouteChance(
                     ReadFloat(settings, "OutboundIndustryRerouteChance", DefaultOutboundIndustryRerouteChance));
                 OutboundIndustryFillFactor = ClampOutboundIndustryFillFactor(
                     ReadFloat(settings, "OutboundIndustryFillFactor", DefaultOutboundIndustryFillFactor));
@@ -833,7 +834,7 @@ namespace FUSE.Infrastructure
 
         public static void SetOutboundIndustryRerouteChance(float value)
         {
-            OutboundIndustryRerouteChance = Mathf.Clamp01(value);
+            OutboundIndustryRerouteChance = ClampOutboundIndustryRerouteChance(value);
             SaveUserOverride(nameof(OutboundIndustryRerouteChance), OutboundIndustryRerouteChance);
         }
 
@@ -875,7 +876,7 @@ namespace FUSE.Infrastructure
 
         internal static int ClampInterchangeToInterchangeMaximumCars(int value)
         {
-            return Mathf.Clamp(value, 0, 200);
+            return Mathf.Clamp(value, 0, InterchangeToInterchangeMaximumCarsLimit);
         }
 
         public static void SetForYourConvenienceShowCabooseIcons(bool enabled)
@@ -894,6 +895,11 @@ namespace FUSE.Infrastructure
         {
             ForYourConvenienceShowCarTagLoads = enabled;
             SaveUserOverride(nameof(ForYourConvenienceShowCarTagLoads), enabled);
+        }
+
+        internal static float ClampOutboundIndustryRerouteChance(float value)
+        {
+            return float.IsNaN(value) ? DefaultOutboundIndustryRerouteChance : Mathf.Clamp01(value);
         }
 
         internal static float ClampOutboundIndustryFillFactor(float value)
@@ -1169,7 +1175,7 @@ namespace FUSE.Infrastructure
                     InterchangeNotAfterHour);
                 EnableOutboundIndustryRerouting =
                     ReadBool(settings, nameof(EnableOutboundIndustryRerouting), EnableOutboundIndustryRerouting);
-                OutboundIndustryRerouteChance = Mathf.Clamp01(
+                OutboundIndustryRerouteChance = ClampOutboundIndustryRerouteChance(
                     ReadFloat(settings, nameof(OutboundIndustryRerouteChance), OutboundIndustryRerouteChance));
                 OutboundIndustryFillFactor = ClampOutboundIndustryFillFactor(
                     ReadFloat(settings, nameof(OutboundIndustryFillFactor), OutboundIndustryFillFactor));

--- a/FUSE/Interface/Console/FuseConsoleCommands.cs
+++ b/FUSE/Interface/Console/FuseConsoleCommands.cs
@@ -31,6 +31,7 @@ namespace FUSE.Interface.Console
             {
                 new FuseReportCommand(),
                 new FuseLoadedCommand(),
+                new FuseStartersCommand(),
                 new FuseUpdateCommand(),
                 new FuseMapsCommand(),
                 new FuseMapLaunchCommand(),
@@ -38,6 +39,9 @@ namespace FUSE.Interface.Console
                 new FuseGraphCommand(),
                 new FuseProgressionsCommand(),
                 new FuseOperationsCommand(),
+                new FuseLiveryRefreshCommand(),
+                new FuseLiveryRefreshAliasCommand(),
+                new FuseLiveryReportCommand(),
                 new FuseDumpGraphCommand(),
                 new FuseDumpRuntimeGraphCommand(),
                 new FuseDumpMandelasCommand(),
@@ -147,6 +151,58 @@ namespace FUSE.Interface.Console
             }
 
             return string.Join("/", names.ToArray());
+        }
+    }
+
+    [ConsoleCommand(
+        "/cs-livery-refresh",
+        "Reload Confusing Supplements-compatible livery textures and reapply each car's saved selection.")]
+    public sealed class FuseLiveryRefreshCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            try
+            {
+                var refreshed = Compatibility.FuseConfusingSupplementsLiveryRegistry
+                    .RefreshLiveCars();
+                return $"FUSE refreshed Confusing Supplements-compatible liveries on {refreshed} car(s).";
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE livery refresh console command failed.", ex);
+                return "FUSE livery refresh failed: " + ex.GetBaseException().Message;
+            }
+        }
+    }
+
+    [ConsoleCommand(
+        "/fuse.livery.refresh",
+        "Reload Confusing Supplements-compatible livery textures and reapply each car's saved selection.")]
+    public sealed class FuseLiveryRefreshAliasCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            return new FuseLiveryRefreshCommand().Execute(components);
+        }
+    }
+
+    [ConsoleCommand(
+        "/fuse.liveries",
+        "Report Confusing Supplements-compatible livery selections, choices, and cached textures.")]
+    public sealed class FuseLiveryReportCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            try
+            {
+                return Compatibility.FuseConfusingSupplementsLiveryRegistry
+                    .BuildDiagnosticReport();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE livery diagnostics console command failed.", ex);
+                return "FUSE livery diagnostics failed: " + ex.GetBaseException().Message;
+            }
         }
     }
 
@@ -483,6 +539,20 @@ namespace FUSE.Interface.Console
                     sb.AppendLine("  " + folder);
                 }
 
+                var definitionOverrides = FuseAssetPackRegistry.GetLegacyDefinitionOverrides();
+                var overrideIssues = FuseAssetPackRegistry.GetLegacyDefinitionOverrideIssues();
+                sb.AppendLine($"Definition overrides: active={definitionOverrides.Length}; issues={overrideIssues.Length}.");
+                foreach (var definitionOverride in definitionOverrides)
+                {
+                    sb.AppendLine(
+                        $"  {definitionOverride.StoreIdentifier} <- {definitionOverride.DefinitionsPath} " +
+                        $"(package {definitionOverride.PackageId})");
+                }
+                foreach (var issue in overrideIssues)
+                {
+                    sb.AppendLine("  ISSUE: " + issue);
+                }
+
                 return sb.ToString();
             }
             catch (Exception ex)
@@ -706,6 +776,26 @@ namespace FUSE.Interface.Console
             }
 
             return FuseLoadReport.GetLastDetailReport();
+        }
+    }
+
+    [ConsoleCommand(
+        "/fuse.starters",
+        "Resume placement of retained Appalachian Railway starter equipment.")]
+    public sealed class FuseStartersCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            try
+            {
+                return FuseCompanyStarterPlacementPatch
+                    .ResumePendingPlacements();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE starters console command failed.", ex);
+                return "FUSE starters failed: " + ex.GetBaseException().Message;
+            }
         }
     }
 
@@ -1182,14 +1272,17 @@ namespace FUSE.Interface.Console
         public string Execute(string[] components)
         {
             var conflicts = FuseRegistry.Conflicts;
+            var actionable = conflicts.Count(conflict => !conflict.IsCooperativeMerge);
+            var cooperative = conflicts.Count(conflict => conflict.IsCooperativeMerge);
             var sb = new StringBuilder();
             sb.AppendLine(
                 $"FUSE registry: exclusive={FuseRegistry.ExclusiveClaimCount} shared={FuseRegistry.SharedClaimCount} " +
-                $"conflicts={conflicts.Count}");
+                $"conflicts={actionable} sharedExtensionTargets={cooperative} records={conflicts.Count}");
             foreach (var conflict in conflicts.OrderByDescending(c => c.AtUtc))
             {
+                var classification = conflict.IsCooperativeMerge ? "shared-extension" : "actionable";
                 sb.AppendLine(
-                    $"  target='{conflict.Target ?? conflict.Kind.ToString()}' kind='{conflict.Kind}' id='{conflict.Id}': " +
+                    $"  [{classification}] target='{conflict.Target ?? conflict.Kind.ToString()}' kind='{conflict.Kind}' id='{conflict.Id}': " +
                     $"owner='{conflict.OwnerPackageId}' attempted='{conflict.AttemptedPackageId}' " +
                     $"resolution='{conflict.Resolution ?? "claim skipped"}' at={conflict.AtUtc:HH:mm:ss}Z");
             }

--- a/FUSE/Patches/FuseAlinasUtilitiesCompatibility.cs
+++ b/FUSE/Patches/FuseAlinasUtilitiesCompatibility.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using FUSE.Infrastructure;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Keeps the supported, separately-installed Alina Utilities mod usable
+    /// when its RailLoader and UMM entry points are both discovered during the
+    /// same startup. Older builds can leave the RailLoader singleton alive
+    /// without an <c>IModdingContext</c>; its Settings getter then throws from
+    /// camera-distance, damage, and main-menu patches before it can fall back
+    /// to the UMM settings object.
+    ///
+    /// FUSE does not replace Alina Utilities. It only supplies the missing
+    /// settings reference on that partially-bound instance. The original mod
+    /// continues to own its settings UI and feature patches.
+    /// </summary>
+    internal static class FuseAlinasUtilitiesCompatibility
+    {
+        private const string PluginTypeName = "AlinasUtils.AlinasUtilsPlugin";
+        private const string UmmModTypeName = "AlinasUtils.UMM.Mod";
+        private const string SettingsFieldName = "_settings";
+
+        private static readonly HashSet<object> RepairedInstances =
+            new HashSet<object>(ReferenceEqualityComparer.Instance);
+
+        internal static string EnsureInstalled()
+        {
+            var foundAssembly = false;
+            var foundShared = false;
+            var repaired = 0;
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (assembly == null || assembly.IsDynamic)
+                {
+                    continue;
+                }
+
+                Type pluginType;
+                try
+                {
+                    pluginType = assembly.GetType(PluginTypeName, false);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (pluginType == null)
+                {
+                    continue;
+                }
+
+                foundAssembly = true;
+                try
+                {
+                    var shared = ReadSharedInstance(pluginType);
+                    if (shared == null)
+                    {
+                        continue;
+                    }
+
+                    foundShared = true;
+                    var settingsField = pluginType.GetField(
+                        SettingsFieldName,
+                        BindingFlags.Instance | BindingFlags.NonPublic);
+                    if (settingsField == null)
+                    {
+                        continue;
+                    }
+
+                    var currentSettings = settingsField.GetValue(shared);
+                    var settings = ResolveSettings(
+                        currentSettings,
+                        currentSettings == null
+                            ? ReadUmmSettings(assembly, settingsField.FieldType)
+                            : null,
+                        () => CreateDefaultSettings(settingsField.FieldType));
+                    if (settings == null || ReferenceEquals(settings, currentSettings))
+                    {
+                        continue;
+                    }
+
+                    settingsField.SetValue(shared, settings);
+                    if (RepairedInstances.Add(shared))
+                    {
+                        repaired++;
+                        FuseLog.Info(
+                            "FUSE repaired a partially-bound Alina Utilities legacy instance by " +
+                            "connecting it to the mod's working settings object. Alina Utilities " +
+                            "remains installed and owns its original features.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Recovered distributions can contain more than one assembly
+                    // with an AlinasUtils identity. One stale or incompatible copy
+                    // must not prevent the compatible copy from being repaired.
+                    FuseLog.Warning(
+                        $"FUSE could not inspect one Alina Utilities " +
+                        $"assembly='{assembly.GetName().Name}': {ex.Message}");
+                }
+            }
+
+            if (repaired > 0)
+            {
+                return $"repaired ({repaired})";
+            }
+
+            if (!foundAssembly)
+            {
+                return "idle (not present)";
+            }
+
+            return foundShared ? "ready" : "idle (no legacy instance)";
+        }
+
+        internal static bool IsTargetAssemblyName(string assemblyName)
+        {
+            return !string.IsNullOrWhiteSpace(assemblyName) &&
+                   assemblyName.StartsWith("AlinasUtils", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static object ResolveSettings(
+            object currentSettings,
+            object ummSettings,
+            Func<object> createDefault)
+        {
+            if (currentSettings != null)
+            {
+                return currentSettings;
+            }
+
+            return ummSettings ?? createDefault?.Invoke();
+        }
+
+        private static object ReadSharedInstance(Type pluginType)
+        {
+            try
+            {
+                var baseType = pluginType.BaseType;
+                var property = baseType?.GetProperty(
+                    "Shared",
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                return property?.GetValue(null, null);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static object ReadUmmSettings(Assembly assembly, Type settingsType)
+        {
+            try
+            {
+                var modType = assembly.GetType(UmmModTypeName, false);
+                var property = modType?.GetProperty(
+                    "Settings",
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                var value = property?.GetValue(null, null);
+                return value != null && settingsType.IsInstanceOfType(value) ? value : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static object CreateDefaultSettings(Type settingsType)
+        {
+            try
+            {
+                return settingsType == null ? null : Activator.CreateInstance(settingsType);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private sealed class ReferenceEqualityComparer : IEqualityComparer<object>
+        {
+            internal static readonly ReferenceEqualityComparer Instance =
+                new ReferenceEqualityComparer();
+
+            bool IEqualityComparer<object>.Equals(object left, object right)
+            {
+                return ReferenceEquals(left, right);
+            }
+
+            int IEqualityComparer<object>.GetHashCode(object value)
+            {
+                return value == null
+                    ? 0
+                    : System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(value);
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseAssetLoaderReplacementCompatibility.cs
+++ b/FUSE/Patches/FuseAssetLoaderReplacementCompatibility.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using HarmonyLib;
+using FUSE.Infrastructure;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// FUSE replaces AssetLoader's asset-pack discovery. Leaving the old mod's
+    /// CheckDefinitions prefix active creates a second set of stores outside
+    /// FUSE's quarantine path; one malformed Definitions.json can then abort
+    /// the Equipment or Customize window while it enumerates those stores.
+    /// Remove only patches owned by AssetLoader. The assembly stays loaded so
+    /// packages with a historical UMM dependency continue to see it installed.
+    /// </summary>
+    internal static class FuseAssetLoaderReplacementCompatibility
+    {
+        internal const string LegacyHarmonyOwner = "AssetLoader";
+
+        internal static string EnsureInstalled(Harmony harmony)
+        {
+            if (harmony == null)
+            {
+                return "unavailable";
+            }
+
+            var assetLoaderType = AccessTools.TypeByName("AssetLoader.Patches.AssetLoaderPatch");
+            if (assetLoaderType == null ||
+                !IsTargetAssemblyName(assetLoaderType.Assembly.GetName().Name))
+            {
+                return "absent";
+            }
+
+            var ownedBefore = CountOwnedPatches();
+            if (ownedBefore == 0)
+            {
+                return "replaced (no active legacy patches)";
+            }
+
+            harmony.UnpatchAll(LegacyHarmonyOwner);
+            var ownedAfter = CountOwnedPatches();
+            if (ownedAfter > 0)
+            {
+                return $"failed ({ownedAfter} patch(es) remain)";
+            }
+
+            FuseLog.Info(
+                $"FUSE disabled {ownedBefore} legacy AssetLoader Harmony patch(es). " +
+                "FUSE asset discovery remains active; the AssetLoader assembly was not removed.");
+            return $"replaced ({ownedBefore} patch(es) disabled)";
+        }
+
+        internal static bool IsTargetAssemblyName(string assemblyName) =>
+            string.Equals(assemblyName, "AssetLoader", StringComparison.OrdinalIgnoreCase);
+
+        private static int CountOwnedPatches()
+        {
+            try
+            {
+                return Harmony.GetAllPatchedMethods()
+                    .Select(Harmony.GetPatchInfo)
+                    .Where(info => info != null)
+                    .Sum(info =>
+                        info.Prefixes.Count(patch => IsLegacyOwner(patch.owner)) +
+                        info.Postfixes.Count(patch => IsLegacyOwner(patch.owner)) +
+                        info.Transpilers.Count(patch => IsLegacyOwner(patch.owner)) +
+                        info.Finalizers.Count(patch => IsLegacyOwner(patch.owner)));
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        private static bool IsLegacyOwner(string owner) =>
+            string.Equals(owner, LegacyHarmonyOwner, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/FUSE/Patches/FuseAssetPackRuntimeStoreContainerPatch.cs
+++ b/FUSE/Patches/FuseAssetPackRuntimeStoreContainerPatch.cs
@@ -25,6 +25,12 @@ namespace FUSE.Patches
                     __result = container;
                     return false;
                 }
+
+                if (FuseAssetPackRegistry.TryLoadLegacyDefinitionOverrideContainer(__instance, out container))
+                {
+                    __result = container;
+                    return false;
+                }
             }
             catch (System.Exception ex)
             {

--- a/FUSE/Patches/FuseAudioPatches.cs
+++ b/FUSE/Patches/FuseAudioPatches.cs
@@ -182,4 +182,47 @@ namespace FUSE.Patches
         }
 
     }
+
+    /// <summary>
+    /// Contains a bad whistle/horn/bell provider at the individual picker
+    /// boundary. Asset packs are third-party inputs; one provider throwing
+    /// while its definitions are enumerated must not abort construction of the
+    /// entire customize window and leave the player locked out of its controls.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FuseCarCustomizeSoundPickerGuardPatch
+    {
+        private static IEnumerable<MethodBase> TargetMethods()
+        {
+            var windowType = typeof(UI.CarCustomizeWindow.CarCustomizeWindow);
+            foreach (var name in new[] { "BuildSoundTabWhistle", "BuildSoundTabHorn", "BuildSoundTabBell" })
+            {
+                var method = AccessTools.DeclaredMethod(windowType, name);
+                if (method == null)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not guard the car customize sound picker because " +
+                        $"'{windowType.FullName}.{name}' could not be resolved.");
+                    continue;
+                }
+
+                yield return method;
+            }
+        }
+
+        private static Exception Finalizer(Exception __exception, MethodBase __originalMethod)
+        {
+            if (__exception == null)
+            {
+                return null;
+            }
+
+            var picker = (__originalMethod?.Name ?? "sound picker").Replace("BuildSoundTab", string.Empty);
+            FuseLog.Warning(
+                $"FUSE contained a broken {picker} definition provider while building the car customize window: " +
+                $"{__exception.GetBaseException().GetType().Name}: {__exception.GetBaseException().Message}. " +
+                "Only that sound picker was omitted; the rest of the window remains available.");
+            return null;
+        }
+    }
 }

--- a/FUSE/Patches/FuseC1CdCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseC1CdCompatibilityPatch.cs
@@ -1,0 +1,72 @@
+using FUSE.Infrastructure;
+using Game;
+using HarmonyLib;
+using Model.Ops;
+
+namespace FUSE.Patches
+{
+    [HarmonyPatch(
+        typeof(Interchange),
+        nameof(Interchange.NextAvailableServiceTime),
+        new[] { typeof(GameDateTime) })]
+    internal static class FuseC1CdNextServiceTimePatch
+    {
+        private static bool Prefix(GameDateTime now, ref GameDateTime __result)
+        {
+            __result = FuseC1CdSchedulePolicy.CalculateNextServiceTime(
+                now,
+                FuseSettings.InterchangeServiceIntervalMinutes,
+                FuseSettings.InterchangeNotBeforeHour,
+                FuseSettings.InterchangeNotAfterHour);
+            return false;
+        }
+    }
+
+    internal static class FuseC1CdSchedulePolicy
+    {
+        internal static GameDateTime CalculateNextServiceTime(
+            GameDateTime now,
+            int intervalMinutes,
+            float notBeforeHour,
+            float notAfterHour)
+        {
+            var interval = FuseSettings.NormalizeInterchangeServiceIntervalMinutes(intervalMinutes);
+            var start = FuseSettings.ClampInterchangeServiceHour(
+                notBeforeHour,
+                FuseSettings.DefaultInterchangeNotBeforeHour);
+            var end = FuseSettings.ClampInterchangeServiceHour(
+                notAfterHour,
+                FuseSettings.DefaultInterchangeNotAfterHour);
+            var candidate = now.AddingMinutes(interval).RoundingMinutes(5);
+
+            if (start <= 0f && end >= 24f)
+            {
+                return candidate;
+            }
+
+            if (start <= end)
+            {
+                if (candidate.Hours < start)
+                {
+                    return candidate.WithHours(start).RoundingMinutes(5);
+                }
+
+                if (candidate.Hours > end)
+                {
+                    return candidate.AddingDays(1f).WithHours(start).RoundingMinutes(5);
+                }
+
+                return candidate;
+            }
+
+            // A window whose start is later than its end crosses midnight
+            // (for example 22:00–06:00). Only the daytime gap is excluded.
+            if (candidate.Hours > end && candidate.Hours < start)
+            {
+                return candidate.WithHours(start).RoundingMinutes(5);
+            }
+
+            return candidate;
+        }
+    }
+}

--- a/FUSE/Patches/FuseCompanyStarterPlacementPatch.cs
+++ b/FUSE/Patches/FuseCompanyStarterPlacementPatch.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using FUSE.Loading;
 using FUSE.Infrastructure;
 using Game.Messages;
 using Game.Progression;
+using Game.Scripting.Interactive;
 using Game.State;
 using HarmonyLib;
 using KeyValue.Runtime;
@@ -13,28 +15,59 @@ using Model.Definition;
 using Model.Ops;
 using Model.Ops.Definition;
 using Track;
+using UI.Common;
 using UnityEngine;
 
 namespace FUSE.Patches
 {
     /// <summary>
     /// Moves the stock East Whittier Company starter equipment into an
-    /// interactive placement queue, and does the same for invalid placements
-    /// from any other setup. This lets the player choose live track after the
-    /// progression has settled instead of depending on one fixed scene marker.
+    /// interactive placement queue when Appalachian Railway's Whittier start
+    /// package is active. This lets the player choose live track after the
+    /// progression and tutorial have settled instead of depending on one fixed
+    /// scene marker.
     /// </summary>
     [HarmonyPatch(typeof(CompanyModeSetup), nameof(CompanyModeSetup.Setup))]
     internal static class FuseCompanyStarterPlacementPatch
     {
+        private const string AppalachianWhittierStartId =
+            "KingG.Appalachian-Railway.start-whit";
+        private static readonly Queue<SetupDescriptor.CarPlacement>
+            PendingPlacements =
+                new Queue<SetupDescriptor.CarPlacement>();
+        private static bool _presenting;
+
         [HarmonyPostfix]
         private static void SetupPostfix(
             SetupDescriptor setupDescriptor,
             ref IEnumerator __result)
         {
-            if (__result != null && setupDescriptor != null)
+            var shouldQueue = __result != null
+                              && setupDescriptor != null
+                              && ShouldQueueStarterSetup(
+                                  setupDescriptor.identifier,
+                                  FuseModLoader.GetLoadedMods());
+            if (TryPrepareStarterQueue(
+                    PendingPlacements,
+                    shouldQueue,
+                    _presenting))
             {
                 __result = RepairAfterInitialDelay(__result, setupDescriptor);
             }
+        }
+
+        internal static bool TryPrepareStarterQueue<T>(
+            Queue<T> placementQueue,
+            bool shouldQueue,
+            bool presentationActive)
+        {
+            if (!shouldQueue || presentationActive)
+            {
+                return false;
+            }
+
+            placementQueue?.Clear();
+            return true;
         }
 
         private static IEnumerator RepairAfterInitialDelay(
@@ -42,7 +75,6 @@ namespace FUSE.Patches
             SetupDescriptor setupDescriptor)
         {
             var repairPending = true;
-            var placementQueue = new Queue<SetupDescriptor.CarPlacement>();
             while (original.MoveNext())
             {
                 yield return original.Current;
@@ -52,14 +84,36 @@ namespace FUSE.Patches
                 }
 
                 repairPending = false;
-                QueueStarterPlacements(setupDescriptor, placementQueue);
+                QueueStarterPlacements(
+                    setupDescriptor,
+                    PendingPlacements);
             }
 
-            if (placementQueue.Count > 0)
+            if (PendingPlacements.Count > 0)
             {
                 yield return null;
-                PresentNextPlacement(placementQueue);
+                while (InteractiveBookWindow.Shared != null
+                       && InteractiveBookWindow.Shared.IsShown)
+                {
+                    yield return null;
+                }
+                PresentNextPlacement();
             }
+        }
+
+        internal static bool ShouldQueueStarterSetup(
+            string setupIdentifier,
+            IEnumerable<string> loadedDefinitionIds)
+        {
+            return !string.IsNullOrWhiteSpace(setupIdentifier)
+                   && setupIdentifier.StartsWith(
+                       "ewh-",
+                       StringComparison.OrdinalIgnoreCase)
+                   && (loadedDefinitionIds ?? Array.Empty<string>()).Any(id =>
+                       string.Equals(
+                           id,
+                           AppalachianWhittierStartId,
+                           StringComparison.OrdinalIgnoreCase));
         }
 
         internal static int QueueStarterPlacements(
@@ -74,13 +128,13 @@ namespace FUSE.Patches
             }
 
             var queued = 0;
-            var queueEntireSetup = IsStockEastWhittierSetup(setupDescriptor);
-            var retained = new List<SetupDescriptor.CarPlacement>(source.Length);
             foreach (var placement in source)
             {
-                if (!queueEntireSetup && PlacementIsUsable(placement))
+                if (placement == null)
                 {
-                    retained.Add(placement);
+                    FuseLog.Warning(
+                        $"FUSE ignored a null Company starter placement in " +
+                        $"setup='{setupDescriptor.identifier ?? string.Empty}'.");
                     continue;
                 }
 
@@ -88,85 +142,214 @@ namespace FUSE.Patches
                 queued++;
                 FuseLog.Info(
                     $"FUSE queued Company starter placement " +
-                    $"setup='{setupDescriptor.identifier ?? string.Empty}' cars={placement?.carIdentifier?.Length ?? 0}. " +
+                    $"setup='{setupDescriptor.identifier ?? string.Empty}' cars={placement.carIdentifier?.Length ?? 0}. " +
                     "The local player will choose its track location.");
             }
 
-            setupDescriptor.placements = retained.ToArray();
+            // Every placement moves to the interactive queue, so the setup keeps none.
+            setupDescriptor.placements = Array.Empty<SetupDescriptor.CarPlacement>();
             return queued;
         }
 
-        private static bool IsStockEastWhittierSetup(
-            SetupDescriptor setupDescriptor)
+        private static bool PresentNextPlacement()
         {
-            return setupDescriptor != null &&
-                   !string.IsNullOrWhiteSpace(setupDescriptor.identifier) &&
-                   setupDescriptor.identifier.StartsWith(
-                       "ewh-",
-                       StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static bool PlacementIsUsable(
-            SetupDescriptor.CarPlacement placement)
-        {
-            if (placement?.marker == null)
+            if (_presenting || PendingPlacements.Count == 0)
             {
                 return false;
             }
 
-            var location = placement.marker.Location;
-            return location.HasValue &&
-                   location.Value.IsValid &&
-                   location.Value.segment != null &&
-                   location.Value.segment.GroupEnabled &&
-                   location.Value.segment.Available;
-        }
-
-        private static void PresentNextPlacement(
-            Queue<SetupDescriptor.CarPlacement> placementQueue)
-        {
-            if (placementQueue == null || placementQueue.Count == 0)
+            var placement = PendingPlacements.Peek();
+            var preparationSucceeded = TryBuildDescriptors(
+                placement,
+                out var descriptors);
+            var consumedEmpty = TryConsumeConfirmedEmpty(
+                PendingPlacements,
+                preparationSucceeded,
+                descriptors.Count);
+            if (!preparationSucceeded)
             {
-                return;
+                Toast.Present(
+                    "Starter equipment retained. Run /fuse.starters when "
+                    + "placement is available.",
+                    ToastPosition.Middle);
+                return false;
             }
-
-            var placement = placementQueue.Dequeue();
-            var descriptors = BuildDescriptors(placement);
-            if (descriptors.Count == 0)
+            if (consumedEmpty)
             {
-                PresentNextPlacement(placementQueue);
-                return;
+                return PresentNextPlacement();
             }
 
             var placer = ConsistPlacer.Instance();
             if (placer == null)
             {
                 FuseLog.Warning(
-                    $"FUSE could not present {placementQueue.Count + 1} queued Company starter cut(s): " +
+                    $"FUSE could not present {PendingPlacements.Count} queued Company starter cut(s): " +
                     "the game's consist placer is unavailable.");
-                return;
+                Toast.Present(
+                    "Starter equipment retained. Run /fuse.starters when "
+                    + "placement is available.",
+                    ToastPosition.Middle);
+                return false;
             }
 
-            placer.Present(
-                descriptors,
-                null,
-                _ => placer.StartCoroutine(PresentAfterFrame(placementQueue)));
-        }
-
-        private static IEnumerator PresentAfterFrame(
-            Queue<SetupDescriptor.CarPlacement> placementQueue)
-        {
-            yield return null;
-            PresentNextPlacement(placementQueue);
-        }
-
-        private static List<CarDescriptor> BuildDescriptors(
-            SetupDescriptor.CarPlacement placement)
-        {
+            _presenting = true;
+            var trainController = TrainController.Shared;
+            if (trainController != null)
+            {
+                // The current game build reports `placed=true` even when its
+                // caught PlaceTrain call failed. Clearing and checking this
+                // public result prevents that false callback from consuming
+                // the retained starter cut.
+                trainController.LastPlacedTrain = null;
+            }
             try
             {
-                var identifiers = placement?.carIdentifier ?? Array.Empty<string>();
-                var descriptors = StateManager.DescriptorsForIdentifiers(identifiers)
+                placer.Present(
+                    descriptors,
+                    null,
+                    placed =>
+                    {
+                        _presenting = false;
+                        var placedCount = TrainController.Shared?
+                            .LastPlacedTrain?.Count ?? 0;
+                        if (!WasPlacementCommitted(
+                                placed,
+                                descriptors.Count,
+                                placedCount))
+                        {
+                            FuseLog.Info(
+                                "FUSE retained "
+                                + PendingPlacements.Count
+                                + " Appalachian Railway starter cut(s) after "
+                                + (placed
+                                    ? "the game did not confirm every car was created."
+                                    : "placement was cancelled."));
+                            Toast.Present(
+                                "Starter equipment retained. Run /fuse.starters "
+                                + "when you are ready to place it.",
+                                ToastPosition.Middle);
+                            return;
+                        }
+
+                        if (PendingPlacements.Count > 0
+                            && ReferenceEquals(
+                                PendingPlacements.Peek(),
+                                placement))
+                        {
+                            PendingPlacements.Dequeue();
+                        }
+                        var activePlacer = ConsistPlacer.Instance();
+                        if (activePlacer != null)
+                        {
+                            activePlacer.StartCoroutine(PresentAfterFrame());
+                        }
+                        else
+                        {
+                            FuseLog.Warning(
+                                "FUSE retained the next starter cut because the consist placer closed after placement.");
+                        }
+                    });
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _presenting = false;
+                FuseLog.Exception(
+                    "FUSE could not open Appalachian Railway starter placement; "
+                    + "the cut remains queued.",
+                    ex);
+                Toast.Present(
+                    "Starter equipment retained. Run /fuse.starters when "
+                    + "placement is available.",
+                    ToastPosition.Middle);
+                return false;
+            }
+        }
+
+        internal static bool WasPlacementCommitted(
+            bool callbackReportedPlaced,
+            int expectedCarCount,
+            int placedCarCount)
+        {
+            return callbackReportedPlaced
+                   && expectedCarCount > 0
+                   && placedCarCount == expectedCarCount;
+        }
+
+        internal static bool TryConsumeConfirmedEmpty<T>(
+            Queue<T> queue,
+            bool preparationSucceeded,
+            int descriptorCount)
+        {
+            if (!preparationSucceeded
+                || descriptorCount != 0
+                || queue == null
+                || queue.Count == 0)
+            {
+                return false;
+            }
+
+            queue.Dequeue();
+            return true;
+        }
+
+        private static IEnumerator PresentAfterFrame()
+        {
+            yield return null;
+            PresentNextPlacement();
+        }
+
+        internal static string ResumePendingPlacements()
+        {
+            if (PendingPlacements.Count == 0)
+                return "No Appalachian Railway starter equipment is pending.";
+            if (_presenting)
+            {
+                if (ConsistPlacer.Instance() == null)
+                {
+                    _presenting = false;
+                }
+                else
+                {
+                return "Starter equipment placement is already active ("
+                       + PendingPlacements.Count
+                       + " cut(s) remaining).";
+                }
+            }
+            if (InteractiveBookWindow.Shared != null
+                && InteractiveBookWindow.Shared.IsShown)
+            {
+                return "Close the tutorial, then run /fuse.starters again. "
+                       + PendingPlacements.Count
+                       + " starter cut(s) are safely retained.";
+            }
+
+            if (!PresentNextPlacement())
+            {
+                if (PendingPlacements.Count == 0)
+                {
+                    return "No Appalachian Railway starter equipment is pending.";
+                }
+
+                return "Starter equipment placement could not be opened; "
+                       + PendingPlacements.Count
+                       + " cut(s) are safely retained.";
+            }
+
+            return "Opened Appalachian Railway starter equipment placement ("
+                   + PendingPlacements.Count
+                   + " cut(s) remaining).";
+        }
+
+        private static bool TryBuildDescriptors(
+            SetupDescriptor.CarPlacement placement,
+            out List<CarDescriptor> descriptors)
+        {
+            descriptors = new List<CarDescriptor>();
+            try
+            {
+                var identifiers = placement.carIdentifier ?? Array.Empty<string>();
+                descriptors = StateManager.DescriptorsForIdentifiers(identifiers)
                     .Select(descriptor =>
                     {
                         descriptor.Properties["oiled"] = placement.oiled;
@@ -190,14 +373,16 @@ namespace FUSE.Patches
                     descriptors,
                     1f);
 
-                return descriptors;
+                return true;
             }
             catch (Exception ex)
             {
                 FuseLog.Exception(
-                    "FUSE failed to prepare a queued Company starter cut.",
+                    "FUSE failed to prepare a queued Company starter cut; "
+                    + "the cut remains queued.",
                     ex);
-                return new List<CarDescriptor>();
+                descriptors = new List<CarDescriptor>();
+                return false;
             }
         }
 

--- a/FUSE/Patches/FuseCustomIndustryTitlePatch.cs
+++ b/FUSE/Patches/FuseCustomIndustryTitlePatch.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using Model.Ops;
+using StrangeCustoms.Tracks.Industries;
+using UI;
+
+namespace FUSE.Patches
+{
+    [HarmonyPatch]
+    internal static class FuseCustomIndustryTitlePatch
+    {
+        private static MethodBase TargetMethod()
+        {
+            return AccessTools.GetDeclaredMethods(typeof(DropdownLocationPickerRowData))
+                .SingleOrDefault(method =>
+                {
+                    if (!method.IsStatic ||
+                        method.ReturnType != typeof(string) ||
+                        method.Name.IndexOf("TitleForComponent", StringComparison.Ordinal) < 0)
+                    {
+                        return false;
+                    }
+
+                    var parameters = method.GetParameters();
+                    return parameters.Length == 1 &&
+                           parameters[0].ParameterType == typeof(IndustryComponent);
+                });
+        }
+
+        internal static bool Prefix(
+            [HarmonyArgument(0)] IndustryComponent component,
+            ref string __result)
+        {
+            if (!TryGetCustomTitle(component as ICustomIndustryTitle, out var title))
+            {
+                return true;
+            }
+
+            __result = title;
+            return false;
+        }
+
+        internal static bool TryGetCustomTitle(ICustomIndustryTitle titled, out string title)
+        {
+            title = titled?.Title;
+            return !string.IsNullOrWhiteSpace(title);
+        }
+    }
+}

--- a/FUSE/Patches/FuseFallFromGraceCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseFallFromGraceCompatibilityPatch.cs
@@ -1,0 +1,91 @@
+using System;
+using FUSE.Infrastructure;
+using Game;
+using HarmonyLib;
+using Model.Ops;
+using Track;
+using UI.Builder;
+using UI.CarInspector;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Native FUSE implementation of the small public behavior contract exposed
+    /// by ZAMU FallFromGrace. The default transform is an identity operation, so
+    /// advertising the replacement cannot silently alter an existing railroad.
+    /// </summary>
+    [HarmonyPatch(typeof(OpsController), "CalculateGraceDays", new[] { typeof(Location), typeof(Location) })]
+    internal static class FuseFallFromGraceCalculationPatch
+    {
+        private static void Postfix(ref int __result)
+        {
+            __result = AdjustGraceDays(
+                __result,
+                FuseSettings.GraceMinimumDays,
+                FuseSettings.GraceMultiplier,
+                FuseSettings.GraceAddedDays);
+        }
+
+        internal static int AdjustGraceDays(int baseDays, int minimumDays, int multiplier, int addedDays)
+        {
+            var adjusted = ((long)baseDays * multiplier) + addedDays;
+            adjusted = Math.Max(minimumDays, adjusted);
+            return adjusted > int.MaxValue
+                ? int.MaxValue
+                : adjusted < int.MinValue
+                    ? int.MinValue
+                    : (int)adjusted;
+        }
+    }
+
+    [HarmonyPatch(typeof(CarInspector), "PopulateWaybillPanel", new[] { typeof(UIPanelBuilder), typeof(Waybill) })]
+    internal static class FuseFallFromGraceInspectorPatch
+    {
+        private static void Postfix(UIPanelBuilder builder, Waybill waybill)
+        {
+            if (waybill.PaymentOnArrival <= 0)
+            {
+                return;
+            }
+
+            try
+            {
+                var row = builder.AddField(
+                    "Due",
+                    () => FormatDue(waybill, TimeWeather.Now),
+                    UIPanelBuilder.Frequency.Periodic);
+                row.RectTransform.SetSiblingIndex(2);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a FallFromGrace-compatible inspector-row error; " +
+                    $"the rest of the car inspector remains usable: {ex.GetBaseException().Message}");
+            }
+        }
+
+        internal static string FormatDue(Waybill waybill, GameDateTime now)
+        {
+            try
+            {
+                if (waybill.Completed)
+                {
+                    return "Completed";
+                }
+
+                var due = waybill.Created.AddingDays(waybill.GraceDays);
+                var interval = due.IntervalString(now, GameDateTimeInterval.Style.Full);
+                return FormatDueStatus(interval, due.TotalSeconds >= now.TotalSeconds);
+            }
+            catch
+            {
+                return "Unavailable";
+            }
+        }
+
+        internal static string FormatDueStatus(string interval, bool remaining)
+        {
+            return (interval ?? string.Empty) + (remaining ? " remaining" : " overdue");
+        }
+    }
+}

--- a/FUSE/Patches/FuseForYourConvenienceCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseForYourConvenienceCompatibilityPatch.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using HarmonyLib;
+using Model;
+using Model.Ops;
+using RollingStock;
+using UI;
+using UI.Map;
+using UI.Tags;
+using TMPro;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    internal static class FuseForYourConveniencePolicy
+    {
+        internal static bool IsActive()
+        {
+            return FuseLegacyCapabilityActivation.IsRequested(
+                "Zamu.ForYourConvenience",
+                "ForYourConvenience");
+        }
+
+        internal static string FormatSpeed(float metersPerSecond)
+        {
+            return Math.Abs(metersPerSecond * 2.23694f)
+                .ToString("0.0", CultureInfo.InvariantCulture) + " MPH";
+        }
+
+        internal static string FormatLoad(float quantity, float capacity, string description)
+        {
+            var percentage = capacity > 0.001f
+                ? Mathf.Clamp01(quantity / capacity) * 100f
+                : 0f;
+            return percentage.ToString("0", CultureInfo.InvariantCulture) + "% " +
+                   (description ?? "Unknown load");
+        }
+    }
+
+    [HarmonyPatch(typeof(Car), nameof(Car.Setup))]
+    internal static class FuseForYourConvenienceCabooseMapIconPatch
+    {
+        private static readonly FieldInfo MapIconField = AccessTools.Field(typeof(Car), "MapIcon");
+
+        private static void Postfix(Car __instance, Car.SetupPrefabs prefabs, bool isGhost)
+        {
+            if (!FuseForYourConveniencePolicy.IsActive() ||
+                !FuseSettings.ForYourConvenienceShowCabooseIcons ||
+                isGhost || __instance == null || __instance.CarType != "NE" ||
+                prefabs.LocomotiveMapIcon == null || MapIconField == null ||
+                MapIconField.GetValue(__instance) != null)
+            {
+                return;
+            }
+
+            try
+            {
+                var icon = UnityEngine.Object.Instantiate(prefabs.LocomotiveMapIcon, __instance.transform);
+                icon.SetText(__instance.Ident.RoadNumber);
+                icon.OnClick = () => CarPickable.HandleShowInspector(__instance);
+                MapIconField.SetValue(__instance, icon);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not add the optional caboose map icon for '" +
+                    __instance.DisplayName + "': " + ex.GetBaseException().Message);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(TagController), "UpdateTag")]
+    internal static class FuseForYourConvenienceCarTagPatch
+    {
+        private static void Postfix(Car car, TagCallout tagCallout)
+        {
+            if (!FuseForYourConveniencePolicy.IsActive() || car == null || tagCallout?.callout == null ||
+                (!FuseSettings.ForYourConvenienceShowCarTagMph &&
+                 !FuseSettings.ForYourConvenienceShowCarTagLoads))
+            {
+                return;
+            }
+
+            try
+            {
+                var text = new StringBuilder(tagCallout.callout.Text ?? string.Empty);
+                if (FuseSettings.ForYourConvenienceShowCarTagMph)
+                {
+                    AppendLine(text, FuseForYourConveniencePolicy.FormatSpeed(car.velocity));
+                }
+
+                if (FuseSettings.ForYourConvenienceShowCarTagLoads && car.Definition?.LoadSlots != null)
+                {
+                    for (var slotIndex = 0; slotIndex < car.Definition.LoadSlots.Count; slotIndex++)
+                    {
+                        var info = car.GetLoadInfo(slotIndex);
+                        if (!info.HasValue)
+                        {
+                            continue;
+                        }
+
+                        var load = CarPrototypeLibrary.instance?.LoadForId(info.Value.LoadId);
+                        var description = load == null
+                            ? info.Value.LoadId
+                            : info.Value.LoadString(load);
+                        AppendLine(
+                            text,
+                            FuseForYourConveniencePolicy.FormatLoad(
+                                info.Value.Quantity,
+                                car.Definition.LoadSlots[slotIndex].MaximumCapacity,
+                                description));
+                    }
+                }
+
+                tagCallout.callout.Text = text.ToString();
+                tagCallout.callout.Layout();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not append optional information to car tag '" +
+                    car.DisplayName + "': " + ex.GetBaseException().Message);
+            }
+        }
+
+        private static void AppendLine(StringBuilder builder, string value)
+        {
+            if (builder.Length > 0)
+            {
+                builder.AppendLine();
+            }
+
+            builder.Append(value);
+        }
+    }
+
+    [HarmonyPatch(typeof(MapBuilder), nameof(MapBuilder.Rebuild))]
+    internal static class FuseForYourConvenienceStationMapPatch
+    {
+        private const float MaximumStationDistance = 250f;
+        private static readonly string[] IdentityRoleSuffixes =
+        {
+            "stationagent",
+            "station",
+            "depot",
+            "agent",
+            "area"
+        };
+        private static readonly FieldInfo AreaIdField = AccessTools.Field(typeof(StationAgent), "areaId");
+        private static readonly FieldInfo PassengerStopIdField = AccessTools.Field(typeof(StationAgent), "passengerStopId");
+
+        private static void Postfix()
+        {
+            if (!FuseForYourConveniencePolicy.IsActive())
+            {
+                return;
+            }
+
+            try
+            {
+                var agents = UnityEngine.Object.FindObjectsOfType<StationAgent>(true)
+                    .Where(agent => agent != null && agent.isActiveAndEnabled)
+                    .Select(agent => new StationSnapshot(
+                        agent,
+                        NormalizeIdentity(AreaIdField?.GetValue(agent) as string),
+                        NormalizeIdentity(PassengerStopIdField?.GetValue(agent) as string)))
+                    .ToArray();
+                if (agents == null || agents.Length == 0)
+                {
+                    return;
+                }
+
+                foreach (var icon in UnityEngine.Object.FindObjectsOfType<MapIcon>(true))
+                {
+                    if (icon == null || icon.OnClick != null || icon.GetComponentInParent<Car>() != null)
+                    {
+                        continue;
+                    }
+
+                    var nearest = FindNearest(
+                        icon.transform.position,
+                        NormalizeIdentity(BuildIconIdentity(icon)),
+                        agents);
+                    if (nearest != null)
+                    {
+                        icon.OnClick = () => nearest.Activate(default(PickableActivateEvent));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not attach optional station-map actions: " +
+                    ex.GetBaseException().Message);
+            }
+        }
+
+        internal static bool IsStationIdentityMatch(
+            string iconIdentity,
+            string areaId,
+            string passengerStopId)
+        {
+            var normalizedIcon = NormalizeIdentity(iconIdentity);
+            if (normalizedIcon.Length < 3)
+            {
+                return false;
+            }
+
+            return IdentityMatches(normalizedIcon, NormalizeIdentity(areaId)) ||
+                   IdentityMatches(normalizedIcon, NormalizeIdentity(passengerStopId));
+        }
+
+        private static bool IdentityMatches(string normalizedIcon, string normalizedStation)
+        {
+            return normalizedStation.Length >= 3 &&
+                   string.Equals(normalizedIcon, normalizedStation, StringComparison.Ordinal);
+        }
+
+        private static string NormalizeIdentity(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            var normalized = new StringBuilder(value.Length);
+            for (var index = 0; index < value.Length; index++)
+            {
+                if (char.IsLetterOrDigit(value[index]))
+                {
+                    normalized.Append(char.ToLowerInvariant(value[index]));
+                }
+            }
+
+            var result = normalized.ToString();
+            for (var index = 0; index < IdentityRoleSuffixes.Length; index++)
+            {
+                var suffix = IdentityRoleSuffixes[index];
+                if (result.Length > suffix.Length + 2 &&
+                    result.EndsWith(suffix, StringComparison.Ordinal))
+                {
+                    return result.Substring(0, result.Length - suffix.Length);
+                }
+            }
+
+            return result;
+        }
+
+        private static string BuildIconIdentity(MapIcon icon)
+        {
+            var identity = new StringBuilder();
+            var label = icon.GetComponentInChildren<TMP_Text>(true);
+            if (label != null && !string.IsNullOrWhiteSpace(label.text))
+            {
+                return label.text;
+            }
+
+            for (var current = icon.transform; current != null; current = current.parent)
+            {
+                identity.Append(' ').Append(current.name);
+            }
+
+            return identity.ToString();
+        }
+
+        private static StationAgent FindNearest(
+            Vector3 position,
+            string iconIdentity,
+            StationSnapshot[] agents)
+        {
+            StationAgent nearest = null;
+            var best = MaximumStationDistance * MaximumStationDistance;
+            for (var index = 0; index < agents.Length; index++)
+            {
+                var snapshot = agents[index];
+                if (!IdentityMatches(iconIdentity, snapshot.AreaId) &&
+                    !IdentityMatches(iconIdentity, snapshot.PassengerStopId))
+                {
+                    continue;
+                }
+
+                var candidate = snapshot.Agent;
+                var offset = candidate.transform.position - position;
+                offset.y = 0f;
+                var distance = offset.sqrMagnitude;
+                if (distance < best)
+                {
+                    nearest = candidate;
+                    best = distance;
+                }
+            }
+
+            return nearest;
+        }
+
+        private sealed class StationSnapshot
+        {
+            internal StationSnapshot(StationAgent agent, string areaId, string passengerStopId)
+            {
+                Agent = agent;
+                AreaId = areaId;
+                PassengerStopId = passengerStopId;
+            }
+
+            internal StationAgent Agent { get; }
+            internal string AreaId { get; }
+            internal string PassengerStopId { get; }
+        }
+    }
+}

--- a/FUSE/Patches/FuseInterchangePatches.cs
+++ b/FUSE/Patches/FuseInterchangePatches.cs
@@ -1,6 +1,7 @@
 using System;
 using FUSE.Runtime.API;
 using FUSE.Infrastructure;
+using Game.State;
 using HarmonyLib;
 using Model.Ops;
 
@@ -23,6 +24,20 @@ namespace FUSE.Patches
                 {
                     var componentContext = unloader.CreateContext(ctx.Now, 0f);
                     unloader.ServeInterchange(componentContext, __instance);
+                }
+
+                // C1CD compatibility: continuous service means an interchange
+                // receives another extra-service slot even when this pass did
+                // not leave any pending orders. Scheduling here avoids the old
+                // brittle IL edit inside OpsController.CheckServiceInterchanges.
+                if (FuseSettings.InterchangeContinuousService && StateManager.IsHost)
+                {
+                    __instance.ScheduleExtra(new Game.GameDateTime?(
+                        FuseC1CdSchedulePolicy.CalculateNextServiceTime(
+                            ctx.Now,
+                            FuseSettings.InterchangeServiceIntervalMinutes,
+                            FuseSettings.InterchangeNotBeforeHour,
+                            FuseSettings.InterchangeNotAfterHour)));
                 }
             }
             catch (Exception ex)

--- a/FUSE/Patches/FuseInterchangeToInterchangeCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseInterchangeToInterchangeCompatibilityPatch.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using HarmonyLib;
+using Model.Ops;
+using Model.Ops.Definition;
+using UI.CarInspector;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    internal static class FuseInterchangeToInterchangePolicy
+    {
+        internal static bool IsActive()
+        {
+            return FuseLegacyCapabilityActivation.IsRequested(
+                "Zamu.Interchange2Interchange",
+                "Interchange2Interchange");
+        }
+
+        internal static int ScaleMaximumCars(int configuredMaximum, float contractMultiplier)
+        {
+            if (configuredMaximum <= 0 || contractMultiplier <= 0f || float.IsNaN(contractMultiplier))
+            {
+                return 0;
+            }
+
+            return Mathf.Clamp(
+                Mathf.RoundToInt(configuredMaximum * contractMultiplier),
+                0,
+                FuseSettings.InterchangeToInterchangeMaximumCarsLimit);
+        }
+    }
+
+    [HarmonyPatch(typeof(OpsController), "RebuildCollections")]
+    internal static class FuseInterchangeToInterchangeContractSetupPatch
+    {
+        private static void Postfix(OpsController __instance)
+        {
+            if (!FuseInterchangeToInterchangePolicy.IsActive() || __instance?.AllInterchanges == null)
+            {
+                return;
+            }
+
+            foreach (var interchange in __instance.AllInterchanges)
+            {
+                if (interchange?.Industry != null)
+                {
+                    interchange.Industry.usesContract = true;
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(Interchange), nameof(Interchange.OrderCars))]
+    internal static class FuseInterchangeToInterchangeOrderPatch
+    {
+        private const string LastOrderTimeKey = "fuse.i2i.lastOrderTime";
+
+        private static void Postfix(Interchange __instance, IIndustryContext ctx)
+        {
+            if (!FuseInterchangeToInterchangePolicy.IsActive() || __instance == null || ctx == null)
+            {
+                return;
+            }
+
+            try
+            {
+                AddInterchangeOrders(__instance, ctx);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not create interchange-to-interchange orders for " +
+                    $"'{__instance.DisplayName}'; normal interchange service remains available: " +
+                    ex.GetBaseException().Message);
+            }
+        }
+
+        private static void AddInterchangeOrders(Interchange source, IIndustryContext ctx)
+        {
+            if (source.Industry == null)
+            {
+                return;
+            }
+
+            source.Industry.usesContract = true;
+            var multiplier = source.Industry.GetContractMultiplier();
+            var maximumCars = FuseInterchangeToInterchangePolicy.ScaleMaximumCars(
+                FuseSettings.InterchangeToInterchangeMaximumCars,
+                multiplier);
+            if (maximumCars <= 0 ||
+                ctx.Now.DaysSince(ctx.GetDateTime(LastOrderTimeKey, Game.GameDateTime.Zero)) < 1f)
+            {
+                return;
+            }
+
+            var controller = OpsController.Shared;
+            var destinations = (controller?.EnabledInterchanges ?? Enumerable.Empty<Interchange>())
+                .Where(candidate => candidate != null && candidate != source && candidate.Industry != null)
+                .ToArray();
+            var cargo = CollectCargo(controller).ToArray();
+            if (destinations.Length == 0 || cargo.Length == 0)
+            {
+                return;
+            }
+
+            var added = 0;
+            var remainingTotal = maximumCars;
+            foreach (var destination in destinations)
+            {
+                if (remainingTotal <= 0)
+                {
+                    break;
+                }
+
+                var remaining = UnityEngine.Random.Range(0, remainingTotal + 1);
+                while (remaining > 0)
+                {
+                    var count = UnityEngine.Random.Range(1, Math.Min(3, remaining) + 1);
+                    remaining -= count;
+                    remainingTotal -= count;
+                    var selection = cargo[UnityEngine.Random.Range(0, cargo.Length)];
+                    source.AddOrder(new Order(
+                        new CarTypeFilter(selection.CarFilter),
+                        selection.Load,
+                        destination,
+                        count,
+                        null,
+                        false));
+                    added += count;
+                }
+            }
+
+            if (added > 0)
+            {
+                ctx.SetDateTime(LastOrderTimeKey, ctx.Now);
+                FuseLog.Info(
+                    $"FUSE scheduled {added} interchange-to-interchange car(s) from '{source.DisplayName}'.");
+            }
+        }
+
+        private static IEnumerable<CargoTarget> CollectCargo(OpsController controller)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var industry in controller?.AllIndustries ?? Array.Empty<Industry>())
+            {
+                if (industry == null || industry.ProgressionDisabled)
+                {
+                    continue;
+                }
+
+                foreach (var component in industry.Components ?? Array.Empty<IndustryComponent>())
+                {
+                    if (component == null || component.ProgressionDisabled || component.carTypeFilter == null ||
+                        component.carTypeFilter.Matches("PB") || component.carTypeFilter.Matches("PBO"))
+                    {
+                        continue;
+                    }
+
+                    var load = LoadFor(component);
+                    var filter = component.carTypeFilter.queryString;
+                    var key = (filter ?? string.Empty) + "\n" + (load?.id ?? string.Empty);
+                    if (load != null && !string.IsNullOrWhiteSpace(filter) && seen.Add(key))
+                    {
+                        yield return new CargoTarget(filter, load);
+                    }
+                }
+            }
+        }
+
+        private static Load LoadFor(IndustryComponent component)
+        {
+            if (component is IndustryLoaderBase loader)
+            {
+                return loader.load;
+            }
+
+            if (component is IndustryUnloader unloader)
+            {
+                return unloader.load;
+            }
+
+            return (component as TeleportLoadingIndustry)?.load;
+        }
+
+        private readonly struct CargoTarget
+        {
+            internal CargoTarget(string carFilter, Load load)
+            {
+                CarFilter = carFilter;
+                Load = load;
+            }
+
+            internal string CarFilter { get; }
+            internal Load Load { get; }
+        }
+    }
+
+    [HarmonyPatch]
+    internal static class FuseInterchangeToInterchangeInspectorPatch
+    {
+        private static MethodBase TargetMethod()
+        {
+            return AccessTools.GetDeclaredMethods(typeof(CarInspector))
+                .SingleOrDefault(method =>
+                {
+                    if (method.Name.IndexOf("ShouldShowIndustry", StringComparison.Ordinal) < 0 ||
+                        method.ReturnType != typeof(bool))
+                    {
+                        return false;
+                    }
+
+                    var parameters = method.GetParameters();
+                    return parameters.Length == 1 && parameters[0].ParameterType == typeof(Industry);
+                });
+        }
+
+        private static void Postfix(Industry industry, ref bool __result)
+        {
+            if (!__result && FuseInterchangeToInterchangePolicy.IsActive() &&
+                industry != null && !industry.ProgressionDisabled &&
+                industry.Components.OfType<Interchange>().Any())
+            {
+                __result = true;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseLegosLibraryCompatibility.cs
+++ b/FUSE/Patches/FuseLegosLibraryCompatibility.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Reflection;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model.Definition;
+using Newtonsoft.Json;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Gives LegosLibraryOfStuff's definition clone operation the same Unity
+    /// value converters used by the game. The library's default Newtonsoft
+    /// clone walks calculated Vector2/Vector3 properties and can report a
+    /// self-referencing loop, aborting the remainder of its catalog edits.
+    /// </summary>
+    internal static class FuseLegosLibraryCompatibility
+    {
+        private const string PatchTypeName =
+            "LegosLibraryOfStuff.ContainerSerializationDeserializePatch";
+
+        private static readonly MethodInfo SerializerSettingsMethod =
+            AccessTools.Method(typeof(ContainerSerialization), "JsonSerializerSettings");
+
+        private static bool _installed;
+        private static int _cloneFailures;
+
+        internal static string EnsureInstalled(Harmony harmony)
+        {
+            if (_installed)
+            {
+                return "installed";
+            }
+
+            if (harmony == null)
+            {
+                return "unavailable (no harmony)";
+            }
+
+            var patchType = AccessTools.TypeByName(PatchTypeName);
+            if (patchType == null)
+            {
+                return "idle (not present)";
+            }
+
+            var cloneItem = AccessTools.DeclaredMethod(
+                patchType,
+                "CloneItem",
+                new[] { typeof(ContainerItem) });
+            if (cloneItem == null || SerializerSettingsMethod == null)
+            {
+                return "idle (surface changed)";
+            }
+
+            harmony.Patch(
+                cloneItem,
+                prefix: new HarmonyMethod(
+                    typeof(FuseLegosLibraryCompatibility),
+                    nameof(CloneItemPrefix)));
+            _installed = true;
+            return "installed";
+        }
+
+        internal static void ResetAfterSuccessfulUnpatch()
+        {
+            _installed = false;
+        }
+
+        private static bool CloneItemPrefix(ContainerItem item, ref ContainerItem __result)
+        {
+            if (item == null)
+            {
+                return true;
+            }
+
+            try
+            {
+                var settings = SerializerSettingsMethod.Invoke(null, null) as JsonSerializerSettings;
+                if (settings == null)
+                {
+                    return true;
+                }
+
+                var json = JsonConvert.SerializeObject(item, Formatting.None, settings);
+                var clone = JsonConvert.DeserializeObject<ContainerItem>(json, settings);
+                if (clone == null)
+                {
+                    return true;
+                }
+
+                __result = clone;
+                return false;
+            }
+            catch (Exception ex)
+            {
+                _cloneFailures++;
+                if (FuseGuardLog.ShouldLog(_cloneFailures))
+                {
+                    FuseLog.Exception(
+                        $"FUSE could not safely clone Lego definition '{item.Identifier}'; " +
+                        "the library's original clone path will be attempted",
+                        ex);
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseLocationPickerDeduplicationPatch.cs
+++ b/FUSE/Patches/FuseLocationPickerDeduplicationPatch.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model.Ops;
+using UI.Builder;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Removes semantically duplicate destinations from the car inspector's
+    /// automatic-waybill picker. Legacy packages can leave multiple runtime
+    /// component objects with the same identifier; Railroader otherwise shows
+    /// every object as a separate, indistinguishable picker row.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FuseLocationPickerDeduplicationPatch
+    {
+        private const string EmptyDestinationKey = "\u0000none";
+        private static int _reported;
+
+        private static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(
+                typeof(UIPanelBuilder),
+                nameof(UIPanelBuilder.AddLocationPicker),
+                new[]
+                {
+                    typeof(string),
+                    typeof(List<ValueTuple<IndustryComponent, Area>>),
+                    typeof(IndustryComponent),
+                    typeof(Action<IndustryComponent>)
+                });
+        }
+
+        private static void Prefix(
+            ref List<ValueTuple<IndustryComponent, Area>> options,
+            ref IndustryComponent selected)
+        {
+            var selectedKey = SelectedDestinationKey(selected, options);
+            var removed = DeduplicateByKey(options, DestinationKey, out var deduplicated);
+            if (removed == 0)
+            {
+                return;
+            }
+
+            options = deduplicated;
+            selected = ResolveCanonicalSelection(selected, selectedKey, deduplicated);
+
+            if (Interlocked.Exchange(ref _reported, 1) == 0)
+            {
+                FuseLog.Info(
+                    $"FUSE removed {removed} duplicate automatic-waybill destination row(s). " +
+                    "The first matching destination remains selectable; runtime industry data was not deleted.");
+            }
+        }
+
+        private static string DestinationKey(ValueTuple<IndustryComponent, Area> option)
+        {
+            var component = option.Item1;
+            var identifier = DestinationKey(component);
+            if (component == null || identifier == null)
+            {
+                return identifier;
+            }
+
+            try
+            {
+                var spanIds = (component.trackSpans ?? Array.Empty<Track.TrackSpan>())
+                    .Where(span => span != null && !string.IsNullOrWhiteSpace(span.id))
+                    .Select(span => span.id.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                var displayName = component.DisplayName?.Trim();
+                if (spanIds.Length == 0 || string.IsNullOrWhiteSpace(displayName))
+                {
+                    return identifier;
+                }
+
+                return string.Join(
+                    "\u001f",
+                    "semantic",
+                    component.GetType().FullName ?? component.GetType().Name,
+                    option.Item2?.identifier?.Trim() ?? string.Empty,
+                    displayName,
+                    string.Join("\u001e", spanIds));
+            }
+            catch
+            {
+                return identifier;
+            }
+        }
+
+        private static string DestinationKey(IndustryComponent component)
+        {
+            if (component == null)
+            {
+                return EmptyDestinationKey;
+            }
+
+            try
+            {
+                var identifier = component.Identifier?.Trim();
+                return string.IsNullOrWhiteSpace(identifier) ? null : identifier;
+            }
+            catch
+            {
+                // A malformed component must not be allowed to break the UI.
+                // A null key tells the helper to preserve that row unchanged.
+                return null;
+            }
+        }
+
+        private static string SelectedDestinationKey(
+            IndustryComponent selected,
+            IList<ValueTuple<IndustryComponent, Area>> options)
+        {
+            if (selected == null || options == null)
+            {
+                return DestinationKey(selected);
+            }
+
+            foreach (var option in options)
+            {
+                if (ReferenceEquals(option.Item1, selected) || option.Item1 == selected)
+                {
+                    return DestinationKey(option);
+                }
+            }
+
+            return DestinationKey(selected);
+        }
+
+        private static IndustryComponent ResolveCanonicalSelection(
+            IndustryComponent selected,
+            string selectedKey,
+            IList<ValueTuple<IndustryComponent, Area>> options)
+        {
+            if (selected == null || selectedKey == null || options == null)
+            {
+                return selected;
+            }
+
+            foreach (var option in options)
+            {
+                if (string.Equals(
+                    selectedKey,
+                    DestinationKey(option),
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return option.Item1;
+                }
+            }
+
+            return selected;
+        }
+
+        internal static int DeduplicateByKey<T>(
+            IList<T> source,
+            Func<T, string> keySelector,
+            out List<T> result)
+        {
+            result = source == null ? new List<T>() : new List<T>(source.Count);
+            if (source == null || source.Count == 0)
+            {
+                return 0;
+            }
+
+            if (keySelector == null)
+            {
+                result.AddRange(source);
+                return 0;
+            }
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var item in source)
+            {
+                var key = keySelector(item);
+                if (key == null || seen.Add(key))
+                {
+                    result.Add(item);
+                }
+            }
+
+            return source.Count - result.Count;
+        }
+
+        internal static T ResolveCanonicalByKey<T>(
+            T selected,
+            IList<T> options,
+            Func<T, string> keySelector)
+        {
+            if (ReferenceEquals(selected, null) || options == null || keySelector == null)
+            {
+                return selected;
+            }
+
+            var selectedKey = keySelector(selected);
+            if (selectedKey == null)
+            {
+                return selected;
+            }
+
+            foreach (var option in options)
+            {
+                var optionKey = keySelector(option);
+                if (string.Equals(selectedKey, optionKey, StringComparison.OrdinalIgnoreCase))
+                {
+                    return option;
+                }
+            }
+
+            return selected;
+        }
+    }
+}

--- a/FUSE/Patches/FuseMessengerIsolationPatch.cs
+++ b/FUSE/Patches/FuseMessengerIsolationPatch.cs
@@ -8,7 +8,7 @@ using HarmonyLib;
 namespace FUSE.Patches
 {
     /// <summary>
-    /// Contains exceptions thrown by map lifecycle event listeners so one broken
+    /// Contains exceptions thrown by guarded messenger event listeners so one broken
     /// listener can never disturb delivery to anyone else — and so the offender is
     /// actually NAMED in the log.
     ///
@@ -28,17 +28,17 @@ namespace FUSE.Patches
     /// (throttled) with the recipient type and handler method name, and dispatch
     /// continues so later-registered listeners still receive the event.
     ///
-    /// Deliberately scoped to the four map lifecycle events only — this is not a
-    /// blanket "never throw from Messenger" patch; every other event keeps its
-    /// stock semantics.
+    /// Deliberately scoped to map lifecycle events and the legacy debug-report
+    /// contribution event — this is not a blanket "never throw from Messenger"
+    /// patch; every other event keeps its stock semantics.
     ///
     /// Generic-method caveat: this targets the CONSTRUCTED <c>WeakAction&lt;T&gt;</c>
     /// methods, one instantiation per event type. That is only reliable because
-    /// every lifecycle event is a struct: each value-type instantiation gets its own
+    /// every guarded event is a struct: each value-type instantiation gets its own
     /// unshared method body, so the patch lands on exactly that instantiation.
     /// Reference-type arguments share one canonical body — patching it is unreliable
     /// and can bleed into unrelated instantiations — so a class-typed event must
-    /// never be added to <see cref="LifecycleEventTypeNames"/>; TargetMethods
+    /// never be added to <see cref="GuardedEventTypeNames"/>; TargetMethods
     /// enforces this with an IsValueType guard.
     /// </summary>
     [HarmonyPatch]
@@ -49,12 +49,13 @@ namespace FUSE.Patches
         // whole patch class. (If EVERY entry failed to resolve, the empty target
         // set would make Harmony reject the class as a whole — FusePatchResilience
         // contains that to a logged skip of this one class.)
-        private static readonly string[] LifecycleEventTypeNames =
+        private static readonly string[] GuardedEventTypeNames =
         {
             "Game.Events.MapWillLoadEvent",
             "Game.Events.MapDidLoadEvent",
             "Game.Events.MapWillUnloadEvent",
-            "Game.Events.MapDidUnloadEvent"
+            "Game.Events.MapDidUnloadEvent",
+            "Railloader.Events.WillCopyDebugInformation"
         };
 
         private static long _suppressed;
@@ -80,22 +81,19 @@ namespace FUSE.Patches
         internal static IEnumerable<MethodBase> TargetMethods()
         {
             var targets = new HashSet<MethodBase>();
-            foreach (var eventTypeName in LifecycleEventTypeNames)
+            foreach (var eventTypeName in GuardedEventTypeNames)
             {
-                // WeakAction<T> and the lifecycle event structs are defined in the
-                // SAME assembly: MvvmLight is compiled into the game's Assembly-CSharp
-                // rather than shipped as a separate DLL, so only the namespace differs
-                // (GalaSoft.MvvmLight.Helpers vs Game.Events), not the assembly. That
-                // makes typeof(WeakAction<>).Assembly.GetType the path actually taken;
-                // AccessTools.TypeByName is a cross-assembly fallback that only engages
-                // if a future game build relocates the events.
+                // WeakAction<T> and the map lifecycle event structs are defined in
+                // Assembly-CSharp, so the assembly lookup resolves those types. The
+                // Railloader debug-report event lives in a separate assembly and
+                // intentionally uses the cross-assembly AccessTools fallback.
                 var eventType = typeof(WeakAction<>).Assembly.GetType(eventTypeName)
                                 ?? AccessTools.TypeByName(eventTypeName);
                 if (eventType == null)
                 {
                     FuseLog.Warning(
-                        $"FUSE messenger isolation could not resolve lifecycle event type '{eventTypeName}'; " +
-                        "listeners for that event stay unguarded. Remaining lifecycle events are still patched.");
+                        $"FUSE messenger isolation could not resolve guarded event type '{eventTypeName}'; " +
+                        "listeners for that event stay unguarded. Remaining guarded events are still patched.");
                     continue;
                 }
 
@@ -168,7 +166,7 @@ namespace FUSE.Patches
                 // BEFORE the throttle decision so every containment is counted
                 // even when its log line below is suppressed.
                 FuseModExceptionRegistry.RecordContained(
-                    __exception, ResolveRecipientType(__instance), "map lifecycle listener");
+                    __exception, ResolveRecipientType(__instance), "messenger listener");
 
                 // First few individually, every previously-unseen offender once, then
                 // heartbeat only — a permanently-broken listener re-throws on every
@@ -180,7 +178,7 @@ namespace FUSE.Patches
                 if (_suppressed <= 5 || newOffender || _suppressed % 100 == 0)
                 {
                     FuseLog.Exception(
-                        $"FUSE contained map lifecycle listener exception #{_suppressed} from {listener}; " +
+                        $"FUSE contained messenger listener exception #{_suppressed} from {listener}; " +
                         "the exception was suppressed and dispatch continued, so later-registered listeners " +
                         "still received the event", __exception);
                     _logged++;

--- a/FUSE/Patches/FuseOutboundIndustryRoutingPatch.cs
+++ b/FUSE/Patches/FuseOutboundIndustryRoutingPatch.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using FUSE.Runtime.Events;
+using Game;
+using HarmonyLib;
+using Model.Ops;
+using Model.Ops.Definition;
+using Track;
+using Track.Search;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    internal enum FuseOutboundRoutingMode
+    {
+        Disabled,
+        Absolute,
+        Configurable,
+    }
+
+    [HarmonyPatch]
+    internal static class FuseOutboundIndustryRoutingPatch
+    {
+        private const float MinimumTripDistanceMeters = 200f;
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(OpsController), nameof(OpsController.AddOrderForOutboundEmptyCar))]
+        private static bool RouteEmpty(
+            OpsController __instance,
+            IOpsCar car,
+            OpsCarPosition carPosition,
+            string orderTag,
+            bool noPayment)
+        {
+            return TryRoute(__instance, car, carPosition, orderTag, noPayment, loaded: false);
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(OpsController), nameof(OpsController.AddOrderForOutboundLoadedCar))]
+        private static bool RouteLoaded(
+            OpsController __instance,
+            IOpsCar car,
+            OpsCarPosition carPosition,
+            string orderTag,
+            bool noPayment)
+        {
+            return TryRoute(__instance, car, carPosition, orderTag, noPayment, loaded: true);
+        }
+
+        private static bool TryRoute(
+            OpsController controller,
+            IOpsCar car,
+            OpsCarPosition origin,
+            string orderTag,
+            bool noPayment,
+            bool loaded)
+        {
+            var mode = ResolveMode(
+                FuseSettings.EnableOutboundIndustryRerouting,
+                FuseLegacyCapabilityActivation.IsRequested("Zamu.AbsoluteMadness", "AbsoluteMadness"),
+                FuseLegacyCapabilityActivation.IsRequested("Zamu.SomeKindOfMadness", "SomeKindOfMadness"));
+            if (mode == FuseOutboundRoutingMode.Disabled || controller == null || car == null)
+            {
+                return true;
+            }
+
+            if (mode == FuseOutboundRoutingMode.Configurable &&
+                UnityEngine.Random.value >= FuseSettings.OutboundIndustryRerouteChance)
+            {
+                return true;
+            }
+
+            try
+            {
+                var candidates = CollectCandidates(controller, car, origin, loaded, mode);
+                var context = new FuseOutboundRoutingContext(car, origin, loaded, candidates);
+                FuseOutboundRoutingEvents.RaisePreparing(context);
+                var selectedIndex = SelectWeightedIndex(
+                    candidates.Select(candidate => candidate.Weight).ToArray(),
+                    UnityEngine.Random.value);
+                if (selectedIndex < 0 || selectedIndex >= candidates.Count)
+                {
+                    return true;
+                }
+
+                var selected = candidates[selectedIndex];
+                var destination = selected.Component;
+                var multiplier = mode == FuseOutboundRoutingMode.Absolute
+                    ? 1f
+                    : FuseSettings.OutboundIndustryPaymentMultiplier;
+                var payment = noPayment
+                    ? 0
+                    : Mathf.RoundToInt(
+                        selected.ProposedPayment ??
+                        (controller.PaymentForMove(origin, destination, car.WeightInTons) * multiplier));
+                var graceDays = selected.ProposedGraceDays ?? controller.CalculateGraceDays(origin, destination);
+                var waybill = new Waybill(
+                    TimeWeather.Now,
+                    origin,
+                    destination,
+                    payment,
+                    false,
+                    orderTag,
+                    graceDays);
+
+                car.SetWaybill(waybill, destination, "FUSE outbound industry routing");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE outbound industry routing failed safely; the base-game interchange route will be used: " +
+                    ex.GetBaseException().Message);
+                return true;
+            }
+        }
+
+        internal static FuseOutboundRoutingMode ResolveMode(
+            bool explicitOptIn,
+            bool absoluteRequested,
+            bool configurableRequested)
+        {
+            if (explicitOptIn || configurableRequested)
+            {
+                return FuseOutboundRoutingMode.Configurable;
+            }
+
+            return absoluteRequested ? FuseOutboundRoutingMode.Absolute : FuseOutboundRoutingMode.Disabled;
+        }
+
+        private static List<FuseOutboundRoutingCandidate> CollectCandidates(
+            OpsController controller,
+            IOpsCar car,
+            OpsCarPosition origin,
+            bool loaded,
+            FuseOutboundRoutingMode mode)
+        {
+            var candidates = new List<FuseOutboundRoutingCandidate>();
+            var fillFactor = mode == FuseOutboundRoutingMode.Absolute
+                ? 1f
+                : FuseSettings.OutboundIndustryFillFactor;
+            var allowShortTrips = mode == FuseOutboundRoutingMode.Absolute || FuseSettings.OutboundIndustryAllowShortTrips;
+
+            foreach (var industry in controller.AllIndustries ?? Array.Empty<Industry>())
+            {
+                if (industry == null || industry.ProgressionDisabled ||
+                    (mode == FuseOutboundRoutingMode.Configurable && !industry.ShouldOrderCars()))
+                {
+                    continue;
+                }
+
+                foreach (var pair in industry.EnumerateComponentContexts(0f))
+                {
+                    var component = pair.Item1;
+                    var componentContext = pair.Item2;
+                    if (component == null || component.ProgressionDisabled ||
+                        component.carTypeFilter == null ||
+                        !component.carTypeFilter.Matches(car.CarType) ||
+                        !TryGetTarget(component, loaded, out var load, out var maxStorage))
+                    {
+                        continue;
+                    }
+
+                    if (loaded && car.QuantityOfLoad(load).Item1 <= load.ZeroThreshold)
+                    {
+                        continue;
+                    }
+
+                    if (!allowShortTrips && !IsLongEnoughTrip(origin, component))
+                    {
+                        continue;
+                    }
+
+                    var committed = componentContext.QuantityInStorage(load) +
+                                    componentContext.QuantityOnOrder(load) +
+                                    componentContext.AvailableCapacityInCars(component.carTypeFilter, load);
+                    var remaining = (maxStorage * fillFactor) - committed;
+                    if (remaining > load.ZeroThreshold)
+                    {
+                        candidates.Add(new FuseOutboundRoutingCandidate(component, remaining));
+                    }
+                }
+            }
+
+            return candidates;
+        }
+
+        private static bool TryGetTarget(
+            IndustryComponent component,
+            bool loaded,
+            out Load load,
+            out float maxStorage)
+        {
+            load = null;
+            maxStorage = 0f;
+            if (!loaded && component is IndustryLoaderBase loader && loader.orderEmpties)
+            {
+                load = loader.load;
+                maxStorage = loader.maxStorage;
+                return load != null;
+            }
+
+            if (loaded && component is IndustryUnloader unloader && unloader.orderLoads)
+            {
+                load = unloader.load;
+                maxStorage = unloader.maxStorage;
+                return load != null;
+            }
+
+            return false;
+        }
+
+        private static bool IsLongEnoughTrip(OpsCarPosition origin, IndustryComponent destination)
+        {
+            if (origin.Spans == null || origin.Spans.Length == 0 ||
+                destination.trackSpans == null || destination.trackSpans.Length == 0)
+            {
+                return false;
+            }
+
+            return Graph.Shared.TryFindDistance(
+                       (Location)origin,
+                       (Location)(OpsCarPosition)destination,
+                       out var distance,
+                       out _) &&
+                   distance > MinimumTripDistanceMeters;
+        }
+
+        internal static int SelectWeightedIndex(IReadOnlyList<float> weights, float unitSample)
+        {
+            if (weights == null || weights.Count == 0)
+            {
+                return -1;
+            }
+
+            var minimum = weights.Min();
+            var offset = minimum < 0f ? -minimum : 0f;
+            var total = weights.Sum(weight => Math.Max(0f, weight + offset));
+            if (total <= 0f || float.IsNaN(total))
+            {
+                return Math.Min(weights.Count - 1, Mathf.FloorToInt(Mathf.Clamp01(unitSample) * weights.Count));
+            }
+
+            var cursor = Mathf.Clamp01(unitSample) * total;
+            for (var index = 0; index < weights.Count; index++)
+            {
+                cursor -= Math.Max(0f, weights[index] + offset);
+                if (cursor <= 0f)
+                {
+                    return index;
+                }
+            }
+
+            return weights.Count - 1;
+        }
+
+    }
+
+    [HarmonyPatch(typeof(OpsController), "InterchangeForPosition", new[] { typeof(OpsCarPosition), typeof(OpsCarPosition?) })]
+    internal static class FuseOutboundIndustryDirectionPatch
+    {
+        private static void Prefix(ref OpsCarPosition? origin)
+        {
+            var requested = FuseLegacyCapabilityActivation.IsRequested(
+                "Zamu.SomeKindOfMadness",
+                "SomeKindOfMadness");
+            if ((FuseSettings.EnableOutboundIndustryRerouting || requested) &&
+                FuseSettings.OutboundIndustryIgnoreOrigin)
+            {
+                origin = null;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(IndustryContext), "AddOrderedCars")]
+    internal static class FuseOutboundIndustryBlockingPatch
+    {
+        private static readonly object RandomGate = new object();
+        private static readonly System.Random Random = new System.Random();
+
+        private static void Prefix(List<IOrder> orders)
+        {
+            var requested = FuseLegacyCapabilityActivation.IsRequested(
+                "Zamu.SomeKindOfMadness",
+                "SomeKindOfMadness");
+            if (orders == null || orders.Count < 2 ||
+                !(FuseSettings.EnableOutboundIndustryRerouting || requested) ||
+                !FuseSettings.OutboundIndustryPreventBlocking)
+            {
+                return;
+            }
+
+            lock (RandomGate)
+            {
+                Shuffle(orders, Random);
+            }
+        }
+
+        internal static void Shuffle<T>(IList<T> items, System.Random random)
+        {
+            if (items == null || random == null)
+            {
+                return;
+            }
+
+            for (var index = items.Count - 1; index > 0; index--)
+            {
+                var swap = random.Next(index + 1);
+                var value = items[index];
+                items[index] = items[swap];
+                items[swap] = value;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FusePassengerStopInvalidSpanGuardPatch.cs
+++ b/FUSE/Patches/FusePassengerStopInvalidSpanGuardPatch.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model.Ops;
+using Track;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Prevents PassengerStop.OnEnable from interpolating a span whose segment
+    /// was removed by a conflicting track package. Railroader only checks that
+    /// nullable endpoints have values before calling Graph.Lerp; a resolved
+    /// location can still contain a null segment and throw from Location.Flipped.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FusePassengerStopInvalidSpanGuardPatch
+    {
+        private static MethodInfo TargetMethod()
+        {
+            return AccessTools.Method(typeof(PassengerStop), "OnEnable");
+        }
+
+        private static void Prefix(PassengerStop __instance)
+        {
+            if (__instance == null)
+            {
+                return;
+            }
+
+            TrackSpan[] spans;
+            try
+            {
+                spans = __instance.GetComponentsInChildren<TrackSpan>(true);
+            }
+            catch
+            {
+                return;
+            }
+
+            foreach (var span in spans.Where(span => span != null && !IsUsable(span)))
+            {
+                var id = span?.id ?? "<unknown>";
+                try
+                {
+                    // Keep the TrackSpan object available for diagnostics, but
+                    // clear endpoints so PassengerStop's own null checks skip it.
+                    span.lower = null;
+                    span.upper = null;
+                    var count = FuseRuntimeGuardCounters.RecordPassengerStopSpanSanitized();
+                    if (count <= 10)
+                    {
+                        FuseLog.Warning(
+                            $"FUSE sanitized invalid passenger-stop span '{id}' on " +
+                            $"'{__instance.identifier ?? __instance.name}'. A conflicting track package removed " +
+                            "an endpoint segment; the stop remains loaded without that span.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not sanitize invalid passenger-stop span '{id}': " +
+                        ex.GetBaseException().Message);
+                }
+            }
+        }
+
+        private static bool IsUsable(TrackSpan span)
+        {
+            if (span == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                return span.IsValid;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FusePrefabStoreAssetPackPatch.cs
+++ b/FUSE/Patches/FusePrefabStoreAssetPackPatch.cs
@@ -28,7 +28,27 @@ namespace FUSE.Patches
             finally
             {
                 // Even a partial store add changes the identifier population.
-                FUSE.Runtime.API.SceneryAPI.InvalidateKnownSceneryIdentifierIndex();
+                try
+                {
+                    FUSE.Runtime.API.SceneryAPI.InvalidateKnownSceneryIdentifierIndex();
+                }
+                catch (System.Exception ex)
+                {
+                    FuseLog.Exception(
+                        "FUSE direct asset pack identifier invalidation failed softly",
+                        ex);
+                }
+
+                try
+                {
+                    FuseEquipmentCatalogWarmup.Schedule(__result);
+                }
+                catch (System.Exception ex)
+                {
+                    FuseLog.Exception(
+                        "FUSE equipment catalog warmup scheduling failed softly",
+                        ex);
+                }
             }
         }
     }

--- a/FUSE/Patches/FusePrefabStoreDefinitionCheckPerformancePatch.cs
+++ b/FUSE/Patches/FusePrefabStoreDefinitionCheckPerformancePatch.cs
@@ -15,12 +15,11 @@ namespace FUSE.Patches
     /// active, so malformed assets still fail at their actual point of use.
     /// </summary>
     [HarmonyPatch(typeof(PrefabStore), "CheckDefinitions")]
-    // AssetLoader 1.0.1 performs all UMM mod-folder asset-store discovery in
-    // its own CheckDefinitions prefix. If this skip prefix runs first,
-    // Harmony suppresses AssetLoader's state-mutating prefix along with the
-    // original method: UMM reports the rolling-stock mods active, but their
-    // Definitions.json files never enter PrefabStore. Run after AssetLoader so
-    // its discovery completes before FUSE skips only the stock diagnostic pass.
+    // Keep this ordering marker for transitional installs that still contain
+    // AssetLoader.dll. FUSE normally disables that mod's patches and performs
+    // catalog plus definitions-only discovery itself. If an older FUSE build
+    // leaves AssetLoader active, running after its prefix avoids suppressing
+    // the legacy discovery side effect along with the stock diagnostic pass.
     [HarmonyAfter("AssetLoader")]
     internal static class FusePrefabStoreDefinitionCheckPerformancePatch
     {

--- a/FUSE/Patches/FuseThirdPartyGuardInstaller.cs
+++ b/FUSE/Patches/FuseThirdPartyGuardInstaller.cs
@@ -75,105 +75,42 @@ namespace FUSE.Patches
                 return;
             }
 
-            string mapEnhancerStatus;
-            try
-            {
-                mapEnhancerStatus = FuseMapEnhancerCullingGuardPatches.EnsureInstalled(_harmony);
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception("FUSE Map Enhancer culling guard failed to install", ex);
-                mapEnhancerStatus = "failed";
-            }
-
-            string rebillStatus;
-            try
-            {
-                rebillStatus = FuseRebillIndustryCarsGuardPatches.EnsureInstalled(_harmony);
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception("FUSE Rebill Industry Cars guard failed to install", ex);
-                rebillStatus = "failed";
-            }
-
-            string brssStatus;
-            try
-            {
-                brssStatus = FuseBrssModMenuGuardPatches.EnsureInstalled(_harmony);
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception("FUSE BRSS mod-menu guard failed to install", ex);
-                brssStatus = "failed";
-            }
-
-            string timeSyncStatus;
-            try
-            {
-                timeSyncStatus = FuseTimeSyncMainThreadGuardPatches.EnsureInstalled(_harmony);
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception("FUSE TimeSync main-thread guard failed to install", ex);
-                timeSyncStatus = "failed";
-            }
-
-            string utilitiesQueryStatus;
-            try
-            {
-                utilitiesQueryStatus = FuseUtilitiesQueryTooltipCompatibility.EnsureInstalled(_harmony);
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception("FUSE RR Utilities query compatibility failed to install", ex);
-                utilitiesQueryStatus = "failed";
-            }
-
-            string utilitiesMapLoadStatus;
-            try
-            {
-                utilitiesMapLoadStatus = FuseUtilitiesMapLoadCompatibility.EnsureInstalled(_harmony);
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception("FUSE RR Utilities map-load compatibility failed to install", ex);
-                utilitiesMapLoadStatus = "failed";
-            }
-
-            string realisticRerailStatus;
-            try
-            {
-                realisticRerailStatus = FuseRealisticRerailCraneGuardPatches.EnsureInstalled(_harmony);
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception("FUSE Realistic Rerail startup guard failed to install", ex);
-                realisticRerailStatus = "failed";
-            }
-
-            string memoryLeakFpsStatus;
-            try
-            {
-                memoryLeakFpsStatus = FuseMemoryLeakFpsCompatibility.EnsureInstalled(_harmony);
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception("FUSE Memory Leak & FPS compatibility failed to install", ex);
-                memoryLeakFpsStatus = "failed";
-            }
-
-            string bmanLocomotiveAudioStatus;
-            try
-            {
-                bmanLocomotiveAudioStatus =
-                    FuseBmanLocomotiveAudioCompatibility.EnsureInstalled(_harmony);
-            }
-            catch (Exception ex)
-            {
-                FuseLog.Exception("FUSE Bman locomotive audio compatibility failed to install", ex);
-                bmanLocomotiveAudioStatus = "failed";
-            }
+            var mapEnhancerStatus = InstallGuard(
+                "Map Enhancer culling guard",
+                () => FuseMapEnhancerCullingGuardPatches.EnsureInstalled(_harmony));
+            var rebillStatus = InstallGuard(
+                "Rebill Industry Cars guard",
+                () => FuseRebillIndustryCarsGuardPatches.EnsureInstalled(_harmony));
+            var brssStatus = InstallGuard(
+                "BRSS mod-menu guard",
+                () => FuseBrssModMenuGuardPatches.EnsureInstalled(_harmony));
+            var timeSyncStatus = InstallGuard(
+                "TimeSync main-thread guard",
+                () => FuseTimeSyncMainThreadGuardPatches.EnsureInstalled(_harmony));
+            var utilitiesQueryStatus = InstallGuard(
+                "RR Utilities query compatibility",
+                () => FuseUtilitiesQueryTooltipCompatibility.EnsureInstalled(_harmony));
+            var utilitiesMapLoadStatus = InstallGuard(
+                "RR Utilities map-load compatibility",
+                () => FuseUtilitiesMapLoadCompatibility.EnsureInstalled(_harmony));
+            var realisticRerailStatus = InstallGuard(
+                "Realistic Rerail startup guard",
+                () => FuseRealisticRerailCraneGuardPatches.EnsureInstalled(_harmony));
+            var memoryLeakFpsStatus = InstallGuard(
+                "Memory Leak & FPS compatibility",
+                () => FuseMemoryLeakFpsCompatibility.EnsureInstalled(_harmony));
+            var bmanLocomotiveAudioStatus = InstallGuard(
+                "Bman locomotive audio compatibility",
+                () => FuseBmanLocomotiveAudioCompatibility.EnsureInstalled(_harmony));
+            var legosLibraryStatus = InstallGuard(
+                "Legos Library compatibility",
+                () => FuseLegosLibraryCompatibility.EnsureInstalled(_harmony));
+            var assetLoaderStatus = InstallGuard(
+                "AssetLoader replacement compatibility",
+                () => FuseAssetLoaderReplacementCompatibility.EnsureInstalled(_harmony));
+            var alinasUtilitiesStatus = InstallGuard(
+                "Alina Utilities compatibility",
+                FuseAlinasUtilitiesCompatibility.EnsureInstalled);
 
             var summary =
                 $"FUSE third-party guards: mapEnhancerCulling='{mapEnhancerStatus}' " +
@@ -183,11 +120,27 @@ namespace FUSE.Patches
                 $"utilitiesMapLoad='{utilitiesMapLoadStatus}' " +
                 $"realisticRerail='{realisticRerailStatus}' " +
                 $"memoryLeakFps='{memoryLeakFpsStatus}' " +
-                $"bmanLocomotiveAudio='{bmanLocomotiveAudioStatus}'.";
+                $"bmanLocomotiveAudio='{bmanLocomotiveAudioStatus}' " +
+                $"legosLibrary='{legosLibraryStatus}' " +
+                $"assetLoader='{assetLoaderStatus}' " +
+                $"alinasUtilities='{alinasUtilitiesStatus}'.";
             if (!string.Equals(summary, _lastSummary, StringComparison.Ordinal))
             {
                 _lastSummary = summary;
                 FuseLog.Info(summary);
+            }
+        }
+
+        private static string InstallGuard(string name, Func<string> install)
+        {
+            try
+            {
+                return install();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception($"FUSE {name} failed to install", ex);
+                return "failed";
             }
         }
 
@@ -210,7 +163,15 @@ namespace FUSE.Patches
                 assemblyName,
                 "GP38Scripts",
                 StringComparison.Ordinal);
-            if (!isRealisticRerail && !isUtilities && !isMemoryLeakFps && !isBmanLocomotiveAudio)
+            var isLegosLibrary = string.Equals(
+                assemblyName,
+                "LegosLibraryOfStuff",
+                StringComparison.Ordinal);
+            var isAssetLoader = FuseAssetLoaderReplacementCompatibility.IsTargetAssemblyName(assemblyName);
+            var isAlinasUtilities = FuseAlinasUtilitiesCompatibility.IsTargetAssemblyName(assemblyName);
+            if (!isRealisticRerail && !isUtilities && !isMemoryLeakFps &&
+                !isBmanLocomotiveAudio && !isLegosLibrary && !isAssetLoader &&
+                !isAlinasUtilities)
             {
                 return;
             }


### PR DESCRIPTION
## 🔗 Related Issue  Supersedes #241 by splitting that change set into a reviewable five-PR stack. This is part 3 of 5 and depends on #243.  ## 📝 Description of the Change  This layer adds the compatibility runtime that sits on top of the authoring and loader foundations from #242 and #243:  - Confusing Supplements adapters for bodygroups, destination signs, label printers, liveries, and refillers, including saved-property compatibility and cleanup. - AssetLoader replacement behavior and guarded integrations for legacy third-party mods. - Gameplay patches for routing, interchange scheduling, industries, starter placement, messaging, prefab handling, and invalid legacy data. - Console commands and focused xUnit or Unity EditMode regressions, selected according to whether the behavior depends on game or Unity types.  The implementation keeps compatibility behavior isolated behind feature-specific builders and Harmony patches. Fault-prone third-party boundaries are guarded so one legacy integration cannot prevent later initialization or shutdown steps. Resource-owning features explicitly restore and destroy Unity objects according to play-mode lifecycle rules.  This PR targets alex/pr241-2-loader-runtime. Its successor is #245.  ## 🔄 Alternatives Considered  - Merge the original monolithic #241. This was replaced with a stack so each architectural layer can be reviewed, tested, and merged independently. - Require legacy package authors to rewrite their mods. That would strand existing packages and saves, so FUSE provides narrowly scoped adapters instead. - Apply broad global patches for each third-party mod. The implementation favors guarded, feature-specific patches and explicit compatibility components to reduce cross-mod side effects.  ## ⚠️ Possible Drawbacks  - Reflection and Harmony integrations can require maintenance when Railroader or a supported third-party mod changes its runtime surface. - Unity material, texture, and customization behavior still benefits from an in-game/EditMode execution pass before release; the automated gate in this environment compiles that harness but does not launch Unity. - The PR is stacked and must be merged after #243. After each predecessor lands on main, the next PR must be retargeted before merging. - Saved-property additions are additive and preserve standard behavior when legacy values or assets are missing; no user save migration is expected.  ## ✅ Verification Process  Validated on current head a1a4ae5d59483a1d75084f4ea33bfce792240aed:  - FUSE.Tests: 2,213 passed, 8 skipped, 0 failed on .NET Framework 4.8. - Python tests: 89 passed. - Focused Unity EditMode test source compilation: succeeded with 0 errors. - Slopwatch: 0 issues. - Git diff check: clean. - Stack topology: every PR edge remains exactly one commit; successor range-diffs are unchanged after the latest #244 fix. - GitHub Actions: fresh current-head checks are queued/running with no visible failure. - CodeRabbit findings raised on earlier heads were individually verified, fixed where genuine, replied to, and resolved.  ## 💡 Additional Information  Stack order:  1. #242 — authoring schema and legacy conversion 2. #243 — package loading and runtime world support 3. #244 — legacy compatibility adapters and gameplay patches 4. #245 — diagnostics and conflict tooling 5. #246 — installer workflows and documentation  Merge procedure: after a predecessor lands on main, retarget the next PR to main before merging it. Keep predecessor branches until the dependent PR has been retargeted.