### PR TITLE
Add optional mod Nexus promotion workflow

### DIFF
--- a/.github/optional-mod-releases.json
+++ b/.github/optional-mod-releases.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "mods": [
+    {
+      "key": "tile-editor-suite",
+      "tagPrefix": "tileeditorsuite-v",
+      "version": "0.26.6",
+      "lastNexusVersion": "0.26.6",
+      "promotionReady": false,
+      "blockedReason": "Nexus is already at 0.26.6, but F-U-S-E-E/Tile_Editor currently has only a v0.26.4 GitHub release whose ZIP uses non-portable backslash entry names. Reconcile the version and cut a portable upstream release before promoting a successor.",
+      "sourceRepository": "F-U-S-E-E/Tile_Editor",
+      "sourceTag": "v0.26.6",
+      "assetName": "Hrogers.TileEditorSuite-0.26.6.zip",
+      "assetSha256": "",
+      "archiveProfile": "tile-editor-suite",
+      "releaseDisplayName": "Tile Editor Suite",
+      "nexusDisplayName": "Hrogers.TileEditorSuite",
+      "nexusVariable": "NEXUS_TILE_EDITOR_FILE_GROUP_ID"
+    },
+    {
+      "key": "toolshed",
+      "tagPrefix": "toolshed-v",
+      "version": "0.3.0",
+      "lastNexusVersion": "0.3.0",
+      "promotionReady": false,
+      "blockedReason": "Toolshed FUSE 0.3.0 is the already-uploaded Nexus baseline. Advance this entry to a checksum-pinned successor before enabling promotion.",
+      "sourceRepository": "F-U-S-E-E/TheToolShed",
+      "sourceTag": "v0.3.0",
+      "assetName": "Toolshed-FUSE-0.3.0.zip",
+      "assetSha256": "39bad6d2b6657fe3a3e595053a252baa3b830a209fa549e47ffd64145bee1f26",
+      "archiveProfile": "toolshed",
+      "releaseDisplayName": "Toolshed FUSE",
+      "nexusDisplayName": "Toolshed FUSE",
+      "nexusVariable": "NEXUS_TOOLSHED_FILE_GROUP_ID"
+    },
+    {
+      "key": "narrow-gauge",
+      "tagPrefix": "narrowgauge-v",
+      "version": "0.4.0",
+      "lastNexusVersion": "0.4.0",
+      "promotionReady": false,
+      "blockedReason": "NarrowGaugeMod 0.4.0 is the already-uploaded Nexus baseline. Advance this entry to a checksum-pinned successor before enabling promotion.",
+      "sourceRepository": "F-U-S-E-E/Narrow_Gauge",
+      "sourceTag": "v0.4.0",
+      "assetName": "NarrowGaugeMod-0.4.0.zip",
+      "assetSha256": "6413dcb94a8431b93b2e14b9010f2332e8741be65fd4a25e6c6183bc13bc10c9",
+      "archiveProfile": "narrow-gauge",
+      "releaseDisplayName": "FUSE Narrow Gauge",
+      "nexusDisplayName": "NarrowGaugeMod",
+      "nexusVariable": "NEXUS_NARROW_GAUGE_FILE_GROUP_ID"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,29 @@ jobs:
           # checkout token persisted in .git/config on the runner.
           persist-credentials: false
 
+      - name: Validate optional-mod release metadata
+        shell: powershell
+        run: |
+          powershell -NoProfile -ExecutionPolicy Bypass `
+            -File "scripts\Resolve-OptionalModRelease.ps1" `
+            -ConfigPath ".github\optional-mod-releases.json" `
+            -ValidateOnly
+          if ($LASTEXITCODE -ne 0) {
+            throw "Optional-mod release metadata validation failed."
+          }
+
+          $metadata = Get-Content ".github\optional-mod-releases.json" -Raw | ConvertFrom-Json
+          foreach ($mod in @($metadata.mods | Where-Object { $_.promotionReady })) {
+            $tag = "$($mod.tagPrefix)$($mod.version)"
+            powershell -NoProfile -ExecutionPolicy Bypass `
+              -File "scripts\Resolve-OptionalModRelease.ps1" `
+              -ConfigPath ".github\optional-mod-releases.json" `
+              -Tag $tag | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+              throw "Could not resolve promotion-ready optional-mod tag '$tag'."
+            }
+          }
+
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,15 @@ jobs:
             }
           }
 
+      - name: Test Nexus release preflight
+        shell: powershell
+        run: |
+          powershell -NoProfile -ExecutionPolicy Bypass `
+            -File "scripts\Test-NexusFileVersion.Tests.ps1"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Nexus release preflight tests failed."
+          }
+
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:

--- a/.github/workflows/release-optional-mod.yml
+++ b/.github/workflows/release-optional-mod.yml
@@ -1,0 +1,163 @@
+name: Release Optional Mod
+
+on:
+  push:
+    tags:
+      - "tileeditorsuite-v*"
+      - "toolshed-v*"
+      - "narrowgauge-v*"
+
+permissions:
+  contents: write
+
+# A release is a promotion of one immutable asset. Serialize the lane so a
+# rerun and a new optional-mod release cannot race on GitHub/Nexus state.
+concurrency:
+  group: release-optional-mod
+  cancel-in-progress: false
+
+jobs:
+  promote-release:
+    # No game assemblies are needed: the selected source repository has already
+    # built and published the asset. Keep deployment and its Nexus credential on
+    # the organization's self-hosted Railroader runner with the core FUSE lane.
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout FUSE release configuration
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve locked optional-mod release
+        id: release
+        shell: powershell
+        env:
+          # Keep the untrusted tag out of the script source. The resolver applies
+          # anchored tag/version checks before writing any value to GITHUB_OUTPUT.
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          powershell -NoProfile -ExecutionPolicy Bypass `
+            -File "scripts\Resolve-OptionalModRelease.ps1" `
+            -ConfigPath ".github\optional-mod-releases.json" `
+            -Tag $env:TAG_NAME `
+            -GitHubOutputPath $env:GITHUB_OUTPUT
+
+      - name: Preflight Nexus configuration
+        id: nexus
+        shell: powershell
+        env:
+          IS_GA: ${{ steps.release.outputs.is_ga }}
+          NEXUS_VARIABLE: ${{ steps.release.outputs.nexus_variable }}
+          NEXUS_API_KEY: ${{ secrets.NEXUSMODS_API_KEY }}
+          TILE_EDITOR_FILE_GROUP_ID: ${{ vars.NEXUS_TILE_EDITOR_FILE_GROUP_ID }}
+          TOOLSHED_FILE_GROUP_ID: ${{ vars.NEXUS_TOOLSHED_FILE_GROUP_ID }}
+          NARROW_GAUGE_FILE_GROUP_ID: ${{ vars.NEXUS_NARROW_GAUGE_FILE_GROUP_ID }}
+        run: |
+          $fileGroupId = switch ($env:NEXUS_VARIABLE) {
+            "NEXUS_TILE_EDITOR_FILE_GROUP_ID" { $env:TILE_EDITOR_FILE_GROUP_ID }
+            "NEXUS_TOOLSHED_FILE_GROUP_ID" { $env:TOOLSHED_FILE_GROUP_ID }
+            "NEXUS_NARROW_GAUGE_FILE_GROUP_ID" { $env:NARROW_GAUGE_FILE_GROUP_ID }
+            default { throw "Unsupported Nexus variable '$env:NEXUS_VARIABLE'." }
+          }
+
+          if ($env:IS_GA -eq "true") {
+            if ([string]::IsNullOrWhiteSpace($fileGroupId)) {
+              throw "Repository variable $env:NEXUS_VARIABLE is not configured."
+            }
+            if ($fileGroupId -notmatch '^[1-9][0-9]*$') {
+              throw "Repository variable $env:NEXUS_VARIABLE must be a numeric Nexus API Info ID."
+            }
+            if ([string]::IsNullOrWhiteSpace($env:NEXUS_API_KEY)) {
+              throw "Repository secret NEXUSMODS_API_KEY is not configured."
+            }
+          }
+
+          $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+          [System.IO.File]::AppendAllText(
+            $env:GITHUB_OUTPUT,
+            "file_group_id=$fileGroupId$([Environment]::NewLine)",
+            $utf8NoBom
+          )
+
+      - name: Download pinned upstream release asset
+        id: package
+        shell: powershell
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REPOSITORY: ${{ steps.release.outputs.source_repository }}
+          SOURCE_TAG: ${{ steps.release.outputs.source_tag }}
+          ASSET_NAME: ${{ steps.release.outputs.asset_name }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+            throw "RUNNER_TEMP is not available."
+          }
+          $downloadRoot = Join-Path $env:RUNNER_TEMP "optional-release-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+          New-Item -ItemType Directory -Path $downloadRoot | Out-Null
+
+          gh release download $env:SOURCE_TAG `
+            --repo $env:SOURCE_REPOSITORY `
+            --pattern $env:ASSET_NAME `
+            --dir $downloadRoot
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not download '$env:ASSET_NAME' from $env:SOURCE_REPOSITORY release $env:SOURCE_TAG."
+          }
+
+          $archives = @(Get-ChildItem -LiteralPath $downloadRoot -File)
+          if ($archives.Count -ne 1 -or $archives[0].Name -cne $env:ASSET_NAME) {
+            throw "Expected exactly '$env:ASSET_NAME'; downloaded: $($archives.Name -join ', ')."
+          }
+          $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+          [System.IO.File]::AppendAllText(
+            $env:GITHUB_OUTPUT,
+            "archive_path=$($archives[0].FullName)$([Environment]::NewLine)",
+            $utf8NoBom
+          )
+
+      - name: Validate package identity, layout, version, and digest
+        shell: powershell
+        env:
+          ARCHIVE_PATH: ${{ steps.package.outputs.archive_path }}
+          MOD_VERSION: ${{ steps.release.outputs.version }}
+          ARCHIVE_PROFILE: ${{ steps.release.outputs.archive_profile }}
+          EXPECTED_SHA256: ${{ steps.release.outputs.asset_sha256 }}
+        run: |
+          powershell -NoProfile -ExecutionPolicy Bypass `
+            -File "scripts\Validate-OptionalModPackage.ps1" `
+            -ArchivePath $env:ARCHIVE_PATH `
+            -Version $env:MOD_VERSION `
+            -Profile $env:ARCHIVE_PROFILE `
+            -ExpectedSha256 $env:EXPECTED_SHA256
+
+      - name: Create FUSE repository release record
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ steps.release.outputs.release_display_name }} v${{ steps.release.outputs.version }}
+          prerelease: ${{ steps.release.outputs.is_ga != 'true' }}
+          generate_release_notes: false
+          # Optional releases must never take the Latest badge from mod-v*,
+          # because FUSE's update and converter links depend on that release.
+          make_latest: false
+          body: |
+            Nexus promotion of `${{ steps.release.outputs.asset_name }}` from
+            [${{ steps.release.outputs.source_repository }} ${{ steps.release.outputs.source_tag }}](${{ steps.release.outputs.source_release_url }}).
+
+            The upstream ZIP is attached unchanged and was verified against the SHA-256 digest locked in `.github/optional-mod-releases.json`.
+          files: ${{ steps.package.outputs.archive_path }}
+          fail_on_unmatched_files: true
+
+      - name: Upload stable release to Nexus Mods
+        if: ${{ steps.release.outputs.is_ga == 'true' }}
+        uses: Nexus-Mods/upload-action@0bf670d75d46988c176c9bfacc94ca0144e0fe3f # v1.0.0-beta.7
+        with:
+          api_key: ${{ secrets.NEXUSMODS_API_KEY }}
+          file_group_id: ${{ steps.nexus.outputs.file_group_id }}
+          filename: ${{ steps.package.outputs.archive_path }}
+          version: ${{ steps.release.outputs.version }}
+          display_name: ${{ steps.release.outputs.nexus_display_name }} ${{ steps.release.outputs.version }}
+          description: |
+            Release ${{ steps.release.outputs.version }}.
+            Source release: ${{ steps.release.outputs.source_release_url }}
+          file_category: main
+          archive_existing_file: true

--- a/.github/workflows/release-optional-mod.yml
+++ b/.github/workflows/release-optional-mod.yml
@@ -93,7 +93,7 @@ jobs:
               throw "Repository variable $env:NEXUS_VARIABLE must be a numeric Nexus API Info ID."
             }
             if ([string]::IsNullOrWhiteSpace($env:NEXUSMODS_API_KEY)) {
-              throw "Environment secret NEXUSMODS_API_KEY is not configured."
+              throw "Repository secret NEXUSMODS_API_KEY is not configured."
             }
 
             powershell -NoProfile -ExecutionPolicy Bypass `

