### PR TITLE
Expand diagnostics and conflict tooling

### DIFF
--- a/FUSE.Tests/Infrastructure/FuseSettingsReadFloatTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseSettingsReadFloatTests.cs
@@ -91,4 +91,5 @@ namespace FUSE.Tests.Infrastructure
             }
         }
     }
+
 }

--- a/FUSE.Tests/Interface/AssetsToolPageTests.cs
+++ b/FUSE.Tests/Interface/AssetsToolPageTests.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using FUSE.Interface.MenuWindow;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Interface
+{
+    public class AssetsToolPageTests
+    {
+        [Fact]
+        public void GroupDuplicateAssets_CollapsesKeysWithTheSameWinnerAndSources()
+        {
+            var groups = AssetsToolPage.GroupDuplicateAssets(new[]
+            {
+                Duplicate("mine", false, "RTM/primary", "RTM/nested"),
+                Duplicate("engine-house", false, "RTM/primary", "RTM/nested"),
+                Duplicate("sound-1", true, "Latoms", "lt-objects")
+            });
+
+            Assert.Equal(2, groups.Length);
+            var identical = Assert.Single(groups, group => !group.DefinitionsDiffer);
+            Assert.Equal(new[] { "mine", "engine-house" }, identical.Keys);
+            Assert.Equal(new[] { "RTM/primary", "RTM/nested" }, identical.Sources);
+
+            var different = Assert.Single(groups, group => group.DefinitionsDiffer);
+            Assert.Equal(new[] { "sound-1" }, different.Keys);
+        }
+
+        [Fact]
+        public void GroupDuplicateAssets_PreservesWinnerOrderAsPartOfTheGroupIdentity()
+        {
+            var groups = AssetsToolPage.GroupDuplicateAssets(new[]
+            {
+                Duplicate("a", false, "winner-a", "source-b"),
+                Duplicate("b", false, "source-b", "winner-a")
+            });
+
+            Assert.Equal(2, groups.Length);
+        }
+
+        [Fact]
+        public void BuildAssetSummary_ReportsGroupedImpactInsteadOfOnePreviewPerKey()
+        {
+            var diagnostics = new FuseAssetPackDiagnostics
+            {
+                UniqueAssetKeys = 10,
+                DuplicateKeys = new[]
+                {
+                    Duplicate("mine", false, "RTM/primary", "RTM/nested"),
+                    Duplicate("engine-house", false, "RTM/primary", "RTM/nested")
+                }
+            };
+
+            var summary = AssetsToolPage.BuildAssetSummary(diagnostics);
+
+            Assert.Contains("Overlapping asset keys: 2", summary);
+            Assert.Contains("Source overlap groups: 1", summary);
+            Assert.Contains("2 key(s)", summary);
+            Assert.Contains("identical copies; no behavior change", summary);
+            Assert.DoesNotContain("1 more duplicate key", summary);
+        }
+
+        private static FuseDuplicateAssetKey Duplicate(
+            string key,
+            bool definitionsDiffer,
+            params string[] sources)
+        {
+            return new FuseDuplicateAssetKey
+            {
+                Key = key,
+                DefinitionsDiffer = definitionsDiffer,
+                Sources = sources
+            };
+        }
+    }
+}

--- a/FUSE.Tests/Interface/AuditsToolPageTests.cs
+++ b/FUSE.Tests/Interface/AuditsToolPageTests.cs
@@ -1,0 +1,34 @@
+using FUSE.Interface.MenuWindow;
+using Xunit;
+
+namespace FUSE.Tests.Interface
+{
+    public sealed class AuditsToolPageTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Base_game_span_without_package_owner_is_not_audited(string owner)
+        {
+            Assert.False(AuditsToolPage.ShouldAuditTrackSpanOwner(owner));
+        }
+
+        [Fact]
+        public void Fuse_owned_span_remains_eligible_for_validation()
+        {
+            Assert.True(AuditsToolPage.ShouldAuditTrackSpanOwner("Katers.SylvaInterchange.FUSE"));
+        }
+
+        [Theory]
+        [InlineData("shared-extension", false)]
+        [InlineData("SHARED-EXTENSION", false)]
+        [InlineData("ownership-conflict", true)]
+        [InlineData("", true)]
+        [InlineData(null, true)]
+        public void Only_actionable_registry_records_are_audit_findings(string classification, bool expected)
+        {
+            Assert.Equal(expected, AuditsToolPage.ShouldAuditConflictRecord(classification));
+        }
+    }
+}

--- a/FUSE.Tests/Interface/FuseWorldLabelsOverlayTests.cs
+++ b/FUSE.Tests/Interface/FuseWorldLabelsOverlayTests.cs
@@ -1,0 +1,22 @@
+using FUSE.Interface;
+using Xunit;
+
+namespace FUSE.Tests.Interface
+{
+    public sealed class FuseWorldLabelsOverlayTests
+    {
+        [Theory]
+        [InlineData(false, false, false, false)]
+        [InlineData(true, true, false, false)]
+        [InlineData(true, false, true, false)]
+        [InlineData(true, false, false, true)]
+        public void ShouldRender_hides_labels_while_disabled_paused_or_a_game_window_is_open(
+            bool enabled,
+            bool paused,
+            bool shownWindow,
+            bool expected)
+        {
+            Assert.Equal(expected, FuseWorldLabelsOverlay.ShouldRender(enabled, paused, shownWindow));
+        }
+    }
+}

--- a/FUSE.Tests/Interface/MenuWindow/DependencyGraphPageTests.cs
+++ b/FUSE.Tests/Interface/MenuWindow/DependencyGraphPageTests.cs
@@ -55,6 +55,21 @@ namespace FUSE.Tests.Interface.MenuWindow
                 DependencyGraphPage.FormatDependencyEdge("c_l_b.assets01", Packages, PresentInModsRoot, advisory: true));
         }
 
+        [Theory]
+        [InlineData("Zamu.StrangeCustoms")]
+        [InlineData("AlinaNova21.AlinasMapMod.FUSE")]
+        [InlineData("AssetLoader")]
+        public void ReplacementCapability_IsIdentifiedAsProvidedByFuse(string dependencyId)
+        {
+            Assert.Contains(
+                "PROVIDED BY FUSE",
+                DependencyGraphPage.FormatDependencyEdge(
+                    dependencyId,
+                    Packages,
+                    PresentInModsRoot,
+                    advisory: false));
+        }
+
         [Fact]
         public void UnknownTarget_IsMissing_ForNativePackages_ButOptionalForLegacyHints()
         {

--- a/FUSE.Tests/Interface/MenuWindow/ModConflictsToolPageTests.cs
+++ b/FUSE.Tests/Interface/MenuWindow/ModConflictsToolPageTests.cs
@@ -1,0 +1,163 @@
+using FUSE.Interface.MenuWindow;
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using FUSE.Runtime.Registry;
+using Xunit;
+
+namespace FUSE.Tests.Interface.MenuWindow
+{
+    [Collection("FuseRegistry")]
+    public sealed class ModConflictsToolPageTests
+    {
+        public ModConflictsToolPageTests()
+        {
+            FuseRegistry.Reset();
+        }
+
+        [Fact]
+        public void BuildGroups_groups_reverse_ownership_records_under_one_package_pair()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Segment,
+                "segment-a",
+                "package-z",
+                "package-a",
+                "later package definition won");
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Node,
+                "node-b",
+                "package-a",
+                "package-z",
+                "later package removal won");
+
+            var group = Assert.Single(ModConflictsToolPage.BuildGroups(FuseRegistry.Conflicts));
+
+            Assert.Equal("package-a", group.FirstPackageId);
+            Assert.Equal("package-z", group.SecondPackageId);
+            Assert.Equal(2, group.Conflicts.Length);
+        }
+
+        [Fact]
+        public void BuildReport_identifies_spatial_overlap_and_lists_both_packages()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Segment,
+                "spatial-overlap:east-whittier",
+                "yard-revamp",
+                "crossover",
+                "spatial track overlap detected; both packages retained");
+
+            var report = ModConflictsToolPage.BuildReport(
+                ModConflictsToolPage.BuildGroups(FuseRegistry.Conflicts));
+
+            Assert.Contains("crossover  <->  yard-revamp", report);
+            Assert.Contains("Potential track-layout overlap", report);
+            Assert.Contains("spatial-overlap:east-whittier", report);
+        }
+
+        [Fact]
+        public void BuildGroups_collapses_definition_fragments_to_their_discovered_mod_ids()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Segment,
+                "segment-a",
+                "Author.RouteA.FUSE.graph",
+                "Author.RouteB.FUSE.track",
+                "later package definition won");
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Span,
+                "span-b",
+                "Author.RouteA.FUSE.operations",
+                "Author.RouteB.FUSE.spans",
+                "later package definition won");
+
+            var group = Assert.Single(ModConflictsToolPage.BuildGroups(
+                FuseRegistry.Conflicts,
+                new[] { "Author.RouteA.FUSE", "Author.RouteB.FUSE" }));
+
+            Assert.Equal("Author.RouteA.FUSE", group.FirstPackageId);
+            Assert.Equal("Author.RouteB.FUSE", group.SecondPackageId);
+            Assert.Equal(2, group.Conflicts.Length);
+        }
+
+        [Fact]
+        public void DeclaredConflicts_are_reported_separately_from_runtime_ownership()
+        {
+            var declaring = new FusePackageManifestSnapshot
+            {
+                Id = "Katers.Route.FUSE",
+                Version = "1.0",
+                ConflictsWith = new[]
+                {
+                    new FuseModRequirement { Id = "Other.Route", NotBefore = "2.0" }
+                }
+            };
+            var conflicting = new FusePackageManifestSnapshot
+            {
+                Id = "Other.Route.FUSE",
+                Version = "2.5"
+            };
+
+            var matches = ModConflictsToolPage.BuildDeclaredConflictMatches(new[] { declaring, conflicting });
+            var match = Assert.Single(matches);
+            var report = ModConflictsToolPage.BuildReport(
+                System.Linq.Enumerable.Empty<ModConflictsToolPage.ConflictGroup>(),
+                matches);
+
+            Assert.Equal("Katers.Route.FUSE", match.DeclaringPackage.Id);
+            Assert.Contains("Author-declared incompatibilities: 1", report);
+            Assert.Contains("DECLARED: Katers.Route.FUSE  X  Other.Route.FUSE", report);
+            Assert.DoesNotContain("Conflict records: 1", report);
+        }
+
+        [Fact]
+        public void DeclaredConflicts_ignore_disabled_declaring_package()
+        {
+            var declaring = new FusePackageManifestSnapshot
+            {
+                Id = "Katers.Route.FUSE",
+                Disabled = true,
+                ConflictsWith = new[]
+                {
+                    new FuseModRequirement { Id = "Other.Route" }
+                }
+            };
+            var conflicting = new FusePackageManifestSnapshot
+            {
+                Id = "Other.Route.FUSE",
+                Version = "2.5"
+            };
+
+            var matches = ModConflictsToolPage.BuildDeclaredConflictMatches(new[] { declaring, conflicting });
+
+            Assert.Empty(matches);
+        }
+
+        [Fact]
+        public void Successful_shared_industry_merge_is_informational_not_actionable()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Industry,
+                "component:kirkland-mine.KirkOBSTrackLoad",
+                "CF.AndrewsCoalPower.FUSE.kirklandcoalpatchpower-migration",
+                "Katers.TuckasegeeSteelWorks.FUSE.kirklandcoal",
+                "shared industry destination overlap; definitions merged into the same runtime location");
+
+            var record = Assert.Single(FuseRegistry.Conflicts);
+            Assert.True(record.IsCooperativeMerge);
+
+            var sharedGroups = ModConflictsToolPage.BuildGroups(
+                new[] { record },
+                new[] { "CF.AndrewsCoalPower.FUSE", "Katers.TuckasegeeSteelWorks.FUSE" });
+            var report = ModConflictsToolPage.BuildReport(
+                System.Linq.Enumerable.Empty<ModConflictsToolPage.ConflictGroup>(),
+                System.Linq.Enumerable.Empty<ModConflictsToolPage.DeclaredConflictMatch>(),
+                sharedGroups);
+
+            Assert.Contains("Package pairs needing attention: 0", report);
+            Assert.Contains("Informational shared-extension records: 1", report);
+            Assert.Contains("SHARED: CF.AndrewsCoalPower.FUSE  +  Katers.TuckasegeeSteelWorks.FUSE", report);
+            Assert.Contains("no mod lost content", report);
+        }
+    }
+}

--- a/FUSE.Tests/Interface/MenuWindow/ModsPanelBuilderTests.cs
+++ b/FUSE.Tests/Interface/MenuWindow/ModsPanelBuilderTests.cs
@@ -107,5 +107,121 @@ namespace FUSE.Tests.Interface.MenuWindow
 
             Assert.Equal("NotEnoughRosters", Assert.Single(result).DisplayName);
         }
+
+        [Theory]
+        [InlineData("Package 'Example' requires 'Missing.Mod', but no matching package was discovered.", "Missing dependency")]
+        [InlineData("Package 'Example' conflictsWith 'Other.Mod'; matching package is enabled.", "Incompatible mod installed")]
+        [InlineData("manifest JSON: Unexpected character at line 12.", "Invalid package data")]
+        public void ClassifyPackageStatus_distinguishes_actionable_failure_types(string fault, string expected)
+        {
+            var snapshot = new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                Faults = new[] { fault }
+            };
+
+            var status = ModsPanelBuilder.ClassifyPackageStatus(snapshot);
+
+            Assert.Equal(expected, status.Label);
+            Assert.Equal("Mods Needing Attention", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_reports_successfully_applied_package()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                AppliedToRuntime = true
+            });
+
+            Assert.Equal("Applied", status.Label);
+            Assert.Equal("Applied Mods", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_keeps_optional_mixinto_skip_non_actionable()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                AppliedToRuntime = true,
+                SkipReason = "mixinto dependency missing 'Optional.Mod'"
+            });
+
+            Assert.Equal("Applied", status.Label);
+            Assert.Contains("Optional content is inactive", status.Detail);
+            Assert.Equal("Applied Mods", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_does_not_hide_actionable_skip_behind_optional_fragment()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                AppliedToRuntime = true,
+                SkipReasons = new[]
+                {
+                    "mixinto dependency missing id='Optional.Mod'",
+                    "runtime apply exception"
+                }
+            });
+
+            Assert.Equal("Partially applied", status.Label);
+            Assert.Equal(
+                "mixinto dependency missing id='Optional.Mod'; runtime apply exception",
+                status.Detail);
+            Assert.Equal("Mods Needing Attention", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_reports_partial_apply_without_calling_whole_package_failed()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                AppliedToRuntime = true,
+                RuntimeFaults = new[] { "runtime apply: one definition failed" }
+            });
+
+            Assert.Equal("Partially applied", status.Label);
+            Assert.Equal("Mods Needing Attention", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_reports_disabled_package_separately()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                Disabled = true,
+                DisabledReason = "disabled in the active profile"
+            });
+
+            Assert.Equal("Disabled", status.Label);
+            Assert.Equal("disabled in the active profile", status.Detail);
+            Assert.Equal("Disabled Mods", status.ListGroup);
+        }
+
+        [Theory]
+        [InlineData(-5f, 0f)]
+        [InlineData(11f, 10f)]
+        [InlineData(4.6f, 5f)]
+        [InlineData(4.4f, 4f)]
+        public void NormalizeNumberSliderValue_clamps_and_quantizes(float value, float expected)
+        {
+            var result = ModsPanelBuilder.NormalizeNumberSliderValue(value, 0f, 10f, 1d);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void NormalizeNumberSliderValue_preserves_unquantized_values()
+        {
+            var result = ModsPanelBuilder.NormalizeNumberSliderValue(4.25f, 0f, 10f, 0d);
+
+            Assert.Equal(4.25f, result);
+        }
     }
 }