--- a/.github/workflows/release-optional-mod.yml
+++ b/.github/workflows/release-optional-mod.yml
@@ -126,7 +126,7 @@ jobs:
             -File "scripts\Validate-OptionalModPackage.ps1" `
             -ArchivePath $env:ARCHIVE_PATH `
             -Version $env:MOD_VERSION `
-            -Profile $env:ARCHIVE_PROFILE `
+            -ArchiveProfile $env:ARCHIVE_PROFILE `
             -ExpectedSha256 $env:EXPECTED_SHA256
 
       - name: Create FUSE repository release record

--- a/.github/workflows/release-optional-mod.yml
+++ b/.github/workflows/release-optional-mod.yml
@@ -18,6 +18,9 @@ concurrency:
 
 jobs:
   promote-release:
+    # The static protected environment gates the job before it reaches the
+    # self-hosted runner or can read the Nexus credential.
+    environment: nexus-release
     # No game assemblies are needed: the selected source repository has already
     # built and published the asset. Keep deployment and its Nexus credential on
     # the organization's self-hosted Railroader runner with the core FUSE lane.
@@ -27,7 +30,27 @@ jobs:
       - name: Checkout FUSE release configuration
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify release tag targets protected main
+        shell: powershell
+        env:
+          TAG_COMMIT: ${{ github.sha }}
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not fetch protected main for release-tag verification."
+          }
+
+          $tagCommit = (git rev-parse "$env:TAG_COMMIT^{commit}").Trim()
+          if ($LASTEXITCODE -ne 0 -or $tagCommit -notmatch '^[0-9a-f]{40}$') {
+            throw "Could not resolve the release tag to a commit."
+          }
+          git merge-base --is-ancestor $tagCommit origin/main
+          if ($LASTEXITCODE -ne 0) {
+            throw "Optional-mod release tags must point to a commit on protected main."
+          }
 
       - name: Resolve locked optional-mod release
         id: release
@@ -48,13 +71,14 @@ jobs:
         shell: powershell
         env:
           IS_GA: ${{ steps.release.outputs.is_ga }}
+          MOD_VERSION: ${{ steps.release.outputs.version }}
           NEXUS_VARIABLE: ${{ steps.release.outputs.nexus_variable }}
-          NEXUS_API_KEY: ${{ secrets.NEXUSMODS_API_KEY }}
+          NEXUSMODS_API_KEY: ${{ secrets.NEXUSMODS_API_KEY }}
           TILE_EDITOR_FILE_GROUP_ID: ${{ vars.NEXUS_TILE_EDITOR_FILE_GROUP_ID }}
           TOOLSHED_FILE_GROUP_ID: ${{ vars.NEXUS_TOOLSHED_FILE_GROUP_ID }}
           NARROW_GAUGE_FILE_GROUP_ID: ${{ vars.NEXUS_NARROW_GAUGE_FILE_GROUP_ID }}
         run: |
-          $fileGroupId = switch ($env:NEXUS_VARIABLE) {
+          $fileId = switch ($env:NEXUS_VARIABLE) {
             "NEXUS_TILE_EDITOR_FILE_GROUP_ID" { $env:TILE_EDITOR_FILE_GROUP_ID }
             "NEXUS_TOOLSHED_FILE_GROUP_ID" { $env:TOOLSHED_FILE_GROUP_ID }
             "NEXUS_NARROW_GAUGE_FILE_GROUP_ID" { $env:NARROW_GAUGE_FILE_GROUP_ID }
@@ -62,23 +86,26 @@ jobs:
           }
 
           if ($env:IS_GA -eq "true") {
-            if ([string]::IsNullOrWhiteSpace($fileGroupId)) {
+            if ([string]::IsNullOrWhiteSpace($fileId)) {
               throw "Repository variable $env:NEXUS_VARIABLE is not configured."
             }
-            if ($fileGroupId -notmatch '^[1-9][0-9]*$') {
+            if ($fileId -notmatch '^[1-9][0-9]*$') {
               throw "Repository variable $env:NEXUS_VARIABLE must be a numeric Nexus API Info ID."
             }
-            if ([string]::IsNullOrWhiteSpace($env:NEXUS_API_KEY)) {
-              throw "Repository secret NEXUSMODS_API_KEY is not configured."
+            if ([string]::IsNullOrWhiteSpace($env:NEXUSMODS_API_KEY)) {
+              throw "Environment secret NEXUSMODS_API_KEY is not configured."
             }
-          }
 
-          $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-          [System.IO.File]::AppendAllText(
-            $env:GITHUB_OUTPUT,
-            "file_group_id=$fileGroupId$([Environment]::NewLine)",
-            $utf8NoBom
-          )
+            powershell -NoProfile -ExecutionPolicy Bypass `
+              -File "scripts\Test-NexusFileVersion.ps1" `
+              -FileId $fileId `
+              -Version $env:MOD_VERSION `
+              -GitHubOutputPath $env:GITHUB_OUTPUT
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+          else {
+            Write-Host "Prerelease tag; Nexus version lookup and upload are skipped."
+          }
 
       - name: Download pinned upstream release asset
         id: package
@@ -148,16 +175,16 @@ jobs:
           fail_on_unmatched_files: true
 
       - name: Upload stable release to Nexus Mods
-        if: ${{ steps.release.outputs.is_ga == 'true' }}
-        uses: Nexus-Mods/upload-action@0bf670d75d46988c176c9bfacc94ca0144e0fe3f # v1.0.0-beta.7
+        if: ${{ steps.release.outputs.is_ga == 'true' && steps.nexus.outputs.publish_required == 'true' }}
+        uses: Nexus-Mods/upload-action@c96019556046053aa26044b44396cd38929daf23 # v1.0.0-beta.10
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
-          file_group_id: ${{ steps.nexus.outputs.file_group_id }}
+          file_id: ${{ steps.nexus.outputs.file_id }}
           filename: ${{ steps.package.outputs.archive_path }}
           version: ${{ steps.release.outputs.version }}
           display_name: ${{ steps.release.outputs.nexus_display_name }} ${{ steps.release.outputs.version }}
           description: |
             Release ${{ steps.release.outputs.version }}.
             Source release: ${{ steps.release.outputs.source_release_url }}
-          file_category: main
-          archive_existing_file: true
+          category: main
+          archive_existing_version: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-and-release:
     # Release jobs wait for an organization reviewer before reaching the
-    # self-hosted runner or receiving the environment-scoped Nexus credential.
+    # self-hosted runner or receiving the repository-scoped Nexus credential.
     environment: nexus-release
     runs-on: self-hosted
     env:
@@ -393,7 +393,7 @@ jobs:
       # Skipped automatically until the repo variable NEXUS_FILE_GROUP_ID is set.
       # Requires:
       #   - variable NEXUS_FILE_GROUP_ID (from "API Info" on the mod's Files tab)
-      #   - nexus-release environment secret NEXUSMODS_API_KEY
+      #   - repository secret NEXUSMODS_API_KEY
       # The secret is NOT checked in this condition: `secrets` is not an
       # available context in a step-level `if`, and referencing it there is a
       # parse error that breaks the whole workflow. With the variable set but the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ concurrency:
 
 jobs:
   build-and-release:
+    # Release jobs wait for an organization reviewer before reaching the
+    # self-hosted runner or receiving the environment-scoped Nexus credential.
+    environment: nexus-release
     runs-on: self-hosted
     env:
       DOTNET_NOLOGO: "true"
@@ -26,11 +29,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           # This lane only builds and publishes release assets (via the
           # GITHUB_TOKEN env the release action receives directly); nothing
           # pushes back to the repo, so don't leave the checkout token
           # persisted in .git/config on the self-hosted runner.
           persist-credentials: false
+
+      - name: Verify release tag targets protected main
+        shell: powershell
+        env:
+          TAG_COMMIT: ${{ github.sha }}
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not fetch protected main for release-tag verification."
+          }
+
+          $tagCommit = (git rev-parse "$env:TAG_COMMIT^{commit}").Trim()
+          if ($LASTEXITCODE -ne 0 -or $tagCommit -notmatch '^[0-9a-f]{40}$') {
+            throw "Could not resolve the release tag to a commit."
+          }
+          git merge-base --is-ancestor $tagCommit origin/main
+          if ($LASTEXITCODE -ne 0) {
+            throw "FUSE release tags must point to a commit on protected main."
+          }
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
@@ -346,24 +369,42 @@ jobs:
       #
       # GA tags only. Release candidates publish as full GitHub releases, so
       # is_prerelease is false for them and gating on it would push every RC to
-      # the public mod page (and archive_existing_file below would churn the
+      # the public mod page (and archiving the existing version would churn the
       # previous file each time). Nexus tracks stable releases only.
       #
+      # NEXUS_FILE_GROUP_ID is a legacy variable name; its API Info value is the
+      # v3 file_id used by the current upload API.
+      - name: Preflight Nexus upload
+        id: nexus
+        if: ${{ vars.NEXUS_FILE_GROUP_ID != '' && steps.version.outputs.is_ga == 'true' }}
+        shell: powershell
+        env:
+          NEXUSMODS_API_KEY: ${{ secrets.NEXUSMODS_API_KEY }}
+          NEXUS_FILE_ID: ${{ vars.NEXUS_FILE_GROUP_ID }}
+          MOD_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          powershell -NoProfile -ExecutionPolicy Bypass `
+            -File "scripts\Test-NexusFileVersion.ps1" `
+            -FileId $env:NEXUS_FILE_ID `
+            -Version $env:MOD_VERSION `
+            -GitHubOutputPath $env:GITHUB_OUTPUT
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       # Skipped automatically until the repo variable NEXUS_FILE_GROUP_ID is set.
       # Requires:
       #   - variable NEXUS_FILE_GROUP_ID (from "API Info" on the mod's Files tab)
-      #   - secret  NEXUSMODS_API_KEY    (https://www.nexusmods.com/settings/api-keys)
+      #   - nexus-release environment secret NEXUSMODS_API_KEY
       # The secret is NOT checked in this condition: `secrets` is not an
       # available context in a step-level `if`, and referencing it there is a
       # parse error that breaks the whole workflow. With the variable set but the
       # key missing, this step fails auth and fails the release job after the
       # GitHub release has already been published — so set both together.
       - name: Upload to Nexus Mods
-        if: ${{ vars.NEXUS_FILE_GROUP_ID != '' && steps.version.outputs.is_ga == 'true' }}
-        uses: Nexus-Mods/upload-action@0bf670d75d46988c176c9bfacc94ca0144e0fe3f # v1.0.0-beta.7
+        if: ${{ vars.NEXUS_FILE_GROUP_ID != '' && steps.version.outputs.is_ga == 'true' && steps.nexus.outputs.publish_required == 'true' }}
+        uses: Nexus-Mods/upload-action@c96019556046053aa26044b44396cd38929daf23 # v1.0.0-beta.10
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
-          file_group_id: ${{ vars.NEXUS_FILE_GROUP_ID }}
+          file_id: ${{ steps.nexus.outputs.file_id }}
           # The Source=nexus variant, not steps.package (which stays github).
           filename: ${{ steps.nexus_package.outputs.archive_path }}
           version: ${{ steps.version.outputs.version }}
@@ -371,5 +412,5 @@ jobs:
           description: |
             Release v${{ steps.version.outputs.version }}.
             See the GitHub release for the full changelog: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
-          file_category: main
-          archive_existing_file: true
+          category: main
+          archive_existing_version: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,25 +303,8 @@ jobs:
           "archive_name=$archiveName" >> $env:GITHUB_OUTPUT
           "archive_path=$archivePath" >> $env:GITHUB_OUTPUT
 
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: FUSE v${{ steps.version.outputs.version }}
-          prerelease: ${{ steps.version.outputs.is_prerelease }}
-          generate_release_notes: true
-          # GitHub gets both: the same core-only zip Nexus receives, plus the
-          # complete bundle and the individual tools.
-          files: |
-            ${{ steps.package.outputs.archive_path }}
-            ${{ steps.bundle.outputs.archive_path }}
-            dist/FUSE-Converter.exe
-            dist/FUSE-Installer.exe
-            dist/FUSEConvertFolder.pyz
-            FUSE.LiveBridge-v${{ steps.version.outputs.version }}.zip
-
       # Provenance stamp for the update check. The core zip attached to the GitHub
-      # release above stays Source="github" (the committed Info.json default); the
+      # release below stays Source="github" (the committed Info.json default); the
       # Nexus upload gets its own copy of the SAME contents with Source re-stamped
       # to "nexus", so an out-of-date player who installed from Nexus is pointed
       # back to Nexus while GitHub remains canonical (docs/RELEASING.md).
@@ -390,6 +373,23 @@ jobs:
             -GitHubOutputPath $env:GITHUB_OUTPUT
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: FUSE v${{ steps.version.outputs.version }}
+          prerelease: ${{ steps.version.outputs.is_prerelease }}
+          generate_release_notes: true
+          # GitHub gets both: the same core-only zip Nexus receives, plus the
+          # complete bundle and the individual tools.
+          files: |
+            ${{ steps.package.outputs.archive_path }}
+            ${{ steps.bundle.outputs.archive_path }}
+            dist/FUSE-Converter.exe
+            dist/FUSE-Installer.exe
+            dist/FUSEConvertFolder.pyz
+            FUSE.LiveBridge-v${{ steps.version.outputs.version }}.zip
+
       # Skipped automatically until the repo variable NEXUS_FILE_GROUP_ID is set.
       # Requires:
       #   - variable NEXUS_FILE_GROUP_ID (from "API Info" on the mod's Files tab)
@@ -397,8 +397,8 @@ jobs:
       # The secret is NOT checked in this condition: `secrets` is not an
       # available context in a step-level `if`, and referencing it there is a
       # parse error that breaks the whole workflow. With the variable set but the
-      # key missing, this step fails auth and fails the release job after the
-      # GitHub release has already been published — so set both together.
+      # key missing, the preflight fails before either release destination is
+      # mutated — so set both together.
       - name: Upload to Nexus Mods
         if: ${{ vars.NEXUS_FILE_GROUP_ID != '' && steps.version.outputs.is_ga == 'true' && steps.nexus.outputs.publish_required == 'true' }}
         uses: Nexus-Mods/upload-action@c96019556046053aa26044b44396cd38929daf23 # v1.0.0-beta.10

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,8 +1,9 @@
 # Releasing
 
-FUSE ships in two independent lanes, each driven by a git tag. Pushing the tag
-is the only trigger — the matching workflow does the build, packaging, and
-GitHub Release.
+FUSE ships through two build-and-release lanes plus one optional-mod promotion
+lane, each driven by a disjoint git tag. Pushing the tag is the only trigger —
+the matching workflow either builds and packages FUSE-owned code or promotes a
+checksum-pinned optional-mod release.
 
 ## Mod release — `mod-v<semver>`
 
@@ -78,6 +79,81 @@ The version flows in via `-p:ExternalEditorVersion=<ver>` (see
 fall back to the dev floor in that csproj. The mod and external-editor version
 numbers are independent — bump and tag them separately.
 
+## Optional mod Nexus promotion — product tags
+
+The optional mods keep their source and build releases in their own repositories,
+but FUSE is the authority that promotes an exact release asset to Nexus:
+
+| Product | Source repository | FUSE tag |
+| --- | --- | --- |
+| Tile Editor Suite | `F-U-S-E-E/Tile_Editor` | `tileeditorsuite-v<semver>` |
+| Toolshed FUSE | `F-U-S-E-E/TheToolShed` | `toolshed-v<semver>` |
+| FUSE Narrow Gauge | `F-U-S-E-E/Narrow_Gauge` | `narrowgauge-v<semver>` |
+
+These tags run
+[`.github/workflows/release-optional-mod.yml`](../.github/workflows/release-optional-mod.yml)
+on the organization's **self-hosted** Railroader runner, keeping deployment and
+the Nexus credential on the same runner as the core FUSE lane. The workflow
+does not rebuild or edit the optional repository. It downloads one versioned
+ZIP from that repository's GitHub release, verifies the SHA-256 and
+product-specific UMM layout locked in
+[`.github/optional-mod-releases.json`](../.github/optional-mod-releases.json),
+attaches the unchanged ZIP to a FUSE repository release record, and uploads the
+same bytes to the product's Nexus file chain. This keeps source ownership in the
+product repository while centralizing Nexus credentials and deployment in FUSE.
+
+Optional GitHub release records always set `make_latest: false`. They must not
+replace the `mod-v*` release behind FUSE's `/releases/latest` update and tool
+download links. Prerelease versions can create a GitHub prerelease record, but
+only a plain `major.minor.patch` version is sent to Nexus.
+
+The versions already uploaded manually to Nexus are recorded as the initial
+baselines:
+
+- Hrogers.TileEditorSuite `0.26.6`
+- Toolshed FUSE `0.3.0`
+- NarrowGaugeMod `0.4.0`
+
+All three baseline entries have `promotionReady: false`, so pushing a baseline
+tag fails before it can archive or replace an existing Nexus file. Toolshed and
+Narrow Gauge have matching, checksum-pinned GitHub assets in the lock file.
+Tile Editor has an additional reconciliation block: Nexus is at `0.26.6`, but
+its public source/release metadata and ZIP are still `0.26.4`, and that ZIP uses
+Windows backslash entry names. Reconcile its six version sources, create a ZIP
+with portable `/` entry names, and cut a matching upstream release before
+enabling its next promotion. Advance the relevant lock entry to a successor and
+enable it only when that exact upstream asset is ready. The release resolver
+fails closed while a baseline is not promotion-ready.
+
+To promote a successor:
+
+1. Build and publish the optional repository's `v<semver>` GitHub release with
+   its final, versioned ZIP.
+2. Download that ZIP and compute its digest with
+   `Get-FileHash -Algorithm SHA256 <archive>`.
+3. Update that product's `version`, `sourceTag`, `assetName`, `assetSha256`, and
+   `promotionReady` fields in `.github/optional-mod-releases.json`. Keep
+   `lastNexusVersion` at the version currently live on Nexus; the resolver
+   rejects candidates that are not newer. CI validates the lock file. Merge
+   this change before tagging.
+4. Tag the locked FUSE commit with the product prefix above and push the tag.
+5. Verify both the non-latest FUSE GitHub release record and the Nexus upload.
+6. After a successful stable upload, advance `lastNexusVersion` to the published
+   version and set `promotionReady: false` in the next FUSE commit. This retains
+   the deployed baseline and prevents a later lock-file rollback from being
+   promoted as a successor.
+
+The repository uses the existing `NEXUSMODS_API_KEY` secret and one Nexus API
+Info file-group variable per product:
+
+- `NEXUS_TILE_EDITOR_FILE_GROUP_ID`
+- `NEXUS_TOOLSHED_FILE_GROUP_ID`
+- `NEXUS_NARROW_GAUGE_FILE_GROUP_ID`
+
+The values are the API Info IDs from the files already uploaded to Nexus, not
+the Nexus mod page IDs. Keep the existing `NEXUS_FILE_GROUP_ID` reserved for
+the core FUSE release lane.
+
 ## Notes
 
 - **The mod lane publishes release candidates as full releases, not GitHub
@@ -90,14 +166,19 @@ numbers are independent — bump and tag them separately.
   it rather than at the last GA, so cut the GA tag when the RCs settle.
 - The external-editor lane still treats **any** suffix as a prerelease. The two
   lanes deliberately differ here; align them if that ever becomes confusing.
-- Nothing writes a version back into the repo. There used to be a
-  `sync-info-json.yml` workflow that committed the released version into
+- For the core mod, nothing writes a version back into the repo. There used to
+  be a `sync-info-json.yml` workflow that committed the released version into
   `FUSE/Info.json` on `main`; it was removed because it fought the pinned-`0.0.0`
   rule above — with it working, a local build would report the last released
-  version and look exactly like a release in UMM. The version lives in the tag
-  and reaches artifacts through `-p:ModVersion`; the repo does not track it.
-- The tag prefixes don't collide: `mod-v*`, `externaleditor-v*`, and the
-  existing `tools-v*` are disjoint globs.
-- To dry-run a lane, push a throwaway tag (e.g. `externaleditor-v0.2.0-rc.1`),
-  confirm the release and its assets, then delete the tag and release with
-  `gh release delete <tag> --yes --cleanup-tag`.
+  version and look exactly like a release in UMM. The core version lives in the
+  tag and reaches artifacts through `-p:ModVersion`; only the optional-mod lock
+  file tracks deployed optional-product versions.
+- The tag prefixes don't collide: `mod-v*`, `externaleditor-v*`,
+  `tileeditorsuite-v*`, `toolshed-v*`, `narrowgauge-v*`, and the existing
+  `tools-v*` are disjoint globs. In particular, do not shorten `toolshed-v*`
+  to `tools-v*`; that older prefix already belongs to the converter tools.
+- To dry-run either build lane, push a throwaway tag (e.g.
+  `externaleditor-v0.2.0-rc.1`), confirm the release and its assets, then delete
+  the tag and release with `gh release delete <tag> --yes --cleanup-tag`.
+  Optional-mod tags are allow-listed by the lock file and are not throwaway
+  dry runs; validate their resolver and package locally before pushing.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -3,7 +3,11 @@
 FUSE ships through two build-and-release lanes plus one optional-mod promotion
 lane, each driven by a disjoint git tag. Pushing the tag is the only trigger —
 the matching workflow either builds and packages FUSE-owned code or promotes a
-checksum-pinned optional-mod release.
+checksum-pinned optional-mod release. Nexus-capable tags are promotion requests:
+the core and optional-mod jobs wait at the protected `nexus-release`
+environment before GitHub assigns the organization's self-hosted runner or
+provides the Nexus credential. One organization member other than the person
+who started the deployment must approve it.
 
 ## Mod release — `mod-v<semver>`
 
@@ -41,6 +45,16 @@ canonical for versioning; the stamp only decides which download link the notice
 shows. The stamp step is GA-only and gated on `NEXUS_FILE_GROUP_ID`, so only stable
 builds are ever stamped `nexus`. The runtime reads it in
 `FUSE.Infrastructure.FuseInstallSource`.
+
+Before a stable upload, the workflow queries the Nexus v3 file-version API for
+the exact release version. A matching live version makes a rerun a successful
+no-op; an absent version proceeds to upload. HTTP errors, authentication errors,
+and malformed responses fail closed before the upload action runs. The legacy
+repository variable name `NEXUS_FILE_GROUP_ID` is retained for compatibility,
+but its API Info value is the Nexus v3 `file_id`. This is version-level replay
+protection; Nexus does not expose the remote archive's SHA-256 in this response,
+so it complements rather than replaces the workflow's checksum validation of
+the source artifact.
 
 The mod version flows in via `-p:ModVersion=<ver>`, which stamps the assemblies
 and `Info.json` (see `Directory.Build.targets`). The release flow is the only
@@ -102,6 +116,13 @@ attaches the unchanged ZIP to a FUSE repository release record, and uploads the
 same bytes to the product's Nexus file chain. This keeps source ownership in the
 product repository while centralizing Nexus credentials and deployment in FUSE.
 
+The protected environment gate is reached before the job is assigned to the
+self-hosted runner. Matching release tags are also protected by repository tag
+rules: only release administrators can create them, they cannot be deleted or
+rewritten, and the workflow verifies that each tag resolves to a commit on
+protected `main`. The tag supplies the requested product and version; the lock
+file and release code on that reviewed commit remain the authority.
+
 Optional GitHub release records always set `make_latest: false`. They must not
 replace the `mod-v*` release behind FUSE's `/releases/latest` update and tool
 download links. Prerelease versions can create a GitHub prerelease record, but
@@ -143,16 +164,31 @@ To promote a successor:
    the deployed baseline and prevents a later lock-file rollback from being
    promoted as a successor.
 
-The repository uses the existing `NEXUSMODS_API_KEY` secret and one Nexus API
-Info file-group variable per product:
+The `nexus-release` environment holds `NEXUSMODS_API_KEY`, and the repository
+holds one Nexus API Info variable per product. The variable names predate the
+v3 API and retain `FILE_GROUP_ID` for compatibility, but their values are v3
+`file_id` values:
 
-- `NEXUS_TILE_EDITOR_FILE_GROUP_ID`
-- `NEXUS_TOOLSHED_FILE_GROUP_ID`
-- `NEXUS_NARROW_GAUGE_FILE_GROUP_ID`
+- `NEXUS_TILE_EDITOR_FILE_GROUP_ID=7822458`
+- `NEXUS_TOOLSHED_FILE_GROUP_ID=7822380`
+- `NEXUS_NARROW_GAUGE_FILE_GROUP_ID=7822374`
 
 The values are the API Info IDs from the files already uploaded to Nexus, not
 the Nexus mod page IDs. Keep the existing `NEXUS_FILE_GROUP_ID` reserved for
-the core FUSE release lane.
+the core FUSE release lane. Stable optional-mod promotions use the same
+fail-closed v3 lookup as core FUSE: an exact version already present is logged
+as a no-op, while only a missing version reaches the pinned upload action.
+
+Repository setup for Nexus publishing therefore requires all of the following:
+
+- A protected `nexus-release` environment with `NEXUSMODS_API_KEY`, required
+  organization-member reviewers, self-review prevention, and deployment tag
+  policies for `mod-v*`, `tileeditorsuite-v*`, `toolshed-v*`, and
+  `narrowgauge-v*`.
+- Active tag rules for those four patterns that restrict creation to release
+  administrators and prevent deletion or rewriting.
+- The four API Info variables described above (the three optional products plus
+  the existing core `NEXUS_FILE_GROUP_ID`).
 
 ## Notes
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -164,10 +164,11 @@ To promote a successor:
    the deployed baseline and prevents a later lock-file rollback from being
    promoted as a successor.
 
-The `nexus-release` environment holds `NEXUSMODS_API_KEY`, and the repository
-holds one Nexus API Info variable per product. The variable names predate the
-v3 API and retain `FILE_GROUP_ID` for compatibility, but their values are v3
-`file_id` values:
+The repository retains the existing `NEXUSMODS_API_KEY` secret and one Nexus
+API Info variable per product. Release jobs can use that repository-scoped
+secret only after the protected `nexus-release` environment gate approves and
+starts the job. The variable names predate the v3 API and retain
+`FILE_GROUP_ID` for compatibility, but their values are v3 `file_id` values:
 
 - `NEXUS_TILE_EDITOR_FILE_GROUP_ID=7822458`
 - `NEXUS_TOOLSHED_FILE_GROUP_ID=7822380`
@@ -181,10 +182,10 @@ as a no-op, while only a missing version reaches the pinned upload action.
 
 Repository setup for Nexus publishing therefore requires all of the following:
 
-- A protected `nexus-release` environment with `NEXUSMODS_API_KEY`, required
-  organization-member reviewers, self-review prevention, and deployment tag
-  policies for `mod-v*`, `tileeditorsuite-v*`, `toolshed-v*`, and
-  `narrowgauge-v*`.
+- A protected `nexus-release` environment with required organization-member
+  reviewers, self-review prevention, and deployment tag policies for `mod-v*`,
+  `tileeditorsuite-v*`, `toolshed-v*`, and `narrowgauge-v*`.
+- The existing repository secret `NEXUSMODS_API_KEY`.
 - Active tag rules for those four patterns that restrict creation to release
   administrators and prevent deletion or rewriting.
 - The four API Info variables described above (the three optional products plus

--- a/scripts/Resolve-OptionalModRelease.ps1
+++ b/scripts/Resolve-OptionalModRelease.ps1
@@ -29,7 +29,7 @@ $allowedProfiles = @{
   'narrow-gauge' = 'NEXUS_NARROW_GAUGE_FILE_GROUP_ID'
 }
 
-function Require-String {
+function Get-RequiredString {
   param(
     [Parameter(Mandatory)]$Object,
     [Parameter(Mandatory)][string]$Property,
@@ -96,20 +96,20 @@ $validatedMods = New-Object System.Collections.Generic.List[object]
 
 foreach ($mod in $mods) {
   $context = "Optional-mod entry"
-  $key = Require-String $mod 'key' $context
+  $key = Get-RequiredString -Object $mod -Property 'key' -Context $context
   $context = "Optional-mod '$key'"
-  $tagPrefix = Require-String $mod 'tagPrefix' $context
-  $version = Require-String $mod 'version' $context
-  $lastNexusVersion = Require-String $mod 'lastNexusVersion' $context
-  $blockedReason = Require-String $mod 'blockedReason' $context -AllowEmpty
-  $sourceRepository = Require-String $mod 'sourceRepository' $context
-  $sourceTag = Require-String $mod 'sourceTag' $context
-  $assetName = Require-String $mod 'assetName' $context
-  $assetSha256 = Require-String $mod 'assetSha256' $context -AllowEmpty
-  $archiveProfile = Require-String $mod 'archiveProfile' $context
-  $releaseDisplayName = Require-String $mod 'releaseDisplayName' $context
-  $nexusDisplayName = Require-String $mod 'nexusDisplayName' $context
-  $nexusVariable = Require-String $mod 'nexusVariable' $context
+  $tagPrefix = Get-RequiredString -Object $mod -Property 'tagPrefix' -Context $context
+  $version = Get-RequiredString -Object $mod -Property 'version' -Context $context
+  $lastNexusVersion = Get-RequiredString -Object $mod -Property 'lastNexusVersion' -Context $context
+  $blockedReason = Get-RequiredString -Object $mod -Property 'blockedReason' -Context $context -AllowEmpty
+  $sourceRepository = Get-RequiredString -Object $mod -Property 'sourceRepository' -Context $context
+  $sourceTag = Get-RequiredString -Object $mod -Property 'sourceTag' -Context $context
+  $assetName = Get-RequiredString -Object $mod -Property 'assetName' -Context $context
+  $assetSha256 = Get-RequiredString -Object $mod -Property 'assetSha256' -Context $context -AllowEmpty
+  $archiveProfile = Get-RequiredString -Object $mod -Property 'archiveProfile' -Context $context
+  $releaseDisplayName = Get-RequiredString -Object $mod -Property 'releaseDisplayName' -Context $context
+  $nexusDisplayName = Get-RequiredString -Object $mod -Property 'nexusDisplayName' -Context $context
+  $nexusVariable = Get-RequiredString -Object $mod -Property 'nexusVariable' -Context $context
 
   if ($null -eq $mod.PSObject.Properties['promotionReady'] -or
       $mod.promotionReady -isnot [bool]) {
@@ -173,9 +173,9 @@ foreach ($mod in $mods) {
     throw "$context is not promotion-ready and must explain why in blockedReason."
   }
 
-  Add-UniqueValue $seenKeys $key 'key'
-  Add-UniqueValue $seenPrefixes $tagPrefix 'tagPrefix'
-  Add-UniqueValue $seenNexusVariables $nexusVariable 'nexusVariable'
+  Add-UniqueValue -Seen $seenKeys -Value $key -Label 'key'
+  Add-UniqueValue -Seen $seenPrefixes -Value $tagPrefix -Label 'tagPrefix'
+  Add-UniqueValue -Seen $seenNexusVariables -Value $nexusVariable -Label 'nexusVariable'
 
   $validatedMods.Add([pscustomobject]@{
       Key = $key

--- a/scripts/Resolve-OptionalModRelease.ps1
+++ b/scripts/Resolve-OptionalModRelease.ps1
@@ -1,0 +1,286 @@
+#requires -Version 5
+<#
+.SYNOPSIS
+Validates optional-mod release metadata and resolves a FUSE release tag.
+
+.DESCRIPTION
+The trusted metadata in .github/optional-mod-releases.json is the allow-list
+between a tag pushed to this repository and an asset downloaded from another
+F-U-S-E-E repository. The resolver fails closed on mismatched versions,
+unexpected repositories, unpinned assets, or a baseline that is not ready for
+promotion.
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)][string]$ConfigPath,
+  [string]$Tag = "",
+  [switch]$ValidateOnly,
+  [string]$GitHubOutputPath = ""
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$semverPattern = '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$'
+$allowedProfiles = @{
+  'tile-editor-suite' = 'NEXUS_TILE_EDITOR_FILE_GROUP_ID'
+  'toolshed' = 'NEXUS_TOOLSHED_FILE_GROUP_ID'
+  'narrow-gauge' = 'NEXUS_NARROW_GAUGE_FILE_GROUP_ID'
+}
+
+function Require-String {
+  param(
+    [Parameter(Mandatory)]$Object,
+    [Parameter(Mandatory)][string]$Property,
+    [Parameter(Mandatory)][string]$Context,
+    [switch]$AllowEmpty
+  )
+
+  $member = $Object.PSObject.Properties[$Property]
+  if ($null -eq $member -or $null -eq $member.Value) {
+    throw "$Context is missing '$Property'."
+  }
+
+  $value = [string]$member.Value
+  if (!$AllowEmpty -and [string]::IsNullOrWhiteSpace($value)) {
+    throw "$Context has an empty '$Property'."
+  }
+  if ($value.Contains("`r") -or $value.Contains("`n")) {
+    throw "$Context '$Property' must be a single line."
+  }
+
+  return $value
+}
+
+function Add-UniqueValue {
+  param(
+    [Parameter(Mandatory)][hashtable]$Seen,
+    [Parameter(Mandatory)][string]$Value,
+    [Parameter(Mandatory)][string]$Label
+  )
+
+  $normalized = $Value.ToLowerInvariant()
+  if ($Seen.ContainsKey($normalized)) {
+    throw "Duplicate optional-mod $Label '$Value'."
+  }
+  $Seen[$normalized] = $true
+}
+
+$resolvedConfigPath = (Resolve-Path -LiteralPath $ConfigPath).Path
+try {
+  $config = Get-Content -LiteralPath $resolvedConfigPath -Raw |
+    ConvertFrom-Json
+}
+catch {
+  throw "Optional-mod release metadata is not valid JSON: $($_.Exception.Message)"
+}
+
+if ($null -eq $config.PSObject.Properties['schemaVersion'] -or
+    [int]$config.schemaVersion -ne 1) {
+  throw "Optional-mod release metadata must use schemaVersion 1."
+}
+if ($null -eq $config.PSObject.Properties['mods']) {
+  throw "Optional-mod release metadata is missing 'mods'."
+}
+
+$mods = @($config.mods)
+if ($mods.Count -eq 0) {
+  throw "Optional-mod release metadata contains no mods."
+}
+
+$seenKeys = @{}
+$seenPrefixes = @{}
+$seenNexusVariables = @{}
+$validatedMods = New-Object System.Collections.Generic.List[object]
+
+foreach ($mod in $mods) {
+  $context = "Optional-mod entry"
+  $key = Require-String $mod 'key' $context
+  $context = "Optional-mod '$key'"
+  $tagPrefix = Require-String $mod 'tagPrefix' $context
+  $version = Require-String $mod 'version' $context
+  $lastNexusVersion = Require-String $mod 'lastNexusVersion' $context
+  $blockedReason = Require-String $mod 'blockedReason' $context -AllowEmpty
+  $sourceRepository = Require-String $mod 'sourceRepository' $context
+  $sourceTag = Require-String $mod 'sourceTag' $context
+  $assetName = Require-String $mod 'assetName' $context
+  $assetSha256 = Require-String $mod 'assetSha256' $context -AllowEmpty
+  $archiveProfile = Require-String $mod 'archiveProfile' $context
+  $releaseDisplayName = Require-String $mod 'releaseDisplayName' $context
+  $nexusDisplayName = Require-String $mod 'nexusDisplayName' $context
+  $nexusVariable = Require-String $mod 'nexusVariable' $context
+
+  if ($null -eq $mod.PSObject.Properties['promotionReady'] -or
+      $mod.promotionReady -isnot [bool]) {
+    throw "$context must set boolean 'promotionReady'."
+  }
+  $promotionReady = [bool]$mod.promotionReady
+
+  if ($key -notmatch '^[a-z0-9]+(?:-[a-z0-9]+)*$') {
+    throw "$context key '$key' must be a lowercase kebab-case identifier."
+  }
+  if ($tagPrefix -notmatch '^[a-z][a-z0-9-]*-v$') {
+    throw "$context tagPrefix '$tagPrefix' must end in '-v'."
+  }
+  if ($version -notmatch $semverPattern) {
+    throw "$context version '$version' is not supported semantic version syntax."
+  }
+  if ($lastNexusVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+$') {
+    throw "$context lastNexusVersion '$lastNexusVersion' must be a stable major.minor.patch version."
+  }
+  try {
+    $candidateCoreVersion = [System.Version]::Parse(($version -split '-', 2)[0])
+    $nexusVersion = [System.Version]::Parse($lastNexusVersion)
+  }
+  catch {
+    throw "$context has a version component outside the supported System.Version range."
+  }
+  if ($candidateCoreVersion -lt $nexusVersion) {
+    throw "$context version '$version' is older than lastNexusVersion '$lastNexusVersion'."
+  }
+  if ($sourceRepository -notmatch '^F-U-S-E-E/[A-Za-z0-9_.-]+$') {
+    throw "$context sourceRepository '$sourceRepository' is outside the F-U-S-E-E organization."
+  }
+  if ($sourceTag -ne "v$version") {
+    throw "$context sourceTag '$sourceTag' must be exactly 'v$version'."
+  }
+  if ($assetName -notmatch '^[A-Za-z0-9][A-Za-z0-9._-]*\.zip$' -or
+      !$assetName.Contains($version)) {
+    throw "$context assetName '$assetName' must be a simple versioned ZIP filename."
+  }
+  if (!$allowedProfiles.ContainsKey($archiveProfile)) {
+    throw "$context archiveProfile '$archiveProfile' is not supported."
+  }
+  $expectedNexusVariable = $allowedProfiles[$archiveProfile]
+  if ($nexusVariable -ne $expectedNexusVariable) {
+    throw "$context must use Nexus variable '$expectedNexusVariable', not '$nexusVariable'."
+  }
+
+  if (![string]::IsNullOrWhiteSpace($assetSha256) -and
+      $assetSha256 -notmatch '^[0-9A-Fa-f]{64}$') {
+    throw "$context assetSha256 is not a full SHA-256 digest."
+  }
+  if ($promotionReady) {
+    if ([string]::IsNullOrWhiteSpace($assetSha256)) {
+      throw "$context is promotion-ready but assetSha256 is empty."
+    }
+    if ($candidateCoreVersion -le $nexusVersion) {
+      throw "$context version '$version' must be newer than lastNexusVersion '$lastNexusVersion' before promotion."
+    }
+  }
+  elseif ([string]::IsNullOrWhiteSpace($blockedReason)) {
+    throw "$context is not promotion-ready and must explain why in blockedReason."
+  }
+
+  Add-UniqueValue $seenKeys $key 'key'
+  Add-UniqueValue $seenPrefixes $tagPrefix 'tagPrefix'
+  Add-UniqueValue $seenNexusVariables $nexusVariable 'nexusVariable'
+
+  $validatedMods.Add([pscustomobject]@{
+      Key = $key
+      TagPrefix = $tagPrefix
+      Version = $version
+      LastNexusVersion = $lastNexusVersion
+      PromotionReady = $promotionReady
+      BlockedReason = $blockedReason
+      SourceRepository = $sourceRepository
+      SourceTag = $sourceTag
+      AssetName = $assetName
+      AssetSha256 = $assetSha256.ToLowerInvariant()
+      ArchiveProfile = $archiveProfile
+      ReleaseDisplayName = $releaseDisplayName
+      NexusDisplayName = $nexusDisplayName
+      NexusVariable = $nexusVariable
+    })
+}
+
+if ($ValidateOnly) {
+  $readyCount = @($validatedMods | Where-Object { $_.PromotionReady }).Count
+  Write-Host "Validated $($validatedMods.Count) optional-mod release entries ($readyCount promotion-ready)."
+  return
+}
+
+if ([string]::IsNullOrWhiteSpace($Tag)) {
+  throw "Specify -Tag unless -ValidateOnly is used."
+}
+if ($Tag.Contains("`r") -or $Tag.Contains("`n")) {
+  throw "Release tag must be a single line."
+}
+
+$matchedMods = New-Object System.Collections.Generic.List[object]
+foreach ($mod in $validatedMods) {
+  $pattern = '^' + [regex]::Escape($mod.TagPrefix) +
+    '(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)$'
+  if ($Tag -match $pattern) {
+    $matchedMods.Add([pscustomobject]@{
+        Mod = $mod
+        Version = $Matches.version
+      })
+  }
+}
+
+if ($matchedMods.Count -ne 1) {
+  $prefixes = @($validatedMods | ForEach-Object { $_.TagPrefix }) -join ', '
+  throw "Tag '$Tag' must use exactly one configured prefix: $prefixes."
+}
+
+$selected = $matchedMods[0].Mod
+$tagVersion = [string]$matchedMods[0].Version
+if ($tagVersion -ne $selected.Version) {
+  throw "Tag '$Tag' requests $tagVersion, but '$($selected.Key)' is locked to $($selected.Version) in $resolvedConfigPath."
+}
+if (!$selected.PromotionReady) {
+  throw "'$($selected.Key)' $tagVersion is recorded as a Nexus baseline, not a promotable release: $($selected.BlockedReason)"
+}
+
+$isGa = $tagVersion -match '^[0-9]+\.[0-9]+\.[0-9]+$'
+$result = [pscustomobject]@{
+  ModKey = $selected.Key
+  Version = $tagVersion
+  LastNexusVersion = $selected.LastNexusVersion
+  IsGa = $isGa.ToString().ToLowerInvariant()
+  SourceRepository = $selected.SourceRepository
+  SourceTag = $selected.SourceTag
+  SourceReleaseUrl = "https://github.com/$($selected.SourceRepository)/releases/tag/$($selected.SourceTag)"
+  AssetName = $selected.AssetName
+  AssetSha256 = $selected.AssetSha256
+  ArchiveProfile = $selected.ArchiveProfile
+  ReleaseDisplayName = $selected.ReleaseDisplayName
+  NexusDisplayName = $selected.NexusDisplayName
+  NexusVariable = $selected.NexusVariable
+}
+
+if (![string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
+  $outputLines = @(
+    "mod_key=$($result.ModKey)",
+    "version=$($result.Version)",
+    "last_nexus_version=$($result.LastNexusVersion)",
+    "is_ga=$($result.IsGa)",
+    "source_repository=$($result.SourceRepository)",
+    "source_tag=$($result.SourceTag)",
+    "source_release_url=$($result.SourceReleaseUrl)",
+    "asset_name=$($result.AssetName)",
+    "asset_sha256=$($result.AssetSha256)",
+    "archive_profile=$($result.ArchiveProfile)",
+    "release_display_name=$($result.ReleaseDisplayName)",
+    "nexus_display_name=$($result.NexusDisplayName)",
+    "nexus_variable=$($result.NexusVariable)"
+  )
+  $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+  $outputWriter = [System.IO.StreamWriter]::new(
+    $GitHubOutputPath,
+    $true,
+    $utf8NoBom
+  )
+  try {
+    foreach ($line in $outputLines) {
+      $outputWriter.WriteLine($line)
+    }
+  }
+  finally {
+    $outputWriter.Dispose()
+  }
+}
+
+return $result

--- a/scripts/Test-NexusFileVersion.Tests.ps1
+++ b/scripts/Test-NexusFileVersion.Tests.ps1
@@ -61,6 +61,9 @@ function Invoke-SuccessCase {
   Assert-Condition `
     -Condition ($global:NexusProbeLastHeaders.apikey -eq 'test-api-key') `
     -Message "$Name did not send the API key header."
+  Assert-Condition `
+    -Condition ($global:NexusProbeLastTimeoutSec -eq 30) `
+    -Message "$Name did not use the expected Nexus request timeout."
 }
 
 function Invoke-FailureCase {
@@ -111,11 +114,15 @@ try {
       [string]$Method,
 
       [Parameter(Mandatory = $true)]
-      [hashtable]$Headers
+      [hashtable]$Headers,
+
+      [Parameter(Mandatory = $true)]
+      [int]$TimeoutSec
     )
 
     $global:NexusProbeLastUri = $Uri
     $global:NexusProbeLastHeaders = $Headers
+    $global:NexusProbeLastTimeoutSec = $TimeoutSec
     if ($global:NexusProbeMockMode -eq 'throw') {
       throw 'Simulated Nexus API failure.'
     }
@@ -221,6 +228,19 @@ try {
     Assert-Condition `
       -Condition ($workflow -notmatch '(?m)^\s+(file_group_id|file_category|archive_existing_file):') `
       -Message "$workflowPath still uses a removed Nexus upload-action input."
+
+    if ([System.IO.Path]::GetFileName($workflowPath) -eq 'release.yml') {
+      $packageIndex = $workflow.IndexOf('- name: Package Nexus variant')
+      $preflightIndex = $workflow.IndexOf('- name: Preflight Nexus upload')
+      $releaseIndex = $workflow.IndexOf('- name: Create GitHub release')
+      Assert-Condition `
+        -Condition (
+          $packageIndex -ge 0 -and
+          $packageIndex -lt $preflightIndex -and
+          $preflightIndex -lt $releaseIndex
+        ) `
+        -Message "$workflowPath must package and preflight Nexus before creating the GitHub release."
+    }
   }
 
   Write-Host 'Nexus file-version preflight tests passed.'
@@ -232,6 +252,7 @@ finally {
   Remove-Variable -Name NexusProbeMockResponse -Scope Global -ErrorAction SilentlyContinue
   Remove-Variable -Name NexusProbeLastUri -Scope Global -ErrorAction SilentlyContinue
   Remove-Variable -Name NexusProbeLastHeaders -Scope Global -ErrorAction SilentlyContinue
+  Remove-Variable -Name NexusProbeLastTimeoutSec -Scope Global -ErrorAction SilentlyContinue
   if (Test-Path -LiteralPath $tempRoot -PathType Container) {
     Remove-Item -LiteralPath $tempRoot -Recurse -Force
   }

--- a/scripts/Test-NexusFileVersion.Tests.ps1
+++ b/scripts/Test-NexusFileVersion.Tests.ps1
@@ -1,0 +1,238 @@
+#requires -Version 5
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$probePath = Join-Path $PSScriptRoot 'Test-NexusFileVersion.ps1'
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
+  'fuse-nexus-probe-tests-{0}' -f [Guid]::NewGuid().ToString('N')
+)
+$originalApiKey = [Environment]::GetEnvironmentVariable('NEXUSMODS_API_KEY')
+
+function Assert-Condition {
+  param(
+    [Parameter(Mandatory = $true)]
+    [bool]$Condition,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  if (!$Condition) {
+    throw $Message
+  }
+}
+
+function Invoke-SuccessCase {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+
+    [Parameter(Mandatory = $true)]
+    [object]$Response,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('true', 'false')]
+    [string]$ExpectedPublishRequired
+  )
+
+  $global:NexusProbeMockMode = 'return'
+  $global:NexusProbeMockResponse = $Response
+  $outputPath = Join-Path $tempRoot "$Name-output.txt"
+
+  & $probePath `
+    -FileId '7822458' `
+    -Version '1.2.3' `
+    -GitHubOutputPath $outputPath `
+    -ApiBaseUrl 'https://mock.nexus.invalid/v3'
+
+  $outputs = Get-Content -LiteralPath $outputPath
+  Assert-Condition `
+    -Condition ($outputs -contains 'file_id=7822458') `
+    -Message "$Name did not emit the file_id output."
+  Assert-Condition `
+    -Condition ($outputs -contains "publish_required=$ExpectedPublishRequired") `
+    -Message "$Name emitted the wrong publish_required output."
+  Assert-Condition `
+    -Condition ($global:NexusProbeLastUri -eq 'https://mock.nexus.invalid/v3/mod-files/7822458/versions') `
+    -Message "$Name called the wrong Nexus endpoint."
+  Assert-Condition `
+    -Condition ($global:NexusProbeLastHeaders.apikey -eq 'test-api-key') `
+    -Message "$Name did not send the API key header."
+}
+
+function Invoke-FailureCase {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+
+    [Parameter(Mandatory = $true)]
+    [object]$Response,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$RequestFailure
+  )
+
+  $global:NexusProbeMockMode = if ($RequestFailure) { 'throw' } else { 'return' }
+  $global:NexusProbeMockResponse = $Response
+  $outputPath = Join-Path $tempRoot "$Name-output.txt"
+  $failed = $false
+
+  try {
+    & $probePath `
+      -FileId '7822458' `
+      -Version '1.2.3' `
+      -GitHubOutputPath $outputPath `
+      -ApiBaseUrl 'https://mock.nexus.invalid/v3'
+  }
+  catch {
+    $failed = $true
+  }
+
+  Assert-Condition -Condition $failed -Message "$Name should have failed closed."
+  Assert-Condition `
+    -Condition (!(Test-Path -LiteralPath $outputPath)) `
+    -Message "$Name wrote outputs despite a failed lookup."
+}
+
+try {
+  New-Item -ItemType Directory -Path $tempRoot | Out-Null
+  [Environment]::SetEnvironmentVariable('NEXUSMODS_API_KEY', 'test-api-key')
+
+  function global:Invoke-RestMethod {
+    [CmdletBinding()]
+    param(
+      [Parameter(Mandatory = $true)]
+      [string]$Uri,
+
+      [Parameter(Mandatory = $true)]
+      [string]$Method,
+
+      [Parameter(Mandatory = $true)]
+      [hashtable]$Headers
+    )
+
+    $global:NexusProbeLastUri = $Uri
+    $global:NexusProbeLastHeaders = $Headers
+    if ($global:NexusProbeMockMode -eq 'throw') {
+      throw 'Simulated Nexus API failure.'
+    }
+    return $global:NexusProbeMockResponse
+  }
+
+  Invoke-SuccessCase `
+    -Name 'existing-version' `
+    -Response ([pscustomobject]@{
+      data = [pscustomobject]@{
+        versions = @([pscustomobject]@{ version = '1.2.3' })
+      }
+    }) `
+    -ExpectedPublishRequired 'false'
+
+  Invoke-SuccessCase `
+    -Name 'missing-version' `
+    -Response ([pscustomobject]@{
+      data = [pscustomobject]@{
+        versions = @([pscustomobject]@{ version = '1.2.2' })
+      }
+    }) `
+    -ExpectedPublishRequired 'true'
+
+  Invoke-SuccessCase `
+    -Name 'empty-version-list' `
+    -Response ([pscustomobject]@{
+      data = [pscustomobject]@{
+        versions = @()
+      }
+    }) `
+    -ExpectedPublishRequired 'true'
+
+  Invoke-SuccessCase `
+    -Name 'case-sensitive-version' `
+    -Response ([pscustomobject]@{
+      data = [pscustomobject]@{
+        versions = @([pscustomobject]@{ version = '1.2.3-RC1' })
+      }
+    }) `
+    -ExpectedPublishRequired 'true'
+
+  Invoke-FailureCase `
+    -Name 'missing-versions-property' `
+    -Response ([pscustomobject]@{ data = [pscustomobject]@{} })
+
+  Invoke-FailureCase `
+    -Name 'invalid-version-entry' `
+    -Response ([pscustomobject]@{
+      data = [pscustomobject]@{
+        versions = @([pscustomobject]@{ id = 'missing-version' })
+      }
+    })
+
+  Invoke-FailureCase `
+    -Name 'scalar-versions-property' `
+    -Response ([pscustomobject]@{
+      data = [pscustomobject]@{
+        versions = [pscustomobject]@{ version = '1.2.3' }
+      }
+    })
+
+  Invoke-FailureCase `
+    -Name 'duplicate-version' `
+    -Response ([pscustomobject]@{
+      data = [pscustomobject]@{
+        versions = @(
+          [pscustomobject]@{ version = '1.2.3' },
+          [pscustomobject]@{ version = '1.2.3' }
+        )
+      }
+    })
+
+  Invoke-FailureCase `
+    -Name 'request-failure' `
+    -Response ([pscustomobject]@{}) `
+    -RequestFailure
+
+  [Environment]::SetEnvironmentVariable('NEXUSMODS_API_KEY', $null)
+  Invoke-FailureCase `
+    -Name 'missing-api-key' `
+    -Response ([pscustomobject]@{})
+
+  $repoRoot = Split-Path -Parent $PSScriptRoot
+  $workflowPaths = @(
+    (Join-Path $repoRoot '.github\workflows\release.yml'),
+    (Join-Path $repoRoot '.github\workflows\release-optional-mod.yml')
+  )
+  foreach ($workflowPath in $workflowPaths) {
+    $workflow = Get-Content -LiteralPath $workflowPath -Raw
+    Assert-Condition `
+      -Condition ($workflow -match '(?m)^\s+environment: nexus-release\s*$') `
+      -Message "$workflowPath does not use the protected Nexus environment."
+    Assert-Condition `
+      -Condition ($workflow -match 'git fetch --no-tags origin main:refs/remotes/origin/main') `
+      -Message "$workflowPath does not verify its tag against protected main."
+    Assert-Condition `
+      -Condition ($workflow -match 'Nexus-Mods/upload-action@c96019556046053aa26044b44396cd38929daf23') `
+      -Message "$workflowPath does not pin Nexus upload-action beta.10."
+    Assert-Condition `
+      -Condition ($workflow -match 'steps\.nexus\.outputs\.publish_required') `
+      -Message "$workflowPath does not gate uploads on the preflight result."
+    Assert-Condition `
+      -Condition ($workflow -notmatch '(?m)^\s+(file_group_id|file_category|archive_existing_file):') `
+      -Message "$workflowPath still uses a removed Nexus upload-action input."
+  }
+
+  Write-Host 'Nexus file-version preflight tests passed.'
+}
+finally {
+  [Environment]::SetEnvironmentVariable('NEXUSMODS_API_KEY', $originalApiKey)
+  Remove-Item -Path Function:\Invoke-RestMethod -ErrorAction SilentlyContinue
+  Remove-Variable -Name NexusProbeMockMode -Scope Global -ErrorAction SilentlyContinue
+  Remove-Variable -Name NexusProbeMockResponse -Scope Global -ErrorAction SilentlyContinue
+  Remove-Variable -Name NexusProbeLastUri -Scope Global -ErrorAction SilentlyContinue
+  Remove-Variable -Name NexusProbeLastHeaders -Scope Global -ErrorAction SilentlyContinue
+  if (Test-Path -LiteralPath $tempRoot -PathType Container) {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+  }
+}