--- a/FUSE.UnityTests/Assets/Tests/FuseSettingsLegacyGameplayPreviewTests.cs
+++ b/FUSE.UnityTests/Assets/Tests/FuseSettingsLegacyGameplayPreviewTests.cs
@@ -1,0 +1,182 @@
+using FUSE.Infrastructure;
+using NUnit.Framework;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace FUSE.UnityTests
+{
+    /// <summary>
+    /// Slider previews update live legacy-gameplay values through the same
+    /// clamps as their commit setters without writing a user override.
+    /// </summary>
+    public class FuseSettingsLegacyGameplayPreviewTests
+    {
+        private const string ControlledUserSettingsJson =
+            "{\n" +
+            "  \"InterchangeNotBeforeHour\": -901.0,\n" +
+            "  \"InterchangeNotAfterHour\": -902.0,\n" +
+            "  \"OutboundIndustryRerouteChance\": -903.0,\n" +
+            "  \"OutboundIndustryFillFactor\": -904.0,\n" +
+            "  \"OutboundIndustryPaymentMultiplier\": -905.0,\n" +
+            "  \"UnrelatedSentinel\": \"preserve-me\"\n" +
+            "}";
+
+        [Test]
+        public void PreviewInterchangeServiceHours_ClampLiveValues()
+        {
+            var originalNotBefore = FuseSettings.InterchangeNotBeforeHour;
+            var originalNotAfter = FuseSettings.InterchangeNotAfterHour;
+            string settingsPath;
+            var originalSettingsFile = CaptureUserSettingsFile(out settingsPath);
+            byte[] controlledSettingsFile = null;
+            try
+            {
+                controlledSettingsFile = InstallControlledUserSettingsFile(settingsPath);
+
+                FuseSettings.PreviewInterchangeNotBeforeHour(-1f);
+                Assert.AreEqual(0f, FuseSettings.InterchangeNotBeforeHour);
+                AssertUserSettingsFileUnchanged(
+                    settingsPath,
+                    controlledSettingsFile,
+                    nameof(FuseSettings.PreviewInterchangeNotBeforeHour));
+
+                FuseSettings.PreviewInterchangeNotAfterHour(float.PositiveInfinity);
+                Assert.AreEqual(24f, FuseSettings.InterchangeNotAfterHour);
+                AssertUserSettingsFileUnchanged(
+                    settingsPath,
+                    controlledSettingsFile,
+                    nameof(FuseSettings.PreviewInterchangeNotAfterHour));
+
+                FuseSettings.PreviewInterchangeNotBeforeHour(float.NaN);
+                Assert.AreEqual(0f, FuseSettings.InterchangeNotBeforeHour);
+                AssertUserSettingsFileUnchanged(
+                    settingsPath,
+                    controlledSettingsFile,
+                    nameof(FuseSettings.PreviewInterchangeNotBeforeHour));
+            }
+            finally
+            {
+                try
+                {
+                    FuseSettings.PreviewInterchangeNotBeforeHour(originalNotBefore);
+                    FuseSettings.PreviewInterchangeNotAfterHour(originalNotAfter);
+                }
+                finally
+                {
+                    RestoreUserSettingsFile(settingsPath, originalSettingsFile);
+                }
+            }
+        }
+
+        [Test]
+        public void PreviewOutboundRoutingValues_ClampLiveValues()
+        {
+            var originalChance = FuseSettings.OutboundIndustryRerouteChance;
+            var originalFillFactor = FuseSettings.OutboundIndustryFillFactor;
+            var originalPaymentMultiplier = FuseSettings.OutboundIndustryPaymentMultiplier;
+            string settingsPath;
+            var originalSettingsFile = CaptureUserSettingsFile(out settingsPath);
+            byte[] controlledSettingsFile = null;
+            try
+            {
+                controlledSettingsFile = InstallControlledUserSettingsFile(settingsPath);
+
+                FuseSettings.PreviewOutboundIndustryRerouteChance(float.NaN);
+                Assert.AreEqual(
+                    FuseSettings.DefaultOutboundIndustryRerouteChance,
+                    FuseSettings.OutboundIndustryRerouteChance);
+                AssertUserSettingsFileUnchanged(
+                    settingsPath,
+                    controlledSettingsFile,
+                    nameof(FuseSettings.PreviewOutboundIndustryRerouteChance));
+
+                FuseSettings.PreviewOutboundIndustryFillFactor(99f);
+                Assert.AreEqual(3f, FuseSettings.OutboundIndustryFillFactor);
+                AssertUserSettingsFileUnchanged(
+                    settingsPath,
+                    controlledSettingsFile,
+                    nameof(FuseSettings.PreviewOutboundIndustryFillFactor));
+
+                FuseSettings.PreviewOutboundIndustryPaymentMultiplier(-1f);
+                Assert.AreEqual(0f, FuseSettings.OutboundIndustryPaymentMultiplier);
+                AssertUserSettingsFileUnchanged(
+                    settingsPath,
+                    controlledSettingsFile,
+                    nameof(FuseSettings.PreviewOutboundIndustryPaymentMultiplier));
+            }
+            finally
+            {
+                try
+                {
+                    FuseSettings.PreviewOutboundIndustryRerouteChance(originalChance);
+                    FuseSettings.PreviewOutboundIndustryFillFactor(originalFillFactor);
+                    FuseSettings.PreviewOutboundIndustryPaymentMultiplier(originalPaymentMultiplier);
+                }
+                finally
+                {
+                    RestoreUserSettingsFile(settingsPath, originalSettingsFile);
+                }
+            }
+        }
+
+        private static byte[] CaptureUserSettingsFile(out string path)
+        {
+            path = FuseSettings.GetUserSettingsPath();
+            return File.Exists(path) ? File.ReadAllBytes(path) : null;
+        }
+
+        private static byte[] InstallControlledUserSettingsFile(string path)
+        {
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var contents = Encoding.UTF8.GetBytes(ControlledUserSettingsJson);
+            File.WriteAllBytes(path, contents);
+            return contents;
+        }
+
+        private static void AssertUserSettingsFileUnchanged(
+            string path,
+            byte[] expectedContents,
+            string previewMethod)
+        {
+            Assert.IsTrue(
+                File.Exists(path),
+                previewMethod + " changed whether the user-settings file exists.");
+            CollectionAssert.AreEqual(
+                expectedContents,
+                File.ReadAllBytes(path),
+                previewMethod + " changed the user-settings file contents.");
+        }
+
+        private static void RestoreUserSettingsFile(string path, byte[] originalContents)
+        {
+            if (originalContents == null)
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+
+                return;
+            }
+
+            if (File.Exists(path) && File.ReadAllBytes(path).SequenceEqual(originalContents))
+            {
+                return;
+            }
+
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllBytes(path, originalContents);
+        }
+    }
+}

--- a/FUSE.UnityTests/Assets/Tests/FuseSettingsLegacyGameplayPreviewTests.cs.meta
+++ b/FUSE.UnityTests/Assets/Tests/FuseSettingsLegacyGameplayPreviewTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c21367e79704b708290d24be654326a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/FUSE/Infrastructure/FuseModSettingsStore.cs
+++ b/FUSE/Infrastructure/FuseModSettingsStore.cs
@@ -109,6 +109,21 @@ namespace FUSE.Infrastructure
 
         public static void SetValue(FuseModDefinition definition, string key, FuseModSettingDefinition setting, JToken value)
         {
+            SetValueCore(definition, key, setting, value, persist: true);
+        }
+
+        internal static void SetValueInMemory(FuseModDefinition definition, string key, FuseModSettingDefinition setting, JToken value)
+        {
+            SetValueCore(definition, key, setting, value, persist: false);
+        }
+
+        private static void SetValueCore(
+            FuseModDefinition definition,
+            string key,
+            FuseModSettingDefinition setting,
+            JToken value,
+            bool persist)
+        {
             if (string.IsNullOrWhiteSpace(definition?.Id) || string.IsNullOrWhiteSpace(key))
             {
                 return;
@@ -121,7 +136,7 @@ namespace FUSE.Infrastructure
                 var scopeKey = GetCurrentScopeKey(scope);
                 var bucket = GetBucket(definition.Id, scope, scopeKey, create: true);
                 bucket[key] = CoerceValue(value, setting);
-                if (SaveNoLock())
+                if (persist && SaveNoLock())
                 {
                     _lastStatus = $"Saved setting '{key}' for package '{definition.Id}' ({DescribeScope(scope)}).";
                 }

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -774,6 +774,13 @@ namespace FUSE.Infrastructure
                 $"FUSE legacy gameplay setting changed: {nameof(InterchangeContinuousService)}={enabled}.");
         }
 
+        internal static void PreviewInterchangeNotBeforeHour(float value)
+        {
+            InterchangeNotBeforeHour = ClampInterchangeServiceHour(
+                value,
+                DefaultInterchangeNotBeforeHour);
+        }
+
         public static void SetInterchangeNotBeforeHour(float value)
         {
             InterchangeNotBeforeHour = ClampInterchangeServiceHour(
@@ -783,6 +790,13 @@ namespace FUSE.Infrastructure
             FuseLog.Info(
                 $"FUSE legacy gameplay setting changed: {nameof(InterchangeNotBeforeHour)}=" +
                 $"{InterchangeNotBeforeHour:F2}.");
+        }
+
+        internal static void PreviewInterchangeNotAfterHour(float value)
+        {
+            InterchangeNotAfterHour = ClampInterchangeServiceHour(
+                value,
+                DefaultInterchangeNotAfterHour);
         }
 
         public static void SetInterchangeNotAfterHour(float value)
@@ -832,16 +846,31 @@ namespace FUSE.Infrastructure
             SaveUserOverride(nameof(EnableOutboundIndustryRerouting), enabled);
         }
 
+        internal static void PreviewOutboundIndustryRerouteChance(float value)
+        {
+            OutboundIndustryRerouteChance = ClampOutboundIndustryRerouteChance(value);
+        }
+
         public static void SetOutboundIndustryRerouteChance(float value)
         {
             OutboundIndustryRerouteChance = ClampOutboundIndustryRerouteChance(value);
             SaveUserOverride(nameof(OutboundIndustryRerouteChance), OutboundIndustryRerouteChance);
         }
 
+        internal static void PreviewOutboundIndustryFillFactor(float value)
+        {
+            OutboundIndustryFillFactor = ClampOutboundIndustryFillFactor(value);
+        }
+
         public static void SetOutboundIndustryFillFactor(float value)
         {
             OutboundIndustryFillFactor = ClampOutboundIndustryFillFactor(value);
             SaveUserOverride(nameof(OutboundIndustryFillFactor), OutboundIndustryFillFactor);
+        }
+
+        internal static void PreviewOutboundIndustryPaymentMultiplier(float value)
+        {
+            OutboundIndustryPaymentMultiplier = ClampOutboundIndustryPaymentMultiplier(value);
         }
 
         public static void SetOutboundIndustryPaymentMultiplier(float value)

--- a/FUSE/Interface/FuseTrackDebugOverlay.cs
+++ b/FUSE/Interface/FuseTrackDebugOverlay.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using FUSE.Runtime.API;
 using FUSE.Infrastructure;
+using FUSE.Compatibility;
 using Model.Ops;
 using Track;
 using UnityEngine;
@@ -240,7 +241,7 @@ namespace FUSE.Interface
             string style;
             try
             {
-                style = segment.style.ToString();
+                style = RailroaderTrackContract.GetStyleName(segment);
             }
             catch
             {

--- a/FUSE/Interface/FuseWorldLabelsOverlay.cs
+++ b/FUSE/Interface/FuseWorldLabelsOverlay.cs
@@ -4,6 +4,7 @@ using FUSE.Runtime.API;
 using FUSE.Runtime.Cache;
 using FUSE.Infrastructure;
 using Track;
+using UI.Common;
 using UnityEngine;
 
 namespace FUSE.Interface
@@ -62,11 +63,13 @@ namespace FUSE.Interface
         public static readonly Color TrackSegmentColor = new Color(1.00f, 0.88f, 0.25f, 1f);   // yellow
 
         private static GameObject _host;
+        private static bool _windowInspectionWarningLogged;
 
         private readonly List<Label> _labels = new List<Label>(256);
         private GUIStyle _labelStyle;
         private Texture2D _backgroundTexture;
         private float _nextRefreshAt;
+        private bool _hasShownGameWindow;
 
         public static void Ensure()
         {
@@ -89,17 +92,20 @@ namespace FUSE.Interface
                 Destroy(_host);
                 _host = null;
             }
+
+            _windowInspectionWarningLogged = false;
         }
 
         private void Update()
         {
-            if (!FuseSettings.ShowWorldLabelsOverlay)
+            if (!FuseSettings.ShowWorldLabelsOverlay || Time.timeScale <= 0f)
             {
                 if (_labels.Count > 0)
                 {
                     _labels.Clear();
                 }
 
+                _nextRefreshAt = 0f;
                 return;
             }
 
@@ -109,12 +115,26 @@ namespace FUSE.Interface
             }
 
             _nextRefreshAt = Time.unscaledTime + RefreshInterval;
+            _hasShownGameWindow = HasShownGameWindow();
+            if (_hasShownGameWindow)
+            {
+                if (_labels.Count > 0)
+                {
+                    _labels.Clear();
+                }
+
+                return;
+            }
+
             RebuildLabels();
         }
 
         private void OnGUI()
         {
-            if (!FuseSettings.ShowWorldLabelsOverlay)
+            if (!ShouldRender(
+                    FuseSettings.ShowWorldLabelsOverlay,
+                    Time.timeScale <= 0f,
+                    _hasShownGameWindow))
             {
                 return;
             }
@@ -182,6 +202,47 @@ namespace FUSE.Interface
                 GUI.Label(new Rect(rect.x + 4f, rect.y + 2f, rect.width - 8f, rect.height - 4f), content, _labelStyle);
                 painted++;
             }
+        }
+
+        internal static bool ShouldRender(bool enabled, bool gamePaused, bool hasShownGameWindow)
+        {
+            return enabled && !gamePaused && !hasShownGameWindow;
+        }
+
+        private static bool HasShownGameWindow()
+        {
+            var manager = WindowManager.Shared;
+            if (manager == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                var windows = manager.GetComponentsInChildren<Window>(true);
+                for (var index = 0; index < windows.Length; index++)
+                {
+                    if (windows[index] != null && windows[index].IsShown)
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // UI teardown can race OnGUI while returning to the main menu.
+                // Failing open keeps a transient manager state from disabling
+                // the overlay for the rest of the session.
+                if (!_windowInspectionWarningLogged)
+                {
+                    _windowInspectionWarningLogged = true;
+                    FuseLog.Warning(
+                        "FUSE world-labels overlay could not inspect game windows: " +
+                        ex.GetBaseException().Message);
+                }
+            }
+
+            return false;
         }
 
         private void OnDestroy()

--- a/FUSE/Interface/MenuWindow/AssetsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/AssetsToolPage.cs
@@ -2,6 +2,7 @@
 using FUSE.Loading;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -21,13 +22,19 @@ namespace FUSE.Interface.MenuWindow
             builder.AddLabel("This tool shows asset information and a list of any duplicate asset keys.");
 
             var diagnostics = FuseAssetPackRegistry.GetDiagnostics();
+            var duplicateGroups = GroupDuplicateAssets(diagnostics.DuplicateKeys);
             builder.AddSection("Asset Resolution");
             builder.AddField("Mode", AssetPackModeText());
             builder.AddField("Stores Scanned", diagnostics.StoreFolders.Length.ToString());
             builder.AddField("Runtime Stores", FusePerformanceMetrics.FormatCount("direct asset pack store count"));
             builder.AddField("Unique Asset Keys", diagnostics.UniqueAssetKeys.ToString());
-            builder.AddField("Duplicate Keys", diagnostics.DuplicateKeys.Length.ToString());
+            builder.AddField("Overlapping Asset Keys", diagnostics.DuplicateKeys.Length.ToString());
+            builder.AddField("Source Overlap Groups", duplicateGroups.Length.ToString());
+            builder.AddField("Identical Copies", diagnostics.DuplicateKeys.Count(item => !item.DefinitionsDiffer).ToString());
+            builder.AddField("Different Definitions", diagnostics.DuplicateKeys.Count(item => item.DefinitionsDiffer).ToString());
             builder.AddField("Failed Definitions", diagnostics.FailedDefinitionLoads.Length.ToString());
+            builder.AddField("Definition Overrides", diagnostics.LegacyDefinitionOverrides.Length.ToString());
+            builder.AddField("Override Issues", diagnostics.LegacyDefinitionOverrideIssues.Length.ToString());
             builder.AddField("Last Direct Mount", FusePerformanceMetrics.FormatTiming("direct asset pack stores"));
             AddWrappedField(
                 builder,
@@ -55,7 +62,8 @@ namespace FUSE.Interface.MenuWindow
 
             builder.Spacer(4f);
 
-            if (!FuseSettings.ShowAdvancedHealthDetails && diagnostics.DuplicateKeys.Length == 0 && diagnostics.FailedDefinitionLoads.Length == 0)
+            if (!FuseSettings.ShowAdvancedHealthDetails && diagnostics.DuplicateKeys.Length == 0 &&
+                diagnostics.FailedDefinitionLoads.Length == 0 && diagnostics.LegacyDefinitionOverrideIssues.Length == 0)
             {
                 builder.AddField("Status", "No asset issues detected");
             }
@@ -69,26 +77,26 @@ namespace FUSE.Interface.MenuWindow
             }
             else
             {
-                builder.AddSection("Duplicate Asset Keys");
+                builder.AddSection("Asset Source Overlaps");
                 if (diagnostics.DuplicateKeys.Length == 0)
                 {
                     builder.AddField("Status", "None detected");
                 }
                 else
                 {
-                    foreach (var duplicate in diagnostics.DuplicateKeys.Take(20))
+                    foreach (var group in duplicateGroups.Take(20))
                     {
-                        BuildDuplicateAssetPreview(builder, duplicate);
+                        BuildDuplicateAssetGroupPreview(builder, group);
                         builder.Spacer(4f);
                         builder.AddHRule();
                     }
 
-                    if (diagnostics.DuplicateKeys.Length > 20)
+                    if (duplicateGroups.Length > 20)
                     {
                         AddWrappedField(
                             builder,
                             "More",
-                            (diagnostics.DuplicateKeys.Length - 20) + " hidden. Export Asset Report for all duplicate keys.",
+                            (duplicateGroups.Length - 20) + " source group(s) hidden. Export Asset Report for every overlapping key.",
                             34f);
                     }
                 }
@@ -108,38 +116,103 @@ namespace FUSE.Interface.MenuWindow
                         (diagnostics.StoreFolders.Length - 40) + " hidden. Export Asset Report for all store paths.",
                         34f);
                 }
+
+                builder.Spacer(4f);
+                builder.AddSection("Definition Overrides");
+                if (diagnostics.LegacyDefinitionOverrides.Length == 0)
+                {
+                    builder.AddField("Status", "None detected");
+                }
+                else
+                {
+                    foreach (var definitionOverride in diagnostics.LegacyDefinitionOverrides.Take(20))
+                    {
+                        AddWrappedField(
+                            builder,
+                            definitionOverride.StoreIdentifier,
+                            definitionOverride.PackageId + " | " + definitionOverride.DefinitionsPath,
+                            44f);
+                    }
+                }
+
+                foreach (var issue in diagnostics.LegacyDefinitionOverrideIssues.Take(20))
+                {
+                    AddWrappedField(builder, "Override Issue", issue, 58f);
+                }
             }
 
             builder.Spacer(8f);
         }
 