--- a/scripts/Test-NexusFileVersion.ps1
+++ b/scripts/Test-NexusFileVersion.ps1
@@ -1,0 +1,112 @@
+#requires -Version 5
+<#
+.SYNOPSIS
+Checks whether a Nexus Mods file already contains a release version.
+
+.DESCRIPTION
+Queries the Nexus Mods v3 file-version endpoint before a release upload. The
+script fails closed when the API cannot be queried or returns an unexpected
+payload. It writes GitHub Actions outputs that allow an existing version to be
+treated as a successful no-op instead of uploading and archiving it again.
+
+The API key is read only from the NEXUSMODS_API_KEY environment variable so it
+is never exposed in a process command line.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^[1-9][0-9]*$')]
+  [string]$FileId,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^[0-9]+\.[0-9]+\.[0-9]+$')]
+  [string]$Version,
+
+  [Parameter(Mandatory = $true)]
+  [string]$GitHubOutputPath,
+
+  [Parameter(Mandatory = $false)]
+  [ValidatePattern('^https?://')]
+  [string]$ApiBaseUrl = 'https://api.nexusmods.com/v3'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$apiKey = [Environment]::GetEnvironmentVariable('NEXUSMODS_API_KEY')
+if ([string]::IsNullOrWhiteSpace($apiKey)) {
+  throw 'Environment secret NEXUSMODS_API_KEY is not configured.'
+}
+
+$outputDirectory = Split-Path -Parent $GitHubOutputPath
+if (![string]::IsNullOrWhiteSpace($outputDirectory) -and
+    !(Test-Path -LiteralPath $outputDirectory -PathType Container)) {
+  throw "GitHub output directory '$outputDirectory' does not exist."
+}
+
+$requestUri = '{0}/mod-files/{1}/versions' -f $ApiBaseUrl.TrimEnd('/'), $FileId
+$headers = @{
+  Accept = 'application/json'
+  apikey = $apiKey
+  'User-Agent' = 'F-U-S-E-E/FuseDevelopmentGroup-release'
+}
+
+try {
+  $response = Invoke-RestMethod `
+    -Uri $requestUri `
+    -Method Get `
+    -Headers $headers `
+    -ErrorAction Stop
+}
+catch {
+  $statusSuffix = ''
+  if ($null -ne $_.Exception.Response -and
+      $null -ne $_.Exception.Response.StatusCode) {
+    $statusSuffix = " (HTTP $([int]$_.Exception.Response.StatusCode))"
+  }
+  throw "Nexus version lookup failed for file ID '$FileId'$statusSuffix."
+}
+
+if ($null -eq $response -or
+    $null -eq $response.PSObject.Properties['data'] -or
+    $null -eq $response.data -or
+    $null -eq $response.data.PSObject.Properties['versions'] -or
+    $null -eq $response.data.versions -or
+    !($response.data.versions -is [System.Array])) {
+  throw "Nexus version lookup for file ID '$FileId' returned an unexpected response."
+}
+
+$versions = @($response.data.versions)
+foreach ($item in $versions) {
+  if ($null -eq $item -or
+      $null -eq $item.PSObject.Properties['version'] -or
+      !($item.version -is [string]) -or
+      [string]::IsNullOrWhiteSpace($item.version)) {
+    throw "Nexus version lookup for file ID '$FileId' returned an invalid version entry."
+  }
+}
+
+$matchingVersions = @(
+  $versions | Where-Object { $_.version -ceq $Version }
+)
+if ($matchingVersions.Count -gt 1) {
+  throw "Nexus file ID '$FileId' contains duplicate entries for version '$Version'."
+}
+
+$alreadyPublished = $matchingVersions.Count -eq 1
+$publishRequired = if ($alreadyPublished) { 'false' } else { 'true' }
+
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::AppendAllText(
+  $GitHubOutputPath,
+  "file_id=$FileId$([Environment]::NewLine)" +
+    "publish_required=$publishRequired$([Environment]::NewLine)",
+  $utf8NoBom
+)
+
+if ($alreadyPublished) {
+  Write-Host "Nexus file ID $FileId already contains version $Version; upload is a no-op."
+}
+else {
+  Write-Host "Nexus file ID $FileId does not contain version $Version; upload is required."
+}