-        private static string BuildAssetSummary(FuseAssetPackDiagnostics diagnostics)
+        internal static string BuildAssetSummary(FuseAssetPackDiagnostics diagnostics)
         {
+            diagnostics = diagnostics ?? new FuseAssetPackDiagnostics();
+            var duplicateGroups = GroupDuplicateAssets(diagnostics.DuplicateKeys);
             var builder = new StringBuilder();
             builder.AppendLine("FUSE Asset Summary");
             builder.AppendLine("Mode: " + AssetPackModeText());
             builder.AppendLine("Stores scanned: " + (diagnostics.StoreFolders?.Length ?? 0));
             builder.AppendLine("Unique asset keys: " + diagnostics.UniqueAssetKeys);
-            builder.AppendLine("Duplicate keys: " + (diagnostics.DuplicateKeys?.Length ?? 0));
+            builder.AppendLine("Overlapping asset keys: " + (diagnostics.DuplicateKeys?.Length ?? 0));
+            builder.AppendLine("Source overlap groups: " + duplicateGroups.Length);
+            builder.AppendLine("Identical duplicate definitions: " + (diagnostics.DuplicateKeys?.Count(item => !item.DefinitionsDiffer) ?? 0));
+            builder.AppendLine("Different duplicate definitions: " + (diagnostics.DuplicateKeys?.Count(item => item.DefinitionsDiffer) ?? 0));
             builder.AppendLine("Failed definitions: " + (diagnostics.FailedDefinitionLoads?.Length ?? 0));
+            builder.AppendLine("Definition overrides: " + (diagnostics.LegacyDefinitionOverrides?.Length ?? 0));
+            builder.AppendLine("Definition override issues: " + (diagnostics.LegacyDefinitionOverrideIssues?.Length ?? 0));
 
-            var duplicates = diagnostics.DuplicateKeys ?? Array.Empty<FuseDuplicateAssetKey>();
-            if (duplicates.Length > 0)
+            if (duplicateGroups.Length > 0)
             {
                 builder.AppendLine();
-                builder.AppendLine("Duplicate preview:");
-                foreach (var duplicate in duplicates.Take(10))
+                builder.AppendLine("Overlap group preview:");
+                foreach (var group in duplicateGroups.Take(10))
                 {
-                    builder.AppendLine("- " + BuildDuplicateAssetPreviewString(duplicate));
+                    builder.AppendLine("- " + BuildDuplicateAssetGroupPreviewString(group));
                 }
 
-                if (duplicates.Length > 10)
+                if (duplicateGroups.Length > 10)
                 {
-                    builder.AppendLine("- " + (duplicates.Length - 10) + " more duplicate key(s); export the asset report for the full list.");
+                    builder.AppendLine("- " + (duplicateGroups.Length - 10) + " more source overlap group(s); export the asset report for every key.");
                 }
             }
 
             return builder.ToString().TrimEnd();
+        }
+
+        internal static FuseDuplicateAssetGroup[] GroupDuplicateAssets(
+            IEnumerable<FuseDuplicateAssetKey> duplicates)
+        {
+            var grouped = new Dictionary<string, FuseDuplicateAssetGroup>(StringComparer.Ordinal);
+            foreach (var duplicate in duplicates ?? Enumerable.Empty<FuseDuplicateAssetKey>())
+            {
+                if (duplicate == null || string.IsNullOrWhiteSpace(duplicate.Key))
+                {
+                    continue;
+                }
+
+                var sources = (duplicate.Sources ?? Array.Empty<string>())
+                    .Where(source => !string.IsNullOrWhiteSpace(source))
+                    .ToArray();
+                var identity = (duplicate.DefinitionsDiffer ? "different" : "identical") +
+                               "\u001e" + string.Join("\u001f", sources);
+                if (!grouped.TryGetValue(identity, out var group))
+                {
+                    group = new FuseDuplicateAssetGroup
+                    {
+                        DefinitionsDiffer = duplicate.DefinitionsDiffer,
+                        Sources = sources
+                    };
+                    grouped.Add(identity, group);
+                }
+
+                group.Keys.Add(duplicate.Key);
+            }
+
+            return grouped.Values
+                .OrderByDescending(group => group.DefinitionsDiffer)
+                .ThenByDescending(group => group.Keys.Count)
+                .ThenBy(group => group.Keys.FirstOrDefault() ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
         }
 
         private static string AssetPackModeText()
@@ -165,11 +238,6 @@ namespace FUSE.Interface.MenuWindow
 
             var sources = duplicateAssetKey.Sources ?? [];
             var preview = sources
-                .Select(source =>
-                {
-                    var name = string.IsNullOrWhiteSpace(source) ? string.Empty : Path.GetFileName(source);
-                    return string.IsNullOrWhiteSpace(name) ? source : name;
-                })
                 .Where(source => !string.IsNullOrWhiteSpace(source))
                 .ToArray();
 
@@ -187,13 +255,17 @@ namespace FUSE.Interface.MenuWindow
             }
         }
 
-        private static void BuildDuplicateAssetPreview(UIPanelBuilder builder, FuseDuplicateAssetKey duplicate)
+        private static void BuildDuplicateAssetGroupPreview(UIPanelBuilder builder, FuseDuplicateAssetGroup group)
         {
-            if (duplicate == null) return;
+            if (group == null)
+            {
+                return;
+            }
 
-            GetDuplicateAssetInfo(duplicate, out string winner, out string[] overridden, out string suffix);
+            GetDuplicateAssetInfo(group.Sources, out string winner, out string[] overridden, out string suffix);
 
-            builder.AddField("Asset Key", duplicate.Key);
+            builder.AddField("Affected Keys", group.Keys.Count.ToString());
+            builder.AddField("Definition Match", group.DefinitionsDiffer ? "Different definitions (review)" : "Identical copies");
 
             if (string.IsNullOrWhiteSpace(winner))
             {
@@ -206,20 +278,53 @@ namespace FUSE.Interface.MenuWindow
             {
                 builder.AddField("Sources Overridden", string.Join(",", overridden) + suffix);
             }
+
+            AddWrappedField(
+                builder,
+                "Example Keys",
+                string.Join(", ", group.Keys.OrderBy(key => key, StringComparer.OrdinalIgnoreCase).Take(4)),
+                44f);
+            AddWrappedField(
+                builder,
+                "Impact",
+                group.DefinitionsDiffer
+                    ? "Definitions differ; FUSE uses the listed winner, so model or behavior can change with source order."
+                    : "Definitions are identical; this is redundant installed content, not a load failure.",
+                44f);
         }
 
-        private static string BuildDuplicateAssetPreviewString(FuseDuplicateAssetKey duplicate)
+        private static string BuildDuplicateAssetGroupPreviewString(FuseDuplicateAssetGroup group)
         {
-            if (duplicate == null)
+            if (group == null)
             {
                 return string.Empty;
             }
 
-            GetDuplicateAssetInfo(duplicate, out string winner, out string[] overridden, out string suffix);
+            GetDuplicateAssetInfo(group.Sources, out string winner, out string[] overridden, out string suffix);
+            var examples = string.Join(", ", group.Keys
+                .OrderBy(key => key, StringComparer.OrdinalIgnoreCase)
+                .Take(3)
+                .Select(InsertBreakHints));
+            var impact = group.DefinitionsDiffer
+                ? "different definitions; winner controls behavior"
+                : "identical copies; no behavior change";
 
             return overridden.Length == 0
-                ? $"{InsertBreakHints(duplicate.Key)} | winner {winner}{suffix}"
-                : $"{InsertBreakHints(duplicate.Key)} | winner {winner} | overridden {string.Join(", ", overridden)}{suffix}";
+                ? $"{group.Keys.Count} key(s) | winner {winner}{suffix} | {impact} | examples {examples}"
+                : $"{group.Keys.Count} key(s) | winner {winner} | overridden {string.Join(", ", overridden)}{suffix} | {impact} | examples {examples}";
+        }
+
+        private static void GetDuplicateAssetInfo(
+            string[] sources,
+            out string winner,
+            out string[] overridden,
+            out string suffix)
+        {
+            GetDuplicateAssetInfo(
+                new FuseDuplicateAssetKey { Sources = sources ?? Array.Empty<string>() },
+                out winner,
+                out overridden,
+                out suffix);
         }
 
         private static string ExportAssetDiagnostics(FuseAssetPackDiagnostics diagnostics, bool openFolder = true)
@@ -248,6 +353,7 @@ namespace FUSE.Interface.MenuWindow
                     duplicates.Add(new JObject
                     {
                         ["key"] = duplicate.Key ?? string.Empty,
+                        ["definitionsDiffer"] = duplicate.DefinitionsDiffer,
                         ["sourceCount"] = sources.Count,
                         ["winner"] = sources.Count > 0 ? sources[0] : string.Empty,
                         ["overridden"] = new JArray(sources.Skip(1)),
@@ -261,6 +367,26 @@ namespace FUSE.Interface.MenuWindow
                     failedDefinitions.Add(failure);
                 }
 
+                var definitionOverrides = new JArray();
+                foreach (var definitionOverride in diagnostics.LegacyDefinitionOverrides ??
+                         Array.Empty<FuseLegacyDefinitionOverrideRegistration>())
+                {
+                    definitionOverrides.Add(new JObject
+                    {
+                        ["storeIdentifier"] = definitionOverride.StoreIdentifier ?? string.Empty,
+                        ["definitionsPath"] = definitionOverride.DefinitionsPath ?? string.Empty,
+                        ["packageId"] = definitionOverride.PackageId ?? string.Empty,
+                        ["packagePath"] = definitionOverride.PackagePath ?? string.Empty,
+                        ["explicit"] = definitionOverride.Explicit
+                    });
+                }
+
+                var definitionOverrideIssues = new JArray();
+                foreach (var issue in diagnostics.LegacyDefinitionOverrideIssues ?? Array.Empty<string>())
+                {
+                    definitionOverrideIssues.Add(issue);
+                }
+
                 var report = new JObject
                 {
                     ["exportedUtc"] = DateTime.UtcNow.ToString("O"),
@@ -269,9 +395,13 @@ namespace FUSE.Interface.MenuWindow
                     ["uniqueAssetKeys"] = diagnostics.UniqueAssetKeys,
                     ["duplicateKeyCount"] = duplicates.Count,
                     ["failedDefinitionLoadCount"] = failedDefinitions.Count,
+                    ["definitionOverrideCount"] = definitionOverrides.Count,
+                    ["definitionOverrideIssueCount"] = definitionOverrideIssues.Count,
                     ["stores"] = stores,
                     ["duplicateKeys"] = duplicates,
-                    ["failedDefinitionLoads"] = failedDefinitions
+                    ["failedDefinitionLoads"] = failedDefinitions,
+                    ["definitionOverrides"] = definitionOverrides,
+                    ["definitionOverrideIssues"] = definitionOverrideIssues
                 };
 
                 File.WriteAllText(path, report.ToString(Newtonsoft.Json.Formatting.Indented));
@@ -291,5 +421,14 @@ namespace FUSE.Interface.MenuWindow
                 return message;
             }
         }
+    }
+
+    internal sealed class FuseDuplicateAssetGroup
+    {
+        internal bool DefinitionsDiffer { get; set; }
+
+        internal string[] Sources { get; set; } = Array.Empty<string>();
+
+        internal List<string> Keys { get; } = new List<string>();
     }
 }

--- a/FUSE/Interface/MenuWindow/AuditsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/AuditsToolPage.cs
@@ -145,13 +145,23 @@ namespace FUSE.Interface.MenuWindow
 
             foreach (var fault in report["packages"]?["faults"] as JArray ?? [])
             {
+                var faultDetail = ReadString(fault["message"], "Package failed during load/apply.") +
+                    " stage='" + ReadString(fault["stage"], "unknown") + "'" +
+                    " package='" + ReadString(fault["packageName"], ReadString(fault["packageId"], "unknown")) + "'" +
+                    " folder='" + ReadString(fault["folderPath"], "unknown") + "'" +
+                    " file='" + ReadString(fault["relativeSourceFile"], ReadString(fault["sourceFile"], "unknown")) + "'" +
+                    " jsonPath='" + ReadString(fault["jsonPath"], "<root>") + "'" +
+                    " expected='" + ReadString(fault["expectedShape"], "see validation message") + "'" +
+                    " received='" + ReadString(fault["receivedValue"], "not captured") + "'";
                 AddFinding(
                     findings,
-                    "Critical",
-                    "Package fault",
+                    "High",
+                    "Package isolated after apply fault",
                     ReadString(fault["packageId"], "(unknown package)"),
-                    ReadString(fault["message"], "Package failed during load/apply."),
-                    "Open Issues, inspect the package fault stage, then fix the source package or compatibility layer.");
+                    faultDetail,
+                    ReadString(
+                        fault["suggestedAction"],
+                        "Inspect the package fault stage, then fix the source package or compatibility layer."));
             }
 
             foreach (var asset in report["unknownSceneryAssets"] as JArray ?? [])
@@ -167,13 +177,17 @@ namespace FUSE.Interface.MenuWindow
 
             foreach (var issue in report["graphPostBindIssues"] as JArray ?? [])
             {
+                var detail = issue.ToString();
+                var isOwnedRemoval = detail.IndexOf(" was removed by '", StringComparison.OrdinalIgnoreCase) >= 0;
                 AddFinding(
                     findings,
-                    "High",
-                    "Graph post-bind issue",
+                    isOwnedRemoval ? "Medium" : "High",
+                    isOwnedRemoval ? "Track package collision" : "Graph post-bind issue",
                     "track graph",
-                    issue.ToString(),
-                    "Inspect the owning track package and verify deleted/replaced node, segment, and span ids.");
+                    detail,
+                    isOwnedRemoval
+                        ? "These packages edit the same route. Disable one package, choose a compatible option/patch, or have the authors coordinate the shared node/segment ownership."
+                        : "Inspect the owning track package and verify deleted/replaced node, segment, and span ids.");
             }
 
             foreach (var skip in report["progressionTransferSkips"] as JArray ?? [])
@@ -189,6 +203,14 @@ namespace FUSE.Interface.MenuWindow
 
             foreach (var conflict in report["conflicts"] as JArray ?? [])
             {
+                if (!ShouldAuditConflictRecord(ReadString(conflict["classification"], string.Empty)))
+                {
+                    // Successful shared industry merges are surfaced as
+                    // informational extension targets on the dedicated Mods
+                    // Fighting page. They are not audit failures.
+                    continue;
+                }
+
                 AddFinding(
                     findings,
                     "Medium",
@@ -226,13 +248,24 @@ namespace FUSE.Interface.MenuWindow
         {
             try
             {
-                foreach (var span in TrackAPI.GetAllSpans() ?? [])
+                foreach (var span in TrackAPI.GetRegisteredSpansForDiagnostics() ?? [])
                 {
                     var id = span?.id ?? "(blank span)";
+                    var owner = FuseRegistry.GetExclusiveOwner(FuseClaimKind.Span, id);
+                    if (!ShouldAuditTrackSpanOwner(owner))
+                    {
+                        // Railroader ships a number of registered placeholder or
+                        // progression spans whose serialized endpoints are empty
+                        // until the game activates them. They are base-game state,
+                        // not FUSE authoring failures. The graph post-bind audit
+                        // separately reports mod-owned spans lost during merging.
+                        continue;
+                    }
+
                     var definition = TrackAPI.GetDefinition(span);
                     if (definition?.Upper == null || definition.Lower == null)
                     {
-                        AddFinding(findings, "High", "Invalid track span", id, "Span definition has missing upper/lower location.", "Inspect the source span and repair or remove invalid endpoints.");
+                        AddFinding(findings, "High", "Invalid FUSE track span", id, $"Owner '{owner}' has a span with missing upper/lower location.", "Inspect the owning package source and repair or remove invalid endpoints.");
                         continue;
                     }
 
@@ -256,6 +289,19 @@ namespace FUSE.Interface.MenuWindow
             }
         }
 
+        internal static bool ShouldAuditConflictRecord(string classification)
+        {
+            return !string.Equals(
+                classification?.Trim(),
+                "shared-extension",
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static bool ShouldAuditTrackSpanOwner(string ownerPackageId)
+        {
+            return !string.IsNullOrWhiteSpace(ownerPackageId);
+        }
+
         private static void AddIndustryAuditFindings(List<AuditFinding> findings)
         {
             try
@@ -273,11 +319,13 @@ namespace FUSE.Interface.MenuWindow
                         AddFinding(findings, "Medium", "Industry missing identifier", id, GetGameObjectPath(industry.gameObject), "Assign a stable industry identifier or remove the orphan scene object.");
                     }
 
-                    var definition = IndustryAPI.GetDefinition(industry);
-                    if (definition == null || definition.Components == null || definition.Components.Count == 0)
-                    {
-                        AddFinding(findings, "Low", "Industry has no components", id, GetGameObjectPath(industry.gameObject), "Verify whether this is scenery-only, a disabled vanilla industry, or a broken industry component binding.");
-                    }
+                    // An Industry is also the game's location container. Base
+                    // depots, passenger/scenery-only locations, fictional
+                    // destinations, and intentionally disabled industries may
+                    // legitimately contain no IndustryComponent children.
+                    // Missing referenced components are already reported by
+                    // package apply/post-bind diagnostics, so emptiness alone
+                    // is not an actionable finding.
                 }
             }
             catch (Exception ex)

--- a/FUSE/Interface/MenuWindow/DependencyGraphPage.cs
+++ b/FUSE/Interface/MenuWindow/DependencyGraphPage.cs
@@ -18,7 +18,7 @@ namespace FUSE.Interface.MenuWindow
             AddWrappedLabel(
                 builder,
                 "Legacy (converted) packages list soft load-order hints: a hint whose target is not installed is optional and does not block loading. " +
-                "Asset-only packs and code-only plugins satisfy a dependency without being FUSE data packages.",
+                "Asset-only packs and code-only plugins satisfy a dependency without being FUSE data packages. Retired package IDs whose runtime capability is replaced by FUSE are labeled PROVIDED BY FUSE.",
                 48f);
 
             builder.Spacer(24f);
@@ -38,13 +38,13 @@ namespace FUSE.Interface.MenuWindow
             // hosted code-only plugins render as PRESENT rather than MISSING
             // (issues #207, #223).
             var undiscovered = manifests
-                .SelectMany(manifest => manifest.LoadAfter.Concat(manifest.LoadBefore))
+                .SelectMany(manifest => manifest.RequiredPackageIds.Concat(manifest.LoadAfter).Concat(manifest.LoadBefore))
                 .Where(id => !string.IsNullOrWhiteSpace(id) && !byId.ContainsKey(id));
             var presentInModsRoot = FuseDataPackageDiscovery.ResolvePackagesPresentInModsRoot(undiscovered);
             var rows = 0;
             foreach (var manifest in manifests)
             {
-                var hasEdges = manifest.LoadAfter.Length > 0 || manifest.LoadBefore.Length > 0 || manifest.Faults.Length > 0;
+                var hasEdges = manifest.RequiredPackageIds.Length > 0 || manifest.LoadAfter.Length > 0 || manifest.LoadBefore.Length > 0 || manifest.Faults.Length > 0;
                 if (!hasEdges && !FuseSettings.ShowAdvancedHealthDetails)
                 {
                     continue;
@@ -57,6 +57,12 @@ namespace FUSE.Interface.MenuWindow
 
                 builder.FieldLabelWidth = 120f;
                 AddWrappedLabel(builder, InsertBreakHints(manifest.Id), 28f);
+                foreach (var dependencyId in manifest.RequiredPackageIds)
+                {
+                    builder.AddField("requires", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId, presentInModsRoot, advisory: false))));
+                    rows++;
+                }
+
                 foreach (var dependencyId in manifest.LoadAfter)
                 {
                     builder.AddField("load after", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId, presentInModsRoot, manifest.IsLegacyConverted))));
@@ -97,7 +103,15 @@ namespace FUSE.Interface.MenuWindow
                 return "(blank) | <color=\"red\">MISSING";
             }
 
-            if (packages != null && packages.TryGetValue(dependencyId, out var dependency))
+            FusePackageManifestSnapshot dependency = null;
+            if (packages != null)
+            {
+                packages.TryGetValue(dependencyId, out dependency);
+                dependency = dependency ?? packages.Values.FirstOrDefault(candidate =>
+                    FuseDeclaredPackageRelationship.SamePackageId(candidate?.Id, dependencyId));
+            }
+
+            if (dependency != null)
             {
                 if (!dependency.Disabled)
                 {
@@ -107,6 +121,11 @@ namespace FUSE.Interface.MenuWindow
                 return advisory
                     ? dependencyId + " | <color=\"grey\">DISABLED (optional hint)"
                     : dependencyId + " | <color=\"yellow\">DISABLED";
+            }
+
+            if (FuseReplacementCapabilityCatalog.IsProvided(dependencyId))
+            {
+                return dependencyId + " | <color=\"green\">PROVIDED BY FUSE";
             }
 
             if (presentInModsRoot != null && presentInModsRoot.Contains(dependencyId))

--- a/FUSE/Interface/MenuWindow/FuseMenuWindow.cs
+++ b/FUSE/Interface/MenuWindow/FuseMenuWindow.cs
@@ -132,6 +132,14 @@ namespace FUSE.Interface.MenuWindow
             {
                 ModsPanelBuilder.CloseAllLegacyModTabs("legacy settings tab no longer visible");
             }
+
+            if (_window != null && _window.IsShown &&
+                _selectedTabState.Value == TabIdTools &&
+                _selectedToolItem.Value == "liveDiagnostics" &&
+                LiveDiagnosticsToolPage.ShouldAutoRefresh(Time.unscaledTime))
+            {
+                RebuildWindow();
+            }
         }
 
         private void BuildFuseMenu(UIPanelBuilder builder)
@@ -442,9 +450,47 @@ namespace FUSE.Interface.MenuWindow
             }
 
             var scrollRects = _window.contentRectTransform.GetComponentsInChildren<ScrollRect>(true);
-            return scrollRects == null || scrollRects.Length == 0
-                ? null
-                : scrollRects[scrollRects.Length - 1];
+            if (scrollRects == null || scrollRects.Length == 0)
+            {
+                return null;
+            }
+
+            // List/detail pages contain two ScrollRects: the navigation list on
+            // the left and the actual page on the right. Component traversal
+            // order is not a UI contract, so choosing the last component made
+            // auto-refresh preserve the left list while the visible page jumped
+            // back to the top. Select the right-most viewport instead; single-
+            // scroll pages naturally select their only viewport.
+            ScrollRect selected = null;
+            var selectedCenterX = float.NegativeInfinity;
+            var selectedArea = float.NegativeInfinity;
+            var corners = new Vector3[4];
+            foreach (var candidate in scrollRects)
+            {
+                if (candidate == null)
+                {
+                    continue;
+                }
+
+                var viewport = candidate.viewport ?? candidate.transform as RectTransform;
+                if (viewport == null)
+                {
+                    continue;
+                }
+
+                viewport.GetWorldCorners(corners);
+                var centerX = (corners[0].x + corners[2].x) * 0.5f;
+                var area = Mathf.Abs((corners[2].x - corners[0].x) * (corners[2].y - corners[0].y));
+                if (centerX > selectedCenterX + 0.01f ||
+                    (Mathf.Abs(centerX - selectedCenterX) <= 0.01f && area > selectedArea))
+                {
+                    selected = candidate;
+                    selectedCenterX = centerX;
+                    selectedArea = area;
+                }
+            }
+
+            return selected ?? scrollRects[0];
         }
 
         public void SetSelectedProfile(string id)

--- a/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
@@ -14,6 +14,7 @@ namespace FUSE.Interface.MenuWindow
         private enum PageId
         {
             General,
+            LegacyGameplay,
         }
 
         private sealed class Page(PageId id)
@@ -30,6 +31,7 @@ namespace FUSE.Interface.MenuWindow
 
             List<UIPanelBuilder.ListItem<Page>> list = [];
             list.Add(new UIPanelBuilder.ListItem<Page>("general", new Page(PageId.General), "Settings", "General"));
+            list.Add(new UIPanelBuilder.ListItem<Page>("legacy-gameplay", new Page(PageId.LegacyGameplay), "Settings", "Legacy Gameplay"));
 
             builder.AddListDetail(list, selectedItem, delegate (UIPanelBuilder builder, Page page)
             {
@@ -48,6 +50,9 @@ namespace FUSE.Interface.MenuWindow
                             case PageId.General:
                                 BuildGeneralSettingsPage(builder);
                                 break;
+                            case PageId.LegacyGameplay:
+                                BuildLegacyGameplaySettingsPage(builder);
+                                break;
                             default:
                                 builder.AddLabel("Unknown page.");
                                 break;
@@ -55,6 +60,234 @@ namespace FUSE.Interface.MenuWindow
                     }, new RectOffset(0, 4, 0, 0));
                 }
             });
+        }
+
+        private static void BuildLegacyGameplaySettingsPage(UIPanelBuilder builder)
+        {
+            builder.AddTitle("Legacy Gameplay Replacements", "");
+            builder.FieldLabelWidth = 200f;
+            builder.Spacing = 6f;
+
+            builder.AddLabel(
+                "FUSE owns these compatibility behaviors so legacy dependencies can be removed. " +
+                "Defaults preserve the base game unless a value below is changed.");
+
+            builder.AddSection("Fall From Grace");
+            builder.AddLabel(
+                "Grace days = max(Minimum, base-game days × Multiplier + Added). " +
+                "The 0 / 1 / 0 defaults are identical to the base game. FUSE also shows the due time in the car inspector.");
+
+            AddIntegerField(builder, "Minimum Days", FuseSettings.GraceMinimumDays, FuseSettings.SetGraceMinimumDays);
+            AddIntegerField(builder, "Multiplier", FuseSettings.GraceMultiplier, FuseSettings.SetGraceMultiplier);
+            AddIntegerField(builder, "Added Days", FuseSettings.GraceAddedDays, FuseSettings.SetGraceAddedDays);
+
+            builder.AddSection("Configurable Interchange Service");
+            builder.AddLabel(
+                "Replaces C1CD. Controls the extra-service interval and optional daily service window for all interchanges.");
+
+            var intervals = new[] { 5, 15, 30, 45, 60, 90, 120, 150, 180, 240, 300, 360, 480, 720, 1080 };
+            var selectedInterval = Array.IndexOf(intervals, FuseSettings.InterchangeServiceIntervalMinutes);
+            if (selectedInterval < 0)
+            {
+                selectedInterval = Array.FindIndex(
+                    intervals,
+                    value => value >= FuseSettings.InterchangeServiceIntervalMinutes);
+                if (selectedInterval < 0)
+                {
+                    selectedInterval = intervals.Length - 1;
+                }
+            }
+
+            builder.AddField(
+                "Serve Interval",
+                builder.AddDropdown(
+                    new List<string>(Array.ConvertAll(intervals, FormatServiceInterval)),
+                    selectedInterval,
+                    index =>
+                    {
+                        if (index >= 0 && index < intervals.Length)
+                        {
+                            FuseSettings.SetInterchangeServiceIntervalMinutes(intervals[index]);
+                        }
+                    }));
+
+            builder.AddField("Continuous Service", control: BuildToggleBoxWithButton(
+                builder,
+                FuseSettings.InterchangeContinuousService,
+                () =>
+                {
+                    FuseSettings.SetInterchangeContinuousService(!FuseSettings.InterchangeContinuousService);
+                    builder.Rebuild();
+                }));
+
+            builder.AddLabel(
+                "When enabled, FUSE schedules the next extra service after every interchange pass, even when no orders remain.");
+
+            builder.AddField("Not Before", control: builder.AddSliderQuantized(
+                () => FuseSettings.InterchangeNotBeforeHour,
+                () => FormatServiceHour(FuseSettings.InterchangeNotBeforeHour),
+                FuseSettings.PreviewInterchangeNotBeforeHour,
+                0.25f,
+                0f,
+                24f,
+                FuseSettings.SetInterchangeNotBeforeHour));
+
+            builder.AddField("Not After", control: builder.AddSliderQuantized(
+                () => FuseSettings.InterchangeNotAfterHour,
+                () => FormatServiceHour(FuseSettings.InterchangeNotAfterHour),
+                FuseSettings.PreviewInterchangeNotAfterHour,
+                0.25f,
+                0f,
+                24f,
+                FuseSettings.SetInterchangeNotAfterHour));
+
+            builder.AddLabel(
+                "Use 00:00–24:00 for all-day service. A start later than the end (for example 22:00–06:00) creates an overnight window.");
+
+            builder.AddSection("Outbound Industry Routing");
+            builder.AddLabel(
+                "Native replacement for AbsoluteMadness and SomeKindOfMadness. It activates automatically when an enabled package requests either legacy id. " +
+                "The switch below is an explicit opt-in for profiles that do not declare the old dependency.");
+
+            builder.AddField("Enable Routing", control: BuildToggleBoxWithButton(
+                builder,
+                FuseSettings.EnableOutboundIndustryRerouting,
+                () =>
+                {
+                    FuseSettings.SetEnableOutboundIndustryRerouting(!FuseSettings.EnableOutboundIndustryRerouting);
+                    builder.Rebuild();
+                }));
+
+            builder.AddField("Route Chance", control: builder.AddSliderQuantized(
+                () => FuseSettings.OutboundIndustryRerouteChance,
+                () => (FuseSettings.OutboundIndustryRerouteChance * 100f).ToString("0", System.Globalization.CultureInfo.InvariantCulture) + "%",
+                FuseSettings.PreviewOutboundIndustryRerouteChance,
+                0.05f,
+                0f,
+                1f,
+                FuseSettings.SetOutboundIndustryRerouteChance));
+
+            builder.AddField("Capacity Target", control: builder.AddSliderQuantized(
+                () => FuseSettings.OutboundIndustryFillFactor,
+                () => FuseSettings.OutboundIndustryFillFactor.ToString("0.0x", System.Globalization.CultureInfo.InvariantCulture),
+                FuseSettings.PreviewOutboundIndustryFillFactor,
+                0.1f,
+                0.1f,
+                3f,
+                FuseSettings.SetOutboundIndustryFillFactor));
+
+            builder.AddField("Payment", control: builder.AddSliderQuantized(
+                () => FuseSettings.OutboundIndustryPaymentMultiplier,
+                () => FuseSettings.OutboundIndustryPaymentMultiplier.ToString("0.0x", System.Globalization.CultureInfo.InvariantCulture),
+                FuseSettings.PreviewOutboundIndustryPaymentMultiplier,
+                0.1f,
+                0f,
+                10f,
+                FuseSettings.SetOutboundIndustryPaymentMultiplier));
+
+            AddBooleanField(
+                builder,
+                "Allow Short Trips",
+                FuseSettings.OutboundIndustryAllowShortTrips,
+                FuseSettings.SetOutboundIndustryAllowShortTrips);
+            AddBooleanField(
+                builder,
+                "Ignore Origin",
+                FuseSettings.OutboundIndustryIgnoreOrigin,
+                FuseSettings.SetOutboundIndustryIgnoreOrigin);
+            AddBooleanField(
+                builder,
+                "Shuffle Orders",
+                FuseSettings.OutboundIndustryPreventBlocking,
+                FuseSettings.SetOutboundIndustryPreventBlocking);
+
+            builder.AddLabel(
+                "If both old packages are requested, the configurable SomeKindOfMadness behavior wins. " +
+                "A routing extension can inspect or adjust candidates through FUSE's native outbound-routing event.");
+
+            builder.AddSection("Interchange-to-Interchange Traffic");
+            builder.AddLabel(
+                "Replaces Interchange2Interchange when an enabled package requests it. " +
+                "Each contracted source interchange can create a daily cut for every other enabled interchange.");
+            AddIntegerField(
+                builder,
+                "Maximum Cars / Cut",
+                FuseSettings.InterchangeToInterchangeMaximumCars,
+                FuseSettings.SetInterchangeToInterchangeMaximumCars);
+
+            builder.AddSection("For Your Convenience");
+            builder.AddLabel(
+                "These visual additions activate only when an enabled package requests ForYourConvenience. " +
+                "The live Industry Dashboard is always available under Tools, and station-map actions are attached without replacing existing icon actions.");
+            AddBooleanField(
+                builder,
+                "Caboose Map Icons",
+                FuseSettings.ForYourConvenienceShowCabooseIcons,
+                FuseSettings.SetForYourConvenienceShowCabooseIcons);
+            AddBooleanField(
+                builder,
+                "Car Tag Speed",
+                FuseSettings.ForYourConvenienceShowCarTagMph,
+                FuseSettings.SetForYourConvenienceShowCarTagMph);
+            AddBooleanField(
+                builder,
+                "Car Tag Loads",
+                FuseSettings.ForYourConvenienceShowCarTagLoads,
+                FuseSettings.SetForYourConvenienceShowCarTagLoads);
+
+            builder.Spacer(32f);
+        }
+
+        private static void AddBooleanField(
+            UIPanelBuilder builder,
+            string label,
+            bool enabled,
+            Action<bool> setter)
+        {
+            builder.AddField(label, control: BuildToggleBoxWithButton(
+                builder,
+                enabled,
+                () =>
+                {
+                    setter(!enabled);
+                    builder.Rebuild();
+                }));
+        }
+
+        private static void AddIntegerField(UIPanelBuilder builder, string label, int value, Action<int> setter)
+        {
+            builder.AddField(
+                label,
+                builder.AddInputField(
+                    value.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    text =>
+                    {
+                        int parsed;
+                        if (int.TryParse(
+                            text,
+                            System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            out parsed))
+                        {
+                            setter(parsed);
+                            builder.Rebuild();
+                        }
+                    }));
+        }
+
+        private static string FormatServiceInterval(int minutes)
+        {
+            return minutes < 60
+                ? minutes + " min"
+                : (minutes / 60f).ToString("0.#", System.Globalization.CultureInfo.InvariantCulture) + " h";
+        }
+
+        private static string FormatServiceHour(float hour)
+        {
+            var totalMinutes = (int)Math.Round(hour * 60f);
+            var displayHour = totalMinutes / 60;
+            var displayMinute = totalMinutes % 60;
+            return $"{displayHour:00}:{displayMinute:00}";
         }
 
         private static void BuildGeneralSettingsPage(UIPanelBuilder builder)