--- a/scripts/Test-NexusFileVersion.ps1
+++ b/scripts/Test-NexusFileVersion.ps1
@@ -56,6 +56,7 @@ try {
     -Uri $requestUri `
     -Method Get `
     -Headers $headers `
+    -TimeoutSec 30 `
     -ErrorAction Stop
 }
 catch {

--- a/scripts/Validate-OptionalModPackage.ps1
+++ b/scripts/Validate-OptionalModPackage.ps1
@@ -18,7 +18,7 @@ param(
     'tile-editor-suite',
     'toolshed',
     'narrow-gauge'
-  )][string]$Profile,
+  )][string]$ArchiveProfile,
   [Parameter(Mandatory)][string]$ExpectedSha256
 )
 
@@ -136,7 +136,7 @@ $profiles = @{
   }
 }
 
-$profileSpec = $profiles[$Profile]
+$profileSpec = $profiles[$ArchiveProfile]
 $archive = [System.IO.Compression.ZipFile]::OpenRead($resolvedArchive)
 try {
   $script:entryMap = @{}
@@ -187,7 +187,7 @@ try {
         throw "Archive entry '$name' contains a segment longer than 255 characters."
       }
       $deviceBaseName = @($normalizedSegment -split '\.', 2)[0]
-      if ($deviceBaseName -match '^(?i:CON|PRN|AUX|NUL|CONIN\$|CONOUT\$|COM[1-9¹²³]|LPT[1-9¹²³])$') {
+      if ($deviceBaseName -match '^(?i:CON|PRN|AUX|NUL|CONIN\$|CONOUT\$|COM[1-9\u00B9\u00B2\u00B3]|LPT[1-9\u00B9\u00B2\u00B3])$') {
         throw "Archive entry '$name' uses reserved Windows device name '$deviceBaseName'."
       }
       $normalizedSegments.Add($normalizedSegment)
@@ -232,7 +232,7 @@ try {
   foreach ($entry in $archive.Entries) {
     if ([string]::IsNullOrEmpty($root)) {
       if ($entry.FullName.Contains('/')) {
-        throw "Profile '$Profile' requires entries at the archive root; found '$($entry.FullName)'."
+        throw "Profile '$ArchiveProfile' requires entries at the archive root; found '$($entry.FullName)'."
       }
     }
     elseif ($entry.FullName -cne "$root/" -and
@@ -240,7 +240,7 @@ try {
           "$root/",
           [System.StringComparison]::Ordinal
         )) {
-      throw "Profile '$Profile' requires the single archive root '$root/'; found '$($entry.FullName)'."
+      throw "Profile '$ArchiveProfile' requires the single archive root '$root/'; found '$($entry.FullName)'."
     }
   }
 
@@ -284,7 +284,7 @@ try {
     throw "Assembly '$assemblyPath' is empty."
   }
 
-  if ($Profile -eq 'tile-editor-suite') {
+  if ($ArchiveProfile -eq 'tile-editor-suite') {
     $packageManifestPath = "$root/PackageManifest.json"
     try {
       $packageManifest = Read-EntryText $packageManifestPath | ConvertFrom-Json
@@ -355,4 +355,4 @@ finally {
   Remove-Variable -Name entryMap -Scope Script -ErrorAction SilentlyContinue
 }
 
-Write-Host "Validated $Profile package '$resolvedArchive' as version $Version (sha256:$actualSha256)."
+Write-Host "Validated $ArchiveProfile package '$resolvedArchive' as version $Version (sha256:$actualSha256)."

--- a/scripts/Validate-OptionalModPackage.ps1
+++ b/scripts/Validate-OptionalModPackage.ps1
@@ -1,0 +1,358 @@
+#requires -Version 5
+<#
+.SYNOPSIS
+Validates an optional-mod release archive before GitHub or Nexus publication.
+
+.DESCRIPTION
+The validator treats the upstream ZIP as untrusted even though its SHA-256 is
+pinned in FUSE. It rejects unsafe or non-portable entry names, checks the UMM
+manifest identity and version, and enforces the established package layout for
+each optional mod. Tile Editor's internal checksum manifest is also verified.
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)][string]$ArchivePath,
+  [Parameter(Mandatory)][string]$Version,
+  [Parameter(Mandatory)][ValidateSet(
+    'tile-editor-suite',
+    'toolshed',
+    'narrow-gauge'
+  )][string]$Profile,
+  [Parameter(Mandatory)][string]$ExpectedSha256
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($Version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$') {
+  throw "Version '$Version' is not supported semantic version syntax."
+}
+if ($ExpectedSha256 -notmatch '^[0-9A-Fa-f]{64}$') {
+  throw "ExpectedSha256 must be a full SHA-256 digest."
+}
+
+$resolvedArchive = (Resolve-Path -LiteralPath $ArchivePath).Path
+$actualSha256 = (Get-FileHash -LiteralPath $resolvedArchive -Algorithm SHA256).Hash.ToLowerInvariant()
+$expectedSha256Normalized = $ExpectedSha256.ToLowerInvariant()
+if ($actualSha256 -ne $expectedSha256Normalized) {
+  throw "Archive SHA-256 is $actualSha256; expected $expectedSha256Normalized."
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+function Get-Entry {
+  param([Parameter(Mandatory)][string]$Name)
+
+  if (!$script:entryMap.ContainsKey($Name)) {
+    throw "Archive is missing required entry '$Name'."
+  }
+  $entry = $script:entryMap[$Name]
+  if ($entry.FullName -cne $Name) {
+    throw "Archive entry '$($entry.FullName)' must use exact casing '$Name'."
+  }
+  return $entry
+}
+
+function Read-EntryText {
+  param([Parameter(Mandatory)][string]$Name)
+
+  $entry = Get-Entry $Name
+  $stream = $entry.Open()
+  try {
+    $reader = [System.IO.StreamReader]::new(
+      $stream,
+      [System.Text.Encoding]::UTF8,
+      $true
+    )
+    try {
+      return $reader.ReadToEnd()
+    }
+    finally {
+      $reader.Dispose()
+    }
+  }
+  finally {
+    $stream.Dispose()
+  }
+}
+
+function Get-EntrySha256 {
+  param([Parameter(Mandatory)]$Entry)
+
+  $stream = $Entry.Open()
+  $algorithm = [System.Security.Cryptography.SHA256]::Create()
+  try {
+    $bytes = $algorithm.ComputeHash($stream)
+    return -join ($bytes | ForEach-Object { $_.ToString('x2') })
+  }
+  finally {
+    $algorithm.Dispose()
+    $stream.Dispose()
+  }
+}
+
+$profiles = @{
+  'tile-editor-suite' = @{
+    Root = 'Hrogers.TileEditorBridge'
+    Manifest = 'Hrogers.TileEditorBridge/Info.json'
+    Id = 'Hrogers.TileEditorBridge'
+    Assembly = 'Hrogers.TileEditorBridge.dll'
+    EntryMethod = 'Hrogers.TileEditorBridge.Main.Load'
+    Required = @(
+      'Hrogers.TileEditorBridge/Hrogers.TileEditorBridge.dll',
+      'Hrogers.TileEditorBridge/PackageManifest.json',
+      'Hrogers.TileEditorBridge/VERSION.txt',
+      'Hrogers.TileEditorBridge/checksums.sha256',
+      'Hrogers.TileEditorBridge/TileEditor/edit_tiles/version.py',
+      'Hrogers.TileEditorBridge/TileEditor/requirements.txt'
+    )
+  }
+  'toolshed' = @{
+    Root = 'Toolshed'
+    Manifest = 'Toolshed/Info.json'
+    Id = 'Toolshed'
+    Assembly = 'Toolshed.dll'
+    EntryMethod = 'Toolshed.Main.Load'
+    Required = @(
+      'Toolshed/Toolshed.dll',
+      'Toolshed/LICENSE',
+      'Toolshed/README.md',
+      'Toolshed/SCAssetPacks/WoodShed/Bundle',
+      'Toolshed/SCAssetPacks/link-pin-coupler/Bundle',
+      'Toolshed/Examples/service-facility-setup-guide.md'
+    )
+  }
+  'narrow-gauge' = @{
+    Root = ''
+    Manifest = 'Info.json'
+    Id = 'FUSE.NarrowGauge'
+    Assembly = 'NarrowGaugeMod.dll'
+    EntryMethod = 'NarrowGaugeMod.Main.Load'
+    Required = @(
+      'NarrowGaugeMod.dll',
+      'README.md'
+    )
+  }
+}
+
+$profileSpec = $profiles[$Profile]
+$archive = [System.IO.Compression.ZipFile]::OpenRead($resolvedArchive)
+try {
+  $script:entryMap = @{}
+  $normalizedPathMap = [System.Collections.Generic.Dictionary[string,string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+  )
+  $normalizedFilePaths = New-Object System.Collections.Generic.List[string]
+  $fileEntries = New-Object System.Collections.Generic.List[object]
+
+  foreach ($entry in $archive.Entries) {
+    $name = $entry.FullName
+    if ([string]::IsNullOrWhiteSpace($name)) {
+      throw "Archive contains an entry with an empty name."
+    }
+    if ($name.Contains('\')) {
+      throw "Archive entry '$name' contains a backslash; ZIP paths must use '/'."
+    }
+    if ($name.StartsWith('/') -or $name -match '^[A-Za-z]:') {
+      throw "Archive entry '$name' uses an absolute path."
+    }
+
+    $segments = @($name.Split('/'))
+    $lastSegmentIndex = $segments.Count - 1
+    $normalizedSegments = New-Object System.Collections.Generic.List[string]
+    $isDirectoryEntry = $name.EndsWith('/')
+    for ($index = 0; $index -lt $segments.Count; $index++) {
+      $segment = $segments[$index]
+      $isDirectoryTerminator = $index -eq $lastSegmentIndex -and
+        [string]::IsNullOrEmpty($segment) -and $isDirectoryEntry
+      if (!$isDirectoryTerminator -and
+          ([string]::IsNullOrEmpty($segment) -or $segment -eq '.' -or $segment -eq '..')) {
+        throw "Archive entry '$name' contains an unsafe path segment."
+      }
+      if ($isDirectoryTerminator) {
+        continue
+      }
+      if ($segment -match '[\x00-\x1F<>:"\\|?*]') {
+        throw "Archive entry '$name' contains a character that is invalid on Windows."
+      }
+      if ($segment.EndsWith('.') -or $segment.EndsWith(' ')) {
+        throw "Archive entry '$name' contains a segment with a trailing dot or space."
+      }
+
+      $normalizedSegment = $segment.Normalize(
+        [System.Text.NormalizationForm]::FormC
+      )
+      if ($normalizedSegment.Length -gt 255) {
+        throw "Archive entry '$name' contains a segment longer than 255 characters."
+      }
+      $deviceBaseName = @($normalizedSegment -split '\.', 2)[0]
+      if ($deviceBaseName -match '^(?i:CON|PRN|AUX|NUL|CONIN\$|CONOUT\$|COM[1-9¹²³]|LPT[1-9¹²³])$') {
+        throw "Archive entry '$name' uses reserved Windows device name '$deviceBaseName'."
+      }
+      $normalizedSegments.Add($normalizedSegment)
+    }
+
+    $normalizedPath = $normalizedSegments -join '/'
+    if ($normalizedPathMap.ContainsKey($normalizedPath)) {
+      throw "Archive entries '$($normalizedPathMap[$normalizedPath])' and '$name' normalize to the same Windows path."
+    }
+    $normalizedPathMap[$normalizedPath] = $name
+    if (!$isDirectoryEntry) {
+      $normalizedFilePaths.Add($normalizedPath)
+    }
+
+    if ($script:entryMap.ContainsKey($name)) {
+      throw "Archive contains duplicate or case-colliding entry '$name'."
+    }
+    $script:entryMap[$name] = $entry
+
+    if (!$name.EndsWith('/')) {
+      $fileEntries.Add($entry)
+    }
+  }
+
+  foreach ($filePath in $normalizedFilePaths) {
+    $childPrefix = "$filePath/"
+    foreach ($candidatePath in $normalizedPathMap.Keys) {
+      if ($candidatePath.StartsWith(
+          $childPrefix,
+          [System.StringComparison]::OrdinalIgnoreCase
+        )) {
+        throw "Archive file '$filePath' conflicts with child path '$candidatePath'."
+      }
+    }
+  }
+
+  if ($fileEntries.Count -eq 0) {
+    throw "Archive contains no files."
+  }
+
+  $root = [string]$profileSpec.Root
+  foreach ($entry in $archive.Entries) {
+    if ([string]::IsNullOrEmpty($root)) {
+      if ($entry.FullName.Contains('/')) {
+        throw "Profile '$Profile' requires entries at the archive root; found '$($entry.FullName)'."
+      }
+    }
+    elseif ($entry.FullName -cne "$root/" -and
+        !$entry.FullName.StartsWith(
+          "$root/",
+          [System.StringComparison]::Ordinal
+        )) {
+      throw "Profile '$Profile' requires the single archive root '$root/'; found '$($entry.FullName)'."
+    }
+  }
+
+  foreach ($required in @($profileSpec.Required)) {
+    $null = Get-Entry $required
+  }
+
+  $manifestPath = [string]$profileSpec.Manifest
+  try {
+    $manifest = Read-EntryText $manifestPath | ConvertFrom-Json
+  }
+  catch {
+    throw "Manifest '$manifestPath' is not valid JSON: $($_.Exception.Message)"
+  }
+
+  $expectedManifestValues = @{
+    Id = [string]$profileSpec.Id
+    Version = $Version
+    AssemblyName = [string]$profileSpec.Assembly
+    EntryMethod = [string]$profileSpec.EntryMethod
+  }
+  foreach ($property in $expectedManifestValues.Keys) {
+    if ($null -eq $manifest.PSObject.Properties[$property]) {
+      throw "Manifest '$manifestPath' is missing '$property'."
+    }
+    $actual = [string]$manifest.$property
+    $expected = [string]$expectedManifestValues[$property]
+    if ($actual -cne $expected) {
+      throw "Manifest '$manifestPath' has $property='$actual'; expected '$expected'."
+    }
+  }
+
+  $assemblyPath = if ([string]::IsNullOrEmpty($root)) {
+    [string]$profileSpec.Assembly
+  }
+  else {
+    "$root/$($profileSpec.Assembly)"
+  }
+  $assemblyEntry = Get-Entry $assemblyPath
+  if ($assemblyEntry.Length -le 0) {
+    throw "Assembly '$assemblyPath' is empty."
+  }
+
+  if ($Profile -eq 'tile-editor-suite') {
+    $packageManifestPath = "$root/PackageManifest.json"
+    try {
+      $packageManifest = Read-EntryText $packageManifestPath | ConvertFrom-Json
+    }
+    catch {
+      throw "Package manifest '$packageManifestPath' is not valid JSON: $($_.Exception.Message)"
+    }
+    if ($null -eq $packageManifest.PSObject.Properties['version'] -or
+        [string]$packageManifest.version -cne $Version) {
+      throw "Package manifest version must be '$Version'."
+    }
+
+    $versionText = (Read-EntryText "$root/VERSION.txt").Trim()
+    if ($versionText -cne $Version) {
+      throw "VERSION.txt contains '$versionText'; expected '$Version'."
+    }
+
+    $pythonVersionSource = Read-EntryText "$root/TileEditor/edit_tiles/version.py"
+    if ($pythonVersionSource -notmatch '__version__\s*=\s*"(?<version>[^"]+)"' -or
+        $Matches.version -cne $Version) {
+      throw "Tile Editor Python version does not match '$Version'."
+    }
+
+    $checksumPath = "$root/checksums.sha256"
+    $checksumText = Read-EntryText $checksumPath
+    $checksums = @{}
+    foreach ($line in @($checksumText -split "`r?`n")) {
+      if ([string]::IsNullOrWhiteSpace($line)) {
+        continue
+      }
+      if ($line -notmatch '^(?<hash>[0-9A-Fa-f]{64})  (?<path>.+)$') {
+        throw "Invalid Tile Editor checksum line '$line'."
+      }
+      $relativePath = $Matches.path
+      if ($relativePath.Contains('\') -or
+          $relativePath.StartsWith('/') -or
+          $relativePath.Contains('../')) {
+        throw "Unsafe Tile Editor checksum path '$relativePath'."
+      }
+      if ($checksums.ContainsKey($relativePath)) {
+        throw "Duplicate Tile Editor checksum path '$relativePath'."
+      }
+      $checksums[$relativePath] = $Matches.hash.ToLowerInvariant()
+    }
+
+    $checkedFileCount = 0
+    foreach ($entry in $fileEntries) {
+      if ($entry.FullName -ceq $checksumPath) {
+        continue
+      }
+      $relativePath = $entry.FullName.Substring($root.Length + 1)
+      if (!$checksums.ContainsKey($relativePath)) {
+        throw "Tile Editor checksum manifest is missing '$relativePath'."
+      }
+      $entryHash = Get-EntrySha256 $entry
+      if ($entryHash -ne $checksums[$relativePath]) {
+        throw "Tile Editor checksum mismatch for '$relativePath'."
+      }
+      $checkedFileCount++
+    }
+    if ($checkedFileCount -ne $checksums.Count) {
+      throw "Tile Editor checksum manifest contains entries that are not in the archive."
+    }
+  }
+}
+finally {
+  $archive.Dispose()
+  Remove-Variable -Name entryMap -Scope Script -ErrorAction SilentlyContinue
+}
+
+Write-Host "Validated $Profile package '$resolvedArchive' as version $Version (sha256:$actualSha256)."

--- a/tools/json_lint.py
+++ b/tools/json_lint.py
@@ -112,7 +112,6 @@ def find_git_executable() -> str | None:
 _FILESYSTEM_WALK_SKIP_DIRS = frozenset(
     name.lower() for name in (
         ".git",
-        ".github",  # only the workflow yml lives here, no .json
         ".vs",
         ".vscode",
         ".idea",


### PR DESCRIPTION
## Summary

- add a FUSE-owned, tag-driven Nexus promotion lane for Tile Editor Suite, Toolshed FUSE, and Narrow Gauge on the organization self-hosted runner
- lock upstream repositories, release tags, asset names, SHA-256 digests, Nexus baselines, and independent product tag namespaces
- validate package identity, version, layout, checksums, and Windows-safe ZIP paths before publishing
- keep optional GitHub releases from replacing the core FUSE Latest release and reject baseline re-uploads or version downgrades
- document the successor promotion and post-release baseline update process

## Initial baselines

- Hrogers.TileEditorSuite 0.26.6
- Toolshed FUSE 0.3.0
- NarrowGaugeMod 0.4.0

All three are recorded with promotionReady set to false because they are already live on Nexus. Tile Editor also remains blocked because its public source and GitHub release are still 0.26.4 and the existing ZIP uses non-portable backslash entry names.

## Validation

- PowerShell syntax and release resolver checks
- blocked-baseline, ready-successor, and downgrade-rejection fixtures
- exact Toolshed 0.3.0 and Narrow Gauge 0.4.0 package validation
- portable Tile Editor package validation and expected rejection of its current upstream ZIP
- malicious Windows ZIP path rejection fixtures
- workflow YAML parsing, JSON lint, Python compilation, and git diff checks
- slopwatch completed with one pre-existing timing warning in TerrainGenerationServiceTests