--- a/FUSE/Interface/MenuWindow/IndustryDashboardToolPage.cs
+++ b/FUSE/Interface/MenuWindow/IndustryDashboardToolPage.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using FUSE.Infrastructure;
+using Model.Ops;
+using UI.Builder;
+using static FUSE.Interface.InterfaceUtils;
+
+namespace FUSE.Interface.MenuWindow
+{
+    internal static class IndustryDashboardToolPage
+    {
+        public static void Build(UIPanelBuilder builder)
+        {
+            builder.AddTitle("Industry Dashboard", "");
+            AddWrappedLabel(
+                builder,
+                "A live, read-only view of the industries and component storage known to the game's operations controller. " +
+                "It remains useful for native FUSE packages and replaces the old ForYourConvenience dashboard when that dependency is requested.",
+                58f);
+
+            builder.HStack(row => row.AddButtonCompact("Refresh", builder.Rebuild), 6f).Height(32f);
+            builder.Spacer(8f);
+
+            var industries = OpsController.Shared?.AllIndustries?
+                .Where(industry => industry != null)
+                .OrderBy(industry => industry.ProgressionDisabled)
+                .ThenBy(industry => industry.name, StringComparer.OrdinalIgnoreCase)
+                .ToArray() ?? Array.Empty<Industry>();
+            builder.AddField("Industries", industries.Length.ToString());
+            if (industries.Length == 0)
+            {
+                builder.AddLabelEmptyState("No operations industries are available in the current scene.");
+                return;
+            }
+
+            foreach (var industry in industries)
+            {
+                BuildIndustry(builder, industry);
+            }
+        }
+
+        private static void BuildIndustry(UIPanelBuilder builder, Industry industry)
+        {
+            builder.AddSection(string.IsNullOrWhiteSpace(industry.name) ? industry.identifier : industry.name);
+            builder.AddField("Id", industry.identifier ?? "(none)");
+            builder.AddField("State", industry.ProgressionDisabled ? "Progression disabled" : "Enabled");
+            builder.AddField("Contract", industry.usesContract ? "Uses company contract" : "Not contracted");
+            builder.AddField("Components", (industry.Components?.Count() ?? 0).ToString());
+
+            try
+            {
+                foreach (var pair in industry.EnumerateComponentContexts(0f))
+                {
+                    var component = pair.Item1;
+                    var context = pair.Item2;
+                    if (component == null)
+                    {
+                        continue;
+                    }
+
+                    var title = string.IsNullOrWhiteSpace(component.DisplayName)
+                        ? component.subIdentifier
+                        : component.DisplayName;
+                    var type = component.GetType().Name;
+                    AddWrappedField(builder, title ?? "Component", type + " — " + ComponentState(component), 36f);
+                    foreach (var field in component.PanelFields(context))
+                    {
+                        AddWrappedField(builder, field.Label, field.Text, 34f);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                AddWrappedField(
+                    builder,
+                    "Component details",
+                    "Unavailable: " + ex.GetBaseException().Message,
+                    42f);
+                FuseLog.Warning(
+                    "FUSE Industry Dashboard could not inspect '" + industry.identifier + "': " +
+                    ex.GetBaseException().Message);
+            }
+
+            builder.Spacer(8f);
+        }
+
+        private static string ComponentState(IndustryComponent component)
+        {
+            var state = component.ProgressionDisabled ? "progression disabled" : "active";
+            var spanCount = component.trackSpans?.Length ?? 0;
+            return state + ", " + spanCount + " track span(s), cars " +
+                   (component.carTypeFilter?.queryString ?? "(none)");
+        }
+    }
+}

--- a/FUSE/Interface/MenuWindow/InspectorToolPage.cs
+++ b/FUSE/Interface/MenuWindow/InspectorToolPage.cs
@@ -169,6 +169,7 @@ namespace FUSE.Interface.MenuWindow
             AddInspectorIndexTargets(results, signatures, "Station", FuseStationRuntimeIndex.Instance, FuseClaimKind.Station, term, limit);
             AddInspectorIndexTargets(results, signatures, "Scenery", FuseSceneryRuntimeIndex.Instance, FuseClaimKind.Scenery, term, limit);
             AddInspectorIndexTargets(results, signatures, "Spliney", FuseSplineyRuntimeIndex.Instance, null, term, limit);
+            AddInspectorIndexTargets(results, signatures, "Water Surface", FuseWaterSurfaceRuntimeIndex.Instance, null, term, limit);
             AddInspectorIndexTargets(results, signatures, "Map Label", FuseMapLabelRuntimeIndex.Instance, null, term, limit);
             AddInspectorIndexTargets(results, signatures, "Progression", FuseProgressionRuntimeIndex.Instance, null, term, limit);
             AddInspectorIndexTargets(results, signatures, "Map Feature", FuseMapFeatureRuntimeIndex.Instance, null, term, limit);

--- a/FUSE/Interface/MenuWindow/LiveDiagnosticsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/LiveDiagnosticsToolPage.cs
@@ -1,0 +1,209 @@
+using FUSE.Infrastructure;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UI.Builder;
+using UI.Common;
+using UnityEngine;
+using static FUSE.Interface.InterfaceUtils;
+
+namespace FUSE.Interface.MenuWindow
+{
+    internal static class LiveDiagnosticsToolPage
+    {
+        private static readonly string[] LevelFilters =
+        {
+            "All",
+            "Warnings + Errors",
+            "Errors"
+        };
+
+        private static string _levelFilter = "All";
+        private static string _search = string.Empty;
+        private static bool _autoRefresh;
+        private static float _nextAutoRefreshAt;
+
+        internal static bool ShouldAutoRefresh(float now)
+        {
+            if (!_autoRefresh || now < _nextAutoRefreshAt)
+            {
+                return false;
+            }
+
+            _nextAutoRefreshAt = now + 1f;
+            return true;
+        }
+
+        public static void Build(UIPanelBuilder builder)
+        {
+            builder.AddTitle("Live Diagnostics", "");
+            builder.AddLabel(
+                "Runtime guards and third-party exceptions are diagnostics, not load-health failures. " +
+                "They live here so the Status page stays focused on actionable package, asset, graph, progression, and conflict problems.");
+            builder.Spacer(8f);
+
+            BuildLogViewer(builder);
+            builder.Spacer(12f);
+            BuildContainedEvents(builder);
+        }
+
+        private static void BuildLogViewer(UIPanelBuilder builder)
+        {
+            builder.AddSection("FUSE Log");
+            builder.AddField("File", string.IsNullOrWhiteSpace(FuseLog.LogFilePath) ? "unavailable" : FuseLog.LogFilePath);
+            builder.AddField("Buffered", FuseLiveLogBuffer.Count + " / " + FuseLiveLogBuffer.Capacity + " recent entries");
+
+            var selectedLevel = Math.Max(0, Array.IndexOf(LevelFilters, _levelFilter));
+            builder.AddField(
+                "Level",
+                builder.AddDropdown(LevelFilters.ToList(), selectedLevel, index =>
+                {
+                    if (index >= 0 && index < LevelFilters.Length)
+                    {
+                        _levelFilter = LevelFilters[index];
+                        builder.Rebuild();
+                    }
+                })).Height(32f);
+
+            builder.AddField(
+                "Contains",
+                builder.AddInputField(_search ?? string.Empty, value => _search = value ?? string.Empty));
+
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Refresh", builder.Rebuild);
+                row.AddButtonCompact(_autoRefresh ? "Pause Auto Refresh" : "Start Auto Refresh", () =>
+                {
+                    _autoRefresh = !_autoRefresh;
+                    _nextAutoRefreshAt = 0f;
+                    builder.Rebuild();
+                });
+                row.AddButtonCompact("Clear Filter", () =>
+                {
+                    _levelFilter = "All";
+                    _search = string.Empty;
+                    builder.Rebuild();
+                });
+            }, 6f).Height(32f);
+
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Copy Visible Log", () =>
+                {
+                    GUIUtility.systemCopyBuffer = FormatEntries(VisibleEntries());
+                    Toast.Present("Copied the visible FUSE log entries.");
+                });
+                row.AddButtonCompact("Open Log Folder", () =>
+                {
+                    var directory = string.IsNullOrWhiteSpace(FuseLog.LogFilePath)
+                        ? Application.persistentDataPath
+                        : Path.GetDirectoryName(FuseLog.LogFilePath);
+                    Application.OpenURL(directory);
+                    Toast.Present("Opened the FUSE log folder.");
+                });
+                row.AddButtonCompact(
+                    FuseLiveConsole.IsEnabled ? "Stop Live Console" : "Open Live Console",
+                    () =>
+                    {
+                        var result = FuseLiveConsole.IsEnabled
+                            ? FuseLiveConsole.Disable()
+                            : FuseLiveConsole.Enable();
+                        Toast.Present(result);
+                        builder.Rebuild();
+                    });
+            }, 6f).Height(32f);
+
+            builder.AddField(
+                "Viewer",
+                _autoRefresh
+                    ? "Auto refresh is on (once per second)."
+                    : "This in-game snapshot refreshes on demand. Open Live Console for a continuously scrolling second-screen view.");
+
+            var entries = VisibleEntries();
+            builder.AddField("Visible", entries.Length.ToString());
+            var lines = FormatEntries(entries);
+            AddWrappedLabel(builder, string.IsNullOrWhiteSpace(lines) ? "No matching FUSE log entries." : lines,
+                Math.Min(1400f, Math.Max(100f, entries.Length * 19f)));
+        }
+
+        private static void BuildContainedEvents(UIPanelBuilder builder)
+        {
+            builder.AddSection("Contained Runtime Events");
+            AddWrappedField(builder, "Compatibility Guards", FuseRuntimeGuardCounters.FormatSummary(), 76f);
+            builder.AddField(
+                "Native Leak Stacks",
+                $"{FuseNativeLeakDiagnostic.ModeLabel} (setting: {(FuseSettings.EnableNativeLeakStackTraces ? "enabled" : "disabled")})");
+
+            var exceptionState = FuseModExceptionRegistry.CaptureReportState();
+            builder.AddField("Observed Exceptions", exceptionState.Total.ToString());
+            AddWrappedLabel(
+                builder,
+                exceptionState.Total == 0
+                    ? "No third-party exceptions have been observed this session."
+                    : "These observations do not change FUSE readiness. Use them to identify repeating mod behavior; attach the health report when reporting a real symptom.",
+                48f);
+
+            foreach (var record in exceptionState.Mods.OrderByDescending(item => item.Count))
+            {
+                var display = string.IsNullOrWhiteSpace(record.DisplayName) ? record.ModId : record.DisplayName;
+                var top = record.Signatures == null
+                    ? null
+                    : record.Signatures.OrderByDescending(item => item.Count).FirstOrDefault();
+                var text = record.Count + " occurrence(s) over " + record.Episodes + " episode(s)";
+                if (top != null)
+                {
+                    text += " — " + top.ExceptionType + " @ " + top.TopOwnedFrame;
+                }
+
+                AddWrappedField(builder, display, text, 52f);
+            }
+
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Copy Diagnostics", () =>
+                {
+                    GUIUtility.systemCopyBuffer = BuildDiagnosticsText();
+                    Toast.Present("Copied FUSE runtime diagnostics.");
+                });
+                row.AddButtonCompact("Copy Full Health Report", () =>
+                {
+                    GUIUtility.systemCopyBuffer = FUSE.Loading.FuseLoadReport.GetLastDetailReport();
+                    Toast.Present("Copied the full FUSE health report.");
+                });
+            }, 6f).Height(32f);
+        }
+
+        private static FuseLiveLogEntry[] VisibleEntries() =>
+            FuseLiveLogBuffer.Snapshot(_levelFilter, _search, 120);
+
+        private static string FormatEntries(FuseLiveLogEntry[] entries) =>
+            string.Join(Environment.NewLine, (entries ?? Array.Empty<FuseLiveLogEntry>())
+                .Select(entry => entry.FormatLine())
+                .ToArray());
+
+        private static string BuildDiagnosticsText()
+        {
+            var state = FuseModExceptionRegistry.CaptureReportState();
+            var text = new StringBuilder();
+            text.AppendLine("FUSE Runtime Diagnostics");
+            text.AppendLine("Generated: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+            text.AppendLine("Guards: " + FuseRuntimeGuardCounters.FormatSummary());
+            text.AppendLine(state.SummaryLine);
+            foreach (var record in state.Mods.OrderByDescending(item => item.Count))
+            {
+                var display = string.IsNullOrWhiteSpace(record.DisplayName) ? record.ModId : record.DisplayName;
+                text.AppendLine($"{display} ({record.ModId}): {record.Count} occurrence(s), {record.Episodes} episode(s)");
+                foreach (var signature in (record.Signatures ?? Array.Empty<FuseModExceptionSignatureSnapshot>())
+                             .OrderByDescending(item => item.Count))
+                {
+                    text.AppendLine(
+                        $"  {signature.ExceptionType} @ {signature.TopOwnedFrame}: " +
+                        $"{signature.Count} occurrence(s), {signature.Episodes} episode(s) — {signature.SampleMessage}");
+                }
+            }
+
+            return text.ToString().TrimEnd();
+        }
+    }
+}

--- a/FUSE/Interface/MenuWindow/ModConflictsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/ModConflictsToolPage.cs
@@ -1,0 +1,414 @@
+using FUSE.Runtime.Registry;
+using FUSE.Loading;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UI.Builder;
+using UI.Common;
+using UnityEngine;
+using static FUSE.Interface.InterfaceUtils;
+
+namespace FUSE.Interface.MenuWindow
+{
+    /// <summary>
+    /// Human-readable package-pair view over the registry's object-level
+    /// conflict history. The raw history remains available through
+    /// /fuse.conflicts and the health report.
+    /// </summary>
+    internal static class ModConflictsToolPage
+    {
+        internal sealed class ConflictGroup
+        {
+            public string FirstPackageId { get; set; }
+            public string SecondPackageId { get; set; }
+            public FuseRegistryConflict[] Conflicts { get; set; }
+        }
+
+        internal sealed class DeclaredConflictMatch
+        {
+            public FusePackageManifestSnapshot DeclaringPackage { get; set; }
+            public FusePackageManifestSnapshot ConflictingPackage { get; set; }
+            public FUSE.Authoring.Data.FuseModRequirement Reference { get; set; }
+        }
+
+        public static void Build(UIPanelBuilder builder)
+        {
+            builder.AddTitle("Mod Conflicts", "");
+            AddWrappedLabel(
+                builder,
+                "Packages are grouped in pairs so you can see which mods are changing the same runtime objects. " +
+                "Declared requires/loadAfter/loadBefore and conditional mixinto layering is expected and is not listed here. " +
+                "FUSE keeps unrelated mods unless the resolution below says that one definition won. Spatial track overlap is advisory because nearby track can be intentional.",
+                62f);
+
+            var registryRecords = FuseRegistry.Conflicts.ToArray();
+            var cooperativeRecords = registryRecords.Where(conflict => conflict.IsCooperativeMerge).ToArray();
+            var registryConflicts = registryRecords.Where(conflict => !conflict.IsCooperativeMerge).ToArray();
+            var spatialConflicts = FuseSpatialTrackConflictDetector.Conflicts.ToArray();
+            var packageSnapshots = (FuseDataPackageDiscovery.GetPackageManifestSnapshots() ?? Array.Empty<FusePackageManifestSnapshot>())
+                .ToArray();
+            var knownPackageIds = packageSnapshots
+                .Select(package => package.Id)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .ToArray();
+            var groups = BuildGroups(registryConflicts.Concat(spatialConflicts), knownPackageIds);
+            var cooperativeGroups = BuildGroups(cooperativeRecords, knownPackageIds);
+            var declaredConflicts = BuildDeclaredConflictMatches(packageSnapshots);
+            builder.AddSection("Overview");
+            AddValueField(builder, "Pairs Needing Attention", groups.Count.ToString());
+            AddValueField(builder, "Declared Incompatibilities", declaredConflicts.Count.ToString());
+            AddValueField(builder, "Ownership Conflicts", registryConflicts.Length.ToString());
+            AddValueField(builder, "Shared Extension Targets", cooperativeRecords.Length.ToString());
+            AddValueField(builder, "Spatial Warnings", spatialConflicts.Length.ToString());
+
+            builder.Spacer(8f);
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Refresh", builder.Rebuild);
+                row.AddButtonCompact("Copy Full Report", () =>
+                {
+                    GUIUtility.systemCopyBuffer = BuildReport(groups, declaredConflicts, cooperativeGroups);
+                    Toast.Present("Copied FUSE mod conflict report to clipboard.");
+                });
+            }, 6f).Height(32f);
+            builder.Spacer(8f);
+
+            if (groups.Count == 0 && declaredConflicts.Count == 0 && cooperativeGroups.Count == 0)
+            {
+                builder.AddField("Status", builder.AddLabelMarkup("<color=\"green\">No mod ownership conflicts have been recorded in this session."));
+                return;
+            }
+
+            if (declaredConflicts.Count > 0)
+            {
+                builder.AddSection("Author-Declared Incompatibilities");
+                AddWrappedLabel(
+                    builder,
+                    "These pairs come from a package's conflictsWith declaration, not from FUSE guessing at nearby track. " +
+                    "The declaring package is skipped while the matching incompatible package/version is enabled.",
+                    48f);
+                foreach (var match in declaredConflicts.Take(30))
+                {
+                    AddWrappedField(builder, "Skipped Package", InsertBreakHints(match.DeclaringPackage.Id), 34f);
+                    AddWrappedField(builder, "Conflicts With", InsertBreakHints(match.ConflictingPackage.Id), 34f);
+                    AddWrappedField(builder, "Versions", FormatDeclaredConflict(match), 42f);
+                    builder.Spacer(6f);
+                }
+
+                if (groups.Count == 0 && cooperativeGroups.Count == 0)
+                {
+                    return;
+                }
+            }
+
+            if (groups.Count > 0)
+            {
+                builder.AddSection("Runtime Ownership Needing Attention");
+                foreach (var group in groups.Take(30))
+                {
+                    AddWrappedField(builder, "Mod A", InsertBreakHints(group.FirstPackageId), 34f);
+                    AddWrappedField(builder, "Mod B", InsertBreakHints(group.SecondPackageId), 34f);
+                    builder.AddField("Records", group.Conflicts.Length.ToString());
+                    builder.AddField("Object Types", FormatKinds(group.Conflicts));
+                    builder.AddField("Result", DescribeGroupResult(group.Conflicts));
+
+                    foreach (var conflict in group.Conflicts.Take(12))
+                    {
+                        AddWrappedField(builder, conflict.Kind.ToString(), FormatConflict(conflict), 54f);
+                    }
+
+                    if (group.Conflicts.Length > 12)
+                    {
+                        AddWrappedField(
+                            builder,
+                            "More",
+                            (group.Conflicts.Length - 12) + " additional records are available in Copy Full Report or /fuse.conflicts.",
+                            34f);
+                    }
+
+                    builder.Spacer(8f);
+                    builder.AddHRule();
+                    builder.Spacer(8f);
+                }
+
+                if (groups.Count > 30)
+                {
+                    AddWrappedField(
+                        builder,
+                        "More Pairs",
+                        (groups.Count - 30) + " additional package pairs are available in Copy Full Report or /fuse.conflicts.",
+                        34f);
+                }
+            }
+
+            if (cooperativeGroups.Count > 0)
+            {
+                builder.AddSection("Shared Extension Targets (Informational)");
+                AddWrappedLabel(
+                    builder,
+                    "These mods touched the same cumulative industry target and FUSE merged their contributions. " +
+                    "Nothing was skipped or replaced, so these records do not count as conflicts or load-health problems.",
+                    50f);
+                foreach (var group in cooperativeGroups.Take(30))
+                {
+                    AddWrappedField(builder, "Mod A", InsertBreakHints(group.FirstPackageId), 34f);
+                    AddWrappedField(builder, "Mod B", InsertBreakHints(group.SecondPackageId), 34f);
+                    builder.AddField("Shared Records", group.Conflicts.Length.ToString());
+                    builder.AddField("Object Types", FormatKinds(group.Conflicts));
+                    builder.AddField("Result", "Definitions merged successfully; no mod lost content.");
+                    foreach (var conflict in group.Conflicts.Take(12))
+                    {
+                        AddWrappedField(builder, conflict.Kind.ToString(), FormatConflict(conflict), 54f);
+                    }
+                    builder.Spacer(8f);
+                    builder.AddHRule();
+                    builder.Spacer(8f);
+                }
+            }
+        }
+
+        internal static List<ConflictGroup> BuildGroups(
+            IEnumerable<FuseRegistryConflict> conflicts,
+            IEnumerable<string> knownPackageIds = null)
+        {
+            var packageRoots = (knownPackageIds ?? Enumerable.Empty<string>())
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(id => id.Length)
+                .ToArray();
+            return (conflicts ?? Enumerable.Empty<FuseRegistryConflict>())
+                .Where(conflict => conflict != null)
+                .Select(conflict => new
+                {
+                    Conflict = conflict,
+                    First = FindPackageRoot(conflict.OwnerPackageId, packageRoots),
+                    Second = FindPackageRoot(conflict.AttemptedPackageId, packageRoots)
+                })
+                .GroupBy(item => BuildPairKey(item.First, item.Second), StringComparer.OrdinalIgnoreCase)
+                .Select(group =>
+                {
+                    var first = group.First();
+                    OrderPackagePair(first.First, first.Second, out var firstId, out var secondId);
+                    return new ConflictGroup
+                    {
+                        FirstPackageId = firstId,
+                        SecondPackageId = secondId,
+                        Conflicts = group
+                            .Select(item => item.Conflict)
+                            .OrderBy(conflict => conflict.Kind)
+                            .ThenBy(conflict => conflict.Id, StringComparer.OrdinalIgnoreCase)
+                            .ToArray()
+                    };
+                })
+                .OrderByDescending(group => group.Conflicts.Length)
+                .ThenBy(group => group.FirstPackageId, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(group => group.SecondPackageId, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        internal static string BuildReport(IEnumerable<ConflictGroup> groups)
+        {
+            return BuildReport(groups, Enumerable.Empty<DeclaredConflictMatch>());
+        }
+
+        internal static string BuildReport(
+            IEnumerable<ConflictGroup> groups,
+            IEnumerable<DeclaredConflictMatch> declaredConflicts)
+        {
+            return BuildReport(groups, declaredConflicts, Enumerable.Empty<ConflictGroup>());
+        }
+
+        internal static string BuildReport(
+            IEnumerable<ConflictGroup> groups,
+            IEnumerable<DeclaredConflictMatch> declaredConflicts,
+            IEnumerable<ConflictGroup> cooperativeGroups)
+        {
+            var materialized = (groups ?? Enumerable.Empty<ConflictGroup>()).ToArray();
+            var declared = (declaredConflicts ?? Enumerable.Empty<DeclaredConflictMatch>()).ToArray();
+            var cooperative = (cooperativeGroups ?? Enumerable.Empty<ConflictGroup>()).ToArray();
+            var sb = new StringBuilder();
+            sb.AppendLine("FUSE Mod Conflict Breakdown");
+            sb.AppendLine("Package pairs needing attention: " + materialized.Length);
+            sb.AppendLine("Actionable conflict/warning records: " + materialized.Sum(group => group.Conflicts?.Length ?? 0));
+            sb.AppendLine("Author-declared incompatibilities: " + declared.Length);
+            sb.AppendLine("Informational shared-extension records: " + cooperative.Sum(group => group.Conflicts?.Length ?? 0));
+            foreach (var match in declared)
+            {
+                sb.AppendLine();
+                sb.AppendLine("DECLARED: " + match.DeclaringPackage.Id + "  X  " + match.ConflictingPackage.Id);
+                sb.AppendLine("  " + FormatDeclaredConflict(match));
+            }
+
+            foreach (var group in materialized)
+            {
+                sb.AppendLine();
+                sb.AppendLine(group.FirstPackageId + "  <->  " + group.SecondPackageId);
+                sb.AppendLine("  object types: " + FormatKinds(group.Conflicts));
+                sb.AppendLine("  result: " + DescribeGroupResult(group.Conflicts));
+                foreach (var conflict in group.Conflicts ?? Array.Empty<FuseRegistryConflict>())
+                {
+                    var id = string.IsNullOrWhiteSpace(conflict?.Id) ? "(unknown target)" : conflict.Id;
+                    var resolution = string.IsNullOrWhiteSpace(conflict?.Resolution) ? "No resolution recorded." : conflict.Resolution;
+                    sb.AppendLine(
+                        "  - " + conflict.Kind + " " + id + " — " + resolution +
+                        " [" + conflict.OwnerPackageId + " -> " + conflict.AttemptedPackageId + "]");
+                }
+            }
+
+            foreach (var group in cooperative)
+            {
+                sb.AppendLine();
+                sb.AppendLine("SHARED: " + group.FirstPackageId + "  +  " + group.SecondPackageId);
+                sb.AppendLine("  result: definitions merged successfully; no mod lost content");
+                foreach (var conflict in group.Conflicts ?? Array.Empty<FuseRegistryConflict>())
+                {
+                    sb.AppendLine("  - " + conflict.Kind + " " + conflict.Id + " — " + conflict.Resolution);
+                }
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        internal static List<DeclaredConflictMatch> BuildDeclaredConflictMatches(
+            IEnumerable<FusePackageManifestSnapshot> packages)
+        {
+            var materialized = (packages ?? Enumerable.Empty<FusePackageManifestSnapshot>())
+                .Where(package =>
+                    package != null &&
+                    !package.Disabled &&
+                    !string.IsNullOrWhiteSpace(package.Id))
+                .ToArray();
+            var result = new List<DeclaredConflictMatch>();
+            foreach (var declaring in materialized)
+            {
+                foreach (var reference in declaring.ConflictsWith ?? Array.Empty<FUSE.Authoring.Data.FuseModRequirement>())
+                {
+                    var target = materialized.FirstOrDefault(candidate =>
+                        !ReferenceEquals(candidate, declaring) &&
+                        FuseDataPackageDiscovery.IsDeclaredConflictMatch(
+                            reference,
+                            candidate.Id,
+                            candidate.Version,
+                            candidate.Disabled));
+                    if (target == null)
+                    {
+                        continue;
+                    }
+
+                    result.Add(new DeclaredConflictMatch
+                    {
+                        DeclaringPackage = declaring,
+                        ConflictingPackage = target,
+                        Reference = reference
+                    });
+                }
+            }
+
+            return result
+                .GroupBy(match =>
+                    match.DeclaringPackage.Id + "\0" + match.ConflictingPackage.Id,
+                    StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .OrderBy(match => match.DeclaringPackage.Id, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(match => match.ConflictingPackage.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static string FormatDeclaredConflict(DeclaredConflictMatch match)
+        {
+            var reference = match?.Reference;
+            var installedVersion = match?.ConflictingPackage?.Version ?? string.Empty;
+            var bounds = string.IsNullOrWhiteSpace(reference?.NotBefore) && string.IsNullOrWhiteSpace(reference?.NotAfter)
+                ? "all versions"
+                : "notBefore=" + (reference?.NotBefore ?? "(none)") + ", notAfter=" + (reference?.NotAfter ?? "(none)");
+            return "Installed version " + (string.IsNullOrWhiteSpace(installedVersion) ? "(unknown)" : installedVersion) +
+                   " matches " + bounds + ".";
+        }
+
+        internal static bool IsSpatialConflict(FuseRegistryConflict conflict)
+        {
+            return conflict != null &&
+                ((conflict.Id ?? string.Empty).StartsWith("spatial-overlap:", StringComparison.OrdinalIgnoreCase) ||
+                 (conflict.Resolution ?? string.Empty).IndexOf("spatial", StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        private static string DescribeGroupResult(IEnumerable<FuseRegistryConflict> conflicts)
+        {
+            var materialized = (conflicts ?? Enumerable.Empty<FuseRegistryConflict>()).ToArray();
+            if (materialized.Any(IsSpatialConflict))
+            {
+                return "Potential track-layout overlap; both mods retained for the author/user to resolve.";
+            }
+
+            if (materialized.Any(conflict => ContainsAny(conflict.Resolution, "won", "suppressed", "skipped", "retained")))
+            {
+                return "At least one conflicting operation was skipped or replaced; see each record below.";
+            }
+
+            return "Both mods contributed to the same target; FUSE retained the shared merge.";
+        }
+
+        private static string FormatKinds(IEnumerable<FuseRegistryConflict> conflicts)
+        {
+            return string.Join(", ", (conflicts ?? Enumerable.Empty<FuseRegistryConflict>())
+                .Select(conflict => conflict.Kind.ToString())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(kind => kind, StringComparer.OrdinalIgnoreCase));
+        }
+
+        private static string FormatConflict(FuseRegistryConflict conflict)
+        {
+            var id = string.IsNullOrWhiteSpace(conflict?.Id) ? "(unknown target)" : conflict.Id;
+            var resolution = string.IsNullOrWhiteSpace(conflict?.Resolution) ? "No resolution recorded." : conflict.Resolution;
+            var definitions = string.IsNullOrWhiteSpace(conflict?.OwnerPackageId) && string.IsNullOrWhiteSpace(conflict?.AttemptedPackageId)
+                ? string.Empty
+                : " [" + conflict.OwnerPackageId + " -> " + conflict.AttemptedPackageId + "]";
+            return InsertBreakHints(id) + " — " + resolution + InsertBreakHints(definitions);
+        }
+
+        private static string FindPackageRoot(string definitionId, IEnumerable<string> packageRoots)
+        {
+            definitionId = string.IsNullOrWhiteSpace(definitionId) ? "(unknown package)" : definitionId.Trim();
+            foreach (var root in packageRoots ?? Enumerable.Empty<string>())
+            {
+                if (string.Equals(definitionId, root, StringComparison.OrdinalIgnoreCase) ||
+                    definitionId.StartsWith(root + ".", StringComparison.OrdinalIgnoreCase))
+                {
+                    return root;
+                }
+            }
+
+            return definitionId;
+        }
+
+        private static string BuildPairKey(string first, string second)
+        {
+            OrderPackagePair(first, second, out var orderedFirst, out var orderedSecond);
+            return orderedFirst + "\0" + orderedSecond;
+        }
+
+        private static void OrderPackagePair(string first, string second, out string orderedFirst, out string orderedSecond)
+        {
+            first = string.IsNullOrWhiteSpace(first) ? "(unknown package)" : first.Trim();
+            second = string.IsNullOrWhiteSpace(second) ? "(unknown package)" : second.Trim();
+            if (StringComparer.OrdinalIgnoreCase.Compare(first, second) <= 0)
+            {
+                orderedFirst = first;
+                orderedSecond = second;
+            }
+            else
+            {
+                orderedFirst = second;
+                orderedSecond = first;
+            }
+        }
+
+        private static bool ContainsAny(string value, params string[] terms)
+        {
+            return !string.IsNullOrWhiteSpace(value) &&
+                terms.Any(term => value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+    }
+}

--- a/FUSE/Interface/MenuWindow/ModsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/ModsPanelBuilder.cs
@@ -15,17 +15,43 @@ using UnityEngine;
 
 namespace FUSE.Interface.MenuWindow
 {
+    internal sealed class FusePackageDisplayStatus
+    {
+        public FusePackageDisplayStatus(string label, string detail, string listGroup, int sortOrder, string markup)
+        {
+            Label = label ?? string.Empty;
+            Detail = detail ?? string.Empty;
+            ListGroup = listGroup ?? string.Empty;
+            SortOrder = sortOrder;
+            Markup = markup ?? string.Empty;
+        }
+
+        public string Label { get; }
+        public string Detail { get; }
+        public string ListGroup { get; }
+        public int SortOrder { get; }
+        public string Markup { get; }
+    }
+
     internal struct ModsPanelBuilder
     {
         public static void Build(UIPanelBuilder builder, UIState<string> selectedItem)
         {
             var manifests = MergeHostedLegacyPackageSnapshots(
                 FuseDataPackageDiscovery.GetPackageManifestSnapshots(),
-                FuseLegacyAssemblyHost.EnumerateAllHostedPlugins().Select(info => info.Manifest));
+                FuseLegacyAssemblyHost.EnumerateAllHostedPlugins().Select(info => info.Manifest))
+                .ToArray();
+            HydratePackageRuntimeState(manifests);
 
             List<UIPanelBuilder.ListItem<FusePackageManifestSnapshot>> list = manifests
-                .OrderBy(m => m.DisplayName)
-                .Select(m => new UIPanelBuilder.ListItem<FusePackageManifestSnapshot>(m.Id, m, "Active Mods", m.DisplayName))
+                .Select(m => new { Manifest = m, Status = ClassifyPackageStatus(m) })
+                .OrderBy(entry => entry.Status.SortOrder)
+                .ThenBy(entry => entry.Manifest.DisplayName)
+                .Select(entry => new UIPanelBuilder.ListItem<FusePackageManifestSnapshot>(
+                    entry.Manifest.Id,
+                    entry.Manifest,
+                    entry.Status.ListGroup,
+                    entry.Manifest.DisplayName))
                 .ToList();
 
             builder.AddListDetail(list, selectedItem, delegate (UIPanelBuilder builder, FusePackageManifestSnapshot manifest)
@@ -36,7 +62,7 @@ namespace FUSE.Interface.MenuWindow
                     // previously selected mod's handler must not stay open.
                     CloseAllLegacyModTabs("mods selection cleared");
                     builder.AddExpandingVerticalSpacer();
-                    builder.AddLabelEmptyState(manifests.Count == 0 ? "No mods found through UMM." : "Select a mod");
+                    builder.AddLabelEmptyState(manifests.Length == 0 ? "No mods found through UMM." : "Select a mod");
                     builder.AddExpandingVerticalSpacer();
                 }
                 else
@@ -87,7 +113,26 @@ namespace FUSE.Interface.MenuWindow
                     Version = hosted.Version ?? string.Empty,
                     FolderName = folderName,
                     FolderPath = folderPath,
-                    IsLegacyHosted = true
+                    RequiredPackageIds = (hosted.RequiredReferences ?? Array.Empty<Railloader.ModReference>())
+                        .Select(reference => reference.Id)
+                        .Where(referenceId => !string.IsNullOrWhiteSpace(referenceId))
+                        .ToArray(),
+                    LoadAfter = (hosted.LoadAfter ?? Array.Empty<Railloader.ModReference>())
+                        .Select(reference => reference.Id)
+                        .Where(referenceId => !string.IsNullOrWhiteSpace(referenceId))
+                        .ToArray(),
+                    LoadBefore = hosted.LoadBefore ?? Array.Empty<string>(),
+                    ConflictsWith = (hosted.ConflictsWith ?? Array.Empty<Railloader.ModReference>())
+                        .Select(reference => new FUSE.Authoring.Data.FuseModRequirement
+                        {
+                            Id = reference.Id,
+                            NotBefore = reference.NotBefore?.ToString(),
+                            NotAfter = reference.NotAfter?.ToString()
+                        })
+                        .ToArray(),
+                    IsLegacyHosted = true,
+                    LoadedFromDisk = true,
+                    AppliedToRuntime = true
                 });
                 AddPackageIdentity(knownFolders, knownIds, folderPath, id);
             }
@@ -118,7 +163,12 @@ namespace FUSE.Interface.MenuWindow
         {
             builder.AddSection(manifest.DisplayName);
 
-            builder.AddField("Status", PackageStatusTextMarkup(manifest));
+            var status = ClassifyPackageStatus(manifest);
+            builder.AddField("Status", status.Markup);
+            if (!string.IsNullOrWhiteSpace(status.Detail))
+            {
+                builder.AddField("State details", status.Detail);
+            }
             builder.AddField("Version", manifest.Version ?? "Unknown");
             builder.AddField("Id", manifest.Id);
             builder.AddField("Folder", manifest.FolderName);
@@ -128,14 +178,24 @@ namespace FUSE.Interface.MenuWindow
 
             builder.AddField("Settings", CountPackageSettings(definitions).ToString());
 
-            if (manifest.Faults.Length > 0)
+            var faults = GetAllFaults(manifest);
+            if (faults.Length > 0)
             {
-                builder.AddField("Faults", string.Join("; ", manifest.Faults));
+                builder.AddField("Faults", string.Join("; ", faults));
             }
 
             if (manifest.Disabled && !string.IsNullOrEmpty(manifest.DisabledReason))
             {
                 builder.AddField("Disabled", manifest.DisabledReason);
+            }
+
+            var skipReasons = GetSkipReasons(manifest);
+            if (skipReasons.Length > 0)
+            {
+                var label = skipReasons.All(FusePackageFaultRegistry.IsOptionalSkipReason)
+                    ? "Optional content"
+                    : "Skipped";
+                builder.AddField(label, string.Join("; ", skipReasons));
             }
 
             var depSummary = BuildDependencySummary(manifest);
@@ -150,7 +210,7 @@ namespace FUSE.Interface.MenuWindow
             {
                 row.AddButton("Copy Mod Info", () =>
                 {
-                    GUIUtility.systemCopyBuffer = BuildSelectedPackageReport(manifest, definitions);
+                    GUIUtility.systemCopyBuffer = BuildSelectedPackageReport(manifest, definitions, status);
                     Toast.Present("Copied mod info to clipboard");
                     builder.Rebuild();
                 });
@@ -180,6 +240,17 @@ namespace FUSE.Interface.MenuWindow
                 if (definitions.Length > 1)
                 {
                     builder.AddLabel(loaded.Definition.Id);
+                }
+
+                if (loaded.FeatureEvaluation.RuleCount > 0)
+                {
+                    builder.AddField("Active feature set", loaded.FeatureEvaluation.Summary);
+                    if (loaded.FeatureEvaluation.DisabledRuleIds.Length > 0)
+                    {
+                        builder.AddField(
+                            "Disabled options",
+                            string.Join(", ", loaded.FeatureEvaluation.DisabledRuleIds));
+                    }
                 }
 
                 foreach (var pair in loaded.Definition.Settings
@@ -316,13 +387,139 @@ namespace FUSE.Interface.MenuWindow
                 return [];
             }
 
+            var manifestFolder = NormalizePath(manifest.FolderPath);
             return FuseModLoader.GetLoadedModsInOrder()
-                .Where(loaded => loaded?.Definition != null)
-                .Where(loaded =>
-                    string.Equals(NormalizePath(loaded.FolderPath), NormalizePath(manifest.FolderPath), StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(loaded.Definition.Id, manifest.Id, StringComparison.OrdinalIgnoreCase) ||
-                    loaded.Definition.Id.StartsWith((manifest.Id ?? string.Empty) + ".", StringComparison.OrdinalIgnoreCase))
+                .Where(loaded => DefinitionBelongsToPackage(loaded, manifest, manifestFolder))
                 .ToArray();
+        }
+
+        private static void HydratePackageRuntimeState(IReadOnlyList<FusePackageManifestSnapshot> manifests)
+        {
+            if (manifests == null || manifests.Count == 0)
+            {
+                return;
+            }
+
+            var loadedIds = new HashSet<string>(
+                FusePackageFaultRegistry.GetLoadedPackageIds(),
+                StringComparer.OrdinalIgnoreCase);
+            var appliedIds = new HashSet<string>(
+                FusePackageFaultRegistry.GetAppliedPackageIds(),
+                StringComparer.OrdinalIgnoreCase);
+            var skipped = FusePackageFaultRegistry.GetSkippedPackages();
+            var disabled = FusePackageFaultRegistry.GetDisabledPackages();
+            var faultsByPackage = FusePackageFaultRegistry.GetFaults()
+                .GroupBy(fault => fault.PackageId, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Select(FormatRuntimeFault).ToArray(),
+                    StringComparer.OrdinalIgnoreCase);
+            var loadedDefinitions = FuseModLoader.GetLoadedModsInOrder()
+                .Where(loaded => loaded?.Definition != null)
+                .Select(loaded => new LoadedDefinitionIdentity(
+                    NormalizePath(loaded.FolderPath),
+                    loaded.Definition.Id))
+                .ToArray();
+
+            foreach (var manifest in manifests.Where(manifest => manifest != null))
+            {
+                var manifestFolder = NormalizePath(manifest.FolderPath);
+                var definitionIds = loadedDefinitions
+                    .Where(loaded => DefinitionBelongsToPackage(loaded, manifest, manifestFolder))
+                    .Select(loaded => loaded.DefinitionId)
+                    .Where(id => !string.IsNullOrWhiteSpace(id))
+                    .ToArray();
+                var registryIds = new[] { manifest.Id }
+                    .Concat(definitionIds)
+                    .Where(id => !string.IsNullOrWhiteSpace(id))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                manifest.LoadedFromDisk = manifest.LoadedFromDisk || registryIds.Any(loadedIds.Contains);
+                manifest.AppliedToRuntime = manifest.AppliedToRuntime || registryIds.Any(appliedIds.Contains);
+
+                var skipReasons = registryIds
+                    .Select(id => skipped.TryGetValue(id, out var reason) ? reason : string.Empty)
+                    .Concat(manifest.SkipReasons ?? Array.Empty<string>())
+                    .Concat(string.IsNullOrWhiteSpace(manifest.SkipReason)
+                        ? Array.Empty<string>()
+                        : new[] { manifest.SkipReason })
+                    .Where(reason => !string.IsNullOrWhiteSpace(reason))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                manifest.SkipReasons = skipReasons;
+                manifest.SkipReason = skipReasons.FirstOrDefault() ?? string.Empty;
+
+                if (!manifest.Disabled)
+                {
+                    var disabledReason = registryIds
+                        .Select(id => disabled.TryGetValue(id, out var reason) ? reason : string.Empty)
+                        .FirstOrDefault(reason => !string.IsNullOrWhiteSpace(reason));
+                    if (!string.IsNullOrWhiteSpace(disabledReason))
+                    {
+                        manifest.Disabled = true;
+                        manifest.DisabledReason = disabledReason;
+                    }
+                }
+
+                manifest.RuntimeFaults = registryIds
+                    .SelectMany(id => faultsByPackage.TryGetValue(id, out var packageFaults)
+                        ? packageFaults
+                        : Array.Empty<string>())
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+            }
+        }
+
+        private static bool DefinitionBelongsToPackage(
+            FuseLoadedMod loaded,
+            FusePackageManifestSnapshot manifest,
+            string normalizedManifestFolder)
+        {
+            if (loaded?.Definition == null)
+            {
+                return false;
+            }
+
+            return DefinitionBelongsToPackage(
+                new LoadedDefinitionIdentity(NormalizePath(loaded.FolderPath), loaded.Definition.Id),
+                manifest,
+                normalizedManifestFolder);
+        }
+
+        private static bool DefinitionBelongsToPackage(
+            LoadedDefinitionIdentity loaded,
+            FusePackageManifestSnapshot manifest,
+            string normalizedManifestFolder)
+        {
+            return loaded != null && manifest != null &&
+                   (string.Equals(loaded.FolderPath, normalizedManifestFolder, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(loaded.DefinitionId, manifest.Id, StringComparison.OrdinalIgnoreCase) ||
+                    loaded.DefinitionId?.StartsWith((manifest.Id ?? string.Empty) + ".", StringComparison.OrdinalIgnoreCase) == true);
+        }
+
+        private sealed class LoadedDefinitionIdentity
+        {
+            internal LoadedDefinitionIdentity(string folderPath, string definitionId)
+            {
+                FolderPath = folderPath;
+                DefinitionId = definitionId;
+            }
+
+            internal string FolderPath { get; }
+            internal string DefinitionId { get; }
+        }
+
+        private static string FormatRuntimeFault(FusePackageFault fault)
+        {
+            if (fault == null)
+            {
+                return string.Empty;
+            }
+
+            return string.IsNullOrWhiteSpace(fault.Stage)
+                ? fault.Message
+                : fault.Stage + ": " + fault.Message;
         }
 
         private static int CountPackageSettings(IEnumerable<FuseLoadedMod> definitions)
@@ -341,6 +538,7 @@ namespace FUSE.Interface.MenuWindow
 
             var parts = new[]
             {
+                manifest.RequiredPackageIds.Length == 0 ? string.Empty : "requires: " + string.Join(", ", manifest.RequiredPackageIds),
                 manifest.LoadAfter.Length == 0 ? string.Empty : "after: " + string.Join(", ", manifest.LoadAfter),
                 manifest.LoadBefore.Length == 0 ? string.Empty : "before: " + string.Join(", ", manifest.LoadBefore)
             }.Where(value => !string.IsNullOrWhiteSpace(value)).ToArray();
@@ -366,25 +564,88 @@ namespace FUSE.Interface.MenuWindow
             }
         }
 
-        private static string BuildSelectedPackageReport(FusePackageManifestSnapshot manifest, IReadOnlyList<FuseLoadedMod> definitions)
+        private static string BuildSelectedPackageReport(
+            FusePackageManifestSnapshot manifest,
+            IReadOnlyList<FuseLoadedMod> definitions,
+            FusePackageDisplayStatus status)
         {
             var builder = new StringBuilder();
             builder.AppendLine("FUSE selected mod");
             builder.AppendLine("Name: " + PackageDisplayName(manifest));
             builder.AppendLine("Id: " + manifest.Id);
             builder.AppendLine("Version: " + BlankAs(manifest.Version, "?"));
-            builder.AppendLine("Status: " + PackageStatusText(manifest));
+            builder.AppendLine("Status: " + status.Label);
+            if (!string.IsNullOrWhiteSpace(status.Detail))
+            {
+                builder.AppendLine("State details: " + status.Detail);
+            }
             builder.AppendLine("Folder: " + manifest.FolderPath);
             builder.AppendLine("Definitions: " + (definitions?.Count ?? 0));
             builder.AppendLine("Settings: " + CountPackageSettings(definitions));
-            if (manifest.Faults.Length > 0)
+            var skipReasons = GetSkipReasons(manifest);
+            if (skipReasons.Length > 0)
             {
-                builder.AppendLine("Faults: " + string.Join("; ", manifest.Faults));
+                builder.AppendLine("Skip reasons: " + string.Join("; ", skipReasons));
+            }
+
+            var faults = GetAllFaults(manifest);
+            if (faults.Length > 0)
+            {
+                builder.AppendLine("Faults: " + string.Join("; ", faults));
+            }
+
+            var definitionIds = (definitions ?? Array.Empty<FuseLoadedMod>())
+                .Where(loaded => loaded?.Definition != null)
+                .Select(loaded => loaded.Definition.Id)
+                .ToArray();
+            var detailedFaults = FusePackageFaultRegistry.GetFaults()
+                .Where(fault => string.Equals(fault.PackageId, manifest.Id, StringComparison.OrdinalIgnoreCase)
+                                || definitionIds.Contains(fault.PackageId, StringComparer.OrdinalIgnoreCase)
+                                || (!string.IsNullOrWhiteSpace(fault.FolderPath)
+                                    && string.Equals(NormalizePath(fault.FolderPath), NormalizePath(manifest.FolderPath), StringComparison.OrdinalIgnoreCase)))
+                .ToArray();
+            if (detailedFaults.Length > 0)
+            {
+                builder.AppendLine("Actionable package diagnostics:");
+                foreach (var fault in detailedFaults)
+                {
+                    builder.AppendLine("- Stage: " + BlankAs(fault.Stage, "unknown"));
+                    builder.AppendLine("  Message: " + BlankAs(fault.Message, "unknown"));
+                    builder.AppendLine("  Package: " + BlankAs(fault.PackageName, fault.PackageId)
+                                       + " [" + fault.PackageId + "]");
+                    builder.AppendLine("  Source root: " + BlankAs(fault.FolderPath, "unknown"));
+                    builder.AppendLine("  Relative file: " + BlankAs(fault.RelativeSourceFile, "unknown"));
+                    builder.AppendLine("  Absolute file: " + BlankAs(fault.SourceFile, "unknown"));
+                    if (!string.IsNullOrWhiteSpace(fault.JsonPath) || fault.LineNumber > 0)
+                    {
+                        builder.AppendLine("  JSON location: " + BlankAs(fault.JsonPath, "<root>")
+                                           + (fault.LineNumber > 0
+                                               ? $" line {fault.LineNumber}, position {fault.LinePosition}"
+                                               : string.Empty));
+                    }
+                    if (!string.IsNullOrWhiteSpace(fault.ValidationCode))
+                        builder.AppendLine("  Validation code: " + fault.ValidationCode);
+                    if (!string.IsNullOrWhiteSpace(fault.ExpectedShape))
+                        builder.AppendLine("  Expected: " + fault.ExpectedShape);
+                    if (!string.IsNullOrWhiteSpace(fault.ReceivedValue))
+                        builder.AppendLine("  Received: " + fault.ReceivedValue);
+                    builder.AppendLine("  Fix: " + BlankAs(fault.SuggestedAction, "Correct the named package source and reload the map."));
+                }
             }
 
             foreach (var loaded in definitions ?? Array.Empty<FuseLoadedMod>())
             {
                 builder.AppendLine("Definition: " + loaded.Definition.Id);
+                if (loaded.FeatureEvaluation.RuleCount > 0)
+                {
+                    builder.AppendLine("Feature rules: " + loaded.FeatureEvaluation.Summary);
+                    if (loaded.FeatureEvaluation.DisabledRuleIds.Length > 0)
+                    {
+                        builder.AppendLine(
+                            "Disabled feature rules: " +
+                            string.Join(", ", loaded.FeatureEvaluation.DisabledRuleIds));
+                    }
+                }
             }
 
             return builder.ToString();
@@ -405,46 +666,170 @@ namespace FUSE.Interface.MenuWindow
             return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
         }
 
-        private static string PackageStatusText(FusePackageManifestSnapshot manifest)
+        internal static FusePackageDisplayStatus ClassifyPackageStatus(FusePackageManifestSnapshot manifest)
         {
             if (manifest == null)
             {
-                return "unknown";
+                return new FusePackageDisplayStatus(
+                    "Unknown",
+                    "Package state is unavailable.",
+                    "Unknown",
+                    80,
+                    "<color=\"orange\">Unknown</color>");
             }
 
             if (manifest.Disabled)
             {
-                return "disabled";
+                return new FusePackageDisplayStatus(
+                    "Disabled",
+                    BlankAs(manifest.DisabledReason, "Disabled by the active mod configuration."),
+                    "Disabled Mods",
+                    60,
+                    "<color=\"yellow\">Disabled</color>");
             }
 
-            if (manifest.Faults.Length > 0)
+            var faults = GetAllFaults(manifest);
+            var skipReasons = GetSkipReasons(manifest);
+            var evidence = string.Join(
+                " | ",
+                faults
+                    .Concat(skipReasons.Where(reason => !FusePackageFaultRegistry.IsOptionalSkipReason(reason)))
+                    .Where(value => !string.IsNullOrWhiteSpace(value)));
+            var problem = ClassifyProblem(evidence);
+            var hasSkips = skipReasons.Length > 0;
+            var optionalSkip = hasSkips && skipReasons.All(FusePackageFaultRegistry.IsOptionalSkipReason);
+
+            if (manifest.AppliedToRuntime &&
+                (faults.Length > 0 || (hasSkips && !optionalSkip)))
             {
-                return manifest.Faults.Length + " fault(s)";
+                var actionableSkipDetail = string.Join(
+                    "; ",
+                    skipReasons.Where(reason => !FusePackageFaultRegistry.IsOptionalSkipReason(reason)));
+                var detail = problem.Length == 0
+                    ? (hasSkips ? string.Join("; ", skipReasons) : "One or more definitions failed while other content applied.")
+                    : problem + ". Other content from this package applied successfully.";
+                if (problem.Length > 0 && !string.IsNullOrWhiteSpace(actionableSkipDetail))
+                {
+                    detail += " Actionable skip: " + actionableSkipDetail;
+                }
+                return new FusePackageDisplayStatus(
+                    "Partially applied",
+                    detail,
+                    "Mods Needing Attention",
+                    20,
+                    "<color=\"orange\">Partially applied</color>");
             }
 
-            return manifest.IsLegacyConverted || manifest.IsLegacyHosted ? "ready | legacy" : "ready";
+            if (faults.Length > 0)
+            {
+                var label = problem.Length == 0 ? "Failed" : problem;
+                return new FusePackageDisplayStatus(
+                    label,
+                    faults[0],
+                    "Mods Needing Attention",
+                    10,
+                    "<color=\"red\">" + label + "</color>");
+            }
+
+            if (hasSkips && !optionalSkip)
+            {
+                var label = problem.Length == 0 ? "Skipped" : problem;
+                return new FusePackageDisplayStatus(
+                    label,
+                    string.Join("; ", skipReasons),
+                    "Mods Needing Attention",
+                    30,
+                    "<color=\"orange\">" + label + "</color>");
+            }
+
+            if (manifest.AppliedToRuntime)
+            {
+                var detail = optionalSkip
+                    ? "Applied successfully. Optional content is inactive: " + string.Join("; ", skipReasons)
+                    : string.Empty;
+                var legacy = manifest.IsLegacyConverted || manifest.IsLegacyHosted
+                    ? " - Legacy compatibility"
+                    : string.Empty;
+                return new FusePackageDisplayStatus(
+                    "Applied",
+                    detail,
+                    "Applied Mods",
+                    40,
+                    "<color=\"green\">Applied</color>" + legacy);
+            }
+
+            if (manifest.LoadedFromDisk)
+            {
+                return new FusePackageDisplayStatus(
+                    "Loaded; awaiting map apply",
+                    optionalSkip ? "Optional content is inactive: " + string.Join("; ", skipReasons) : string.Empty,
+                    "Ready Mods",
+                    50,
+                    "<color=\"green\">Loaded</color> - awaiting map apply");
+            }
+
+            return new FusePackageDisplayStatus(
+                "Discovered; ready to load",
+                optionalSkip ? "Optional content is inactive: " + string.Join("; ", skipReasons) : string.Empty,
+                "Ready Mods",
+                50,
+                "<color=\"green\">Ready</color>");
         }
 
-        private static string PackageStatusTextMarkup(FusePackageManifestSnapshot manifest)
+        private static string[] GetAllFaults(FusePackageManifestSnapshot manifest)
         {
-            if (manifest == null)
+            return (manifest?.Faults ?? Array.Empty<string>())
+                .Concat(manifest?.RuntimeFaults ?? Array.Empty<string>())
+                .Where(fault => !string.IsNullOrWhiteSpace(fault))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static string[] GetSkipReasons(FusePackageManifestSnapshot manifest)
+        {
+            return (manifest?.SkipReasons ?? Array.Empty<string>())
+                .Concat(string.IsNullOrWhiteSpace(manifest?.SkipReason)
+                    ? Array.Empty<string>()
+                    : new[] { manifest.SkipReason })
+                .Where(reason => !string.IsNullOrWhiteSpace(reason))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static string ClassifyProblem(string evidence)
+        {
+            if (string.IsNullOrWhiteSpace(evidence))
             {
-                return "<color=\"orange\">Unknown";
+                return string.Empty;
             }
 
-            if (manifest.Disabled)
+            if (ContainsAny(evidence, "conflictswith", "conflicts with", "incompatible"))
             {
-                return "<color=\"yellow\">Disabled";
+                return "Incompatible mod installed";
             }
 
-            if (manifest.Faults.Length > 0)
+            if (ContainsAny(
+                evidence,
+                "dependency missing",
+                "no matching package",
+                " requires '",
+                "required package",
+                "required dependency"))
             {
-                return "<color=\"red\">Error: " + manifest.Faults.Length + " fault(s)";
+                return "Missing dependency";
             }
 
-            return manifest.IsLegacyConverted || manifest.IsLegacyHosted
-                ? "<color=\"green\">Ready</color> - Legacy"
-                : "<color=\"green\"Ready";
+            if (ContainsAny(evidence, "manifest json", "json:", "json ", "deserial", "schema", "could not be parsed"))
+            {
+                return "Invalid package data";
+            }
+
+            return string.Empty;
+        }
+
+        private static bool ContainsAny(string value, params string[] candidates)
+        {
+            return candidates.Any(candidate => value.IndexOf(candidate, StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         private static string GetSettingLabel(string key, FuseModSettingDefinition setting)
@@ -464,7 +849,7 @@ namespace FUSE.Interface.MenuWindow
                     BuildEnumSettingControl(builder, definition, key, setting);
                     break;
                 case "number":
-                    BuildTextSettingControl(builder, definition, key, setting, isNumber: true);
+                    BuildNumberSettingControl(builder, definition, key, setting);
                     break;
                 case "path":
                 case "color":
@@ -474,13 +859,25 @@ namespace FUSE.Interface.MenuWindow
                     break;
             }
 
+            var featureRules = definition?.FeatureRules == null
+                ? Enumerable.Empty<FuseFeatureRule>()
+                : definition.FeatureRules.Values;
+            var controlsFeature = featureRules
+                .Any(rule => rule != null && string.Equals(rule.Setting, key, StringComparison.Ordinal));
             if (FuseSettings.ShowAdvancedHealthDetails)
             {
                 builder.AddField(" ", DescribePackageSetting(key, setting));
             }
-            else if (!string.IsNullOrWhiteSpace(setting?.Description))
+            else if (controlsFeature || !string.IsNullOrWhiteSpace(setting?.Description))
             {
-                builder.AddField(" ", setting.Description);
+                var note = string.IsNullOrWhiteSpace(setting?.Description)
+                    ? string.Empty
+                    : setting.Description.Trim() + " ";
+                if (controlsFeature)
+                {
+                    note += "This option changes authored map content and takes effect after saving/reloading the map.";
+                }
+                builder.AddField(" ", note.Trim());
             }
         }
 
@@ -544,6 +941,59 @@ namespace FUSE.Interface.MenuWindow
                 });
                 AddResetSettingButton(row, definition, key, setting);
             }, 8f).Height(32f);
+        }
+
+        private static void BuildNumberSettingControl(
+            UIPanelBuilder builder,
+            FuseModDefinition definition,
+            string key,
+            FuseModSettingDefinition setting)
+        {
+            if (!setting.Min.HasValue || !setting.Max.HasValue
+                || setting.Min.Value >= setting.Max.Value)
+            {
+                BuildTextSettingControl(builder, definition, key, setting, isNumber: true);
+                return;
+            }
+
+            var minimum = (float)setting.Min.Value;
+            var maximum = (float)setting.Max.Value;
+            var step = setting.Step.GetValueOrDefault(0d);
+            builder.HStack(row =>
+            {
+                AddSettingRowLabel(row, GetSettingLabel(key, setting));
+                row.AddSlider(
+                    () => (float)FuseModSettingsStore.GetNumberValue(definition, key, setting),
+                    () => FuseModSettingsStore.GetNumberValue(definition, key, setting)
+                        .ToString("0.###", System.Globalization.CultureInfo.InvariantCulture),
+                    value =>
+                    {
+                        var selected = NormalizeNumberSliderValue(value, minimum, maximum, step);
+                        FuseModSettingsStore.SetValueInMemory(definition, key, setting, new JValue(selected));
+                    },
+                    minimum,
+                    maximum,
+                    wholeNumbers: false,
+                    editingEndedAction: value =>
+                    {
+                        var selected = NormalizeNumberSliderValue(value, minimum, maximum, step);
+                        FuseModSettingsStore.SetValue(definition, key, setting, new JValue(selected));
+                    });
+                AddResetSettingButton(row, definition, key, setting);
+            }, 8f).Height(32f);
+        }
+
+        internal static float NormalizeNumberSliderValue(float value, float minimum, float maximum, double step)
+        {
+            var selected = Math.Max(minimum, Math.Min(maximum, value));
+            if (step <= 0d)
+            {
+                return selected;
+            }
+
+            selected = minimum
+                + (float)(Math.Round((selected - minimum) / step) * step);
+            return Math.Max(minimum, Math.Min(maximum, selected));
         }
 
         private static void SaveTextSetting(FuseModDefinition definition, string key, FuseModSettingDefinition setting, string value, bool isNumber)

--- a/FUSE/Interface/MenuWindow/RuntimeActionsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/RuntimeActionsToolPage.cs
@@ -172,11 +172,13 @@ namespace FUSE.Interface.MenuWindow
             builder.AppendLine("Stations: " + SafeCount(() => StationAPI.GetAllStationAgents().Count()));
             builder.AppendLine("Passenger Stops: " + SafeCount(() => StationAPI.GetAllPassengerStops().Count()));
             builder.AppendLine("Scenery: " + SafeCount(() => SceneryAPI.GetAllScenery().Count()));
+            builder.AppendLine("Water Surfaces: " + SafeCount(() => WaterSurfaceAPI.GetAllWaterSurfaces().Count()));
             builder.AppendLine();
             builder.AppendLine("FUSE Registry");
             builder.AppendLine("Exclusive Claims: " + FUSE.Runtime.Registry.FuseRegistry.ExclusiveClaimCount);
             builder.AppendLine("Shared Claims: " + FUSE.Runtime.Registry.FuseRegistry.SharedClaimCount);
-            builder.AppendLine("Conflicts: " + FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count);
+            builder.AppendLine("Conflicts: " + FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => !conflict.IsCooperativeMerge));
+            builder.AppendLine("Shared Extension Targets: " + FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => conflict.IsCooperativeMerge));
             return builder.ToString().TrimEnd();
         }
 
@@ -236,6 +238,7 @@ namespace FUSE.Interface.MenuWindow
                     ["scenery"] = SafeCount(() => SceneryAPI.GetAllScenery().Count()),
                     ["sceneClones"] = SafeCount(() => SceneCloneAPI.GetAllSceneClones().Count()),
                     ["splineys"] = SafeCount(() => SplineyAPI.GetAllSplineys().Count()),
+                    ["waterSurfaces"] = SafeCount(() => WaterSurfaceAPI.GetAllWaterSurfaces().Count()),
                     ["mapLabels"] = SafeCount(() => MapAPI.GetAllMapLabels().Count()),
                     ["mapMasks"] = SafeCount(() => MapAPI.GetAllMapMasks().Count()),
                     ["progressions"] = SafeCount(() => ProgressionAPI.GetAllProgressions().Count()),
@@ -245,7 +248,9 @@ namespace FUSE.Interface.MenuWindow
                 {
                     ["exclusiveClaims"] = FUSE.Runtime.Registry.FuseRegistry.ExclusiveClaimCount,
                     ["sharedClaims"] = FUSE.Runtime.Registry.FuseRegistry.SharedClaimCount,
-                    ["conflicts"] = FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count
+                    ["conflicts"] = FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => !conflict.IsCooperativeMerge),
+                    ["sharedExtensionTargets"] = FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => conflict.IsCooperativeMerge),
+                    ["overlapRecords"] = FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count
                 },
                 ["assets"] = new JObject
                 {

--- a/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
@@ -5,7 +5,6 @@ using FUSE.Authoring.Migrations;
 using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
-using System.Linq;
 using System.Text;
 using UI.Builder;
 using UI.Common;
@@ -51,11 +50,7 @@ namespace FUSE.Interface.MenuWindow
                 return;
             }
             var data = checklistData.Value;
-            var modExceptionState = FuseModExceptionRegistry.CaptureReportState();
-            var hasAdvisories =
-                data.NoticesCount > data.BlockingNoticesCount ||
-                !FuseRuntimeGuardCounters.AllIdle ||
-                modExceptionState.Total > 0;
+            var hasAdvisories = data.NoticesCount > data.BlockingNoticesCount;
 
             builder.AddSection("Overview");
 
@@ -77,83 +72,7 @@ namespace FUSE.Interface.MenuWindow
             AddReadinessRow(builder, "Progression", data.ProgressionTransferSkipCount == 0, "0 transfer skips", data.ProgressionTransferSkipCount + " skip(s)");
             AddReadinessRow(builder, "Registry", data.ConflictCount == 0, "0 conflicts", data.ConflictCount + " conflict(s)");
             AddNoticeRow(builder, data.NoticesCount, data.BlockingNoticesCount);
-            // Live session counters, not snapshot state.
-            AddAdvisoryRow(
-                builder,
-                "Guards",
-                FuseRuntimeGuardCounters.AllIdle,
-                "idle",
-                FuseRuntimeGuardCounters.GuardTotal + " compatibility event(s) contained");
-            // Session-cumulative third-party exception observations — same
-            // live-counter semantics as Guards, sourced from the exception
-            // registry rather than the load snapshot. One atomic capture here
-            // (rows + totals + summary line under the registry's lock), reused
-            // by the readiness row and the breakdown section below so a
-            // concurrent log event can never render contradictory rows.
-            var modExceptions = modExceptionState.Mods;
-            // Same threshold as the health report (FuseLoadReport
-            // HasModExceptionProblem): a one-off third-party exception is
-            // informational, not a "Review" — only a recurring thrower flips
-            // this row (issue #208).
-            var problemModCount = modExceptions.Count(record => record.IsProblem);
-            AddReadinessRow(
-                builder,
-                "Mod Health",
-                problemModCount == 0,
-                modExceptionState.Total == 0
-                    ? "0 exceptions observed"
-                    : $"{modExceptionState.Total} below-threshold exception(s) observed across {modExceptions.Length} mod(s) (informational)",
-                $"{modExceptionState.Total} exception(s) across {modExceptions.Length} mod(s); {problemModCount} recurring");
-            builder.Spacer(6f);
-
-            // Full per-guard breakdown (this window is the only UI surface, so
-            // the counters must be readable here, not just in copied reports).
-            builder.AddSection("Runtime Guards");
-            InterfaceUtils.AddWrappedLabel(builder, FuseRuntimeGuardCounters.FormatSummary(), 76f);
-            builder.AddField(
-                "Native leak stacks",
-                $"{FuseNativeLeakDiagnostic.ModeLabel} (FUSE setting: {(FuseSettings.EnableNativeLeakStackTraces ? "enabled" : "disabled")})");
-            InterfaceUtils.AddWrappedLabel(
-                builder,
-                FuseRuntimeGuardCounters.AllIdle
-                    ? "All idle — no broken content needed containing this session."
-                    : "Non-zero counters show compatibility events FUSE handled successfully. They remain visible for troubleshooting but do not make the session unhealthy by themselves.",
-                48f);
-            builder.Spacer(6f);
-
-            // Per-mod breakdown for the third-party exception registry,
-            // mirroring the Runtime Guards treatment above (this window is
-            // the only UI surface, so the observations must be readable
-            // here, not just in copied reports).
-            builder.AddSection("Mod Health");
-            builder.AddLabel(modExceptionState.SummaryLine);
-            if (modExceptions.Length > 0)
-            {
-                foreach (var record in modExceptions.OrderByDescending(item => item.Count).Take(5))
-                {
-                    var display = string.IsNullOrWhiteSpace(record.DisplayName) ? record.ModId : record.DisplayName;
-                    InterfaceUtils.AddWrappedField(builder, display, DescribeModExceptionRecord(record), 52f);
-                }
-
-                if (modExceptions.Length > 5)
-                {
-                    InterfaceUtils.AddWrappedLabel(
-                        builder,
-                        $"...and {modExceptions.Length - 5} more mod(s) — full list in the health report.",
-                        28f);
-                }
-            }
-
-            InterfaceUtils.AddWrappedLabel(
-                builder,
-                modExceptionState.Total == 0
-                    ? "All idle — no third-party mod exceptions were observed this session."
-                    : problemModCount == 0
-                        ? "Below-threshold third-party exceptions were observed and logged for reference; a mod counts as a problem at (" +
-                          FuseModExceptionRegistry.ProblemEpisodeThreshold + "+ episodes or " +
-                          FuseModExceptionRegistry.ProblemCountThreshold + "+ occurrences). Details are in FUSE.log and the health report."
-                        : "Recurring counts are third-party mod faults FUSE observed or contained; offenders are named in FUSE.log and the health report.",
-                48f);
+            builder.AddField("Runtime Diagnostics", "Tools > Live Diagnostics (guards, observed exceptions, and the live FUSE log)");
             builder.Spacer(6f);
 
             builder.AddSection("Actions");
@@ -253,24 +172,6 @@ namespace FUSE.Interface.MenuWindow
             return token != null && bool.TryParse(token.ToString(), out var value) ? value : fallback;
         }
 
-        /// <summary>
-        /// One-line per-mod value for the Mod Health breakdown: counts plus
-        /// the mod's top signature (by count), matching the per-mod row the
-        /// health report renders so the two surfaces read the same.
-        /// </summary>
-        private static string DescribeModExceptionRecord(FuseModExceptionSnapshot record)
-        {
-            var text = $"{record.Count} exception(s) over {record.Episodes} episode(s)";
-            var signatures = record.Signatures;
-            if (signatures != null && signatures.Length > 0)
-            {
-                var top = signatures.OrderByDescending(item => item.Count).First();
-                text += $" — top: {top.ExceptionType} @ {top.TopOwnedFrame}";
-            }
-
-            return text;
-        }
-
         private static void AddReadinessRow(UIPanelBuilder builder, string label, bool ok, string okText, string problemText)
         {
             var value = ok
@@ -318,7 +219,7 @@ namespace FUSE.Interface.MenuWindow
                 {
                     HasProblems = reportSnapshot.HasProblems,
                     AppliedPackagesCount = reportSnapshot.AppliedPackageIds.Length,
-                    ConflictCount = reportSnapshot.Conflicts.Length,
+                    ConflictCount = reportSnapshot.ActionableConflictCount,
                     FaultCount = reportSnapshot.Faults.Length,
                     GraphIssueCount = reportSnapshot.GraphPostBindIssues.Length,
                     LoadedPackagesCount = reportSnapshot.LoadedPackageIds.Length,
@@ -358,17 +259,13 @@ namespace FUSE.Interface.MenuWindow
             builder.AppendLine("Profile: " + FuseModSetService.ActiveSetName);
             builder.AppendLine("Profile Hash: " + FuseModSetService.GetActiveSetFingerprint());
             builder.AppendLine("Loaded Packages: " + ReadInt(counts["loadedPackages"]));
-            builder.AppendLine("Applied Packages: " + ReadInt(counts["appliedPackages"]));
+            builder.AppendLine("Applied Definitions: " + ReadInt(counts["appliedDefinitions"] ?? counts["appliedPackages"]));
             builder.AppendLine("Faults: " + ReadInt(counts["faultedPackages"]));
             builder.AppendLine("Conflicts: " + ReadInt(counts["conflicts"]));
             builder.AppendLine("Unknown Assets: " + ReadInt(counts["unknownSceneryAssets"]));
             builder.AppendLine("Graph Issues: " + ReadInt(counts["graphIssues"]));
             builder.AppendLine("Transfer Skips: " + ReadInt(counts["progressionTransferSkips"]));
             builder.AppendLine("Suppressions: " + ReadInt(counts["suppressions"]));
-            builder.AppendLine("Runtime Guards: " + FuseRuntimeGuardCounters.FormatSummary());
-            builder.AppendLine(
-                "Native Leak Detection: " + FuseNativeLeakDiagnostic.ModeLabel +
-                " (FUSE stack setting " + (FuseSettings.EnableNativeLeakStackTraces ? "enabled" : "disabled") + ")");
             builder.AppendLine("Map Load: " + FusePerformanceMetrics.FormatTiming("map load total"));
             builder.AppendLine("Runtime Apply: " + FusePerformanceMetrics.FormatTiming("apply resident definitions"));
             return builder.ToString().TrimEnd();

--- a/FUSE/Interface/MenuWindow/ToolsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/ToolsPanelBuilder.cs
@@ -14,7 +14,10 @@ namespace FUSE.Interface.MenuWindow
             Inspector,
             DependencyGraph,
             Assets,
+            Conflicts,
             Audits,
+            LiveDiagnostics,
+            IndustryDashboard,
             Stats,
             Actions,
             Benchmark
@@ -41,7 +44,10 @@ namespace FUSE.Interface.MenuWindow
             list.Add(new UIPanelBuilder.ListItem<Page>("inspector", new Page(PageId.Inspector), "Tools", "Object Inspector"));
             list.Add(new UIPanelBuilder.ListItem<Page>("dependencyGraph", new Page(PageId.DependencyGraph), "Tools", "Dependency Graph"));
             list.Add(new UIPanelBuilder.ListItem<Page>("assets", new Page(PageId.Assets), "Tools", "Assets Report"));
+            list.Add(new UIPanelBuilder.ListItem<Page>("conflicts", new Page(PageId.Conflicts), "Tools", "Mod Conflicts"));
             list.Add(new UIPanelBuilder.ListItem<Page>("audits", new Page(PageId.Audits), "Tools", "Diagnostics Report"));
+            list.Add(new UIPanelBuilder.ListItem<Page>("liveDiagnostics", new Page(PageId.LiveDiagnostics), "Tools", "Live Diagnostics"));
+            list.Add(new UIPanelBuilder.ListItem<Page>("industryDashboard", new Page(PageId.IndustryDashboard), "Tools", "Industry Dashboard"));
             list.Add(new UIPanelBuilder.ListItem<Page>("stats", new Page(PageId.Stats), "Tools", "World Stats"));
             list.Add(new UIPanelBuilder.ListItem<Page>("actions", new Page(PageId.Actions), "Tools", "Runtime Actions"));
             list.Add(new UIPanelBuilder.ListItem<Page>("benchmark", new Page(PageId.Benchmark), "Tools", "Scenery Benchmark"));
@@ -69,8 +75,17 @@ namespace FUSE.Interface.MenuWindow
                             case PageId.Assets:
                                 AssetsToolPage.Build(builder);
                                 break;
+                            case PageId.Conflicts:
+                                ModConflictsToolPage.Build(builder);
+                                break;
                             case PageId.Audits:
                                 AuditsToolPage.Build(builder);
+                                break;
+                            case PageId.LiveDiagnostics:
+                                LiveDiagnosticsToolPage.Build(builder);
+                                break;
+                            case PageId.IndustryDashboard:
+                                IndustryDashboardToolPage.Build(builder);
                                 break;
                             case PageId.Stats:
                                 BuildStatsPage(builder);
@@ -108,6 +123,7 @@ namespace FUSE.Interface.MenuWindow
             builder.AddField("Scenery", SafeCount(() => SceneryAPI.GetAllScenery().Count()).ToString());
             builder.AddField("Scene Clones", SafeCount(() => SceneCloneAPI.GetAllSceneClones().Count()).ToString());
             builder.AddField("Splineys", SafeCount(() => SplineyAPI.GetAllSplineys().Count()).ToString());
+            builder.AddField("Water Surfaces", SafeCount(() => WaterSurfaceAPI.GetAllWaterSurfaces().Count()).ToString());
             builder.AddField("Map Labels", SafeCount(() => MapAPI.GetAllMapLabels().Count()).ToString());
             builder.AddField("Map Masks", SafeCount(() => MapAPI.GetAllMapMasks().Count()).ToString());
             builder.AddField("Progressions", SafeCount(() => ProgressionAPI.GetAllProgressions().Count()).ToString());
@@ -117,7 +133,12 @@ namespace FUSE.Interface.MenuWindow
             builder.AddSection("Registry");
             builder.AddField("Exclusive Claims", FUSE.Runtime.Registry.FuseRegistry.ExclusiveClaimCount.ToString());
             builder.AddField("Shared Claims", FUSE.Runtime.Registry.FuseRegistry.SharedClaimCount.ToString());
-            builder.AddField("Conflicts", FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count.ToString());
+            builder.AddField(
+                "Conflicts",
+                FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => !conflict.IsCooperativeMerge).ToString());
+            builder.AddField(
+                "Shared Extension Targets",
+                FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => conflict.IsCooperativeMerge).ToString());
             builder.AddField("Asset Stores", FUSE.Infrastructure.FusePerformanceMetrics.FormatCount("direct asset pack store count"));
         }
     }


### PR DESCRIPTION
Part 4 of 5 replacing #241. Depends on the compatibility/patches PR and should be merged after it.

Review scope
- Expand the in-game diagnostics, dependency graph, audits, assets, and mod status views.
- Add conflict and industry dashboards plus live diagnostics.
- Add settings, overlay, and runtime action integrations.
- Add focused UI and presentation-model tests.

This PR targets alex/pr241-3-compatibility-patches so the delta is 21 files. The final stack tip has the exact same Git tree as #241.

The branch workflows will be dispatched manually because stacked PR bases do not match the workflows' main-only pull_request trigger.
Stack
1. #242 — authoring schema and legacy conversion
2. #243 — package loading and runtime world support
3. #244 — legacy compatibility adapters and gameplay patches
4. #245 — diagnostics and conflict tooling
5. #246 — installer workflows and documentation

Independent branch validation
- [CI](https://github.com/F-U-S-E-E/FuseDevelopmentGroup/actions/runs/32413633344), [Python Tests](https://github.com/F-U-S-E-E/FuseDevelopmentGroup/actions/runs/32413636082), [JSON Lint](https://github.com/F-U-S-E-E/FuseDevelopmentGroup/actions/runs/32413638795), and [.NET Lint](https://github.com/F-U-S-E-E/FuseDevelopmentGroup/actions/runs/32413641696) all passed on 2b9c0ee.

Merge procedure: after a predecessor lands on main, retarget the next PR to main before merging it. Keep predecessor branches until the dependent PR has been retargeted.