### PR TITLE
Review: lifecycle, profiles, diagnostics, and performance

### DIFF
--- a/FUSE.Converter/Conversion/LegacyAudioConverter.cs
+++ b/FUSE.Converter/Conversion/LegacyAudioConverter.cs
@@ -119,7 +119,7 @@ namespace FUSE.Converter.Conversion
             var info = new JObject
             {
                 ["$schema"] = ".\\schemas\\umm-info.schema.json",
-                ["Id"] = manifest.Id + ".FUSE",
+                ["Id"] = LegacyDefinitionConverter.ConvertedPackageId(manifest.Id) ?? manifest.Id + ".FUSE",
                 ["DisplayName"] = manifest.Name + " (FUSE)",
                 ["Author"] = manifest.Author ?? string.Empty,
                 ["Version"] = manifest.Version ?? "1.0.0",
@@ -218,7 +218,7 @@ namespace FUSE.Converter.Conversion
                 var info = new JObject
                 {
                     ["$schema"] = ".\\schemas\\umm-info.schema.json",
-                    ["Id"] = manifest.Id + ".FUSE",
+                    ["Id"] = LegacyDefinitionConverter.ConvertedPackageId(manifest.Id) ?? manifest.Id + ".FUSE",
                     ["DisplayName"] = manifest.Name + " (FUSE Audio)",
                     ["Author"] = manifest.Author ?? string.Empty,
                     ["Version"] = manifest.Version ?? "1.0.0",

--- a/FUSE.Converter/Conversion/LegacyAudioConverter.cs
+++ b/FUSE.Converter/Conversion/LegacyAudioConverter.cs
@@ -398,10 +398,11 @@ namespace FUSE.Converter.Conversion
         public static JObject BuildAudioSkeleton(string modId, string modName, string modVersion, string author)
         {
             var rail = FuseFragmentBuilder.Build(modId, modName, modVersion, author, "audio");
+            var convertedPackageId = LegacyDefinitionConverter.ConvertedPackageId(modId) ?? $"{modId}.FUSE";
             // The audio skeleton extends the base with an audio
             // section (whistles/horns/bells dicts) plus the
             // suppressBase arrays the audio variant uses.
-            rail["id"] = $"{modId}.FUSE.Audio";
+            rail["id"] = $"{convertedPackageId}.Audio";
             rail["name"] = $"{modName} (FUSE Audio)";
             rail["audio"] = new JObject
             {

--- a/FUSE.Converter/Conversion/LegacyConverterConstants.cs
+++ b/FUSE.Converter/Conversion/LegacyConverterConstants.cs
@@ -157,10 +157,27 @@ namespace FUSE.Converter.Conversion
         public static readonly HashSet<string> CoreLegacyRequirements = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "railroader", "railloader", "rail-loader",
+            "railloader.injector", "railloader.interchange",
+            "assetloader",
+            "alinanova21.mapeditor", "mapeditor", "mmapeditor",
             "zamu.strangecustoms", "strangecustoms",
             "zamu.confusingsupplements", "confusingsupplements",
+            "zamu.foryourconvenience", "foryourconvenience",
+            "alinanova21.alinasmapmod", "alinasmapmod", "alinamapmod",
             "fuse",
         };
+
+        public static bool IsCoreLegacyRequirement(string packageId)
+        {
+            var value = (packageId ?? string.Empty).Trim();
+            while (value.EndsWith(".FUSE", StringComparison.OrdinalIgnoreCase) ||
+                   value.EndsWith(".RAIL", StringComparison.OrdinalIgnoreCase))
+            {
+                value = value.Substring(0, value.Length - 5);
+            }
+
+            return CoreLegacyRequirements.Contains(value);
+        }
 
         /// <summary>
         /// Component type alias table — port of the dictionary

--- a/FUSE.Converter/Conversion/LegacyDefinitionConverter.cs
+++ b/FUSE.Converter/Conversion/LegacyDefinitionConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
@@ -42,13 +43,18 @@ namespace FUSE.Converter.Conversion
         /// </summary>
         public static JObject ConvertRequirement(JToken item)
         {
+            return ConvertReference(item, true);
+        }
+
+        private static JObject ConvertReference(JToken item, bool filterReplacementCapabilities)
+        {
             if (item == null) return null;
 
             if (item.Type == JTokenType.String)
             {
                 var requirementId = item.Value<string>()?.Trim();
                 if (string.IsNullOrEmpty(requirementId)) return null;
-                if (LegacyConverterConstants.CoreLegacyRequirements.Contains(requirementId)) return null;
+                if (filterReplacementCapabilities && LegacyConverterConstants.IsCoreLegacyRequirement(requirementId)) return null;
                 return new JObject { ["id"] = requirementId };
             }
 
@@ -56,7 +62,7 @@ namespace FUSE.Converter.Conversion
 
             var id = (obj.Value<string>("id") ?? obj.Value<string>("Id") ?? string.Empty).Trim();
             if (string.IsNullOrEmpty(id)) return null;
-            if (LegacyConverterConstants.CoreLegacyRequirements.Contains(id)) return null;
+            if (filterReplacementCapabilities && LegacyConverterConstants.IsCoreLegacyRequirement(id)) return null;
 
             var result = new JObject
             {
@@ -75,18 +81,51 @@ namespace FUSE.Converter.Conversion
         /// </summary>
         public static JArray ConvertRequirements(JToken value)
         {
+            return ConvertReferences(value, true);
+        }
+
+        private static JArray ConvertReferences(JToken value, bool filterReplacementCapabilities)
+        {
             var result = new JArray();
             if (!(value is JArray arr)) return result;
 
             foreach (var item in arr)
             {
-                var converted = ConvertRequirement(item);
+                var converted = ConvertReference(item, filterReplacementCapabilities);
                 if (converted != null)
                 {
                     result.Add(converted);
                 }
             }
             return result;
+        }
+
+        public static JArray LegacyConflictsWith(string modFolder)
+        {
+            var path = Path.Combine(modFolder ?? string.Empty, "Definition.json");
+            if (!File.Exists(path))
+            {
+                return new JArray();
+            }
+
+            try
+            {
+                var definition = LegacyJsonReader.ReadJson(path) as JObject;
+                var converted = ConvertReferences(
+                    definition?["conflictsWith"] ?? definition?["ConflictsWith"],
+                    false);
+                return new JArray(converted.OfType<JObject>().Select(reference =>
+                    JsonCleanHelper.CleanObject(new JObject
+                    {
+                        ["Id"] = reference["id"]?.DeepClone(),
+                        ["NotBefore"] = reference["notBefore"]?.DeepClone(),
+                        ["NotAfter"] = reference["notAfter"]?.DeepClone()
+                    })));
+            }
+            catch (Exception)
+            {
+                return new JArray();
+            }
         }
 
         /// <summary>
@@ -100,7 +139,7 @@ namespace FUSE.Converter.Conversion
         {
             var text = (requirementId ?? string.Empty).Trim();
             if (string.IsNullOrEmpty(text)) return null;
-            if (LegacyConverterConstants.CoreLegacyRequirements.Contains(text)) return null;
+            if (LegacyConverterConstants.IsCoreLegacyRequirement(text)) return null;
             if (text.EndsWith(".FUSE", StringComparison.OrdinalIgnoreCase)) return text;
             return text + ".FUSE";
         }
@@ -114,19 +153,33 @@ namespace FUSE.Converter.Conversion
         /// </summary>
         public static List<string> LegacyLoadAfter(string modFolder)
         {
-            var result = new List<string>();
+            var dependencies = LegacyDependencies(modFolder);
+            var result = new List<string>(dependencies.Requires);
+            result.AddRange(dependencies.LoadAfter);
+            return Deduplicate(result);
+        }
+
+        /// <summary>
+        /// Reads hard requirements separately from advisory ordering. The old
+        /// converter flattened both into LoadAfter, which made a missing required
+        /// package look optional to FUSE.
+        /// </summary>
+        public static (List<string> Requires, List<string> LoadAfter) LegacyDependencies(string modFolder)
+        {
+            var required = new List<string>();
+            var loadAfter = new List<string>();
             var path = Path.Combine(modFolder ?? string.Empty, "Definition.json");
-            if (!File.Exists(path)) return result;
+            if (!File.Exists(path)) return (required, loadAfter);
 
             JObject definition;
             try
             {
                 definition = LegacyJsonReader.ReadJson(path) as JObject;
-                if (definition == null) return result;
+                if (definition == null) return (required, loadAfter);
             }
             catch (Exception)
             {
-                return result;
+                return (required, loadAfter);
             }
 
             var requirements =
@@ -141,37 +194,97 @@ namespace FUSE.Converter.Conversion
                 var packageId = FusePackageId((requirement as JObject)?.Value<string>("id"));
                 if (!string.IsNullOrEmpty(packageId))
                 {
-                    result.Add(packageId);
+                    required.Add(packageId);
                 }
             }
 
             var loadAfterToken = definition["loadAfter"] ?? definition["LoadAfter"];
-            var loadAfterList = new List<string>();
             if (loadAfterToken is JArray la)
             {
                 foreach (var item in la)
                 {
-                    if (item.Type == JTokenType.String) loadAfterList.Add(item.Value<string>());
+                    var id = item.Type == JTokenType.String
+                        ? item.Value<string>()
+                        : (item as JObject)?.Value<string>("id") ?? (item as JObject)?.Value<string>("Id");
+                    var packageId = FusePackageId(id);
+                    if (!string.IsNullOrEmpty(packageId)) loadAfter.Add(packageId);
                 }
             }
             else if (loadAfterToken?.Type == JTokenType.String)
             {
-                loadAfterList.Add(loadAfterToken.Value<string>());
-            }
-
-            foreach (var item in loadAfterList)
-            {
-                var packageId = FusePackageId(item);
+                var packageId = FusePackageId(loadAfterToken.Value<string>());
                 if (!string.IsNullOrEmpty(packageId))
                 {
-                    result.Add(packageId);
+                    loadAfter.Add(packageId);
                 }
             }
 
-            // Dedup preserving first-seen order (case-insensitive).
+            foreach (var id in EnumerateMixintoRequirementIds(
+                         definition["mixintos"] ?? definition["Mixintos"]))
+            {
+                var packageId = FusePackageId(id);
+                if (!string.IsNullOrEmpty(packageId))
+                {
+                    loadAfter.Add(packageId);
+                }
+            }
+
+            return (Deduplicate(required), Deduplicate(loadAfter));
+        }
+
+        private static IEnumerable<string> EnumerateMixintoRequirementIds(JToken value)
+        {
+            if (value == null || value.Type == JTokenType.Null)
+            {
+                yield break;
+            }
+
+            if (value is JArray array)
+            {
+                foreach (var item in array)
+                {
+                    foreach (var id in EnumerateMixintoRequirementIds(item))
+                    {
+                        yield return id;
+                    }
+                }
+
+                yield break;
+            }
+
+            if (!(value is JObject obj))
+            {
+                yield break;
+            }
+
+            foreach (var requirement in ConvertRequirements(obj["requires"] ?? obj["Requires"]).OfType<JObject>())
+            {
+                var id = requirement.Value<string>("id");
+                if (!string.IsNullOrWhiteSpace(id))
+                {
+                    yield return id;
+                }
+            }
+
+            foreach (var property in obj.Properties())
+            {
+                if (string.Equals(property.Name, "requires", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                foreach (var id in EnumerateMixintoRequirementIds(property.Value))
+                {
+                    yield return id;
+                }
+            }
+        }
+
+        private static List<string> Deduplicate(IEnumerable<string> values)
+        {
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var ordered = new List<string>();
-            foreach (var item in result)
+            foreach (var item in values ?? Array.Empty<string>())
             {
                 if (seen.Add(item))
                 {
@@ -213,7 +326,7 @@ namespace FUSE.Converter.Conversion
                 return (metadata, orderedFiles);
             }
 
-            void Record(string target, string reference, JArray requirements)
+            void Record(string target, string reference, JArray requirements, JArray conflictsWith)
             {
                 var referencedFile = ExtractFileReference(reference);
                 if (string.IsNullOrEmpty(referencedFile)) return;
@@ -229,6 +342,7 @@ namespace FUSE.Converter.Conversion
                     ["target"] = (target ?? string.Empty).Trim(),
                     ["sourceFile"] = sourceFile,
                     ["requires"] = requirements ?? new JArray(),
+                    ["conflictsWith"] = conflictsWith ?? new JArray(),
                 });
             }
 
@@ -238,7 +352,7 @@ namespace FUSE.Converter.Conversion
 
                 if (value.Type == JTokenType.String)
                 {
-                    Record(target, value.Value<string>(), null);
+                    Record(target, value.Value<string>(), null, null);
                     return;
                 }
 
@@ -251,8 +365,9 @@ namespace FUSE.Converter.Conversion
                 if (!(value is JObject obj)) return;
 
                 var requirements = ConvertRequirements(obj["requires"] ?? obj["Requires"]);
+                var conflictsWith = ConvertReferences(obj["conflictsWith"] ?? obj["ConflictsWith"], false);
                 var reference = obj.Value<string>("mixinto") ?? obj.Value<string>("Mixinto");
-                Record(target, reference, requirements);
+                Record(target, reference, requirements, conflictsWith);
             }
 
             var mixintos = definition["mixintos"] as JObject ?? definition["Mixintos"] as JObject;

--- a/FUSE.Converter/Conversion/LegacyDefinitionConverter.cs
+++ b/FUSE.Converter/Conversion/LegacyDefinitionConverter.cs
@@ -117,7 +117,7 @@ namespace FUSE.Converter.Conversion
                 return new JArray(converted.OfType<JObject>().Select(reference =>
                     JsonCleanHelper.CleanObject(new JObject
                     {
-                        ["Id"] = reference["id"]?.DeepClone(),
+                        ["Id"] = ConvertedPackageId(reference.Value<string>("id")),
                         ["NotBefore"] = reference["notBefore"]?.DeepClone(),
                         ["NotAfter"] = reference["notAfter"]?.DeepClone()
                     })));

--- a/FUSE.Converter/Conversion/LegacyDefinitionConverter.cs
+++ b/FUSE.Converter/Conversion/LegacyDefinitionConverter.cs
@@ -132,7 +132,8 @@ namespace FUSE.Converter.Conversion
         /// Port of <c>fuse_package_id</c>. A legacy requirement id
         /// like "MyMod" becomes "MyMod.FUSE" (the converter shipped
         /// alongside the original package); ids already ending in
-        /// ".FUSE" pass through unchanged. Core legacy requirements
+        /// ".FUSE" pass through unchanged and legacy ".RAIL" suffixes
+        /// are replaced. Core legacy requirements
         /// return null so they get dropped from the LoadAfter chain.
         /// </summary>
         public static string FusePackageId(string requirementId)
@@ -140,7 +141,19 @@ namespace FUSE.Converter.Conversion
             var text = (requirementId ?? string.Empty).Trim();
             if (string.IsNullOrEmpty(text)) return null;
             if (LegacyConverterConstants.IsCoreLegacyRequirement(text)) return null;
+            return ConvertedPackageId(text);
+        }
+
+        internal static string ConvertedPackageId(string packageId)
+        {
+            var text = (packageId ?? string.Empty).Trim();
+            if (string.IsNullOrEmpty(text)) return null;
             if (text.EndsWith(".FUSE", StringComparison.OrdinalIgnoreCase)) return text;
+            if (text.EndsWith(".RAIL", StringComparison.OrdinalIgnoreCase))
+            {
+                text = text.Substring(0, text.Length - ".RAIL".Length).Trim();
+            }
+            if (string.IsNullOrEmpty(text)) return null;
             return text + ".FUSE";
         }
 

--- a/FUSE.Converter/Conversion/LegacyKindDetector.cs
+++ b/FUSE.Converter/Conversion/LegacyKindDetector.cs
@@ -78,18 +78,19 @@ namespace FUSE.Converter.Conversion
             if (!Directory.Exists(sourcePath)) return Kinds.Unknown;
 
             if (ContainsNativeFuseFragment(sourcePath)) return Kinds.Native;
-            if (ContainsCompiledPlugin(sourcePath)
+            var containsCompiledPlugin = ContainsCompiledPlugin(sourcePath);
+            if (containsCompiledPlugin
                 && !DetectsDirectRouteData(sourcePath)
                 && !DetectsDirectAudio(sourcePath))
             {
                 return Kinds.Code;
             }
-            if (DetectsAudio(sourcePath) && !DetectsRouteData(sourcePath))
+            var detectsRouteData = DetectsRouteData(sourcePath);
+            if (DetectsAudio(sourcePath) && !detectsRouteData)
             {
                 return Kinds.Audio;
             }
-            if (DetectsRouteData(sourcePath)) return Kinds.Route;
-            if (ContainsCompiledPlugin(sourcePath)) return Kinds.Code;
+            if (detectsRouteData) return Kinds.Route;
             if (FindMapTileSources(sourcePath).Count > 0) return Kinds.MapTile;
             if (FindAssetPackSources(sourcePath).Count > 0) return Kinds.Asset;
             return Kinds.Unknown;

--- a/FUSE.Converter/Conversion/LegacyKindDetector.cs
+++ b/FUSE.Converter/Conversion/LegacyKindDetector.cs
@@ -67,6 +67,10 @@ namespace FUSE.Converter.Conversion
                 {
                     return Kinds.Archive;
                 }
+                if (sourcePath.EndsWith(".fuse.json", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Kinds.Native;
+                }
                 if (sourcePath.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
                     && !JsonManifestNames.Contains(Path.GetFileName(sourcePath)))
                 {
@@ -100,7 +104,7 @@ namespace FUSE.Converter.Conversion
         {
             try
             {
-                return Directory.EnumerateFiles(folder, "*.fuse.json", SearchOption.TopDirectoryOnly).Any();
+                return Directory.EnumerateFiles(folder, "*.fuse.json", SearchOption.AllDirectories).Any();
             }
             catch (Exception)
             {

--- a/FUSE.Converter/Conversion/LegacyKindDetector.cs
+++ b/FUSE.Converter/Conversion/LegacyKindDetector.cs
@@ -30,6 +30,9 @@ namespace FUSE.Converter.Conversion
             public const string Route = "route";
             public const string Audio = "audio";
             public const string Asset = "asset";
+            public const string MapTile = "map_tile";
+            public const string Native = "native";
+            public const string Code = "code";
             public const string Archive = "archive";
             public const string Unknown = "unknown";
         }
@@ -74,14 +77,46 @@ namespace FUSE.Converter.Conversion
 
             if (!Directory.Exists(sourcePath)) return Kinds.Unknown;
 
+            if (ContainsNativeFuseFragment(sourcePath)) return Kinds.Native;
+            if (ContainsCompiledPlugin(sourcePath)
+                && !DetectsDirectRouteData(sourcePath)
+                && !DetectsDirectAudio(sourcePath))
+            {
+                return Kinds.Code;
+            }
             if (DetectsAudio(sourcePath) && !DetectsRouteData(sourcePath))
             {
                 return Kinds.Audio;
             }
             if (DetectsRouteData(sourcePath)) return Kinds.Route;
-            if (FindMapTileSources(sourcePath).Any()) return Kinds.Route;
-            if (FindAssetPackSources(sourcePath).Any()) return Kinds.Asset;
+            if (ContainsCompiledPlugin(sourcePath)) return Kinds.Code;
+            if (FindMapTileSources(sourcePath).Count > 0) return Kinds.MapTile;
+            if (FindAssetPackSources(sourcePath).Count > 0) return Kinds.Asset;
             return Kinds.Unknown;
+        }
+
+        private static bool ContainsNativeFuseFragment(string folder)
+        {
+            try
+            {
+                return Directory.EnumerateFiles(folder, "*.fuse.json", SearchOption.TopDirectoryOnly).Any();
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        private static bool ContainsCompiledPlugin(string folder)
+        {
+            try
+            {
+                return Directory.EnumerateFiles(folder, "*.dll", SearchOption.TopDirectoryOnly).Any();
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -104,6 +139,49 @@ namespace FUSE.Converter.Conversion
                 catch (Exception) { /* malformed JSON ignored — counted in conversion later */ }
             }
             return false;
+        }
+
+        private static bool DetectsDirectRouteData(string sourcePath)
+        {
+            IEnumerable<string> paths;
+            try
+            {
+                paths = Directory.EnumerateFiles(sourcePath, "*.json", SearchOption.TopDirectoryOnly);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            foreach (var path in paths)
+            {
+                if (JsonManifestNames.Contains(Path.GetFileName(path))) continue;
+                try
+                {
+                    var data = LegacyJsonReader.ReadJson(path) as JObject;
+                    if (data != null && data.Properties().Any(p => LegacyDataKeys.Contains(p.Name))) return true;
+                }
+                catch (Exception)
+                {
+                    // Malformed files are reported by conversion after the package kind is known.
+                    continue;
+                }
+            }
+            return false;
+        }
+
+        private static bool DetectsDirectAudio(string sourcePath)
+        {
+            try
+            {
+                return Directory.EnumerateFiles(sourcePath, "*.json", SearchOption.TopDirectoryOnly)
+                    .Where(path => !JsonManifestNames.Contains(Path.GetFileName(path)))
+                    .Any(DetectsAudioFile);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
 
         public static bool DetectsAudio(string sourcePath)

--- a/FUSE.Converter/Conversion/LegacyTrackConverter.cs
+++ b/FUSE.Converter/Conversion/LegacyTrackConverter.cs
@@ -31,6 +31,7 @@ namespace FUSE.Converter.Conversion
                 ["position"] = VectorHelper.Vector(obj?["position"] ?? obj?["localPosition"]),
                 ["rotation"] = VectorHelper.Vector(obj?["rotation"] ?? obj?["localRotation"]),
                 ["flipSwitchStand"] = obj?.Value<bool?>("flipSwitchStand") ?? false,
+                ["isDiamond"] = obj?.Value<bool?>("isDiamond") ?? obj?.Value<bool?>("IsDiamond") ?? false,
             };
         }
 
@@ -58,15 +59,20 @@ namespace FUSE.Converter.Conversion
             }
 
             var partial = string.IsNullOrEmpty(startNodeId) || string.IsNullOrEmpty(endNodeId);
+            var flags = FirstInt(obj, 0, "flags", "Flags");
+            var hasFlags = obj.ContainsKey("flags") || obj.ContainsKey("Flags");
+            var style = obj.Value<string>("Style") ?? obj.Value<string>("style");
 
             var result = new JObject
             {
-                ["style"] = obj.Value<string>("Style") ?? obj.Value<string>("style") ?? "standard",
+                ["style"] = style ?? StyleFromFlags(flags),
                 ["trackClass"] = obj.Value<string>("trackClass") ?? obj.Value<string>("TrackClass") ?? "main",
                 ["speedLimit"] = FirstInt(obj, 45, "speedLimit", "SpeedLimit"),
                 ["priority"] = obj.Value<int?>("priority") ?? 0,
                 ["groupId"] = groupId,
                 ["gauge"] = obj.Value<string>("gauge") ?? obj.Value<string>("Gauge"),
+                ["bridgeSupportsSteel"] = hasFlags && (flags & 4) != 0,
+                ["yard"] = hasFlags && (flags & 16) != 0,
             };
 
             if (!string.IsNullOrEmpty(startNodeId))
@@ -86,6 +92,8 @@ namespace FUSE.Converter.Conversion
                 // overwrite values the original author committed to.
                 result["partial"] = true;
                 result["preserveStyle"] = !obj.ContainsKey("Style") && !obj.ContainsKey("style");
+                result["preserveBridgeSupportsSteel"] = !hasFlags && string.IsNullOrEmpty(style);
+                result["preserveYard"] = !hasFlags && string.IsNullOrEmpty(style);
                 result["preserveTrackClass"] = !obj.ContainsKey("trackClass") && !obj.ContainsKey("TrackClass");
                 result["preserveSpeedLimit"] = !obj.ContainsKey("speedLimit") && !obj.ContainsKey("SpeedLimit");
                 result["preservePriority"] = !obj.ContainsKey("priority");
@@ -364,6 +372,14 @@ namespace FUSE.Converter.Conversion
                 }
             }
             return fallback;
+        }
+
+        private static string StyleFromFlags(int flags)
+        {
+            if ((flags & 8) != 0) return "tunnel";
+            if ((flags & 2) != 0) return "bridge";
+            if ((flags & 16) != 0) return "yard";
+            return "standard";
         }
     }
 }

--- a/FUSE.Converter/Conversion/LegacyTrackConverter.cs
+++ b/FUSE.Converter/Conversion/LegacyTrackConverter.cs
@@ -60,7 +60,7 @@ namespace FUSE.Converter.Conversion
 
             var partial = string.IsNullOrEmpty(startNodeId) || string.IsNullOrEmpty(endNodeId);
             var flags = FirstInt(obj, 0, "flags", "Flags");
-            var hasFlags = obj.ContainsKey("flags") || obj.ContainsKey("Flags");
+            var hasFlags = HasNonNullValue(obj, "flags") || HasNonNullValue(obj, "Flags");
             var style = obj.Value<string>("Style") ?? obj.Value<string>("style");
 
             var result = new JObject
@@ -101,6 +101,12 @@ namespace FUSE.Converter.Conversion
             }
 
             return result;
+        }
+
+        private static bool HasNonNullValue(JObject obj, string key)
+        {
+            JToken value;
+            return obj.TryGetValue(key, out value) && value.Type != JTokenType.Null;
         }
 
         /// <summary>

--- a/FUSE.Converter/FuseLegacyConverter.cs
+++ b/FUSE.Converter/FuseLegacyConverter.cs
@@ -167,8 +167,16 @@ namespace FUSE.Converter
 
             EmitTrackGroupCoverageWarning(declaredInitialGroups, result.Report);
 
-            var legacyLoadAfter = LegacyDefinitionConverter.LegacyLoadAfter(modFolder);
-            WriteInfoJson(outputFolder, manifest, result.WrittenFragments, result.Report, legacyLoadAfter);
+            var legacyDependencies = LegacyDefinitionConverter.LegacyDependencies(modFolder);
+            var legacyConflictsWith = LegacyDefinitionConverter.LegacyConflictsWith(modFolder);
+            WriteInfoJson(
+                outputFolder,
+                manifest,
+                result.WrittenFragments,
+                result.Report,
+                legacyDependencies.Requires,
+                legacyDependencies.LoadAfter,
+                legacyConflictsWith);
 
             // Asset packs + map tiles are file-system payloads that
             // ride alongside the converted *.fuse.json fragments.
@@ -228,14 +236,10 @@ namespace FUSE.Converter
         }
 
         /// <summary>
-        /// Kind-aware dispatcher: routes to <see cref="ConvertMod"/>
-        /// for route packages,
-        /// <see cref="LegacyAudioConverter.ConvertAudioMod"/> for
-        /// audio packages, and produces an empty-success result with
-        /// a warning for asset / unknown kinds (the user can copy
-        /// asset packs verbatim — that's already what
-        /// <see cref="ConvertMod"/> does at the end of the route
-        /// path).
+        /// Kind-aware dispatcher. Only legacy JSON route and audio data
+        /// are conversion inputs. Native FUSE, compiled code, map-tile,
+        /// and asset-only packages are installed directly instead of
+        /// being copied into misleading zero-fragment conversions.
         /// </summary>
         public static FuseConversionResult ConvertPackage(string modFolder, string outputFolder, string requestedKind = "auto")
         {
@@ -245,68 +249,50 @@ namespace FUSE.Converter
                 case "audio":
                     return LegacyAudioConverter.ConvertAudioMod(modFolder, outputFolder);
                 case "asset":
-                    return ConvertAssetOnly(modFolder, outputFolder);
+                    return UnsupportedPackage(
+                        modFolder,
+                        outputFolder,
+                        "Asset-pack-only package detected. FUSE loads supported asset packs directly; install this package with the FUSE installer instead of converting it.");
+                case "map_tile":
+                    return UnsupportedPackage(
+                        modFolder,
+                        outputFolder,
+                        "Legacy map-tile package detected. FUSE's Alina compatibility loads supported tile data directly; install this package with the FUSE installer instead of converting it.");
+                case "native":
+                    return UnsupportedPackage(
+                        modFolder,
+                        outputFolder,
+                        "This package already contains FUSE-native *.fuse.json data. No conversion is needed; install the original package with the FUSE installer.");
+                case "code":
+                    return UnsupportedPackage(
+                        modFolder,
+                        outputFolder,
+                        "Compiled code mod detected. The converter only translates RailLoader JSON data and cannot reproduce DLL behavior; install a compatible code mod directly or ask its author for a FUSE-native version.");
                 case "route":
+                    return ConvertMod(modFolder, outputFolder);
                 case "unknown":
                 default:
-                    return ConvertMod(modFolder, outputFolder);
+                    return UnsupportedPackage(
+                        modFolder,
+                        outputFolder,
+                        "No convertible RailLoader JSON data was detected. Expected route, track, scenery, industry, progression, or supported audio JSON; code, assets, map tiles, and native FUSE packages are installed rather than converted.");
             }
         }
 
-        /// <summary>
-        /// Asset-only conversion: just copies asset-pack folders and
-        /// writes a FUSE Info.json. Used when the source has no
-        /// JSON-side data (no tracks/industries/etc.) but does ship
-        /// asset packs (Catalog.json + Definitions.json + bundle).
-        /// </summary>
-        private static FuseConversionResult ConvertAssetOnly(string modFolder, string outputFolder)
+        private static FuseConversionResult UnsupportedPackage(string modFolder, string outputFolder, string reason)
         {
             var result = new FuseConversionResult
             {
                 OutputFolderPath = outputFolder,
+                Success = false,
             };
-
-            if (LegacyAssetCopier.PathsOverlap(modFolder, outputFolder))
-            {
-                result.Success = false;
-                result.Report.Add(Error("Output folder overlaps the source folder; refusing to convert in place (it would overwrite the original mod).", modFolder));
-                return result;
-            }
 
             var manifest = LegacyManifestReader.Read(modFolder);
             result.ModId = manifest.Id;
             result.ModName = manifest.Name;
             result.ModVersion = manifest.Version;
             result.Author = manifest.Author;
-
-            try
-            {
-                Directory.CreateDirectory(outputFolder);
-                var assetRoots = LegacyKindDetector.FindAssetPackSources(modFolder);
-                if (assetRoots.Count > 0)
-                {
-                    LegacyAssetCopier.CopyAssetSources(modFolder, outputFolder, assetRoots, result);
-                }
-
-                var info = new JObject
-                {
-                    ["$schema"] = ".\\schemas\\umm-info.schema.json",
-                    ["Id"] = manifest.Id + ".FUSE",
-                    ["DisplayName"] = manifest.Name + " (FUSE)",
-                    ["Author"] = manifest.Author ?? string.Empty,
-                    ["Version"] = manifest.Version ?? "1.0.0",
-                    ["ManagerVersion"] = "0.27.10",
-                    ["Requirements"] = new JArray("FUSE"),
-                    ["LoadAfter"] = new JArray("FUSE"),
-                    ["FuseAssetPacks"] = JArray.FromObject(assetRoots.Count > 0 ? assetRoots : (System.Collections.Generic.IEnumerable<string>)new[] { "." }),
-                };
-                File.WriteAllText(Path.Combine(outputFolder, "Info.json"), info.ToString(Formatting.Indented));
-                result.Success = true;
-            }
-            catch (Exception ex)
-            {
-                result.Report.Add(Error("Asset-only conversion failed: " + ex.Message, modFolder));
-            }
+            result.Report.Add(Error(reason, modFolder));
             return result;
         }
 
@@ -397,19 +383,21 @@ namespace FUSE.Converter
 
         private static void WriteInfoJson(string outputFolder, LegacyManifestReader.LegacyManifest manifest,
                                           List<string> fragments, List<FuseConversionReportEntry> report,
-                                          List<string> legacyLoadAfter = null)
+                                          List<string> legacyRequires = null,
+                                          List<string> legacyLoadAfter = null,
+                                          JArray legacyConflictsWith = null)
         {
             try
             {
-                // LoadAfter starts with "FUSE" (the runtime), then
-                // every legacy requirement / loadAfter id remapped
-                // via LegacyDefinitionConverter.FusePackageId so we
-                // wait for any sibling-converted packages.
-                var loadAfter = new JArray("FUSE");
-                if (legacyLoadAfter != null)
-                {
-                    foreach (var id in legacyLoadAfter) loadAfter.Add(id);
-                }
+                // UMM only needs to start FUSE first. Data-package requirements
+                // and ordering belong to FUSE's own dependency graph; keeping
+                // them separate preserves hard-vs-advisory legacy semantics.
+                var fuseRequires = legacyRequires == null
+                    ? new JArray()
+                    : JArray.FromObject(legacyRequires);
+                var fuseLoadAfter = legacyLoadAfter == null
+                    ? new JArray()
+                    : JArray.FromObject(legacyLoadAfter);
 
                 var info = new JObject
                 {
@@ -420,7 +408,10 @@ namespace FUSE.Converter
                     ["Version"] = manifest.Version ?? "1.0.0",
                     ["ManagerVersion"] = "0.27.10",
                     ["Requirements"] = new JArray("FUSE"),
-                    ["LoadAfter"] = loadAfter,
+                    ["LoadAfter"] = new JArray("FUSE"),
+                    ["FuseRequires"] = fuseRequires,
+                    ["FuseLoadAfter"] = fuseLoadAfter,
+                    ["FuseConflictsWith"] = legacyConflictsWith ?? new JArray(),
                     ["FuseDataFiles"] = JArray.FromObject(fragments),
                 };
 

--- a/FUSE.Converter/FuseLegacyConverter.cs
+++ b/FUSE.Converter/FuseLegacyConverter.cs
@@ -402,7 +402,7 @@ namespace FUSE.Converter
                 var info = new JObject
                 {
                     ["$schema"] = ".\\schemas\\umm-info.schema.json",
-                    ["Id"] = $"{manifest.Id}.FUSE",
+                    ["Id"] = LegacyDefinitionConverter.ConvertedPackageId(manifest.Id) ?? $"{manifest.Id}.FUSE",
                     ["DisplayName"] = $"{manifest.Name} (FUSE)",
                     ["Author"] = manifest.Author ?? string.Empty,
                     ["Version"] = manifest.Version ?? "1.0.0",

--- a/FUSE.ConverterCli/CliOptions.cs
+++ b/FUSE.ConverterCli/CliOptions.cs
@@ -18,7 +18,7 @@ internal sealed class CliOptions
     public bool Quiet { get; set; }
     public bool ShowHelp { get; set; }
 
-    private static readonly string[] Kinds = { "auto", "route", "audio", "asset" };
+    private static readonly string[] Kinds = { "auto", "route", "audio" };
     private static readonly string[] Formats = { "console", "json", "markdown", "all" };
 
     public bool WriteJsonReport => Format is "json" or "all";
@@ -53,13 +53,13 @@ internal sealed class CliOptions
                 case "--kind":
                     if (++index >= args.Length)
                     {
-                        error = "--kind requires a value (auto, route, audio, or asset).";
+                        error = "--kind requires a value (auto, route, or audio).";
                         return null;
                     }
 
                     if (!Kinds.Contains(args[index]))
                     {
-                        error = $"--kind: invalid value '{args[index]}'. Allowed: auto, route, audio, asset.";
+                        error = $"--kind: invalid value '{args[index]}'. Allowed: auto, route, audio.";
                         return null;
                     }
 
@@ -142,16 +142,18 @@ ARGUMENTS:
 OPTIONS:
   --out <dir>     Output root. Each mod converts into '<dir>\<ModFolder>.FUSE'.
                   Default: '.\FUSEConverted'.
-  --kind <kind>   Force a package kind: auto | route | audio | asset. Default: auto.
+  --kind <kind>   Force a JSON package kind: auto | route | audio. Default: auto.
   --clean         Replace an existing '.FUSE' output folder for each converted mod.
-  --batch         Treat each input as a container of mods and convert every
-                  recognized child folder.
+  --batch         Treat each input as a container of mods. JSON packages are
+                  converted; code/assets/tiles/native packages are reported
+                  with their correct install guidance.
   --validate      Validate converted fragments and print fix-hints (default: on).
   --no-validate   Skip validation.
   --strict        Exit with code 2 when validation produces warnings, not just errors.
   --format <fmt>  console (default) | json | markdown | all. json writes
                   conversion-report.json and markdown writes conversion-report.md
-                  into each mod's output folder; all writes both.
+                  into successful output packages. Failed/unsupported inputs
+                  write under '<out>\_conversion-reports'; all writes both.
   --quiet         Suppress per-diagnostic console output; print only summaries.
   -h, --help      Show this help.
 

--- a/FUSE.ConverterCli/Program.cs
+++ b/FUSE.ConverterCli/Program.cs
@@ -122,7 +122,7 @@ internal static class Program
             }
 
             var recognized = Directory.GetDirectories(input)
-                .Where(child => FuseLegacyConverter.DetectKind(child, options.Kind) != "unknown")
+                .Where(child => FuseLegacyConverter.DetectKind(child, options.Kind) != "unknown" || LooksLikeModFolder(child))
                 .OrderBy(child => child, StringComparer.OrdinalIgnoreCase)
                 .ToList();
             if (recognized.Count == 0)
@@ -135,6 +135,13 @@ internal static class Program
         }
 
         return folders;
+    }
+
+    private static bool LooksLikeModFolder(string folder)
+    {
+        return File.Exists(Path.Combine(folder, "Definition.json"))
+            || File.Exists(Path.Combine(folder, "Info.json"))
+            || Directory.EnumerateFiles(folder, "*.dll", SearchOption.TopDirectoryOnly).Any();
     }
 
     /// <summary>
@@ -204,8 +211,10 @@ internal static class Program
     }
 
     /// <summary>
-    /// Writes conversion-report.json / conversion-report.md (the legacy
-    /// Python converter's report file names) into the mod's output folder.
+    /// Writes conversion-report.json / conversion-report.md. Successful
+    /// conversions keep reports inside the package. Failed/unsupported
+    /// inputs use a sibling _conversion-reports folder so a report-only
+    /// directory cannot be mistaken for an installable .FUSE package.
     /// </summary>
     private static void WriteReports(
         CliOptions options,
@@ -218,9 +227,20 @@ internal static class Program
             return;
         }
 
-        if (!Directory.Exists(result.OutputFolderPath))
+        var reportFolder = result.Success
+            ? result.OutputFolderPath
+            : Path.Combine(
+                Path.GetDirectoryName(result.OutputFolderPath) ?? ".",
+                "_conversion-reports",
+                Path.GetFileName(result.OutputFolderPath));
+
+        try
         {
-            Console.Error.WriteLine($"fuse-convert: cannot write reports; output folder does not exist: {result.OutputFolderPath}");
+            Directory.CreateDirectory(reportFolder);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"fuse-convert: cannot create report folder '{reportFolder}': {ex.Message}");
             return;
         }
 
@@ -240,7 +260,7 @@ internal static class Program
             try
             {
                 File.WriteAllText(
-                    Path.Combine(result.OutputFolderPath, "conversion-report.json"),
+                    Path.Combine(reportFolder, "conversion-report.json"),
                     report.ToString(Formatting.Indented));
             }
             catch (Exception ex)
@@ -262,7 +282,7 @@ internal static class Program
                 (validationDiagnostics.Count > 0 ? FuseValidationRenderer.ToMarkdown(validationDiagnostics) : "No validation findings.\n");
             try
             {
-                File.WriteAllText(Path.Combine(result.OutputFolderPath, "conversion-report.md"), markdown);
+                File.WriteAllText(Path.Combine(reportFolder, "conversion-report.md"), markdown);
             }
             catch (Exception ex)
             {

--- a/FUSE.ConverterCli/Program.cs
+++ b/FUSE.ConverterCli/Program.cs
@@ -139,9 +139,24 @@ internal static class Program
 
     private static bool LooksLikeModFolder(string folder)
     {
-        return File.Exists(Path.Combine(folder, "Definition.json"))
-            || File.Exists(Path.Combine(folder, "Info.json"))
-            || Directory.EnumerateFiles(folder, "*.dll", SearchOption.TopDirectoryOnly).Any();
+        if (File.Exists(Path.Combine(folder, "Definition.json"))
+            || File.Exists(Path.Combine(folder, "Info.json")))
+        {
+            return true;
+        }
+
+        try
+        {
+            return Directory.EnumerateFiles(folder, "*.dll", SearchOption.TopDirectoryOnly).Any();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/FUSE.Core.Tests/ValidationHelpCoverageTests.cs
+++ b/FUSE.Core.Tests/ValidationHelpCoverageTests.cs
@@ -24,6 +24,14 @@ namespace Fuse.Core.Tests
             "ValidatorSource.Game.cs",
         };
 
+        private static readonly string[] DynamicallyEmittedCodes =
+        {
+            "fuse.mixinto.conflict.id.blank",
+            "fuse.mixinto.conflict.null",
+            "fuse.mixinto.requirement.id.blank",
+            "fuse.mixinto.requirement.null",
+        };
+
         private static HashSet<string> EmittedCodes()
         {
             var codes = new HashSet<string>();
@@ -42,7 +50,23 @@ namespace Fuse.Core.Tests
                 }
             }
 
+            foreach (var code in DynamicallyEmittedCodes)
+            {
+                codes.Add(code);
+            }
+
             return codes;
+        }
+
+        [Theory]
+        [InlineData("fuse.mixinto.conflict.id.blank")]
+        [InlineData("fuse.mixinto.conflict.null")]
+        [InlineData("fuse.mixinto.requirement.id.blank")]
+        [InlineData("fuse.mixinto.requirement.null")]
+        public void Dynamic_Mixinto_Codes_Have_Catalog_Entries(string code)
+        {
+            Assert.True(FuseValidationHelp.TryGet(code, out var entry));
+            Assert.NotNull(entry);
         }
 
         [Fact]

--- a/FUSE.Core/Migrations/FuseMigration.cs
+++ b/FUSE.Core/Migrations/FuseMigration.cs
@@ -78,6 +78,7 @@ namespace Fuse.Core.Migrations
             definition.Audio = definition.Audio ?? new FuseAudioRoot();
             definition.Progression = definition.Progression ?? new FuseProgressionRoot();
             definition.Settings = definition.Settings ?? new Dictionary<string, FuseModSettingDefinition>();
+            definition.FeatureRules = definition.FeatureRules ?? new Dictionary<string, FuseFeatureRule>();
             definition.Extensions = definition.Extensions ?? new Dictionary<string, object>();
 
             foreach (var setting in definition.Settings.Values.Where(setting => setting != null))
@@ -86,6 +87,7 @@ namespace Fuse.Core.Migrations
                 setting.Scope = string.IsNullOrWhiteSpace(setting.Scope) ? "user" : setting.Scope.Trim();
                 setting.Values = setting.Values ?? Array.Empty<string>();
             }
+            NormalizeFeatureRules(definition.FeatureRules);
 
             definition.Tracks.Nodes = definition.Tracks.Nodes ?? new Dictionary<string, FuseNode>();
             definition.Tracks.Segments = definition.Tracks.Segments ?? new Dictionary<string, FuseSegment>();
@@ -105,6 +107,7 @@ namespace Fuse.Core.Migrations
             definition.World.Scenery = definition.World.Scenery ?? new Dictionary<string, FuseScenery>();
             definition.World.SpawnPoints = definition.World.SpawnPoints ?? Array.Empty<FuseSpawnPoint>();
             definition.World.Splineys = definition.World.Splineys ?? new Dictionary<string, FuseSpliney>();
+            definition.World.WaterSurfaces = definition.World.WaterSurfaces ?? new Dictionary<string, FuseWaterSurface>();
             definition.World.TelegraphPoles = definition.World.TelegraphPoles ?? new Dictionary<string, FuseTelegraphPoles>();
             definition.World.TelegraphPoleMovements = definition.World.TelegraphPoleMovements ?? Array.Empty<FuseTelegraphPoleMovement>();
             definition.World.MapLabels = definition.World.MapLabels ?? new Dictionary<string, FuseMapLabel>();
@@ -120,6 +123,7 @@ namespace Fuse.Core.Migrations
             definition.World.Removals = definition.World.Removals ?? new FuseWorldRemovals();
             definition.World.Removals.Scenery = definition.World.Removals.Scenery ?? Array.Empty<string>();
             definition.World.Removals.Splineys = definition.World.Removals.Splineys ?? Array.Empty<string>();
+            definition.World.Removals.WaterSurfaces = definition.World.Removals.WaterSurfaces ?? Array.Empty<string>();
             definition.World.Removals.TelegraphPoles = definition.World.Removals.TelegraphPoles ?? Array.Empty<string>();
             definition.World.Removals.MapLabels = definition.World.Removals.MapLabels ?? Array.Empty<string>();
             definition.World.Removals.MapMasks = definition.World.Removals.MapMasks ?? Array.Empty<string>();
@@ -303,7 +307,49 @@ namespace Fuse.Core.Migrations
             mixinto.Target = string.IsNullOrWhiteSpace(mixinto.Target) ? null : mixinto.Target.Trim();
             mixinto.SourceFile = string.IsNullOrWhiteSpace(mixinto.SourceFile) ? null : mixinto.SourceFile.Trim();
             mixinto.Requires = mixinto.Requires ?? Array.Empty<FuseModRequirement>();
-            foreach (var requirement in mixinto.Requires)
+            mixinto.ConflictsWith = mixinto.ConflictsWith ?? Array.Empty<FuseModRequirement>();
+            NormalizeModReferences(mixinto.Requires);
+            NormalizeModReferences(mixinto.ConflictsWith);
+        }
+
+        private static void NormalizeFeatureRules(IDictionary<string, FuseFeatureRule> rules)
+        {
+            if (rules == null)
+                return;
+            foreach (var rule in rules.Values.Where(rule => rule != null))
+            {
+                rule.Operator = string.IsNullOrWhiteSpace(rule.Operator) ? "equals" : rule.Operator.Trim();
+                rule.Targets = rule.Targets ?? new FuseFeatureTargets();
+                var targets = rule.Targets;
+                targets.TrackNodes = targets.TrackNodes ?? Array.Empty<string>();
+                targets.TrackSegments = targets.TrackSegments ?? Array.Empty<string>();
+                targets.TrackSpans = targets.TrackSpans ?? Array.Empty<string>();
+                targets.TrackAreas = targets.TrackAreas ?? Array.Empty<string>();
+                targets.Loads = targets.Loads ?? Array.Empty<string>();
+                targets.Industries = targets.Industries ?? Array.Empty<string>();
+                targets.IndustryComponents = targets.IndustryComponents ?? Array.Empty<string>();
+                targets.Loaders = targets.Loaders ?? Array.Empty<string>();
+                targets.Turntables = targets.Turntables ?? Array.Empty<string>();
+                targets.Stations = targets.Stations ?? Array.Empty<string>();
+                targets.Scenery = targets.Scenery ?? Array.Empty<string>();
+                targets.Splineys = targets.Splineys ?? Array.Empty<string>();
+                targets.WaterSurfaces = targets.WaterSurfaces ?? Array.Empty<string>();
+                targets.TelegraphPoles = targets.TelegraphPoles ?? Array.Empty<string>();
+                targets.MapLabels = targets.MapLabels ?? Array.Empty<string>();
+                targets.MapMasks = targets.MapMasks ?? Array.Empty<string>();
+                targets.MapTiles = targets.MapTiles ?? Array.Empty<string>();
+                targets.SceneClones = targets.SceneClones ?? Array.Empty<string>();
+                targets.Progressions = targets.Progressions ?? Array.Empty<string>();
+                targets.MapFeatures = targets.MapFeatures ?? Array.Empty<string>();
+                targets.Whistles = targets.Whistles ?? Array.Empty<string>();
+                targets.Horns = targets.Horns ?? Array.Empty<string>();
+                targets.Bells = targets.Bells ?? Array.Empty<string>();
+            }
+        }
+
+        private static void NormalizeModReferences(FuseModRequirement[] references)
+        {
+            foreach (var requirement in references ?? Array.Empty<FuseModRequirement>())
             {
                 if (requirement == null)
                 {

--- a/FUSE.Core/Model/FuseIndustryComponentTypes.cs
+++ b/FUSE.Core/Model/FuseIndustryComponentTypes.cs
@@ -99,6 +99,7 @@ namespace Fuse.Core.Model
                 { "pay-for-resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
                 { "confusingsupplements.pay4resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
                 { "confusingsupplements.industrycomponents.pay4resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
+                { "adrfdr.pay4resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
                 { "confusingsupplements.empty", "ConfusingSupplements.IndustryComponents.Empty" },
                 { "confusingsupplements.industrycomponents.empty", "ConfusingSupplements.IndustryComponents.Empty" }
             };

--- a/FUSE.Core/Model/FuseModDefinition.cs
+++ b/FUSE.Core/Model/FuseModDefinition.cs
@@ -26,6 +26,7 @@ namespace Fuse.Core.Model
         public FuseAudioRoot Audio { get; set; } = new FuseAudioRoot();
         public FuseProgressionRoot Progression { get; set; } = new FuseProgressionRoot();
         public Dictionary<string, FuseModSettingDefinition> Settings { get; set; } = new Dictionary<string, FuseModSettingDefinition>();
+        public Dictionary<string, FuseFeatureRule> FeatureRules { get; set; } = new Dictionary<string, FuseFeatureRule>();
         public FuseEditorState Editor { get; set; }
         public Dictionary<string, object> Extensions { get; set; } = new Dictionary<string, object>();
     }
@@ -50,6 +51,12 @@ namespace Fuse.Core.Model
         /// instead of treating it as a package fault.
         /// </summary>
         public FuseModRequirement[] Requires { get; set; }
+
+        /// <summary>
+        /// Optional legacy incompatibility references. If any matching package
+        /// is enabled, only this conditional fragment is skipped.
+        /// </summary>
+        public FuseModRequirement[] ConflictsWith { get; set; }
     }
 
     public sealed class FuseModRequirement

--- a/FUSE.Core/Model/FuseModSettingsDefinition.cs
+++ b/FUSE.Core/Model/FuseModSettingsDefinition.cs
@@ -20,4 +20,39 @@ namespace Fuse.Core.Model
         public bool Advanced { get; set; }
         public bool ReloadRequired { get; set; }
     }
+
+    public sealed class FuseFeatureRule
+    {
+        public string Setting { get; set; }
+        public string Operator { get; set; } = "equals";
+        public JToken Value { get; set; }
+        public FuseFeatureTargets Targets { get; set; } = new FuseFeatureTargets();
+    }
+
+    public sealed class FuseFeatureTargets
+    {
+        public string[] TrackNodes { get; set; } = Array.Empty<string>();
+        public string[] TrackSegments { get; set; } = Array.Empty<string>();
+        public string[] TrackSpans { get; set; } = Array.Empty<string>();
+        public string[] TrackAreas { get; set; } = Array.Empty<string>();
+        public string[] Loads { get; set; } = Array.Empty<string>();
+        public string[] Industries { get; set; } = Array.Empty<string>();
+        public string[] IndustryComponents { get; set; } = Array.Empty<string>();
+        public string[] Loaders { get; set; } = Array.Empty<string>();
+        public string[] Turntables { get; set; } = Array.Empty<string>();
+        public string[] Stations { get; set; } = Array.Empty<string>();
+        public string[] Scenery { get; set; } = Array.Empty<string>();
+        public string[] Splineys { get; set; } = Array.Empty<string>();
+        public string[] WaterSurfaces { get; set; } = Array.Empty<string>();
+        public string[] TelegraphPoles { get; set; } = Array.Empty<string>();
+        public string[] MapLabels { get; set; } = Array.Empty<string>();
+        public string[] MapMasks { get; set; } = Array.Empty<string>();
+        public string[] MapTiles { get; set; } = Array.Empty<string>();
+        public string[] SceneClones { get; set; } = Array.Empty<string>();
+        public string[] Progressions { get; set; } = Array.Empty<string>();
+        public string[] MapFeatures { get; set; } = Array.Empty<string>();
+        public string[] Whistles { get; set; } = Array.Empty<string>();
+        public string[] Horns { get; set; } = Array.Empty<string>();
+        public string[] Bells { get; set; } = Array.Empty<string>();
+    }
 }

--- a/FUSE.Core/Model/FuseRemovedTrackSnapshots.cs
+++ b/FUSE.Core/Model/FuseRemovedTrackSnapshots.cs
@@ -3,7 +3,7 @@ namespace Fuse.Core.Model
     /// <summary>
     /// Serializable node snapshot used to restore base-game track removed by a
     /// FUSE package. Preserved fields: id, transform, switch stand flip, thrown
-    /// state, and public CTC flags. Lossy fields: turntable links, private CTC
+    /// state, diamond-crossing state, and public CTC flags. Lossy fields: turntable links, private CTC
     /// display state, event delegates, and runtime cache state.
     /// </summary>
     public sealed class FuseRemovedNodeSnapshot
@@ -12,6 +12,7 @@ namespace Fuse.Core.Model
         public FuseVector3 Position { get; set; }
         public FuseVector3 Rotation { get; set; }
         public bool FlipSwitchStand { get; set; }
+        public bool IsDiamond { get; set; }
         public bool IsThrown { get; set; }
         public bool IsCtcSwitch { get; set; }
         public bool IsCtcSwitchUnlocked { get; set; }
@@ -19,7 +20,7 @@ namespace Fuse.Core.Model
 
     /// <summary>
     /// Serializable segment snapshot used to restore base-game track removed by a
-    /// FUSE package. Preserved fields: id, endpoints, style, class, group,
+    /// FUSE package. Preserved fields: id, endpoints, style/structure flags, class, group,
     /// priority, speed limit, availability flags, endpoint transforms, and
     /// measured length. Lossy fields: private Bezier caches, turntable links,
     /// editor gizmo state, and generated mesh state.
@@ -30,6 +31,7 @@ namespace Fuse.Core.Model
         public string StartNodeId { get; set; }
         public string EndNodeId { get; set; }
         public string Style { get; set; }
+        public int StructureFlags { get; set; }
         public string TrackClass { get; set; }
         public string GroupId { get; set; }
         public int Priority { get; set; }

--- a/FUSE.Core/Model/FuseTrackDefinition.cs
+++ b/FUSE.Core/Model/FuseTrackDefinition.cs
@@ -24,6 +24,7 @@ namespace Fuse.Core.Model
         public FuseVector3 Position { get; set; }
         public FuseVector3 Rotation { get; set; }
         public bool FlipSwitchStand { get; set; }
+        public bool IsDiamond { get; set; }
         public string GroupId { get; set; }
         public string[] Tags { get; set; }
     }
@@ -39,8 +40,12 @@ namespace Fuse.Core.Model
         public string GroupId { get; set; }
         public string[] Tags { get; set; }
         public string Gauge { get; set; }
+        public bool BridgeSupportsSteel { get; set; }
+        public bool Yard { get; set; }
         public bool Partial { get; set; }
         public bool PreserveStyle { get; set; }
+        public bool PreserveBridgeSupportsSteel { get; set; }
+        public bool PreserveYard { get; set; }
         public bool PreserveTrackClass { get; set; }
         public bool PreserveSpeedLimit { get; set; }
         public bool PreservePriority { get; set; }

--- a/FUSE.Core/Model/FuseWorldDefinition.cs
+++ b/FUSE.Core/Model/FuseWorldDefinition.cs
@@ -8,6 +8,7 @@ namespace Fuse.Core.Model
         public Dictionary<string, FuseScenery> Scenery { get; set; } = new Dictionary<string, FuseScenery>();
         public FuseSpawnPoint[] SpawnPoints { get; set; } = Array.Empty<FuseSpawnPoint>();
         public Dictionary<string, FuseSpliney> Splineys { get; set; } = new Dictionary<string, FuseSpliney>();
+        public Dictionary<string, FuseWaterSurface> WaterSurfaces { get; set; } = new Dictionary<string, FuseWaterSurface>();
         public Dictionary<string, FuseTelegraphPoles> TelegraphPoles { get; set; } = new Dictionary<string, FuseTelegraphPoles>();
         public FuseTelegraphPoleMovement[] TelegraphPoleMovements { get; set; } = Array.Empty<FuseTelegraphPoleMovement>();
         public Dictionary<string, FuseMapLabel> MapLabels { get; set; } = new Dictionary<string, FuseMapLabel>();
@@ -35,6 +36,7 @@ namespace Fuse.Core.Model
     {
         public string[] Scenery { get; set; } = Array.Empty<string>();
         public string[] Splineys { get; set; } = Array.Empty<string>();
+        public string[] WaterSurfaces { get; set; } = Array.Empty<string>();
         public string[] TelegraphPoles { get; set; } = Array.Empty<string>();
         public string[] MapLabels { get; set; } = Array.Empty<string>();
         public string[] MapMasks { get; set; } = Array.Empty<string>();
@@ -94,6 +96,17 @@ namespace Fuse.Core.Model
         public float OffsetY { get; set; }
         public string HeadStyle { get; set; }
         public string TailStyle { get; set; }
+        public string AssetIdentifier { get; set; }
+        public string Prefab { get; set; }
+        public float Spacing { get; set; } = 5f;
+        public FuseVector3 InstanceScale { get; set; } = FuseVector3.one;
+        public FuseVector3 RotationOffset { get; set; }
+        public float LateralOffset { get; set; }
+        public float VerticalOffset { get; set; }
+        public bool SnapToTerrain { get; set; }
+        public bool AlignToSlope { get; set; }
+        public bool PlaceAtEnd { get; set; } = true;
+        public int MaximumInstances { get; set; } = 1024;
         public FuseSplineyPoint[] Points { get; set; }
     }
 
@@ -102,6 +115,20 @@ namespace Fuse.Core.Model
         public FuseVector3 Position { get; set; }
         public FuseVector3 Rotation { get; set; }
         public float? Width { get; set; }
+    }
+
+    public sealed class FuseWaterSurface
+    {
+        public FuseVector3[] Points { get; set; } = Array.Empty<FuseVector3>();
+        public string SourceLakePath { get; set; }
+        public string MaterialName { get; set; }
+        public bool LockHeight { get; set; } = true;
+        public bool SnapToTerrain { get; set; }
+        public bool EnableCollider { get; set; } = true;
+        public float UvScale { get; set; } = 1f;
+        public float TriangleDensity { get; set; } = 0.2f;
+        public float MaximumTriangleArea { get; set; } = 50f;
+        public float YOffset { get; set; }
     }
 
     public sealed class FuseTelegraphPoles

--- a/FUSE.Core/Validation/FuseDefinitionValidator.cs
+++ b/FUSE.Core/Validation/FuseDefinitionValidator.cs
@@ -15,6 +15,13 @@ namespace Fuse.Core.Validation
     /// </summary>
     public sealed class FuseDefinitionValidator : IValidator<FuseModDefinition>
     {
+        private static readonly HashSet<string> ValidFeatureRuleOperators =
+            new HashSet<string>(new[]
+            {
+                "equals", "notEquals", "greaterThan", "greaterThanOrEqual",
+                "lessThan", "lessThanOrEqual"
+            }, StringComparer.OrdinalIgnoreCase);
+
         public ValidationResult Validate(FuseModDefinition value)
         {
             var result = new ValidationResult();
@@ -52,6 +59,7 @@ namespace Fuse.Core.Validation
             ValidateAudio(result, value.Audio);
             ValidateProgression(result, value.Progression);
             ValidateSettings(result, value.Settings);
+            ValidateFeatureRules(result, value);
             return result;
         }
 
@@ -100,20 +108,30 @@ namespace Fuse.Core.Validation
                 result.AddWarning("mixinto.sourceFile", "Mixinto sourceFile is blank; conversion provenance will be less clear.", "fuse.mixinto.sourceFile.blank");
             }
 
-            var requirements = mixinto.Requires ?? Array.Empty<FuseModRequirement>();
-            for (var index = 0; index < requirements.Length; index++)
+            ValidateMixintoReferences(result, mixinto.Requires, "requires", "requirement");
+            ValidateMixintoReferences(result, mixinto.ConflictsWith, "conflictsWith", "conflict");
+        }
+
+        private static void ValidateMixintoReferences(
+            ValidationResult result,
+            FuseModRequirement[] references,
+            string propertyName,
+            string kind)
+        {
+            var materialized = references ?? Array.Empty<FuseModRequirement>();
+            for (var index = 0; index < materialized.Length; index++)
             {
-                var requirement = requirements[index];
-                var path = $"mixinto.requires[{index}]";
+                var requirement = materialized[index];
+                var path = $"mixinto.{propertyName}[{index}]";
                 if (requirement == null)
                 {
-                    result.AddWarning(path, "Null mixinto requirement will be ignored.", "fuse.mixinto.requirement.null");
+                    result.AddWarning(path, $"Null mixinto {kind} will be ignored.", $"fuse.mixinto.{kind}.null");
                     continue;
                 }
 
                 if (string.IsNullOrWhiteSpace(requirement.Id))
                 {
-                    result.AddWarning($"{path}.id", "Mixinto requirement id is blank and will be ignored.", "fuse.mixinto.requirement.id.blank");
+                    result.AddWarning($"{path}.id", $"Mixinto {kind} id is blank and will be ignored.", $"fuse.mixinto.{kind}.id.blank");
                 }
             }
         }
@@ -163,6 +181,111 @@ namespace Fuse.Core.Validation
                     result.AddWarning(path, "Server-scoped reload-required settings should be documented for multiplayer profile sharing.", "fuse.settings.server.reloadRequired", pair.Key);
                 }
             }
+        }
+
+        private static void ValidateFeatureRules(ValidationResult result, FuseModDefinition definition)
+        {
+            var rules = definition.FeatureRules;
+            if (rules == null)
+                return;
+            foreach (var pair in rules)
+            {
+                var path = $"featureRules.{pair.Key}";
+                if (string.IsNullOrWhiteSpace(pair.Key))
+                {
+                    result.AddError("featureRules", "Feature rule IDs must not be blank.", "fuse.featureRule.id.blank");
+                    continue;
+                }
+                var rule = pair.Value;
+                if (rule == null)
+                {
+                    result.AddError(path, "Feature rule definition is required.", "fuse.featureRule.required");
+                    continue;
+                }
+                if (string.IsNullOrWhiteSpace(rule.Setting) ||
+                    !definition.Settings.TryGetValue(rule.Setting, out var setting) || setting == null)
+                {
+                    result.AddError($"{path}.setting", "Feature rule must reference a setting declared by this definition.", "fuse.featureRule.setting.missing", rule.Setting);
+                }
+                else
+                {
+                    var normalizedOperator = (rule.Operator ?? "equals").Trim();
+                    if ((normalizedOperator.Equals("greaterThan", StringComparison.OrdinalIgnoreCase) ||
+                         normalizedOperator.Equals("greaterThanOrEqual", StringComparison.OrdinalIgnoreCase) ||
+                         normalizedOperator.Equals("lessThan", StringComparison.OrdinalIgnoreCase) ||
+                         normalizedOperator.Equals("lessThanOrEqual", StringComparison.OrdinalIgnoreCase)) &&
+                        FuseSettingTypes.NormalizeType(setting.Type) != "number")
+                    {
+                        result.AddError($"{path}.operator", "Numeric feature-rule comparisons require a number setting.", "fuse.featureRule.operator.type", rule.Operator);
+                    }
+                    if (!setting.ReloadRequired)
+                    {
+                        result.AddWarning($"settings.{rule.Setting}.reloadRequired", "Settings used by feature rules take effect on map reload; set reloadRequired to true so players are told clearly.", "fuse.featureRule.setting.reloadRequired", rule.Setting);
+                    }
+                }
+                if (!ValidFeatureRuleOperators.Contains((rule.Operator ?? "equals").Trim()))
+                    result.AddError($"{path}.operator", "Feature rule operator is not supported.", "fuse.featureRule.operator", rule.Operator);
+                if (rule.Value == null)
+                    result.AddError($"{path}.value", "Feature rule comparison value is required.", "fuse.featureRule.value.required");
+                ValidateFeatureTargets(result, definition, path, rule.Targets);
+            }
+        }
+
+        private static void ValidateFeatureTargets(ValidationResult result, FuseModDefinition definition, string path, FuseFeatureTargets targets)
+        {
+            if (targets == null)
+            {
+                result.AddError($"{path}.targets", "Feature rule targets are required.", "fuse.featureRule.targets.required");
+                return;
+            }
+            var componentIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var industry in definition.Operations.Industries)
+                foreach (var component in industry.Value?.Components ?? new Dictionary<string, FuseIndustryComponent>())
+                    componentIds.Add(industry.Key + "/" + component.Key);
+            var count = 0;
+            count += ValidateFeatureTargetIds(result, path, "trackNodes", targets.TrackNodes, definition.Tracks.Nodes.Keys);
+            count += ValidateFeatureTargetIds(result, path, "trackSegments", targets.TrackSegments, definition.Tracks.Segments.Keys);
+            count += ValidateFeatureTargetIds(result, path, "trackSpans", targets.TrackSpans, definition.Tracks.Spans.Keys);
+            count += ValidateFeatureTargetIds(result, path, "trackAreas", targets.TrackAreas, definition.Tracks.Areas.Keys);
+            count += ValidateFeatureTargetIds(result, path, "loads", targets.Loads, definition.Operations.Loads.Keys);
+            count += ValidateFeatureTargetIds(result, path, "industries", targets.Industries, definition.Operations.Industries.Keys);
+            count += ValidateFeatureTargetIds(result, path, "industryComponents", targets.IndustryComponents, componentIds);
+            count += ValidateFeatureTargetIds(result, path, "loaders", targets.Loaders, definition.Operations.Loaders.Keys);
+            count += ValidateFeatureTargetIds(result, path, "turntables", targets.Turntables, definition.Operations.Turntables.Keys);
+            count += ValidateFeatureTargetIds(result, path, "stations", targets.Stations, definition.Operations.Stations.Keys);
+            count += ValidateFeatureTargetIds(result, path, "scenery", targets.Scenery, definition.World.Scenery.Keys);
+            count += ValidateFeatureTargetIds(result, path, "splineys", targets.Splineys, definition.World.Splineys.Keys);
+            count += ValidateFeatureTargetIds(result, path, "waterSurfaces", targets.WaterSurfaces, definition.World.WaterSurfaces.Keys);
+            count += ValidateFeatureTargetIds(result, path, "telegraphPoles", targets.TelegraphPoles, definition.World.TelegraphPoles.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapLabels", targets.MapLabels, definition.World.MapLabels.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapMasks", targets.MapMasks, definition.World.MapMasks.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapTiles", targets.MapTiles, definition.World.MapTiles.Keys);
+            count += ValidateFeatureTargetIds(result, path, "sceneClones", targets.SceneClones, definition.World.SceneClones.Keys);
+            count += ValidateFeatureTargetIds(result, path, "progressions", targets.Progressions, definition.Progression.Progressions.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapFeatures", targets.MapFeatures, definition.Progression.MapFeatures.Keys);
+            count += ValidateFeatureTargetIds(result, path, "whistles", targets.Whistles, definition.Audio.Whistles.Keys);
+            count += ValidateFeatureTargetIds(result, path, "horns", targets.Horns, definition.Audio.Horns.Keys);
+            count += ValidateFeatureTargetIds(result, path, "bells", targets.Bells, definition.Audio.Bells.Keys);
+            if (count == 0)
+                result.AddError($"{path}.targets", "Feature rule must target at least one authored object.", "fuse.featureRule.targets.empty");
+        }
+
+        private static int ValidateFeatureTargetIds(ValidationResult result, string path, string property, IEnumerable<string> values, IEnumerable<string> defined)
+        {
+            var ids = (values ?? Array.Empty<string>()).ToArray();
+            var known = new HashSet<string>(defined ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var index = 0; index < ids.Length; index++)
+            {
+                var id = ids[index];
+                if (string.IsNullOrWhiteSpace(id))
+                    result.AddError($"{path}.targets.{property}[{index}]", "Feature target ID must not be blank.", "fuse.featureRule.target.blank");
+                else if (!known.Contains(id))
+                    result.AddError($"{path}.targets.{property}[{index}]", "Feature target must name an object authored in this definition.", "fuse.featureRule.target.missing", id);
+                else if (!seen.Add(id))
+                    result.AddWarning($"{path}.targets.{property}[{index}]", "Feature target is listed more than once in this rule.", "fuse.featureRule.target.duplicate", id);
+            }
+            return ids.Length;
         }
 
         private static void ValidateTrack(ValidationResult result, FuseTrackDefinition tracks, FuseOperationsDefinition operations)
@@ -548,6 +671,7 @@ namespace Fuse.Core.Validation
             {
                 ValidateWorldRemovalTargets(result, "world.removals.scenery", world.Removals.Scenery, world.Scenery.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.splineys", world.Removals.Splineys, world.Splineys.Keys);
+                ValidateWorldRemovalTargets(result, "world.removals.waterSurfaces", world.Removals.WaterSurfaces, world.WaterSurfaces.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.telegraphPoles", world.Removals.TelegraphPoles, world.TelegraphPoles.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.mapLabels", world.Removals.MapLabels, world.MapLabels.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.mapMasks", world.Removals.MapMasks, world.MapMasks.Keys);
@@ -598,11 +722,52 @@ namespace Fuse.Core.Validation
 
             foreach (var spliney in world.Splineys)
             {
-                Required(result, $"world.splineys.{spliney.Key}.type", spliney.Value.Type);
-                if (spliney.Value.Points == null || spliney.Value.Points.Length < 2)
+                var path = $"world.splineys.{spliney.Key}";
+                var value = spliney.Value;
+                if (value == null)
                 {
-                    result.AddError($"world.splineys.{spliney.Key}.points", "Spliney objects require at least two points.", "fuse.spliney.points");
+                    result.AddError(path, "Spliney definition is required.", "fuse.spliney.required");
+                    continue;
                 }
+                Required(result, $"{path}.type", value.Type);
+                if (value.Points == null || value.Points.Length < 2)
+                {
+                    result.AddError($"{path}.points", "Spliney objects require at least two points.", "fuse.spliney.points");
+                }
+                if (IsObjectLine(value.Type))
+                {
+                    if (string.IsNullOrWhiteSpace(value.AssetIdentifier)
+                        == string.IsNullOrWhiteSpace(value.Prefab))
+                    {
+                        result.AddError(
+                            path,
+                            "Object-line splineys require exactly one of assetIdentifier or prefab.",
+                            "fuse.spliney.objectLine.source");
+                    }
+                    if (value.Spacing <= 0f)
+                        result.AddError($"{path}.spacing", "Object-line spacing must be greater than 0.", "fuse.spliney.objectLine.spacing", value.Spacing);
+                    if (value.MaximumInstances < 1 || value.MaximumInstances > 4096)
+                        result.AddError($"{path}.maximumInstances", "Object-line maximumInstances must be between 1 and 4096.", "fuse.spliney.objectLine.maximumInstances", value.MaximumInstances);
+                }
+            }
+
+            foreach (var waterSurface in world.WaterSurfaces)
+            {
+                var path = $"world.waterSurfaces.{waterSurface.Key}";
+                var value = waterSurface.Value;
+                if (value == null)
+                {
+                    result.AddError(path, "Water surface definition is required.", "fuse.waterSurface.required");
+                    continue;
+                }
+                if (value.Points == null || value.Points.Length < 3)
+                    result.AddError($"{path}.points", "Water surfaces require at least three boundary points.", "fuse.waterSurface.points");
+                if (value.TriangleDensity <= 0f || value.TriangleDensity > 1f)
+                    result.AddError($"{path}.triangleDensity", "Triangle density must be greater than 0 and at most 1.", "fuse.waterSurface.triangleDensity", value.TriangleDensity);
+                if (value.MaximumTriangleArea <= 0f)
+                    result.AddError($"{path}.maximumTriangleArea", "Maximum triangle area must be greater than 0.", "fuse.waterSurface.maximumTriangleArea", value.MaximumTriangleArea);
+                if (value.UvScale <= 0f)
+                    result.AddError($"{path}.uvScale", "UV scale must be greater than 0.", "fuse.waterSurface.uvScale", value.UvScale);
             }
 
             foreach (var telegraph in world.TelegraphPoles)
@@ -705,6 +870,14 @@ namespace Fuse.Core.Validation
 
                 Required(result, $"world.sceneClones.{sceneClone.Key}.targetPath", sceneClone.Value.TargetPath);
             }
+        }
+
+        private static bool IsObjectLine(string type)
+        {
+            return string.Equals(type, "objectLine", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(type, "object-line", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(type, "fence", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(type, "retainingWall", StringComparison.OrdinalIgnoreCase);
         }
 
         private static void ValidateWorldRemovalTargets(ValidationResult result, string path, IEnumerable<string> removals, IEnumerable<string> definitions)

--- a/FUSE.Core/Validation/Help/fuse-validation-help.json
+++ b/FUSE.Core/Validation/Help/fuse-validation-help.json
@@ -161,6 +161,30 @@
     "fix": "Replace the null value with an object that sets directory and sourceFolder.",
     "example": "{\"world\":{\"mapTiles\":{\"newValley\":{\"directory\":\"mapTiles\",\"sourceFolder\":\"newValley\"}}}}"
   },
+  "fuse.mixinto.conflict.id.blank": {
+    "title": "Mixinto conflict id is blank",
+    "why": "An entry in mixinto.conflictsWith has a blank or whitespace-only id, so FUSE ignores that conflict entirely. The fragment may apply alongside a package it was intended to exclude.",
+    "fix": "Set the conflict's id to the identifier of the incompatible mod, or delete the entry if no conflict is intended.",
+    "example": "{\"mixinto\": {\"conflictsWith\": [{\"id\": \"IncompatibleMod\"}]}}"
+  },
+  "fuse.mixinto.conflict.null": {
+    "title": "Null mixinto conflict entry",
+    "why": "The mixinto.conflictsWith array contains a null entry, which FUSE skips at load. A null entry cannot exclude an incompatible package.",
+    "fix": "Remove the null entry from conflictsWith, or replace it with a conflict object that has an id.",
+    "example": "{\"mixinto\": {\"conflictsWith\": [{\"id\": \"IncompatibleMod\"}]}}"
+  },
+  "fuse.mixinto.requirement.id.blank": {
+    "title": "Mixinto requirement id is blank",
+    "why": "An entry in mixinto.requires has a blank or whitespace-only id, so FUSE ignores that requirement entirely. The fragment will not be gated on the mod you meant to require and may apply even when that mod is absent.",
+    "fix": "Set the requirement's id to the identifier of the mod this fragment depends on, or delete the entry if no dependency is intended.",
+    "example": "{\"mixinto\": {\"requires\": [{\"id\": \"ExampleMod\"}]}}"
+  },
+  "fuse.mixinto.requirement.null": {
+    "title": "Null mixinto requirement entry",
+    "why": "The mixinto.requires array contains a null entry, which FUSE skips at load. A null requirement cannot gate the fragment, so any conditional-loading intent behind it is silently lost.",
+    "fix": "Remove the null entry from the requires array, or replace it with a requirement object that has an id.",
+    "example": "{\"mixinto\": {\"requires\": [{\"id\": \"ExampleMod\"}]}}"
+  },
   "fuse.mixinto.sourceFile.blank": {
     "title": "Mixinto sourceFile is blank",
     "why": "The mixinto section is present but sourceFile is blank. sourceFile records which legacy file produced this converted fragment; leaving it empty makes the conversion provenance less clear when debugging the mod later.",

--- a/FUSE.Core/Validation/Help/fuse-validation-help.json
+++ b/FUSE.Core/Validation/Help/fuse-validation-help.json
@@ -41,6 +41,78 @@
     "fix": "Make the top level of the file a JSON object, with at least id and name set.",
     "example": "{\"id\":\"my-mod\",\"name\":\"My Mod\"}"
   },
+  "fuse.featureRule.id.blank": {
+    "title": "Feature rule ID is blank",
+    "why": "A key under featureRules is empty or whitespace, so FUSE cannot identify the rule or report which player option controls it. This is an error and the definition does not pass validation.",
+    "fix": "Give every feature rule a non-empty, unique key that describes the option-controlled feature.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.operator": {
+    "title": "Feature rule operator is unsupported",
+    "why": "The operator is not one of equals, notEquals, greaterThan, greaterThanOrEqual, lessThan, or lessThanOrEqual, so FUSE cannot evaluate the rule deterministically.",
+    "fix": "Replace operator with one of the supported names; use equals for a normal on/off or choice setting.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.operator.type": {
+    "title": "Numeric feature comparison uses a non-number setting",
+    "why": "greaterThan, greaterThanOrEqual, lessThan, and lessThanOrEqual compare numbers, but the referenced setting is not type number. The comparison cannot have a reliable meaning.",
+    "fix": "Change the setting to type number, or use equals/notEquals for bool, enum, or text settings.",
+    "example": "{\"settings\":{\"yardSize\":{\"type\":\"number\",\"default\":1,\"reloadRequired\":true}},\"featureRules\":{\"large-yard\":{\"setting\":\"yardSize\",\"operator\":\"greaterThanOrEqual\",\"value\":2,\"targets\":{\"trackSegments\":[\"yard-2\"]}}}}"
+  },
+  "fuse.featureRule.required": {
+    "title": "Feature rule definition is null",
+    "why": "A key under featureRules maps to JSON null instead of a rule object, so it has no setting, comparison, or targets to evaluate.",
+    "fix": "Remove the null entry, or replace it with a rule object containing setting, operator, value, and targets.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.setting.missing": {
+    "title": "Feature rule references a missing setting",
+    "why": "The rule's setting is blank or does not name a setting declared in this same definition. Without that option FUSE has no player value to evaluate.",
+    "fix": "Add the setting under settings, or correct featureRules.<id>.setting to the exact declared setting ID.",
+    "example": "{\"settings\":{\"yardEnabled\":{\"type\":\"bool\",\"default\":true,\"reloadRequired\":true}},\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.setting.reloadRequired": {
+    "title": "Feature-controlled setting is not marked reload-required",
+    "why": "Feature rules change which authored objects are applied during map load. A setting used by a rule cannot safely rebuild that content immediately, so leaving reloadRequired false would mislead players about when the option takes effect.",
+    "fix": "Set reloadRequired to true on the referenced setting and mention the reload in its description.",
+    "example": "{\"settings\":{\"yardEnabled\":{\"type\":\"bool\",\"default\":true,\"reloadRequired\":true,\"description\":\"Reload the map after changing this option.\"}}}"
+  },
+  "fuse.featureRule.target.blank": {
+    "title": "Feature rule contains a blank target ID",
+    "why": "One of the rule's target arrays contains an empty or whitespace-only value. A blank value cannot name an authored object and would never control anything.",
+    "fix": "Remove the blank array entry, or replace it with the exact ID of an object authored in this definition.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.target.duplicate": {
+    "title": "Feature rule lists the same target more than once",
+    "why": "The same object ID appears repeatedly in one target array. FUSE can still evaluate the rule, but the duplicate adds noise and commonly indicates a copy/paste mistake.",
+    "fix": "Keep each target ID only once in that rule's target array.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\",\"yard-2\"]}}}}"
+  },
+  "fuse.featureRule.target.missing": {
+    "title": "Feature rule target does not exist",
+    "why": "A target ID does not name an object authored in this definition. Feature rules intentionally do not guess at dependency-owned or base-game objects, so the target could never be enabled or disabled by this package.",
+    "fix": "Correct the ID and target category, or author the referenced object in this definition before targeting it.",
+    "example": "{\"tracks\":{\"segments\":{\"yard-1\":{\"startNodeId\":\"n1\",\"endNodeId\":\"n2\"}}},\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.targets.empty": {
+    "title": "Feature rule has no targets",
+    "why": "The targets object exists but all of its arrays are empty, so changing the setting would not enable or disable any authored content.",
+    "fix": "Add at least one valid object ID to the appropriate target category, or remove the unused rule.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.targets.required": {
+    "title": "Feature rule targets are missing",
+    "why": "The rule's targets value is null, so the rule cannot identify which authored objects it controls.",
+    "fix": "Add a targets object with at least one supported category and authored object ID.",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
+  "fuse.featureRule.value.required": {
+    "title": "Feature rule comparison value is missing",
+    "why": "The rule has no value to compare with the selected setting. FUSE cannot decide whether the rule is active without a bool, number, string, or enum value.",
+    "fix": "Set value to the setting value that should activate this rule, such as true, 2, or \"large\".",
+    "example": "{\"featureRules\":{\"enable-yard\":{\"setting\":\"yardEnabled\",\"operator\":\"equals\",\"value\":true,\"targets\":{\"trackSegments\":[\"yard-1\"]}}}}"
+  },
   "fuse.map.displayName.blank": {
     "title": "Map displayName is blank",
     "why": "The map declaration has no displayName, so wherever the map is offered for selection (console listings, menus) FUSE falls back to the package name. That usually reads worse than a purpose-written map title.",
@@ -88,18 +160,6 @@
     "why": "An entry under world.mapTiles maps to null instead of a tile source object, so FUSE has no directory or sourceFolder to load map tiles from. This is an error until the entry is a real object.",
     "fix": "Replace the null value with an object that sets directory and sourceFolder.",
     "example": "{\"world\":{\"mapTiles\":{\"newValley\":{\"directory\":\"mapTiles\",\"sourceFolder\":\"newValley\"}}}}"
-  },
-  "fuse.mixinto.requirement.id.blank": {
-    "title": "Mixinto requirement id is blank",
-    "why": "An entry in mixinto.requires has a blank or whitespace-only id, so FUSE ignores that requirement entirely. The fragment will not be gated on the mod you meant to require and may apply even when that mod is absent.",
-    "fix": "Set the requirement's id to the identifier of the mod this fragment depends on, or delete the entry if no dependency is intended.",
-    "example": "{\"mixinto\": {\"requires\": [{\"id\": \"ExampleMod\"}]}}"
-  },
-  "fuse.mixinto.requirement.null": {
-    "title": "Null mixinto requirement entry",
-    "why": "The mixinto.requires array contains a null entry, which FUSE skips at load. A null requirement cannot gate the fragment, so any conditional-loading intent behind it is silently lost.",
-    "fix": "Remove the null entry from the requires array, or replace it with a requirement object that has an id.",
-    "example": "{\"mixinto\": {\"requires\": [{\"id\": \"ExampleMod\"}]}}"
   },
   "fuse.mixinto.sourceFile.blank": {
     "title": "Mixinto sourceFile is blank",
@@ -413,11 +473,35 @@
     "fix": "Document the reload requirement in the setting's description so multiplayer users know a reload is needed. Alternatively drop reloadRequired or move the setting off server scope if either is unnecessary.",
     "example": "{\"settings\": {\"trackGauge\": {\"type\": \"number\", \"scope\": \"server\", \"reloadRequired\": true, \"description\": \"Synced to all players; requires a reload to apply.\"}}}"
   },
+  "fuse.spliney.objectLine.maximumInstances": {
+    "title": "Object line instance limit is out of range",
+    "why": "maximumInstances is below 1 or above 4096. A non-positive limit cannot place an object, while an unbounded repeated line can freeze or exhaust the game.",
+    "fix": "Set maximumInstances between 1 and 4096; use the smallest limit that safely covers the authored line.",
+    "example": "{\"world\":{\"splineys\":{\"yard-fence\":{\"type\":\"objectLine\",\"assetIdentifier\":\"FencePanel\",\"spacing\":3,\"maximumInstances\":500,\"points\":[{\"position\":{\"x\":0,\"y\":560,\"z\":0}},{\"position\":{\"x\":30,\"y\":560,\"z\":0}}]}}}}"
+  },
+  "fuse.spliney.objectLine.source": {
+    "title": "Object line needs exactly one model source",
+    "why": "An objectLine has neither assetIdentifier nor prefab, or it sets both. FUSE needs one unambiguous source for the repeated fence, wall, pipe, or other rigid module.",
+    "fix": "Set exactly one of assetIdentifier (PrefabStore asset) or prefab (loaded scene prefab path), and remove the other field.",
+    "example": "{\"world\":{\"splineys\":{\"yard-fence\":{\"type\":\"objectLine\",\"assetIdentifier\":\"FencePanel\",\"spacing\":3,\"points\":[{\"position\":{\"x\":0,\"y\":560,\"z\":0}},{\"position\":{\"x\":30,\"y\":560,\"z\":0}}]}}}}"
+  },
+  "fuse.spliney.objectLine.spacing": {
+    "title": "Object line spacing is not positive",
+    "why": "spacing is zero or negative, so FUSE cannot advance along the path while placing repeated modules.",
+    "fix": "Set spacing to a positive distance in metres that matches the module length or desired gap.",
+    "example": "{\"world\":{\"splineys\":{\"yard-fence\":{\"type\":\"objectLine\",\"assetIdentifier\":\"FencePanel\",\"spacing\":3,\"points\":[{\"position\":{\"x\":0,\"y\":560,\"z\":0}},{\"position\":{\"x\":30,\"y\":560,\"z\":0}}]}}}}"
+  },
   "fuse.spliney.points": {
     "title": "Spliney needs at least two points",
     "why": "The spliney's points array is missing or has fewer than two entries. Spliney objects require at least two points to define a path; this is an error and must be fixed.",
     "fix": "Add a points array with two or more point entries (each with a position) tracing the spliney's path.",
     "example": "{\"world\": {\"splineys\": {\"yardFence\": {\"type\": \"fence\", \"points\": [{\"position\": {\"x\": 0, \"y\": 560, \"z\": 0}}, {\"position\": {\"x\": 25, \"y\": 560, \"z\": 10}}]}}}}"
+  },
+  "fuse.spliney.required": {
+    "title": "Spliney definition is null",
+    "why": "A key under world.splineys maps to JSON null instead of a spline definition, so there is no type or path to build.",
+    "fix": "Remove the null entry, or replace it with a spliney object containing type and at least two points.",
+    "example": "{\"world\":{\"splineys\":{\"yard-road\":{\"type\":\"road\",\"points\":[{\"position\":{\"x\":0,\"y\":560,\"z\":0}},{\"position\":{\"x\":30,\"y\":560,\"z\":0}}]}}}}"
   },
   "fuse.telegraph.points": {
     "title": "Telegraph pole set needs two points",
@@ -598,6 +682,36 @@
     "why": "Error: the turntable's subdivisions value is below 4 or above 32, outside the range the validator allows. The document fails validation, so the turntable definition is rejected.",
     "fix": "Set subdivisions to a whole number between 4 and 32 (inclusive) under operations.turntables.<id>. The default is 16 if you have no specific need.",
     "example": "{\"operations\": {\"turntables\": {\"ewh-turntable\": {\"radius\": 12.5, \"subdivisions\": 16}}}}"
+  },
+  "fuse.waterSurface.maximumTriangleArea": {
+    "title": "Water surface maximum triangle area is not positive",
+    "why": "maximumTriangleArea is zero or negative, so the mesh generator has no valid upper bound for water-surface triangles.",
+    "fix": "Set maximumTriangleArea to a positive square-metre value; 50 is a practical starting point for a lake.",
+    "example": "{\"world\":{\"waterSurfaces\":{\"mill-pond\":{\"points\":[{\"x\":0,\"y\":550,\"z\":0},{\"x\":50,\"y\":550,\"z\":0},{\"x\":25,\"y\":550,\"z\":40}],\"maximumTriangleArea\":50}}}}"
+  },
+  "fuse.waterSurface.points": {
+    "title": "Water surface needs at least three boundary points",
+    "why": "The water surface has fewer than three points, so its boundary cannot form a polygon and no visible lake mesh can be generated.",
+    "fix": "Add at least three non-collinear world-space boundary points in perimeter order.",
+    "example": "{\"world\":{\"waterSurfaces\":{\"mill-pond\":{\"points\":[{\"x\":0,\"y\":550,\"z\":0},{\"x\":50,\"y\":550,\"z\":0},{\"x\":25,\"y\":550,\"z\":40}]}}}}"
+  },
+  "fuse.waterSurface.required": {
+    "title": "Water surface definition is null",
+    "why": "A key under world.waterSurfaces maps to JSON null instead of a water-surface object, so FUSE has no boundary or rendering profile to build.",
+    "fix": "Remove the null entry, or replace it with a water-surface object containing at least three points.",
+    "example": "{\"world\":{\"waterSurfaces\":{\"mill-pond\":{\"points\":[{\"x\":0,\"y\":550,\"z\":0},{\"x\":50,\"y\":550,\"z\":0},{\"x\":25,\"y\":550,\"z\":40}]}}}}"
+  },
+  "fuse.waterSurface.triangleDensity": {
+    "title": "Water surface triangle density is out of range",
+    "why": "triangleDensity must be greater than 0 and no more than 1. Values outside that range cannot produce the bounded tessellation FUSE expects.",
+    "fix": "Set triangleDensity within (0, 1]; 0.2 is the default and a useful starting point.",
+    "example": "{\"world\":{\"waterSurfaces\":{\"mill-pond\":{\"points\":[{\"x\":0,\"y\":550,\"z\":0},{\"x\":50,\"y\":550,\"z\":0},{\"x\":25,\"y\":550,\"z\":40}],\"triangleDensity\":0.2}}}}"
+  },
+  "fuse.waterSurface.uvScale": {
+    "title": "Water surface UV scale is not positive",
+    "why": "uvScale is zero or negative, so the lake material cannot receive a valid repeating texture coordinate scale.",
+    "fix": "Set uvScale to a positive number; 1 uses the source material's normal scale.",
+    "example": "{\"world\":{\"waterSurfaces\":{\"mill-pond\":{\"points\":[{\"x\":0,\"y\":550,\"z\":0},{\"x\":50,\"y\":550,\"z\":0},{\"x\":25,\"y\":550,\"z\":40}],\"uvScale\":1}}}}"
   },
   "fuse.world.removal.blank": {
     "title": "Blank world removal ID",

--- a/FUSE.ExternalEditor.UiTests/LegacyImportServiceTests.cs
+++ b/FUSE.ExternalEditor.UiTests/LegacyImportServiceTests.cs
@@ -36,6 +36,9 @@ public class LegacyImportServiceTests
             var projects = new ProjectService();
             var def = projects.Load(result.FirstFragmentPath!);
             Assert.False(string.IsNullOrEmpty(def.Id));
+            Assert.True(def.Tracks.Nodes.TryGetValue("n_legacy", out var legacyNode));
+            Assert.Equal(new FuseVector3(10, 20, 30), legacyNode.Position);
+            Assert.Equal(FuseVector3.zero, legacyNode.Rotation);
 
             TrackOps.AddNode(def.Tracks, "n_test", new FuseVector3(1, 2, 3), default);
             var editedPath = Path.Combine(outDir, "edited.fuse.json");

--- a/FUSE.ExternalEditor.UiTests/LegacyImportServiceTests.cs
+++ b/FUSE.ExternalEditor.UiTests/LegacyImportServiceTests.cs
@@ -21,7 +21,8 @@ public class LegacyImportServiceTests
         {
             File.WriteAllText(Path.Combine(src, "Definition.json"),
                 "{\"id\":\"my.legacy.mod\",\"name\":\"My Legacy Mod\",\"version\":\"1.2.3\",\"author\":\"me\"}");
-            File.WriteAllText(Path.Combine(src, "data.json"), "{}");
+            File.WriteAllText(Path.Combine(src, "data.json"),
+                "{\"tracks\":{\"nodes\":{\"n_legacy\":{\"position\":{\"x\":10,\"y\":20,\"z\":30},\"rotation\":{\"x\":0,\"y\":0,\"z\":0}}}}}");
 
             var result = new LegacyImportService().Convert(src, outDir);
 

--- a/FUSE.ExternalEditor.UiTests/TerrainGenerationServiceTests.cs
+++ b/FUSE.ExternalEditor.UiTests/TerrainGenerationServiceTests.cs
@@ -134,8 +134,7 @@ public class TerrainGenerationServiceTests
         // Progress<T> posts its callbacks asynchronously to the thread pool (no SynchronizationContext
         // in headless xUnit), so they can trail GenerateRegionAsync's completion. Await their delivery
         // with a bounded timeout instead of a fixed delay that a loaded CI runner can outrun.
-        var delivered = await Task.WhenAny(allReported.Task, Task.Delay(TimeSpan.FromSeconds(2)));
-        Assert.True(delivered == allReported.Task, "expected all 6 Progress<T> callbacks to be delivered");
+        await allReported.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
         lock (reports)
         {
             Assert.Equal(6, reports.Count);

--- a/FUSE.Tests/API/FuseLegacyPlaceholderIndustryComponentTests.cs
+++ b/FUSE.Tests/API/FuseLegacyPlaceholderIndustryComponentTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using System.Runtime.Serialization;
+using FUSE.Runtime.API;
+using Model.Ops;
+using Model.Ops.Definition;
+using Track;
+using Xunit;
+
+namespace FUSE.Tests.API
+{
+    public sealed class FuseLegacyPlaceholderIndustryComponentTests
+    {
+        [Fact]
+        public void ConfusingSupplementsEmpty_RemainsVisibleAndAcceptsEveryAutoDestinationKind()
+        {
+            var component = (FuseLegacyPlaceholderIndustryComponent)
+                FormatterServices.GetUninitializedObject(typeof(FuseLegacyPlaceholderIndustryComponent));
+            component.trackSpans = new TrackSpan[1];
+
+            Assert.True(component.IsVisible);
+            Assert.All(
+                Enum.GetValues(typeof(AutoDestinationType)).Cast<AutoDestinationType>(),
+                destinationType => Assert.True(component.WantsAutoDestination(destinationType)));
+        }
+    }
+}

--- a/FUSE.Tests/API/SceneryApiLegacyHelperTests.cs
+++ b/FUSE.Tests/API/SceneryApiLegacyHelperTests.cs
@@ -1,0 +1,30 @@
+using FUSE.Authoring.Data;
+using FUSE.Runtime.API;
+using Xunit;
+
+namespace FUSE.Tests.API
+{
+    public sealed class SceneryApiLegacyHelperTests
+    {
+        [Theory]
+        [InlineData("TurntableMeasurementTool")]
+        [InlineData("scenery://TurntableMeasurementTool")]
+        [InlineData("ALW_ModRes_TurntableMeasurementTool")]
+        public void Turntable_measurement_plate_is_editor_only(string identifier)
+        {
+            Assert.True(SceneryAPI.IsEditorOnlyLegacySceneryReference(new FuseScenery
+            {
+                AssetIdentifier = identifier
+            }));
+        }
+
+        [Fact]
+        public void Ordinary_turntable_scenery_is_not_editor_only()
+        {
+            Assert.False(SceneryAPI.IsEditorOnlyLegacySceneryReference(new FuseScenery
+            {
+                AssetIdentifier = "scenery://ALW_ModRes_plate50x250"
+            }));
+        }
+    }
+}

--- a/FUSE.Tests/API/TrackApiCompanionExtensionTests.cs
+++ b/FUSE.Tests/API/TrackApiCompanionExtensionTests.cs
@@ -36,8 +36,12 @@ namespace FUSE.Tests.API
                 StartNodeId = "a",
                 EndNodeId = "b",
                 Gauge = "DualGauge",
+                BridgeSupportsSteel = true,
+                Yard = true,
                 Partial = true,
                 PreserveStyle = true,
+                PreserveBridgeSupportsSteel = true,
+                PreserveYard = true,
                 PreserveTrackClass = true,
                 PreserveSpeedLimit = true,
                 PreservePriority = true,
@@ -52,8 +56,12 @@ namespace FUSE.Tests.API
             var clone = Assert.IsType<FuseSegment>(cloneMethod.Invoke(null, new object[] { source }));
 
             Assert.Equal("DualGauge", clone.Gauge);
+            Assert.True(clone.BridgeSupportsSteel);
+            Assert.True(clone.Yard);
             Assert.True(clone.Partial);
             Assert.True(clone.PreserveStyle);
+            Assert.True(clone.PreserveBridgeSupportsSteel);
+            Assert.True(clone.PreserveYard);
             Assert.True(clone.PreserveTrackClass);
             Assert.True(clone.PreserveSpeedLimit);
             Assert.True(clone.PreservePriority);

--- a/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
+++ b/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using FUSE.Compatibility;
 using FUSE.Interface.Console;
 using KeyValue.Runtime;
-using Model.Definition.Data;
 using System.Linq;
 using System.Reflection;
 using System.IO;
@@ -114,6 +113,9 @@ namespace FUSE.Tests.Compatibility
 
             Assert.Equal("shared-label", grouped.SavedPropertyId);
             Assert.Equal("road-name", ungrouped.SavedPropertyId);
+            Assert.Equal(
+                "cs.labelprinter.road-name",
+                FuseConfusingSupplementsLabelPrinterBuilder.SavedPropertyKey(ungrouped.SavedPropertyId));
             Assert.Equal(string.Empty, FuseConfusingSupplementsLabelPrinterBuilder.ReadText(Value.Null()));
         }
 
@@ -173,22 +175,11 @@ namespace FUSE.Tests.Compatibility
             string targetIdentifier,
             bool expected)
         {
-            var source = new CarDefinition
-            {
-                LoadSlots = new List<LoadSlot>
-                {
-                    new LoadSlot { RequiredLoadIdentifier = sourceIdentifier }
-                }
-            };
-            var target = new CarDefinition
-            {
-                LoadSlots = new List<LoadSlot>
-                {
-                    new LoadSlot { RequiredLoadIdentifier = targetIdentifier }
-                }
-            };
-
-            Assert.Equal(expected, FuseConfusingSupplementsRefillerRuntime.CanReceiveFrom(source, target));
+            Assert.Equal(
+                expected,
+                FuseConfusingSupplementsRefillerPolicy.CanTargetReceiveFromSource(
+                    new[] { sourceIdentifier },
+                    new[] { targetIdentifier }));
         }
 
         [Fact]
@@ -196,11 +187,11 @@ namespace FUSE.Tests.Compatibility
         {
             var remainingTransfer = 10f;
 
-            var firstSlot = FuseConfusingSupplementsRefillerTransferPolicy.Take(
+            var firstSlot = FuseConfusingSupplementsRefillerPolicy.Take(
                 ref remainingTransfer,
                 6f,
                 10f);
-            var secondSlot = FuseConfusingSupplementsRefillerTransferPolicy.Take(
+            var secondSlot = FuseConfusingSupplementsRefillerPolicy.Take(
                 ref remainingTransfer,
                 8f,
                 10f);

--- a/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
+++ b/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
@@ -64,6 +64,26 @@ namespace FUSE.Tests.Compatibility
         }
 
         [Fact]
+        public void BodygroupsBuilder_StaleSavedValueSelectsFirstDeclaredOption()
+        {
+            var options = new List<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>>
+            {
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "pilot",
+                    new FuseConfusingSupplementsBodygroupOption()),
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "snowplow",
+                    new FuseConfusingSupplementsBodygroupOption())
+            };
+
+            var selected = FuseConfusingSupplementsBodygroupsBuilder.ReadSelectedOption(
+                Value.String("removed-option"),
+                options);
+
+            Assert.Equal("pilot", selected);
+        }
+
+        [Fact]
         public void ReplacementSurface_AccountsForEveryRegisteredRollingStockKind()
         {
             Assert.Equal(
@@ -79,16 +99,17 @@ namespace FUSE.Tests.Compatibility
         }
 
         [Fact]
-        public void LabelPrinter_SavedPropertyIdUsesGroupThenNameFallback()
+        public void LabelPrinter_SavedPropertyIdTrimsGroupThenNameFallback()
         {
             var grouped = new FuseConfusingSupplementsLabelPrinterComponent
             {
                 Name = "Visible Name",
-                Group = "shared-label"
+                Group = " shared-label "
             };
             var ungrouped = new FuseConfusingSupplementsLabelPrinterComponent
             {
-                Name = "road-name"
+                Name = " road-name ",
+                Group = "   "
             };
 
             Assert.Equal("shared-label", grouped.SavedPropertyId);
@@ -168,6 +189,25 @@ namespace FUSE.Tests.Compatibility
             };
 
             Assert.Equal(expected, FuseConfusingSupplementsRefillerRuntime.CanReceiveFrom(source, target));
+        }
+
+        [Fact]
+        public void RefillerTransferBudget_IsSharedAcrossTargetSlots()
+        {
+            var remainingTransfer = 10f;
+
+            var firstSlot = FuseConfusingSupplementsRefillerTransferPolicy.Take(
+                ref remainingTransfer,
+                6f,
+                10f);
+            var secondSlot = FuseConfusingSupplementsRefillerTransferPolicy.Take(
+                ref remainingTransfer,
+                8f,
+                10f);
+
+            Assert.Equal(6f, firstSlot);
+            Assert.Equal(4f, secondSlot);
+            Assert.Equal(0f, remainingTransfer);
         }
 
         [Fact]

--- a/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
+++ b/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Effects.Decals;
 using FUSE.Compatibility;
 using FUSE.Interface.Console;
 using KeyValue.Runtime;
@@ -140,25 +141,50 @@ namespace FUSE.Tests.Compatibility
             Assert.Contains("/fuse.liveries", keywords);
         }
 
-        [Fact]
-        public void RefillerCompatibility_MatchesLoadIdentifiersCaseInsensitively()
+        [Theory]
+        [InlineData("diesel", "DIESEL", true)]
+        [InlineData("diesel", "coal", false)]
+        [InlineData(null, "diesel", false)]
+        [InlineData("diesel", null, false)]
+        [InlineData("", "diesel", false)]
+        [InlineData("diesel", "", false)]
+        public void RefillerCompatibility_MatchesLoadIdentifiersCaseInsensitively(
+            string sourceIdentifier,
+            string targetIdentifier,
+            bool expected)
         {
             var source = new CarDefinition
             {
                 LoadSlots = new List<LoadSlot>
                 {
-                    new LoadSlot { RequiredLoadIdentifier = "diesel" }
+                    new LoadSlot { RequiredLoadIdentifier = sourceIdentifier }
                 }
             };
             var target = new CarDefinition
             {
                 LoadSlots = new List<LoadSlot>
                 {
-                    new LoadSlot { RequiredLoadIdentifier = "DIESEL" }
+                    new LoadSlot { RequiredLoadIdentifier = targetIdentifier }
                 }
             };
 
-            Assert.True(FuseConfusingSupplementsRefillerRuntime.CanReceiveFrom(source, target));
+            Assert.Equal(expected, FuseConfusingSupplementsRefillerRuntime.CanReceiveFrom(source, target));
+        }
+
+        [Fact]
+        public void LabelPrinter_RejectsUnsupportedDecalContentWithoutThrowing()
+        {
+            var supported = FuseConfusingSupplementsLabelPrinterBuilder.TryGetTemplateName(
+                DecalContent.RoadNumber,
+                out var supportedTemplate);
+            var unsupported = FuseConfusingSupplementsLabelPrinterBuilder.TryGetTemplateName(
+                (DecalContent)int.MaxValue,
+                out var unsupportedTemplate);
+
+            Assert.True(supported);
+            Assert.Equal("Number", supportedTemplate);
+            Assert.False(unsupported);
+            Assert.Null(unsupportedTemplate);
         }
 
         [Fact]

--- a/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
+++ b/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using FUSE.Compatibility;
 using FUSE.Interface.Console;
 using KeyValue.Runtime;
-using Model.Definition.Components;
 using Model.Definition.Data;
 using System.Linq;
 using System.Reflection;
@@ -169,22 +168,6 @@ namespace FUSE.Tests.Compatibility
             };
 
             Assert.Equal(expected, FuseConfusingSupplementsRefillerRuntime.CanReceiveFrom(source, target));
-        }
-
-        [Fact]
-        public void LabelPrinter_RejectsUnsupportedDecalContentWithoutThrowing()
-        {
-            var supported = FuseConfusingSupplementsLabelPrinterBuilder.TryGetTemplateName(
-                DecalContent.RoadNumber,
-                out var supportedTemplate);
-            var unsupported = FuseConfusingSupplementsLabelPrinterBuilder.TryGetTemplateName(
-                (DecalContent)int.MaxValue,
-                out var unsupportedTemplate);
-
-            Assert.True(supported);
-            Assert.Equal("Number", supportedTemplate);
-            Assert.False(unsupported);
-            Assert.Null(unsupportedTemplate);
         }
 
         [Fact]

--- a/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
+++ b/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
-using Effects.Decals;
 using FUSE.Compatibility;
 using FUSE.Interface.Console;
 using KeyValue.Runtime;
+using Model.Definition.Components;
 using Model.Definition.Data;
 using System.Linq;
 using System.Reflection;

--- a/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
+++ b/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
@@ -1,0 +1,207 @@
+using System.Collections.Generic;
+using FUSE.Compatibility;
+using FUSE.Interface.Console;
+using KeyValue.Runtime;
+using Model.Definition.Data;
+using System.Linq;
+using System.Reflection;
+using System.IO;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Compatibility
+{
+    public sealed class FuseConfusingSupplementsCompatibilityTests
+    {
+        [Fact]
+        public void BodygroupsComponent_UsesLegacyWireKindWithFuseOwnedType()
+        {
+            var component = new FuseConfusingSupplementsBodygroupsComponent();
+
+            Assert.Equal("ConfusingSupplements.Bodygroups", component.Kind);
+            Assert.Empty(component.Groups);
+            Assert.Contains(component.Kind, FuseConfusingSupplementsCompatibility.ImplementedComponentKinds);
+        }
+
+        [Fact]
+        public void BodygroupsBuilder_EmptySavedValueSelectsFirstDeclaredOption()
+        {
+            var options = new List<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>>
+            {
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "pilot",
+                    new FuseConfusingSupplementsBodygroupOption { Name = "Pilot" }),
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "snowplow",
+                    new FuseConfusingSupplementsBodygroupOption { Name = "Snowplow" })
+            };
+
+            var selected = FuseConfusingSupplementsBodygroupsBuilder.ReadSelectedOption(
+                Value.Null(),
+                options);
+
+            Assert.Equal("pilot", selected);
+        }
+
+        [Fact]
+        public void BodygroupsBuilder_SavedValueWinsOverDefault()
+        {
+            var options = new List<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>>
+            {
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "pilot",
+                    new FuseConfusingSupplementsBodygroupOption()),
+                new KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>(
+                    "snowplow",
+                    new FuseConfusingSupplementsBodygroupOption())
+            };
+
+            var selected = FuseConfusingSupplementsBodygroupsBuilder.ReadSelectedOption(
+                Value.String("snowplow"),
+                options);
+
+            Assert.Equal("snowplow", selected);
+        }
+
+        [Fact]
+        public void ReplacementSurface_AccountsForEveryRegisteredRollingStockKind()
+        {
+            Assert.Equal(
+                new[]
+                {
+                    "ConfusingSupplements.Bodygroups",
+                    "ConfusingSupplements.DestinationSign",
+                    "ConfusingSupplements.LabelPrinter",
+                    "CS.LiverySwap",
+                    "ConfusingSupplements.Refiller"
+                },
+                FuseConfusingSupplementsCompatibility.ImplementedComponentKinds);
+        }
+
+        [Fact]
+        public void LabelPrinter_SavedPropertyIdUsesGroupThenNameFallback()
+        {
+            var grouped = new FuseConfusingSupplementsLabelPrinterComponent
+            {
+                Name = "Visible Name",
+                Group = "shared-label"
+            };
+            var ungrouped = new FuseConfusingSupplementsLabelPrinterComponent
+            {
+                Name = "road-name"
+            };
+
+            Assert.Equal("shared-label", grouped.SavedPropertyId);
+            Assert.Equal("road-name", ungrouped.SavedPropertyId);
+            Assert.Equal(string.Empty, FuseConfusingSupplementsLabelPrinterBuilder.ReadText(Value.Null()));
+        }
+
+        [Theory]
+        [InlineData(-1, 3, false, 0)]
+        [InlineData(2, 3, false, -1)]
+        [InlineData(-1, 3, true, 2)]
+        [InlineData(0, 3, true, -1)]
+        [InlineData(0, 0, false, -1)]
+        public void DestinationSign_CyclesThroughHiddenAndNamedStates(
+            int current,
+            int count,
+            bool previous,
+            int expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseConfusingSupplementsDestinationSignController.NextIndex(current, count, previous));
+        }
+
+        [Theory]
+        [InlineData("paint.PNG", true)]
+        [InlineData("paint.jpeg", true)]
+        [InlineData("paint.JPG", true)]
+        [InlineData("readme.txt", false)]
+        public void LiveryRegistry_AcceptsOnlySupportedTextureFiles(string path, bool expected)
+        {
+            Assert.Equal(expected, FuseConfusingSupplementsLiveryRegistry.IsTextureFile(path));
+        }
+
+        [Fact]
+        public void LiveryCompatibility_RegistersRefreshAndDiagnosticCommands()
+        {
+            var commands = FuseConsoleCommands.CreateAll();
+            var keywords = commands.Select(command => CustomAttributeData
+                    .GetCustomAttributes(command.GetType())
+                    .Single(attribute =>
+                        attribute.AttributeType.FullName ==
+                        "UI.Console.ConsoleCommandAttribute")
+                    .ConstructorArguments[0]
+                    .Value as string)
+                .ToArray();
+
+            Assert.Contains("/cs-livery-refresh", keywords);
+            Assert.Contains("/fuse.liveries", keywords);
+        }
+
+        [Fact]
+        public void RefillerCompatibility_MatchesLoadIdentifiersCaseInsensitively()
+        {
+            var source = new CarDefinition
+            {
+                LoadSlots = new List<LoadSlot>
+                {
+                    new LoadSlot { RequiredLoadIdentifier = "diesel" }
+                }
+            };
+            var target = new CarDefinition
+            {
+                LoadSlots = new List<LoadSlot>
+                {
+                    new LoadSlot { RequiredLoadIdentifier = "DIESEL" }
+                }
+            };
+
+            Assert.True(FuseConfusingSupplementsRefillerRuntime.CanReceiveFrom(source, target));
+        }
+
+        [Fact]
+        public void StrangeCustomsFileCache_NormalizesPathsAndTracksEntryState()
+        {
+            var relative = Path.Combine("fixtures", "audio.wav");
+            Assert.Equal(Path.GetFullPath(relative), StrangeCustoms.FileCache.NormalizePath(relative));
+
+            var entry = new StrangeCustoms.FileCache.CacheEntry<string>(relative);
+            string observed = null;
+            entry.Register(value => observed = value);
+            entry.Set("loaded");
+
+            Assert.True(entry.IsValid);
+            Assert.False(entry.IsLoading);
+            Assert.Equal("loaded", entry.Value);
+            Assert.Equal("loaded", observed);
+
+            entry.Invalidate();
+            Assert.False(entry.IsValid);
+            Assert.Null(entry.Value);
+        }
+
+        [Fact]
+        public void StrangeCustomsFlowyBuilder_AdaptsLegacyDataToNativeSpliney()
+        {
+            var definition = StrangeCustoms.FlowyThingBuilder.ConvertDefinition(
+                JObject.Parse(@"{
+                    'handler': 'StrangeCustoms.FlowyThingBuilder',
+                    'style': 'River',
+                    'profile': 'River profile',
+                    'points': [
+                        { 'position': { 'x': 1, 'y': 2, 'z': 3 }, 'width': 4 },
+                        { 'position': { 'x': 5, 'y': 6, 'z': 7 }, 'width': 8 }
+                    ]
+                }"));
+
+            Assert.Equal("river", definition.Type);
+            Assert.Equal("River profile", definition.Profile);
+            Assert.Equal(-0.1f, definition.OffsetY);
+            Assert.Equal(2, definition.Points.Length);
+            Assert.Equal(4f, definition.Points[0].Width);
+            Assert.Equal(7f, definition.Points[1].Position.z);
+        }
+    }
+}

--- a/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
+++ b/FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs
@@ -183,6 +183,14 @@ namespace FUSE.Tests.Compatibility
         }
 
         [Fact]
+        public void RefillerCompatibility_SearchesAllSourceAndTargetSlots()
+        {
+            Assert.True(FuseConfusingSupplementsRefillerPolicy.CanTargetReceiveFromSource(
+                new[] { "water", "diesel" },
+                new[] { "coal", "DIESEL" }));
+        }
+
+        [Fact]
         public void RefillerTransferBudget_IsSharedAcrossTargetSlots()
         {
             var remainingTransfer = 10f;

--- a/FUSE.Tests/Compatibility/FuseLegacyDebugInformationTests.cs
+++ b/FUSE.Tests/Compatibility/FuseLegacyDebugInformationTests.cs
@@ -1,0 +1,51 @@
+using System;
+using FUSE.Compatibility;
+using GalaSoft.MvvmLight.Messaging;
+using Railloader.Events;
+using Xunit;
+
+namespace FUSE.Tests.Compatibility
+{
+    public sealed class FuseLegacyDebugInformationTests
+    {
+        [Fact]
+        public void Collect_DispatchesLegacyEventAndNormalizesMultilineContributions()
+        {
+            var recipient = new DebugRecipient();
+            var lines = FuseLegacyDebugInformation.Collect(recipient.Handle);
+
+            Assert.Contains("first", lines);
+            Assert.Contains("second", lines);
+            Assert.Contains("third", lines);
+        }
+
+        [Fact]
+        public void Collect_BoundsOversizedLegacyContributions()
+        {
+            var recipient = new OversizedDebugRecipient();
+            var lines = FuseLegacyDebugInformation.Collect(recipient.Handle);
+
+            Assert.True(lines.Count <= FuseLegacyDebugInformation.MaximumLines + 1);
+            Assert.Contains(lines, line => line.StartsWith("[FUSE truncated", StringComparison.Ordinal));
+        }
+
+        public sealed class DebugRecipient
+        {
+            public void Handle(WillCopyDebugInformation message)
+            {
+                message.AppendLine("first\r\nsecond\nthird");
+            }
+        }
+
+        public sealed class OversizedDebugRecipient
+        {
+            public void Handle(WillCopyDebugInformation message)
+            {
+                for (var index = 0; index <= FuseLegacyDebugInformation.MaximumLines; index++)
+                {
+                    message.AppendLine("line " + index);
+                }
+            }
+        }
+    }
+}

--- a/FUSE.Tests/Compatibility/FuseLegacyInstallDetectorTests.cs
+++ b/FUSE.Tests/Compatibility/FuseLegacyInstallDetectorTests.cs
@@ -1,0 +1,28 @@
+using FUSE.Compatibility;
+using Xunit;
+
+namespace FUSE.Tests.Compatibility
+{
+    public sealed class FuseLegacyInstallDetectorTests
+    {
+        [Theory]
+        [InlineData("Railloader")]
+        [InlineData("Railloader.Injector")]
+        [InlineData("Railloader.Interchange")]
+        [InlineData("StrangeCustoms")]
+        public void IsLegacyLoaderAssemblyName_RecognizesEveryReplacedAssembly(string assemblyName)
+        {
+            Assert.True(FuseLegacyInstallDetector.IsLegacyLoaderAssemblyName(assemblyName));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("FUSE")]
+        [InlineData("UnityModManager")]
+        public void IsLegacyLoaderAssemblyName_DoesNotFlagCurrentRuntimeAssemblies(string assemblyName)
+        {
+            Assert.False(FuseLegacyInstallDetector.IsLegacyLoaderAssemblyName(assemblyName));
+        }
+    }
+}

--- a/FUSE.Tests/Compatibility/FuseLegacyTypeRegistryTests.cs
+++ b/FUSE.Tests/Compatibility/FuseLegacyTypeRegistryTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Linq;
+using FUSE.Compatibility;
+using Xunit;
+
+namespace FUSE.Tests.Compatibility
+{
+    public sealed class FuseLegacyTypeRegistryTests
+    {
+        [Fact]
+        public void RegisterSubType_ReplacesSameIdentifierCaseInsensitively()
+        {
+            var identifier = "test-" + Guid.NewGuid().ToString("N");
+
+            FuseLegacyTypeRegistry.RegisterSubType(typeof(TestBase), identifier, typeof(FirstImplementation));
+            FuseLegacyTypeRegistry.RegisterSubType(typeof(TestBase), identifier.ToUpperInvariant(), typeof(SecondImplementation));
+
+            var registrations = FuseLegacyTypeRegistry.Snapshot(typeof(TestBase));
+            var registration = Assert.Single(registrations, pair =>
+                string.Equals(pair.Key, identifier, StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(typeof(SecondImplementation), registration.Value);
+        }
+
+        [Fact]
+        public void RegisterSubType_RejectsUnrelatedImplementation()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                FuseLegacyTypeRegistry.RegisterSubType(
+                    typeof(TestBase),
+                    "invalid-" + Guid.NewGuid().ToString("N"),
+                    typeof(string)));
+        }
+
+        private abstract class TestBase
+        {
+        }
+
+        private sealed class FirstImplementation : TestBase
+        {
+        }
+
+        private sealed class SecondImplementation : TestBase
+        {
+        }
+    }
+}

--- a/FUSE.Tests/Converter/FuseLegacyConverterTests.cs
+++ b/FUSE.Tests/Converter/FuseLegacyConverterTests.cs
@@ -75,6 +75,94 @@ namespace FUSE.Tests.Converter
         }
 
         [Fact]
+        public void ConvertMod_preserves_issue_240_hard_dependencies_and_object_load_after_ids()
+        {
+            var modFolder = Path.Combine(_workspace, "Katers.SylvaYardTurntable");
+            Directory.CreateDirectory(modFolder);
+
+            // Regression fixture reduced from issue #240. Both dependency lists use
+            // the Railloader object form, and the real package contains a trailing
+            // comma in loadAfter. Older converter builds stringified those objects
+            // into entries such as "{'id': 'Katers.SylvaInterchange'}.FUSE" and
+            // incorrectly treated every hard requirement as advisory ordering.
+            File.WriteAllText(Path.Combine(modFolder, "Definition.json"), @"{
+                ""manifestVersion"": 5,
+                ""id"": ""Katers.SylvaYardTurntable"",
+                ""name"": ""Katers Sylva Yard Turntable"",
+                ""version"": ""1.2.6"",
+                ""requires"": [
+                    { ""id"": ""railloader"", ""notBefore"": ""1.10.0.2"" },
+                    { ""id"": ""Zamu.StrangeCustoms"", ""notBefore"": ""1.10.25017.313"" },
+                    { ""id"": ""AlinaNova21.AlinasMapMod"", ""notBefore"": ""1.5.25131.608"" },
+                    { ""id"": ""C_L_B.ASSETS01"", ""notBefore"": ""2.5.4"" },
+                    { ""id"": ""Katers.SylvaInterchange"", ""notBefore"": ""3.0"" },
+                    { ""id"": ""C_L_B.DKW"", ""notBefore"": ""1.1"" }
+                ],
+                ""loadAfter"": [
+                    { ""id"": ""Katers.SylvaInterchange"", },
+                    { ""id"": ""Katers.SylvaYPassingext"" }
+                ]
+            }");
+            File.WriteAllText(Path.Combine(modFolder, "SylvaYardTurntable.json"),
+                "{ \"tracks\": { \"nodes\": { \"n\": { \"position\": { \"x\": 0, \"y\": 0, \"z\": 0 } } } } }");
+
+            var outputFolder = Path.Combine(_workspace, "Katers.SylvaYardTurntable.FUSE");
+            var result = FuseLegacyConverter.ConvertMod(modFolder, outputFolder);
+
+            Assert.True(result.Success);
+            var info = JObject.Parse(File.ReadAllText(Path.Combine(outputFolder, "Info.json")));
+            Assert.Equal(new[]
+            {
+                "C_L_B.ASSETS01.FUSE",
+                "Katers.SylvaInterchange.FUSE",
+                "C_L_B.DKW.FUSE"
+            }, info.Value<JArray>("FuseRequires").Values<string>());
+            Assert.Equal(new[]
+            {
+                "Katers.SylvaInterchange.FUSE",
+                "Katers.SylvaYPassingext.FUSE"
+            }, info.Value<JArray>("FuseLoadAfter").Values<string>());
+            Assert.DoesNotContain(
+                info.Value<JArray>("FuseLoadAfter").Values<string>(),
+                dependency => dependency.IndexOf("{'id'", StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        [Fact]
+        public void ConvertMod_preserves_top_level_and_conditional_conflictsWith()
+        {
+            var modFolder = Path.Combine(_workspace, "conflicting.mod");
+            Directory.CreateDirectory(modFolder);
+            File.WriteAllText(Path.Combine(modFolder, "Definition.json"), @"{
+                ""id"": ""Author.Conflict"",
+                ""name"": ""Conflict Fixture"",
+                ""version"": ""1.0"",
+                ""conflictsWith"": [ { ""id"": ""Other.Route"", ""notBefore"": ""2.0"" } ],
+                ""mixintos"": {
+                    ""game-graph"": {
+                        ""mixinto"": ""file(track.json)"",
+                        ""conflictsWith"": [ ""Conditional.Route"" ]
+                    }
+                }
+            }");
+            File.WriteAllText(
+                Path.Combine(modFolder, "track.json"),
+                "{ \"nodes\": { \"N1\": { \"position\": { \"x\": 0, \"y\": 0, \"z\": 0 } } } }");
+
+            var outputFolder = Path.Combine(_workspace, "conflicting.mod.FUSE");
+            var result = FuseLegacyConverter.ConvertMod(modFolder, outputFolder);
+
+            Assert.True(result.Success);
+            var info = JObject.Parse(File.ReadAllText(Path.Combine(outputFolder, "Info.json")));
+            var manifestConflict = Assert.Single((JArray)info["FuseConflictsWith"]);
+            Assert.Equal("Other.Route", manifestConflict.Value<string>("Id"));
+            Assert.Equal("2.0", manifestConflict.Value<string>("NotBefore"));
+
+            var fragment = JObject.Parse(File.ReadAllText(Path.Combine(outputFolder, "track.fuse.json")));
+            var conditionalConflict = Assert.Single((JArray)fragment["mixinto"]["conflictsWith"]);
+            Assert.Equal("Conditional.Route", conditionalConflict.Value<string>("id"));
+        }
+
+        [Fact]
         public void ConvertMod_refuses_when_output_overlaps_source()
         {
             var modFolder = Path.Combine(_workspace, "inplace.mod");
@@ -174,6 +262,46 @@ namespace FUSE.Tests.Converter
 
             Assert.False(result.Success);
             Assert.Contains(result.Report, r => r.Level == FuseConversionReportLevel.Error);
+        }
+
+        [Fact]
+        public void ConvertPackage_rejects_asset_only_package_with_install_guidance()
+        {
+            var modFolder = Path.Combine(_workspace, "asset.mod");
+            Directory.CreateDirectory(modFolder);
+            File.WriteAllText(Path.Combine(modFolder, "bundle"), "asset");
+            File.WriteAllText(Path.Combine(modFolder, "Catalog.json"), "{}");
+            File.WriteAllText(Path.Combine(modFolder, "Definitions.json"), "{}");
+            var outputFolder = Path.Combine(_workspace, "asset.mod.FUSE");
+
+            var result = FuseLegacyConverter.ConvertPackage(modFolder, outputFolder);
+
+            Assert.False(result.Success);
+            Assert.Empty(result.WrittenFragments);
+            Assert.False(Directory.Exists(outputFolder));
+            Assert.Contains(result.Report, entry =>
+                entry.Level == FuseConversionReportLevel.Error
+                && entry.Message.IndexOf("install this package", StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        [Fact]
+        public void ConvertPackage_rejects_compiled_code_instead_of_reporting_zero_fragment_success()
+        {
+            var modFolder = Path.Combine(_workspace, "code.mod");
+            Directory.CreateDirectory(modFolder);
+            File.WriteAllText(Path.Combine(modFolder, "Info.json"),
+                "{ \"Id\": \"code.mod\", \"DisplayName\": \"Code Mod\", \"AssemblyName\": \"Code.dll\" }");
+            File.WriteAllText(Path.Combine(modFolder, "Code.dll"), "not-a-real-assembly");
+            var outputFolder = Path.Combine(_workspace, "code.mod.FUSE");
+
+            var result = FuseLegacyConverter.ConvertPackage(modFolder, outputFolder);
+
+            Assert.False(result.Success);
+            Assert.Empty(result.WrittenFragments);
+            Assert.False(Directory.Exists(outputFolder));
+            Assert.Contains(result.Report, entry =>
+                entry.Level == FuseConversionReportLevel.Error
+                && entry.Message.IndexOf("cannot reproduce DLL behavior", StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         [Fact]

--- a/FUSE.Tests/Converter/FuseLegacyConverterTests.cs
+++ b/FUSE.Tests/Converter/FuseLegacyConverterTests.cs
@@ -75,6 +75,24 @@ namespace FUSE.Tests.Converter
         }
 
         [Fact]
+        public void ConvertMod_replaces_legacy_rail_suffix_in_package_id()
+        {
+            var modFolder = Path.Combine(_workspace, "legacy-suffix.mod");
+            Directory.CreateDirectory(modFolder);
+            File.WriteAllText(Path.Combine(modFolder, "Definition.json"),
+                "{ \"id\": \"acme.route.RAIL\", \"name\": \"Legacy Suffix\" }");
+            File.WriteAllText(Path.Combine(modFolder, "tracks.json"),
+                "{ \"tracks\": { \"nodes\": { \"node-A\": { \"position\": { \"x\": 1, \"y\": 2, \"z\": 3 } } } } }");
+
+            var outputFolder = Path.Combine(_workspace, "legacy-suffix.mod.FUSE");
+            var result = FuseLegacyConverter.ConvertMod(modFolder, outputFolder);
+
+            Assert.True(result.Success);
+            var info = JObject.Parse(File.ReadAllText(Path.Combine(outputFolder, "Info.json")));
+            Assert.Equal("acme.route.FUSE", info.Value<string>("Id"));
+        }
+
+        [Fact]
         public void ConvertMod_preserves_issue_240_hard_dependencies_and_object_load_after_ids()
         {
             var modFolder = Path.Combine(_workspace, "Katers.SylvaYardTurntable");

--- a/FUSE.Tests/Converter/FuseLegacyConverterTests.cs
+++ b/FUSE.Tests/Converter/FuseLegacyConverterTests.cs
@@ -172,7 +172,7 @@ namespace FUSE.Tests.Converter
             Assert.True(result.Success);
             var info = JObject.Parse(File.ReadAllText(Path.Combine(outputFolder, "Info.json")));
             var manifestConflict = Assert.Single((JArray)info["FuseConflictsWith"]);
-            Assert.Equal("Other.Route", manifestConflict.Value<string>("Id"));
+            Assert.Equal("Other.Route.FUSE", manifestConflict.Value<string>("Id"));
             Assert.Equal("2.0", manifestConflict.Value<string>("NotBefore"));
 
             var fragment = JObject.Parse(File.ReadAllText(Path.Combine(outputFolder, "track.fuse.json")));

--- a/FUSE.Tests/Converter/LegacyAudioConverterTests.cs
+++ b/FUSE.Tests/Converter/LegacyAudioConverterTests.cs
@@ -194,6 +194,17 @@ namespace FUSE.Tests.Converter
         // BuildAudioSkeleton
         // ------------------------------------------------------------------
 
+        [Theory]
+        [InlineData("modX", "modX.FUSE.Audio")]
+        [InlineData("modX.RAIL", "modX.FUSE.Audio")]
+        [InlineData("modX.rail", "modX.FUSE.Audio")]
+        [InlineData("modX.FUSE", "modX.FUSE.Audio")]
+        public void BuildAudioSkeleton_normalizes_legacy_package_suffix(string modId, string expected)
+        {
+            var rail = LegacyAudioConverter.BuildAudioSkeleton(modId, "Mod X", "2.0", "alex");
+            Assert.Equal(expected, rail.Value<string>("id"));
+        }
+
         [Fact]
         public void BuildAudioSkeleton_carries_audio_subsection_plus_suppress_arrays()
         {

--- a/FUSE.Tests/Converter/LegacyDefinitionConverterTests.cs
+++ b/FUSE.Tests/Converter/LegacyDefinitionConverterTests.cs
@@ -50,7 +50,28 @@ namespace FUSE.Tests.Converter
         {
             Assert.Null(LegacyDefinitionConverter.ConvertRequirement(JToken.Parse("\"Railroader\"")));
             Assert.Null(LegacyDefinitionConverter.ConvertRequirement(JToken.Parse("\"StrangeCustoms\"")));
+            Assert.Null(LegacyDefinitionConverter.ConvertRequirement(JToken.Parse("\"AlinaNova21.AlinasMapMod\"")));
+            Assert.Null(LegacyDefinitionConverter.ConvertRequirement(JToken.Parse("\"Railloader.Interchange\"")));
+            Assert.Null(LegacyDefinitionConverter.ConvertRequirement(JToken.Parse("\"AssetLoader\"")));
             Assert.Null(LegacyDefinitionConverter.ConvertRequirement(JToken.Parse("\"FUSE\"")));
+        }
+
+        [Fact]
+        public void ConvertRequirement_keeps_alina_content_pack_as_real_dependency()
+        {
+            var converted = LegacyDefinitionConverter.ConvertRequirement(
+                JToken.Parse("\"AlinaNova21.AlinasMapExpansionSW\""));
+
+            Assert.Equal("AlinaNova21.AlinasMapExpansionSW", converted.Value<string>("id"));
+        }
+
+        [Fact]
+        public void ConvertRequirement_keeps_zamu_mod_without_native_parity_as_real_dependency()
+        {
+            var converted = LegacyDefinitionConverter.ConvertRequirement(
+                JToken.Parse("\"Zamu.SomeKindOfMadness\""));
+
+            Assert.Equal("Zamu.SomeKindOfMadness", converted.Value<string>("id"));
         }
 
         [Fact]
@@ -173,6 +194,84 @@ namespace FUSE.Tests.Converter
             }
         }
 
+        [Fact]
+        public void LegacyDependencies_preserves_hard_requirements_separately_from_ordering()
+        {
+            var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                Directory.CreateDirectory(temp);
+                File.WriteAllText(Path.Combine(temp, "Definition.json"), @"{
+                    ""requires"": [ { ""id"": ""RequiredMod"", ""notBefore"": ""2.0"" } ],
+                    ""loadAfter"": [ { ""id"": ""OptionalOrderingMod"" } ]
+                }");
+
+                var result = LegacyDefinitionConverter.LegacyDependencies(temp);
+
+                Assert.Equal(new[] { "RequiredMod.FUSE" }, result.Requires);
+                Assert.Equal(new[] { "OptionalOrderingMod.FUSE" }, result.LoadAfter);
+            }
+            finally
+            {
+                try { Directory.Delete(temp, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void LegacyDependencies_orders_after_conditional_mixinto_requirements_without_making_them_hard()
+        {
+            var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                Directory.CreateDirectory(temp);
+                File.WriteAllText(Path.Combine(temp, "Definition.json"), @"{
+                    ""mixintos"": {
+                        ""game-graph"": {
+                            ""mixinto"": ""file(optional-track.json)"",
+                            ""requires"": [ ""OptionalBase"" ]
+                        }
+                    }
+                }");
+
+                var result = LegacyDefinitionConverter.LegacyDependencies(temp);
+
+                Assert.Empty(result.Requires);
+                Assert.Equal(new[] { "OptionalBase.FUSE" }, result.LoadAfter);
+            }
+            finally
+            {
+                try { Directory.Delete(temp, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void LegacyConflictsWith_preserves_core_ids_and_version_bounds_for_manifest_enforcement()
+        {
+            var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                Directory.CreateDirectory(temp);
+                File.WriteAllText(Path.Combine(temp, "Definition.json"), @"{
+                    ""conflictsWith"": [
+                        { ""id"": ""Other.Route"", ""notBefore"": ""2.0"", ""notAfter"": ""3.0"" },
+                        ""Zamu.StrangeCustoms""
+                    ]
+                }");
+
+                var result = LegacyDefinitionConverter.LegacyConflictsWith(temp);
+
+                Assert.Equal(2, result.Count);
+                Assert.Equal("Other.Route", result[0].Value<string>("Id"));
+                Assert.Equal("2.0", result[0].Value<string>("NotBefore"));
+                Assert.Equal("3.0", result[0].Value<string>("NotAfter"));
+                Assert.Equal("Zamu.StrangeCustoms", result[1].Value<string>("Id"));
+            }
+            finally
+            {
+                try { Directory.Delete(temp, true); } catch { }
+            }
+        }
+
         // ------------------------------------------------------------------
         // MixintoMetadata
         // ------------------------------------------------------------------
@@ -241,6 +340,33 @@ namespace FUSE.Tests.Converter
                 Assert.NotNull(requires);
                 Assert.Single(requires);
                 Assert.Equal("DependencyMod", ((JObject)requires[0]).Value<string>("id"));
+            }
+            finally
+            {
+                try { Directory.Delete(temp, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void MixintoMetadata_preserves_conditional_conflictsWith()
+        {
+            var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                Directory.CreateDirectory(temp);
+                File.WriteAllText(Path.Combine(temp, "Definition.json"), @"{
+                    ""mixintos"": {
+                        ""game-graph"": {
+                            ""mixinto"": ""file(optional.json)"",
+                            ""conflictsWith"": [ { ""id"": ""Other.Route"", ""notBefore"": ""2.0"" } ]
+                        }
+                    }
+                }");
+
+                var (metadata, _) = LegacyDefinitionConverter.MixintoMetadata(temp);
+                var conflict = Assert.Single((JArray)metadata["optional.json"]["conflictsWith"]);
+                Assert.Equal("Other.Route", conflict.Value<string>("id"));
+                Assert.Equal("2.0", conflict.Value<string>("notBefore"));
             }
             finally
             {

--- a/FUSE.Tests/Converter/LegacyDefinitionConverterTests.cs
+++ b/FUSE.Tests/Converter/LegacyDefinitionConverterTests.cs
@@ -247,7 +247,7 @@ namespace FUSE.Tests.Converter
         }
 
         [Fact]
-        public void LegacyConflictsWith_preserves_core_ids_and_version_bounds_for_manifest_enforcement()
+        public void LegacyConflictsWith_normalizes_ids_and_preserves_version_bounds_for_manifest_enforcement()
         {
             var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             try
@@ -255,7 +255,7 @@ namespace FUSE.Tests.Converter
                 Directory.CreateDirectory(temp);
                 File.WriteAllText(Path.Combine(temp, "Definition.json"), @"{
                     ""conflictsWith"": [
-                        { ""id"": ""Other.Route"", ""notBefore"": ""2.0"", ""notAfter"": ""3.0"" },
+                        { ""id"": ""acme.route.RAIL"", ""notBefore"": ""2.0"", ""notAfter"": ""3.0"" },
                         ""Zamu.StrangeCustoms""
                     ]
                 }");
@@ -263,10 +263,10 @@ namespace FUSE.Tests.Converter
                 var result = LegacyDefinitionConverter.LegacyConflictsWith(temp);
 
                 Assert.Equal(2, result.Count);
-                Assert.Equal("Other.Route", result[0].Value<string>("Id"));
+                Assert.Equal("acme.route.FUSE", result[0].Value<string>("Id"));
                 Assert.Equal("2.0", result[0].Value<string>("NotBefore"));
                 Assert.Equal("3.0", result[0].Value<string>("NotAfter"));
-                Assert.Equal("Zamu.StrangeCustoms", result[1].Value<string>("Id"));
+                Assert.Equal("Zamu.StrangeCustoms.FUSE", result[1].Value<string>("Id"));
             }
             finally
             {

--- a/FUSE.Tests/Converter/LegacyDefinitionConverterTests.cs
+++ b/FUSE.Tests/Converter/LegacyDefinitionConverterTests.cs
@@ -119,9 +119,11 @@ namespace FUSE.Tests.Converter
 
         [Theory]
         [InlineData("SomeMod", "SomeMod.FUSE")]
+        [InlineData("SomeMod.RAIL", "SomeMod.FUSE")]
+        [InlineData("somemod.rail", "somemod.FUSE")]
         [InlineData("Already.FUSE", "Already.FUSE")]
         [InlineData("ALREADY.FUSE", "ALREADY.FUSE")]
-        public void FusePackageId_appends_suffix_unless_already_present(string input, string expected)
+        public void FusePackageId_normalizes_converted_package_suffix(string input, string expected)
         {
             Assert.Equal(expected, LegacyDefinitionConverter.FusePackageId(input));
         }

--- a/FUSE.Tests/Converter/LegacyKindDetectorTests.cs
+++ b/FUSE.Tests/Converter/LegacyKindDetectorTests.cs
@@ -72,13 +72,48 @@ namespace FUSE.Tests.Converter
         }
 
         [Fact]
-        public void DetectKind_returns_route_for_map_tile_folder()
+        public void DetectKind_returns_map_tile_for_map_tile_folder()
         {
             var folder = Path.Combine(_workspace, "tiles");
             Directory.CreateDirectory(folder);
             File.WriteAllText(Path.Combine(folder, "tile-0-0.data"), "binary");
-            // map-tile folder reports as route (route covers tiles).
+            Assert.Equal("map_tile", LegacyKindDetector.DetectKind(folder, "auto"));
+        }
+
+        [Fact]
+        public void DetectKind_returns_code_for_compiled_plugin()
+        {
+            var folder = Path.Combine(_workspace, "plugin");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(Path.Combine(folder, "Plugin.dll"), "not-a-real-assembly");
+            var nested = Path.Combine(folder, "schemas");
+            Directory.CreateDirectory(nested);
+            File.WriteAllText(Path.Combine(nested, "example.json"),
+                "{ \"tracks\": { \"nodes\": {} } }");
+
+            Assert.Equal("code", LegacyKindDetector.DetectKind(folder, "auto"));
+        }
+
+        [Fact]
+        public void DetectKind_returns_route_for_mixed_code_and_convertible_json()
+        {
+            var folder = Path.Combine(_workspace, "mixed-plugin");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(Path.Combine(folder, "Plugin.dll"), "not-a-real-assembly");
+            File.WriteAllText(Path.Combine(folder, "track.json"),
+                "{ \"tracks\": { \"nodes\": {} } }");
+
             Assert.Equal("route", LegacyKindDetector.DetectKind(folder, "auto"));
+        }
+
+        [Fact]
+        public void DetectKind_returns_native_for_fuse_fragment()
+        {
+            var folder = Path.Combine(_workspace, "native");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(Path.Combine(folder, "track.fuse.json"), "{}");
+
+            Assert.Equal("native", LegacyKindDetector.DetectKind(folder, "auto"));
         }
 
         [Fact]

--- a/FUSE.Tests/Converter/LegacyKindDetectorTests.cs
+++ b/FUSE.Tests/Converter/LegacyKindDetectorTests.cs
@@ -127,6 +127,18 @@ namespace FUSE.Tests.Converter
         }
 
         [Fact]
+        public void DetectKind_returns_audio_for_mixed_code_and_audio_json()
+        {
+            var folder = Path.Combine(_workspace, "mixed-audio-plugin");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(Path.Combine(folder, "Plugin.dll"), "not-a-real-assembly");
+            File.WriteAllText(Path.Combine(folder, "horns.json"),
+                "[ { \"layers\": [ \"a.wav\" ] } ]");
+
+            Assert.Equal("audio", LegacyKindDetector.DetectKind(folder, "auto"));
+        }
+
+        [Fact]
         public void DetectKind_returns_unknown_for_empty_folder()
         {
             var folder = Path.Combine(_workspace, "empty");

--- a/FUSE.Tests/Converter/LegacyKindDetectorTests.cs
+++ b/FUSE.Tests/Converter/LegacyKindDetectorTests.cs
@@ -117,6 +117,27 @@ namespace FUSE.Tests.Converter
         }
 
         [Fact]
+        public void DetectKind_returns_native_for_nested_route_shaped_fuse_fragment()
+        {
+            var folder = Path.Combine(_workspace, "nested-native");
+            var data = Path.Combine(folder, "Data");
+            Directory.CreateDirectory(data);
+            File.WriteAllText(Path.Combine(data, "track.fuse.json"),
+                "{ \"tracks\": { \"nodes\": {} } }");
+
+            Assert.Equal("native", LegacyKindDetector.DetectKind(folder, "auto"));
+        }
+
+        [Fact]
+        public void DetectKind_returns_native_for_direct_fuse_fragment_file()
+        {
+            var fragment = Path.Combine(_workspace, "track.fuse.json");
+            File.WriteAllText(fragment, "{ \"tracks\": { \"nodes\": {} } }");
+
+            Assert.Equal("native", LegacyKindDetector.DetectKind(fragment, "auto"));
+        }
+
+        [Fact]
         public void DetectKind_returns_audio_for_horns_layered_json()
         {
             var folder = Path.Combine(_workspace, "audio");

--- a/FUSE.Tests/Converter/LegacyTrackStructureConverterTests.cs
+++ b/FUSE.Tests/Converter/LegacyTrackStructureConverterTests.cs
@@ -1,0 +1,55 @@
+using FUSE.Converter.Conversion;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Converter
+{
+    public sealed class LegacyTrackStructureConverterTests
+    {
+        [Fact]
+        public void ConvertNode_PreservesDiamondCrossingMarker()
+        {
+            var converted = LegacyTrackConverter.ConvertNode(JObject.Parse(
+                "{ 'position': [1,2,3], 'rotation': [0,90,0], 'isDiamond': true }"));
+
+            Assert.True(converted.Value<bool>("isDiamond"));
+        }
+
+        [Theory]
+        [InlineData(0, "standard", false, false)]
+        [InlineData(2, "bridge", false, false)]
+        [InlineData(6, "bridge", true, false)]
+        [InlineData(8, "tunnel", false, false)]
+        [InlineData(18, "bridge", false, true)]
+        public void ConvertSegment_DecodesFlagsBasedTrackStructure(
+            int flags,
+            string expectedStyle,
+            bool expectedSteel,
+            bool expectedYard)
+        {
+            var legacy = new JObject
+            {
+                ["a"] = "node-a",
+                ["b"] = "node-b",
+                ["flags"] = flags
+            };
+
+            var converted = LegacyTrackConverter.ConvertSegment(legacy);
+
+            Assert.Equal(expectedStyle, converted.Value<string>("style"));
+            Assert.Equal(expectedSteel, converted.Value<bool>("bridgeSupportsSteel"));
+            Assert.Equal(expectedYard, converted.Value<bool>("yard"));
+        }
+
+        [Fact]
+        public void ConvertPartialSegment_PreservesUnspecifiedStructureFields()
+        {
+            var converted = LegacyTrackConverter.ConvertSegment(JObject.Parse("{ 'a': 'node-a' }"));
+
+            Assert.True(converted.Value<bool>("partial"));
+            Assert.True(converted.Value<bool>("preserveStyle"));
+            Assert.True(converted.Value<bool>("preserveBridgeSupportsSteel"));
+            Assert.True(converted.Value<bool>("preserveYard"));
+        }
+    }
+}

--- a/FUSE.Tests/Converter/LegacyTrackStructureConverterTests.cs
+++ b/FUSE.Tests/Converter/LegacyTrackStructureConverterTests.cs
@@ -51,5 +51,23 @@ namespace FUSE.Tests.Converter
             Assert.True(converted.Value<bool>("preserveBridgeSupportsSteel"));
             Assert.True(converted.Value<bool>("preserveYard"));
         }
+
+        [Theory]
+        [InlineData("flags")]
+        [InlineData("Flags")]
+        public void ConvertPartialSegment_TreatsNullFlagsAsUnspecified(string propertyName)
+        {
+            var legacy = new JObject
+            {
+                ["a"] = "node-a",
+                [propertyName] = JValue.CreateNull()
+            };
+
+            var converted = LegacyTrackConverter.ConvertSegment(legacy);
+
+            Assert.True(converted.Value<bool>("partial"));
+            Assert.True(converted.Value<bool>("preserveBridgeSupportsSteel"));
+            Assert.True(converted.Value<bool>("preserveYard"));
+        }
     }
 }

--- a/FUSE.Tests/Data/FuseIndustryComponentTypesTests.cs
+++ b/FUSE.Tests/Data/FuseIndustryComponentTypesTests.cs
@@ -32,6 +32,7 @@ namespace FUSE.Tests.Data
             [InlineData("passenger-stop", "passengerStop")]
             [InlineData("paxstationcomponent", "passengerStop")]
             [InlineData("alinasmapmod.paxstationcomponent", "passengerStop")]
+            [InlineData("ADRFDR.Pay4Resource", "ConfusingSupplements.IndustryComponents.Pay4Resource")]
             public void Known_Aliases_NormalizeToCanonical(string input, string expected)
             {
                 Assert.Equal(expected, FuseIndustryComponentTypes.Normalize(input));

--- a/FUSE.Tests/FUSE.Tests.csproj
+++ b/FUSE.Tests/FUSE.Tests.csproj
@@ -55,6 +55,9 @@
     <None Include="..\schemas\fuse-mod.example.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\schemas\fuse-mod.schema.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <!-- The main FUSE project references game-shipped assemblies with <Private>false</Private>
@@ -116,6 +119,14 @@
     </Reference>
     <Reference Include="AssetPack.Common" Condition="Exists('$(UnityManagedDir)\AssetPack.Common.dll')">
       <HintPath>$(UnityManagedDir)\AssetPack.Common.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+    <Reference Include="KeyValue.Runtime" Condition="Exists('$(UnityManagedDir)\KeyValue.Runtime.dll')">
+      <HintPath>$(UnityManagedDir)\KeyValue.Runtime.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+    <Reference Include="Unity.RenderPipelines.Universal.Runtime" Condition="Exists('$(UnityManagedDir)\Unity.RenderPipelines.Universal.Runtime.dll')">
+      <HintPath>$(UnityManagedDir)\Unity.RenderPipelines.Universal.Runtime.dll</HintPath>
       <Private>true</Private>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule" Condition="Exists('$(UnityManagedDir)\UnityEngine.AssetBundleModule.dll')">

--- a/FUSE.Tests/Infrastructure/FuseLiveLogBufferTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseLiveLogBufferTests.cs
@@ -1,0 +1,54 @@
+using System;
+using FUSE.Infrastructure;
+using Xunit;
+
+namespace FUSE.Tests.Infrastructure
+{
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class FuseLiveLogBufferTestCollection
+    {
+        public const string Name = "Fuse live log buffer tests";
+    }
+
+    [Collection(FuseLiveLogBufferTestCollection.Name)]
+    public class FuseLiveLogBufferTests
+    {
+        public FuseLiveLogBufferTests()
+        {
+            FuseLiveLogBuffer.ResetForTests();
+        }
+
+        [Fact]
+        public void Snapshot_FiltersBySeverityAndText()
+        {
+            var now = new DateTime(2026, 8, 19, 12, 0, 0, DateTimeKind.Local);
+            FuseLiveLogBuffer.Append(now, "INFO", "mounted track package");
+            FuseLiveLogBuffer.Append(now.AddSeconds(1), "WARN", "missing optional asset alias");
+            FuseLiveLogBuffer.Append(now.AddSeconds(2), "ERROR", "bad track json");
+
+            var warnings = FuseLiveLogBuffer.Snapshot("Warnings + Errors", string.Empty, 20);
+            Assert.Equal(2, warnings.Length);
+            Assert.Equal("WARN", warnings[0].Level);
+            Assert.Equal("ERROR", warnings[1].Level);
+
+            var json = FuseLiveLogBuffer.Snapshot("All", "json", 20);
+            Assert.Single(json);
+            Assert.Equal("bad track json", json[0].Message);
+        }
+
+        [Fact]
+        public void Buffer_IsBoundedAndSnapshotReturnsNewestEntriesInOrder()
+        {
+            var now = DateTime.Now;
+            for (var index = 0; index < FuseLiveLogBuffer.Capacity + 25; index++)
+            {
+                FuseLiveLogBuffer.Append(now.AddMilliseconds(index), "INFO", "line " + index);
+            }
+
+            Assert.Equal(FuseLiveLogBuffer.Capacity, FuseLiveLogBuffer.Count);
+            var latest = FuseLiveLogBuffer.Snapshot("All", string.Empty, 3);
+            Assert.Equal(new[] { "line 1022", "line 1023", "line 1024" },
+                new[] { latest[0].Message, latest[1].Message, latest[2].Message });
+        }
+    }
+}

--- a/FUSE.Tests/Infrastructure/FuseModSetServiceTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseModSetServiceTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Linq;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Infrastructure
+{
+    public sealed class FuseModSetServiceTests
+    {
+        [Fact]
+        public void VisibleProfileMods_IncludeProfileDisabledLegacyConvertedPackage()
+        {
+            var packages = new[]
+            {
+                new FusePackageManifestSnapshot
+                {
+                    Id = "Katers.TurntableOfDoom.FUSE",
+                    DisplayName = "Turntable of Doom and Despair",
+                    Version = "1.0.0",
+                    FolderName = "Turntable of Doom and Despair",
+                    FolderPath = @"C:\Railroader\Mods\Turntable of Doom and Despair",
+                    Disabled = true,
+                    DisabledReason = "disabled by active FUSE mod set",
+                    IsLegacyConverted = true
+                }
+            };
+
+            var visible = FuseModSetService.MergeVisibleProfileMods(
+                Array.Empty<FuseUmmModInfo>(),
+                packages);
+            var legacy = Assert.Single(visible);
+
+            Assert.Equal("Katers.TurntableOfDoom.FUSE", legacy.Id);
+            Assert.Equal("Turntable of Doom and Despair", legacy.DisplayName);
+            Assert.True(legacy.IsFuseDataPackage);
+            Assert.True(legacy.IsLegacyConverted);
+            Assert.Equal("legacy converted data", legacy.ProfileSource);
+        }
+
+        [Fact]
+        public void NewProfile_EnablesEveryVisibleLegacyAndUmmPackage()
+        {
+            var mods = new[]
+            {
+                new FuseUmmModInfo { Id = "UMM.Plugin", FolderName = "UMM Plugin" },
+                new FuseUmmModInfo
+                {
+                    Id = "Legacy.Track.FUSE",
+                    FolderName = "Legacy Track",
+                    IsLegacyConverted = true,
+                    IsFuseDataPackage = true
+                }
+            };
+
+            var set = FuseModSetService.CreateSetDefinition("set-test", "Test", mods, "now");
+
+            Assert.Equal(new[] { "Legacy.Track.FUSE", "UMM.Plugin" }, set.EnabledModIds);
+            Assert.Equal(new[] { "Legacy Track", "UMM Plugin" }, set.EnabledFolderNames);
+        }
+
+        [Fact]
+        public void ManifestDisabledPackage_IsNotPresentedAsProfileEnableable()
+        {
+            var visible = FuseModSetService.MergeVisibleProfileMods(
+                Array.Empty<FuseUmmModInfo>(),
+                new[]
+                {
+                    new FusePackageManifestSnapshot
+                    {
+                        Id = "Author.Disabled.FUSE",
+                        FolderName = "Author Disabled",
+                        Disabled = true,
+                        DisabledReason = "disabled by package manifest"
+                    }
+                });
+
+            Assert.Empty(visible);
+        }
+
+        [Fact]
+        public void LegacyPackageToggle_PersistsBothIdAndFolderMembership()
+        {
+            var set = new FuseModSet { Id = "set-test", Name = "Test" };
+            var legacy = new FuseUmmModInfo
+            {
+                Id = "Legacy.Track.FUSE",
+                DisplayName = "Legacy Track",
+                FolderName = "Legacy Track"
+            };
+
+            Assert.False(FuseModSetService.IsModEnabledInSet(set, legacy));
+            Assert.True(FuseModSetService.ToggleModMembership(set, legacy));
+            Assert.True(FuseModSetService.IsModEnabledInSet(set, legacy));
+            Assert.Contains("Legacy.Track.FUSE", set.EnabledModIds);
+            Assert.Contains("Legacy Track", set.EnabledFolderNames);
+
+            Assert.False(FuseModSetService.ToggleModMembership(set, legacy));
+            Assert.False(FuseModSetService.IsModEnabledInSet(set, legacy));
+            Assert.Empty(set.EnabledModIds);
+            Assert.Empty(set.EnabledFolderNames);
+        }
+
+        [Fact]
+        public void DisabledPackage_IsRejectedByIdAndFolderAdmissionGate()
+        {
+            var set = new FuseModSet
+            {
+                EnabledModIds = new[] { "Other.Package" },
+                EnabledFolderNames = new[] { "Other Folder" }
+            };
+
+            Assert.False(FuseModSetService.IsPackageEnabledInSet(
+                set,
+                "Legacy.Track.FUSE",
+                @"C:\Railroader\Mods\Legacy Track"));
+
+            set.EnabledFolderNames = set.EnabledFolderNames.Concat(new[] { "Legacy Track" }).ToArray();
+            Assert.True(FuseModSetService.IsPackageEnabledInSet(
+                set,
+                "Legacy.Track.FUSE",
+                @"C:\Railroader\Mods\Legacy Track"));
+        }
+    }
+}

--- a/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseRuntimeGuardCountersTests.cs
@@ -34,6 +34,7 @@ namespace FUSE.Tests.Infrastructure
                 "rebillAutoConfigSuppressed=0 " +
                 "brssModMenuDeferred=0 " +
                 "timeSyncMainThread=0 " +
+                "passengerStopSpansSanitized=0 " +
                 "flares=0 switchRailsBackfilled=0 frameSpikes=0",
                 FuseRuntimeGuardCounters.FormatSummary());
         }
@@ -92,18 +93,20 @@ namespace FUSE.Tests.Infrastructure
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordBrssModMenuDeferred());
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordTimeSyncMainThreadMarshaled());
             Assert.Equal(1, FuseRuntimeGuardCounters.RecordSwitchGeometryRailsBackfilled());
+            Assert.Equal(1, FuseRuntimeGuardCounters.RecordPassengerStopSpanSanitized());
 
             // Third-party containment must surface as guard activity: an
             // active suppression storm reading as "guards idle" would hide
             // the offender from every report surface.
             Assert.False(FuseRuntimeGuardCounters.AllIdle);
-            Assert.Equal(6, FuseRuntimeGuardCounters.GuardTotal);
+            Assert.Equal(7, FuseRuntimeGuardCounters.GuardTotal);
             var summary = FuseRuntimeGuardCounters.FormatSummary();
             Assert.Contains("mapEnhancerCullingGuarded=2", summary);
             Assert.Contains("rebillAutoConfigSuppressed=1", summary);
             Assert.Contains("brssModMenuDeferred=1", summary);
             Assert.Contains("timeSyncMainThread=1", summary);
             Assert.Contains("switchRailsBackfilled=1", summary);
+            Assert.Contains("passengerStopSpansSanitized=1", summary);
         }
     }
 }

--- a/FUSE.Tests/Infrastructure/FuseUmmStateTests.cs
+++ b/FUSE.Tests/Infrastructure/FuseUmmStateTests.cs
@@ -1,0 +1,26 @@
+using FUSE.Infrastructure;
+using Xunit;
+
+namespace FUSE.Tests.Infrastructure
+{
+    public class FuseUmmStateTests
+    {
+        [Theory]
+        [InlineData(true, true, true, false, true)]
+        [InlineData(false, true, true, false, false)]
+        [InlineData(true, false, true, false, false)]
+        [InlineData(true, true, false, false, false)]
+        [InlineData(true, true, true, true, false)]
+        public void Runtime_ownership_requires_a_successfully_started_enabled_entry(
+            bool enabled,
+            bool started,
+            bool loaded,
+            bool errorOnLoading,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseUmmState.IsActiveRuntimeState(enabled, started, loaded, errorOnLoading));
+        }
+    }
+}

--- a/FUSE.Tests/Interface/AssetsToolPageTests.cs
+++ b/FUSE.Tests/Interface/AssetsToolPageTests.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using FUSE.Interface.MenuWindow;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Interface
+{
+    public class AssetsToolPageTests
+    {
+        [Fact]
+        public void GroupDuplicateAssets_CollapsesKeysWithTheSameWinnerAndSources()
+        {
+            var groups = AssetsToolPage.GroupDuplicateAssets(new[]
+            {
+                Duplicate("mine", false, "RTM/primary", "RTM/nested"),
+                Duplicate("engine-house", false, "RTM/primary", "RTM/nested"),
+                Duplicate("sound-1", true, "Latoms", "lt-objects")
+            });
+
+            Assert.Equal(2, groups.Length);
+            var identical = Assert.Single(groups, group => !group.DefinitionsDiffer);
+            Assert.Equal(new[] { "mine", "engine-house" }, identical.Keys);
+            Assert.Equal(new[] { "RTM/primary", "RTM/nested" }, identical.Sources);
+
+            var different = Assert.Single(groups, group => group.DefinitionsDiffer);
+            Assert.Equal(new[] { "sound-1" }, different.Keys);
+        }
+
+        [Fact]
+        public void GroupDuplicateAssets_PreservesWinnerOrderAsPartOfTheGroupIdentity()
+        {
+            var groups = AssetsToolPage.GroupDuplicateAssets(new[]
+            {
+                Duplicate("a", false, "winner-a", "source-b"),
+                Duplicate("b", false, "source-b", "winner-a")
+            });
+
+            Assert.Equal(2, groups.Length);
+        }
+
+        [Fact]
+        public void BuildAssetSummary_ReportsGroupedImpactInsteadOfOnePreviewPerKey()
+        {
+            var diagnostics = new FuseAssetPackDiagnostics
+            {
+                UniqueAssetKeys = 10,
+                DuplicateKeys = new[]
+                {
+                    Duplicate("mine", false, "RTM/primary", "RTM/nested"),
+                    Duplicate("engine-house", false, "RTM/primary", "RTM/nested")
+                }
+            };
+
+            var summary = AssetsToolPage.BuildAssetSummary(diagnostics);
+
+            Assert.Contains("Overlapping asset keys: 2", summary);
+            Assert.Contains("Source overlap groups: 1", summary);
+            Assert.Contains("2 key(s)", summary);
+            Assert.Contains("identical copies; no behavior change", summary);
+            Assert.DoesNotContain("1 more duplicate key", summary);
+        }
+
+        private static FuseDuplicateAssetKey Duplicate(
+            string key,
+            bool definitionsDiffer,
+            params string[] sources)
+        {
+            return new FuseDuplicateAssetKey
+            {
+                Key = key,
+                DefinitionsDiffer = definitionsDiffer,
+                Sources = sources
+            };
+        }
+    }
+}

--- a/FUSE.Tests/Interface/AuditsToolPageTests.cs
+++ b/FUSE.Tests/Interface/AuditsToolPageTests.cs
@@ -1,0 +1,34 @@
+using FUSE.Interface.MenuWindow;
+using Xunit;
+
+namespace FUSE.Tests.Interface
+{
+    public sealed class AuditsToolPageTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Base_game_span_without_package_owner_is_not_audited(string owner)
+        {
+            Assert.False(AuditsToolPage.ShouldAuditTrackSpanOwner(owner));
+        }
+
+        [Fact]
+        public void Fuse_owned_span_remains_eligible_for_validation()
+        {
+            Assert.True(AuditsToolPage.ShouldAuditTrackSpanOwner("Katers.SylvaInterchange.FUSE"));
+        }
+
+        [Theory]
+        [InlineData("shared-extension", false)]
+        [InlineData("SHARED-EXTENSION", false)]
+        [InlineData("ownership-conflict", true)]
+        [InlineData("", true)]
+        [InlineData(null, true)]
+        public void Only_actionable_registry_records_are_audit_findings(string classification, bool expected)
+        {
+            Assert.Equal(expected, AuditsToolPage.ShouldAuditConflictRecord(classification));
+        }
+    }
+}

--- a/FUSE.Tests/Interface/FuseWorldLabelsOverlayTests.cs
+++ b/FUSE.Tests/Interface/FuseWorldLabelsOverlayTests.cs
@@ -1,0 +1,22 @@
+using FUSE.Interface;
+using Xunit;
+
+namespace FUSE.Tests.Interface
+{
+    public sealed class FuseWorldLabelsOverlayTests
+    {
+        [Theory]
+        [InlineData(false, false, false, false)]
+        [InlineData(true, true, false, false)]
+        [InlineData(true, false, true, false)]
+        [InlineData(true, false, false, true)]
+        public void ShouldRender_hides_labels_while_disabled_paused_or_a_game_window_is_open(
+            bool enabled,
+            bool paused,
+            bool shownWindow,
+            bool expected)
+        {
+            Assert.Equal(expected, FuseWorldLabelsOverlay.ShouldRender(enabled, paused, shownWindow));
+        }
+    }
+}

--- a/FUSE.Tests/Interface/MenuWindow/DependencyGraphPageTests.cs
+++ b/FUSE.Tests/Interface/MenuWindow/DependencyGraphPageTests.cs
@@ -55,6 +55,21 @@ namespace FUSE.Tests.Interface.MenuWindow
                 DependencyGraphPage.FormatDependencyEdge("c_l_b.assets01", Packages, PresentInModsRoot, advisory: true));
         }
 
+        [Theory]
+        [InlineData("Zamu.StrangeCustoms")]
+        [InlineData("AlinaNova21.AlinasMapMod.FUSE")]
+        [InlineData("AssetLoader")]
+        public void ReplacementCapability_IsIdentifiedAsProvidedByFuse(string dependencyId)
+        {
+            Assert.Contains(
+                "PROVIDED BY FUSE",
+                DependencyGraphPage.FormatDependencyEdge(
+                    dependencyId,
+                    Packages,
+                    PresentInModsRoot,
+                    advisory: false));
+        }
+
         [Fact]
         public void UnknownTarget_IsMissing_ForNativePackages_ButOptionalForLegacyHints()
         {

--- a/FUSE.Tests/Interface/MenuWindow/ModConflictsToolPageTests.cs
+++ b/FUSE.Tests/Interface/MenuWindow/ModConflictsToolPageTests.cs
@@ -1,0 +1,140 @@
+using FUSE.Interface.MenuWindow;
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using FUSE.Runtime.Registry;
+using Xunit;
+
+namespace FUSE.Tests.Interface.MenuWindow
+{
+    [Collection("FuseRegistry")]
+    public sealed class ModConflictsToolPageTests
+    {
+        public ModConflictsToolPageTests()
+        {
+            FuseRegistry.Reset();
+        }
+
+        [Fact]
+        public void BuildGroups_groups_reverse_ownership_records_under_one_package_pair()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Segment,
+                "segment-a",
+                "package-z",
+                "package-a",
+                "later package definition won");
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Node,
+                "node-b",
+                "package-a",
+                "package-z",
+                "later package removal won");
+
+            var group = Assert.Single(ModConflictsToolPage.BuildGroups(FuseRegistry.Conflicts));
+
+            Assert.Equal("package-a", group.FirstPackageId);
+            Assert.Equal("package-z", group.SecondPackageId);
+            Assert.Equal(2, group.Conflicts.Length);
+        }
+
+        [Fact]
+        public void BuildReport_identifies_spatial_overlap_and_lists_both_packages()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Segment,
+                "spatial-overlap:east-whittier",
+                "yard-revamp",
+                "crossover",
+                "spatial track overlap detected; both packages retained");
+
+            var report = ModConflictsToolPage.BuildReport(
+                ModConflictsToolPage.BuildGroups(FuseRegistry.Conflicts));
+
+            Assert.Contains("crossover  <->  yard-revamp", report);
+            Assert.Contains("Potential track-layout overlap", report);
+            Assert.Contains("spatial-overlap:east-whittier", report);
+        }
+
+        [Fact]
+        public void BuildGroups_collapses_definition_fragments_to_their_discovered_mod_ids()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Segment,
+                "segment-a",
+                "Author.RouteA.FUSE.graph",
+                "Author.RouteB.FUSE.track",
+                "later package definition won");
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Span,
+                "span-b",
+                "Author.RouteA.FUSE.operations",
+                "Author.RouteB.FUSE.spans",
+                "later package definition won");
+
+            var group = Assert.Single(ModConflictsToolPage.BuildGroups(
+                FuseRegistry.Conflicts,
+                new[] { "Author.RouteA.FUSE", "Author.RouteB.FUSE" }));
+
+            Assert.Equal("Author.RouteA.FUSE", group.FirstPackageId);
+            Assert.Equal("Author.RouteB.FUSE", group.SecondPackageId);
+            Assert.Equal(2, group.Conflicts.Length);
+        }
+
+        [Fact]
+        public void DeclaredConflicts_are_reported_separately_from_runtime_ownership()
+        {
+            var declaring = new FusePackageManifestSnapshot
+            {
+                Id = "Katers.Route.FUSE",
+                Version = "1.0",
+                ConflictsWith = new[]
+                {
+                    new FuseModRequirement { Id = "Other.Route", NotBefore = "2.0" }
+                }
+            };
+            var conflicting = new FusePackageManifestSnapshot
+            {
+                Id = "Other.Route.FUSE",
+                Version = "2.5"
+            };
+
+            var matches = ModConflictsToolPage.BuildDeclaredConflictMatches(new[] { declaring, conflicting });
+            var match = Assert.Single(matches);
+            var report = ModConflictsToolPage.BuildReport(
+                System.Linq.Enumerable.Empty<ModConflictsToolPage.ConflictGroup>(),
+                matches);
+
+            Assert.Equal("Katers.Route.FUSE", match.DeclaringPackage.Id);
+            Assert.Contains("Author-declared incompatibilities: 1", report);
+            Assert.Contains("DECLARED: Katers.Route.FUSE  X  Other.Route.FUSE", report);
+            Assert.DoesNotContain("Conflict records: 1", report);
+        }
+
+        [Fact]
+        public void Successful_shared_industry_merge_is_informational_not_actionable()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Industry,
+                "component:kirkland-mine.KirkOBSTrackLoad",
+                "CF.AndrewsCoalPower.FUSE.kirklandcoalpatchpower-migration",
+                "Katers.TuckasegeeSteelWorks.FUSE.kirklandcoal",
+                "shared industry destination overlap; definitions merged into the same runtime location");
+
+            var record = Assert.Single(FuseRegistry.Conflicts);
+            Assert.True(record.IsCooperativeMerge);
+
+            var sharedGroups = ModConflictsToolPage.BuildGroups(
+                new[] { record },
+                new[] { "CF.AndrewsCoalPower.FUSE", "Katers.TuckasegeeSteelWorks.FUSE" });
+            var report = ModConflictsToolPage.BuildReport(
+                System.Linq.Enumerable.Empty<ModConflictsToolPage.ConflictGroup>(),
+                System.Linq.Enumerable.Empty<ModConflictsToolPage.DeclaredConflictMatch>(),
+                sharedGroups);
+
+            Assert.Contains("Package pairs needing attention: 0", report);
+            Assert.Contains("Informational shared-extension records: 1", report);
+            Assert.Contains("SHARED: CF.AndrewsCoalPower.FUSE  +  Katers.TuckasegeeSteelWorks.FUSE", report);
+            Assert.Contains("no mod lost content", report);
+        }
+    }
+}

--- a/FUSE.Tests/Interface/MenuWindow/ModsPanelBuilderTests.cs
+++ b/FUSE.Tests/Interface/MenuWindow/ModsPanelBuilderTests.cs
@@ -107,5 +107,99 @@ namespace FUSE.Tests.Interface.MenuWindow
 
             Assert.Equal("NotEnoughRosters", Assert.Single(result).DisplayName);
         }
+
+        [Theory]
+        [InlineData("Package 'Example' requires 'Missing.Mod', but no matching package was discovered.", "Missing dependency")]
+        [InlineData("Package 'Example' conflictsWith 'Other.Mod'; matching package is enabled.", "Incompatible mod installed")]
+        [InlineData("manifest JSON: Unexpected character at line 12.", "Invalid package data")]
+        public void ClassifyPackageStatus_distinguishes_actionable_failure_types(string fault, string expected)
+        {
+            var snapshot = new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                Faults = new[] { fault }
+            };
+
+            var status = ModsPanelBuilder.ClassifyPackageStatus(snapshot);
+
+            Assert.Equal(expected, status.Label);
+            Assert.Equal("Mods Needing Attention", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_reports_successfully_applied_package()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                AppliedToRuntime = true
+            });
+
+            Assert.Equal("Applied", status.Label);
+            Assert.Equal("Applied Mods", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_keeps_optional_mixinto_skip_non_actionable()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                AppliedToRuntime = true,
+                SkipReason = "mixinto dependency missing 'Optional.Mod'"
+            });
+
+            Assert.Equal("Applied", status.Label);
+            Assert.Contains("Optional content is inactive", status.Detail);
+            Assert.Equal("Applied Mods", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_does_not_hide_actionable_skip_behind_optional_fragment()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                AppliedToRuntime = true,
+                SkipReasons = new[]
+                {
+                    "mixinto dependency missing id='Optional.Mod'",
+                    "runtime apply exception"
+                }
+            });
+
+            Assert.Equal("Partially applied", status.Label);
+            Assert.Contains("runtime apply exception", status.Detail);
+            Assert.Equal("Mods Needing Attention", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_reports_partial_apply_without_calling_whole_package_failed()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                AppliedToRuntime = true,
+                RuntimeFaults = new[] { "runtime apply: one definition failed" }
+            });
+
+            Assert.Equal("Partially applied", status.Label);
+            Assert.Equal("Mods Needing Attention", status.ListGroup);
+        }
+
+        [Fact]
+        public void ClassifyPackageStatus_reports_disabled_package_separately()
+        {
+            var status = ModsPanelBuilder.ClassifyPackageStatus(new FusePackageManifestSnapshot
+            {
+                Id = "Example",
+                Disabled = true,
+                DisabledReason = "disabled in the active profile"
+            });
+
+            Assert.Equal("Disabled", status.Label);
+            Assert.Equal("disabled in the active profile", status.Detail);
+            Assert.Equal("Disabled Mods", status.ListGroup);
+        }
     }
 }

--- a/FUSE.Tests/Loading/FuseAssetLoaderDefinitionOverrideTests.cs
+++ b/FUSE.Tests/Loading/FuseAssetLoaderDefinitionOverrideTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.IO;
+using System.Linq;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseAssetLoaderDefinitionOverrideTests : IDisposable
+    {
+        private readonly string _root;
+
+        public FuseAssetLoaderDefinitionOverrideTests()
+        {
+            _root = Path.Combine(
+                Path.GetTempPath(),
+                "FuseAssetLoaderDefinitionOverrideTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(_root))
+                {
+                    Directory.Delete(_root, recursive: true);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Best-effort temporary fixture cleanup.
+                System.Diagnostics.Debug.WriteLine(ex);
+            }
+        }
+
+        [Fact]
+        public void Implicit_discovery_matches_AssetLoader_immediate_child_convention()
+        {
+            var package = CreatePackage("RollingStock", "RollingStock.Mod", null);
+            var definitionsOnly = CreateDefinitions(package, @"fm-flatcar03\Definitions.json");
+            var catalogChild = CreateDefinitions(package, @"catalog-store\Definitions.json");
+            File.WriteAllText(Path.Combine(Path.GetDirectoryName(catalogChild), "Catalog.json"), "{}");
+            CreateDefinitions(package, @"nested\ignored-store\Definitions.json");
+
+            var candidates = FuseAssetPackRegistry.DiscoverDefinitionOverrideCandidatesForPackage(
+                package,
+                out var issues);
+
+            var candidate = Assert.Single(candidates);
+            Assert.Equal("fm-flatcar03", candidate.StoreIdentifier);
+            Assert.Equal(Path.GetFullPath(definitionsOnly), candidate.DefinitionsPath);
+            Assert.False(candidate.Explicit);
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Explicit_manifest_entry_supports_nested_definition_file_and_target()
+        {
+            const string info = @"{
+  ""Id"": ""Native.Override.Mod"",
+  ""FuseDefinitionOverrides"": [
+    {
+      ""StoreIdentifier"": ""ne-caboose03"",
+      ""Path"": ""overrides/caboose/Definitions.json""
+    }
+  ]
+}";
+            var package = CreatePackage("NativeOverride", "Native.Override.Mod", info);
+            var definitions = CreateDefinitions(package, @"overrides\caboose\Definitions.json");
+
+            var candidates = FuseAssetPackRegistry.DiscoverDefinitionOverrideCandidatesForPackage(
+                package,
+                out var issues);
+
+            var candidate = Assert.Single(candidates);
+            Assert.Equal("ne-caboose03", candidate.StoreIdentifier);
+            Assert.Equal(Path.GetFullPath(definitions), candidate.DefinitionsPath);
+            Assert.True(candidate.Explicit);
+            Assert.Empty(issues);
+        }
+
+        [Fact]
+        public void Explicit_manifest_entry_cannot_escape_package_folder()
+        {
+            const string info = @"{
+  ""Id"": ""Unsafe.Override.Mod"",
+  ""FuseDefinitionOverrides"": {
+    ""StoreIdentifier"": ""shared"",
+    ""Path"": ""../outside/Definitions.json""
+  }
+}";
+            var package = CreatePackage("UnsafeOverride", "Unsafe.Override.Mod", info);
+
+            var candidates = FuseAssetPackRegistry.DiscoverDefinitionOverrideCandidatesForPackage(
+                package,
+                out var issues);
+
+            Assert.Empty(candidates);
+            Assert.Contains(issues, issue => issue.Contains("escapes the package folder"));
+        }
+
+        [Fact]
+        public void Explicit_candidate_wins_duplicate_target_deterministically()
+        {
+            var legacy = new FuseLegacyDefinitionOverrideRegistration
+            {
+                StoreIdentifier = "fm-flatcar03",
+                DefinitionsPath = @"C:\Mods\Legacy\fm-flatcar03\Definitions.json",
+                PackageId = "Legacy",
+                PackagePath = @"C:\Mods\Legacy",
+                Explicit = false
+            };
+            var explicitCandidate = new FuseLegacyDefinitionOverrideRegistration
+            {
+                StoreIdentifier = "fm-flatcar03",
+                DefinitionsPath = @"C:\Mods\Native\overrides\Definitions.json",
+                PackageId = "Native",
+                PackagePath = @"C:\Mods\Native",
+                Explicit = true
+            };
+
+            var winners = FuseAssetPackRegistry.SelectLegacyDefinitionOverrides(
+                new[] { legacy, explicitCandidate },
+                out var issues);
+
+            Assert.Same(explicitCandidate, winners["fm-flatcar03"]);
+            Assert.Single(issues);
+            Assert.Contains("selected", issues[0]);
+            Assert.Contains("ignored", issues[0]);
+        }
+
+        [Fact]
+        public void Target_store_identifiers_remain_case_sensitive_like_PrefabStore()
+        {
+            var upper = Candidate("Store", @"C:\Mods\A\Definitions.json", "A");
+            var lower = Candidate("store", @"C:\Mods\B\Definitions.json", "B");
+
+            var winners = FuseAssetPackRegistry.SelectLegacyDefinitionOverrides(
+                new[] { upper, lower },
+                out var issues);
+
+            Assert.Equal(2, winners.Count);
+            Assert.Empty(issues);
+        }
+
+        private string CreatePackage(string folderName, string id, string infoText)
+        {
+            var package = Path.Combine(_root, folderName);
+            Directory.CreateDirectory(package);
+            File.WriteAllText(
+                Path.Combine(package, "Info.json"),
+                infoText ?? "{\"Id\":\"" + id + "\"}");
+            return package;
+        }
+
+        private static string CreateDefinitions(string package, string relativePath)
+        {
+            var path = Path.Combine(package, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllText(path, "{\"objects\":[]}");
+            return path;
+        }
+
+        private static FuseLegacyDefinitionOverrideRegistration Candidate(
+            string storeIdentifier,
+            string definitionsPath,
+            string packageId)
+        {
+            return new FuseLegacyDefinitionOverrideRegistration
+            {
+                StoreIdentifier = storeIdentifier,
+                DefinitionsPath = definitionsPath,
+                PackageId = packageId,
+                PackagePath = Path.GetDirectoryName(definitionsPath),
+                Explicit = false
+            };
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseAssetPackDiscoveryOrderTests.cs
+++ b/FUSE.Tests/Loading/FuseAssetPackDiscoveryOrderTests.cs
@@ -74,6 +74,15 @@ namespace FUSE.Tests.Loading
             return full;
         }
 
+        private string CreateCatalogOnlyPackFolder(string relative)
+        {
+            var full = Path.Combine(_modsRoot, relative);
+            Directory.CreateDirectory(full);
+            File.WriteAllText(Path.Combine(full, "Catalog.json"), "{}");
+            File.WriteAllText(Path.Combine(full, "Definitions.json"), "{}");
+            return full;
+        }
+
         [Fact]
         public void Discovery_yields_root_packs_before_SCAssetPacks_packs()
         {
@@ -137,6 +146,24 @@ namespace FUSE.Tests.Loading
         }
 
         [Fact]
+        public void Discovery_yields_package_root_catalog_store_before_child_stores()
+        {
+            var modFolder = Path.Combine(_modsRoot, "RootCatalogMod");
+            Directory.CreateDirectory(modFolder);
+            File.WriteAllText(Path.Combine(modFolder, "Catalog.json"), "{}");
+            File.WriteAllText(Path.Combine(modFolder, "Definitions.json"), "{}");
+            var child = CreatePackFolder(@"RootCatalogMod\child-store");
+
+            var folders = FuseAssetPackRegistry
+                .EnumerateFallbackAssetPackFolders(modFolder)
+                .Select(Path.GetFullPath)
+                .ToArray();
+
+            Assert.Equal(Path.GetFullPath(modFolder), folders[0]);
+            Assert.Contains(Path.GetFullPath(child), folders);
+        }
+
+        [Fact]
         public void Discovery_yields_model_only_packs_without_definitions()
         {
             var modFolder = Path.Combine(_modsRoot, "WhistleModels");
@@ -150,6 +177,23 @@ namespace FUSE.Tests.Loading
                 .ToArray();
 
             Assert.Contains(Path.GetFullPath(modelPack), folders);
+        }
+
+        [Fact]
+        public void Discovery_yields_catalog_stores_without_a_local_bundle()
+        {
+            var modFolder = Path.Combine(_modsRoot, "DefinitionsOnlyCatalogMod");
+            Directory.CreateDirectory(modFolder);
+
+            var catalogStore = CreateCatalogOnlyPackFolder(
+                @"DefinitionsOnlyCatalogMod\player-coal-load");
+
+            var folders = FuseAssetPackRegistry
+                .EnumerateFallbackAssetPackFolders(modFolder)
+                .Select(Path.GetFullPath)
+                .ToArray();
+
+            Assert.Contains(Path.GetFullPath(catalogStore), folders);
         }
 
         [Fact]

--- a/FUSE.Tests/Loading/FuseDeclaredPackageRelationshipTests.cs
+++ b/FUSE.Tests/Loading/FuseDeclaredPackageRelationshipTests.cs
@@ -1,0 +1,81 @@
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseDeclaredPackageRelationshipTests
+    {
+        [Fact]
+        public void Requires_marks_later_override_as_expected_when_resolved_order_agrees()
+        {
+            var existing = Snapshot(1, "Katers.SylvaInterchange.FUSE");
+            var later = Snapshot(2, "Katers.SylvaInterchangeHYSpans.FUSE");
+            later.RequiredPackageIds = new[] { "Katers.SylvaInterchange" };
+
+            Assert.True(FuseDeclaredPackageRelationship.IsExpectedLaterOverride(existing, later));
+        }
+
+        [Fact]
+        public void LoadAfter_object_id_alias_marks_later_override_as_expected()
+        {
+            var existing = Snapshot(3, "Katers.SylvaInterchange.FUSE");
+            var later = Snapshot(4, "Katers.SylvaInterchangeHYSpans.FUSE");
+            later.LoadAfter = new[] { "Katers.SylvaInterchange.FUSE" };
+
+            Assert.True(FuseDeclaredPackageRelationship.IsExpectedLaterOverride(existing, later));
+        }
+
+        [Fact]
+        public void LoadBefore_on_base_marks_later_override_as_expected()
+        {
+            var existing = Snapshot(1, "base.route");
+            var later = Snapshot(2, "extension.route");
+            existing.LoadBefore = new[] { "extension.route" };
+
+            Assert.True(FuseDeclaredPackageRelationship.IsExpectedLaterOverride(existing, later));
+        }
+
+        [Fact]
+        public void Conditional_mixinto_requirement_marks_later_override_as_expected()
+        {
+            var existing = Snapshot(1, "base.route");
+            var later = Snapshot(2, "extension.route");
+            var definition = new FuseModDefinition
+            {
+                Mixinto = new FuseMixintoDefinition
+                {
+                    Requires = new[] { new FuseModRequirement { Id = "base.route" } }
+                }
+            };
+
+            Assert.True(FuseDeclaredPackageRelationship.IsExpectedLaterOverride(
+                existing,
+                later,
+                laterDefinition: definition));
+        }
+
+        [Fact]
+        public void Declaration_does_not_hide_conflict_when_resolved_order_contradicts_it()
+        {
+            var existing = Snapshot(4, "base.route");
+            var later = Snapshot(2, "extension.route");
+            later.LoadAfter = new[] { "base.route" };
+
+            Assert.False(FuseDeclaredPackageRelationship.IsExpectedLaterOverride(existing, later));
+        }
+
+        [Fact]
+        public void Unrelated_packages_remain_conflicts()
+        {
+            Assert.False(FuseDeclaredPackageRelationship.IsExpectedLaterOverride(
+                Snapshot(1, "yard-a"),
+                Snapshot(2, "yard-b")));
+        }
+
+        private static FusePackageManifestSnapshot Snapshot(int order, string id)
+        {
+            return new FusePackageManifestSnapshot { Order = order, Id = id };
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseDefinitionFileDiscoveryTests.cs
+++ b/FUSE.Tests/Loading/FuseDefinitionFileDiscoveryTests.cs
@@ -117,6 +117,31 @@ namespace FUSE.Tests.Loading
         }
 
         [Fact]
+        public void AlinaUtilities_registry_is_not_discovered_as_a_data_package()
+        {
+            // Alina Utilities is a dual-format executable mod. Its registry.json
+            // is updater/catalog metadata, not a native FUSE definition. A FUSE
+            // requirement in Info.json must not promote that support file into
+            // the data-package loader.
+            var folder = CreateModFolder("AlinasUtils");
+            File.WriteAllText(Path.Combine(folder, "Info.json"), @"{
+  ""Id"": ""AlinaNova21.AlinasUtils"",
+  ""DisplayName"": ""Alina's Utilities"",
+  ""Version"": ""1.0.0"",
+  ""AssemblyName"": ""AlinasUtils.dll"",
+  ""EntryMethod"": ""AlinasUtils.UMM.Mod.Load"",
+  ""Requirements"": [""FUSE""],
+  ""LoadAfter"": [""FUSE""]
+}");
+            File.WriteAllText(
+                Path.Combine(folder, "registry.json"),
+                @"{ ""mods"": [{ ""id"": ""AlinaNova21.AlinasUtils"" }] }");
+
+            Assert.Empty(FuseDefinitionFileDiscovery.ResolveFallbackDefinitionPaths(folder));
+            Assert.Empty(FuseDataPackageDiscovery.DiscoverPackageFolders(_root));
+        }
+
+        [Fact]
         public void NativePackageWithMalformedInfo_IsStillDiscoveredForFaultReporting()
         {
             var folder = CreateModFolder("BrokenNativePackage");

--- a/FUSE.Tests/Loading/FuseDefinitionFileDiscoveryTests.cs
+++ b/FUSE.Tests/Loading/FuseDefinitionFileDiscoveryTests.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using Fuse.Core.Bridge;
 using FUSE.Loading;
 using Xunit;
@@ -151,6 +154,33 @@ namespace FUSE.Tests.Loading
             var discovered = FuseDataPackageDiscovery.DiscoverPackageFolders(_root);
 
             Assert.Equal(new[] { folder }, discovered);
+        }
+
+        [Fact]
+        public void DisabledPackage_DoesNotValidateItsOwnDependencies()
+        {
+            var folder = CreateModFolder("DisabledPackage");
+            File.WriteAllText(Path.Combine(folder, "Info.json"), @"{
+  ""Id"": ""Disabled.Package"",
+  ""FuseDataFile"": ""content.fuse.json"",
+  ""FuseDisabled"": true,
+  ""FuseRequires"": [""Missing.Package""]
+}");
+
+            var discover = typeof(FuseDataPackageDiscovery).GetMethod(
+                "DiscoverPackageManifests",
+                BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(discover);
+
+            var manifests = ((IEnumerable)discover.Invoke(null, new object[] { _root }))
+                .Cast<object>()
+                .ToArray();
+            var manifest = Assert.Single(manifests);
+            var manifestType = manifest.GetType();
+            var faults = (IEnumerable)manifestType.GetProperty("Faults").GetValue(manifest);
+
+            Assert.True((bool)manifestType.GetProperty("Disabled").GetValue(manifest));
+            Assert.Empty(faults.Cast<object>());
         }
     }
 }

--- a/FUSE.Tests/Loading/FuseDefinitionFileDiscoveryTests.cs
+++ b/FUSE.Tests/Loading/FuseDefinitionFileDiscoveryTests.cs
@@ -115,5 +115,17 @@ namespace FUSE.Tests.Loading
 
             Assert.Empty(FuseDataPackageDiscovery.DiscoverPackageFolders(_root));
         }
+
+        [Fact]
+        public void NativePackageWithMalformedInfo_IsStillDiscoveredForFaultReporting()
+        {
+            var folder = CreateModFolder("BrokenNativePackage");
+            File.WriteAllText(Path.Combine(folder, "Info.json"), "{ \"Id\": \"BrokenNativePackage\", ");
+            File.WriteAllText(Path.Combine(folder, "track.fuse.json"), "{}");
+
+            var discovered = FuseDataPackageDiscovery.DiscoverPackageFolders(_root);
+
+            Assert.Equal(new[] { folder }, discovered);
+        }
     }
 }

--- a/FUSE.Tests/Loading/FuseDirectStoreLegosLibraryReproTests.cs
+++ b/FUSE.Tests/Loading/FuseDirectStoreLegosLibraryReproTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using FUSE.Loading;
+using FUSE.Patches;
 using HarmonyLib;
 using Model.Definition;
 using Model.Definition.Data;
@@ -55,6 +56,34 @@ namespace FUSE.Tests.Loading
         {
             _h = harness;
             _out = output;
+        }
+
+        [Fact]
+        public void CompatibilityLatch_ReentersInstallerAfterSuccessfulUnpatch()
+        {
+            var installedField = typeof(FuseLegosLibraryCompatibility).GetField(
+                "_installed",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(installedField);
+            var original = (bool)installedField.GetValue(null);
+
+            try
+            {
+                installedField.SetValue(null, true);
+                Assert.Equal(
+                    "installed",
+                    FuseLegosLibraryCompatibility.EnsureInstalled(null));
+
+                FuseLegosLibraryCompatibility.ResetAfterSuccessfulUnpatch();
+
+                Assert.Equal(
+                    "unavailable (no harmony)",
+                    FuseLegosLibraryCompatibility.EnsureInstalled(null));
+            }
+            finally
+            {
+                installedField.SetValue(null, original);
+            }
         }
 
         // ------------------------------------------------------------------

--- a/FUSE.Tests/Loading/FuseDirectStoreLegosLibraryReproTests.cs
+++ b/FUSE.Tests/Loading/FuseDirectStoreLegosLibraryReproTests.cs
@@ -61,28 +61,34 @@ namespace FUSE.Tests.Loading
         [Fact]
         public void CompatibilityLatch_ReentersInstallerAfterSuccessfulUnpatch()
         {
-            var installedField = typeof(FuseLegosLibraryCompatibility).GetField(
-                "_installed",
+            var cloneInstalledField = typeof(FuseLegosLibraryCompatibility).GetField(
+                "_cloneCompatibilityInstalled",
                 BindingFlags.NonPublic | BindingFlags.Static);
-            Assert.NotNull(installedField);
-            var original = (bool)installedField.GetValue(null);
+            var detailInstalledField = typeof(FuseLegosLibraryCompatibility).GetField(
+                "_detailModelCompatibilityInstalled",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(cloneInstalledField);
+            Assert.NotNull(detailInstalledField);
+            var originalClone = (bool)cloneInstalledField.GetValue(null);
+            var originalDetail = (bool)detailInstalledField.GetValue(null);
 
             try
             {
-                installedField.SetValue(null, true);
-                Assert.Equal(
-                    "installed",
-                    FuseLegosLibraryCompatibility.EnsureInstalled(null));
+                cloneInstalledField.SetValue(null, true);
+                detailInstalledField.SetValue(null, true);
 
                 FuseLegosLibraryCompatibility.ResetAfterSuccessfulUnpatch();
 
+                Assert.False((bool)cloneInstalledField.GetValue(null));
+                Assert.False((bool)detailInstalledField.GetValue(null));
                 Assert.Equal(
                     "unavailable (no harmony)",
                     FuseLegosLibraryCompatibility.EnsureInstalled(null));
             }
             finally
             {
-                installedField.SetValue(null, original);
+                cloneInstalledField.SetValue(null, originalClone);
+                detailInstalledField.SetValue(null, originalDetail);
             }
         }
 

--- a/FUSE.Tests/Loading/FuseFeatureRuleEvaluatorTests.cs
+++ b/FUSE.Tests/Loading/FuseFeatureRuleEvaluatorTests.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseFeatureRuleEvaluatorTests
+    {
+        [Fact]
+        public void FalseBooleanRule_RemovesEveryNamedTargetAndKeepsUntargetedObjects()
+        {
+            var definition = DefinitionWithOptionalObjects();
+
+            var result = FuseFeatureRuleEvaluator.Apply(
+                definition,
+                (_, __) => new JValue(false));
+
+            Assert.Equal(1, result.DisabledRuleCount);
+            Assert.Equal(4, result.RemovedObjectCount);
+            Assert.DoesNotContain("optional-node", definition.Tracks.Nodes.Keys);
+            Assert.DoesNotContain("optional-segment", definition.Tracks.Segments.Keys);
+            Assert.DoesNotContain("optional-scenery", definition.World.Scenery.Keys);
+            Assert.DoesNotContain("optional-component", definition.Operations.Industries["yard"].Components.Keys);
+            Assert.Contains("always-scenery", definition.World.Scenery.Keys);
+        }
+
+        [Fact]
+        public void TrueBooleanRule_KeepsTargets()
+        {
+            var definition = DefinitionWithOptionalObjects();
+
+            var result = FuseFeatureRuleEvaluator.Apply(
+                definition,
+                (_, __) => new JValue(true));
+
+            Assert.Equal(1, result.EnabledRuleCount);
+            Assert.Equal(0, result.RemovedObjectCount);
+            Assert.Contains("optional-node", definition.Tracks.Nodes.Keys);
+            Assert.Contains("optional-scenery", definition.World.Scenery.Keys);
+        }
+
+        [Theory]
+        [InlineData("high", "equals", "high", true)]
+        [InlineData("low", "notEquals", "high", true)]
+        [InlineData(4, "greaterThanOrEqual", 4, true)]
+        [InlineData(3, "lessThan", 4, true)]
+        [InlineData(5, "lessThanOrEqual", 4, false)]
+        public void Matches_SupportsChoiceAndNumericOperators(object current, string operation, object expected, bool matches)
+        {
+            Assert.Equal(matches, FuseFeatureRuleEvaluator.Matches(JToken.FromObject(current), operation, JToken.FromObject(expected)));
+        }
+
+        [Fact]
+        public void MultipleFalseRules_TargetingSameObject_CountRemovalOnce()
+        {
+            var definition = DefinitionWithOptionalObjects();
+            definition.FeatureRules["second"] = new FuseFeatureRule
+            {
+                Setting = "enabled",
+                Value = new JValue(true),
+                Targets = new FuseFeatureTargets { Scenery = new[] { "optional-scenery" } }
+            };
+
+            var result = FuseFeatureRuleEvaluator.Apply(
+                definition,
+                (_, __) => new JValue(false));
+
+            Assert.Equal(2, result.DisabledRuleCount);
+            Assert.Equal(4, result.RemovedObjectCount);
+        }
+
+        private static FuseModDefinition DefinitionWithOptionalObjects()
+        {
+            var definition = new FuseModDefinition
+            {
+                Id = "feature-test",
+                Name = "Feature Test"
+            };
+            definition.Settings["enabled"] = new FuseModSettingDefinition
+            {
+                Type = "bool",
+                Default = new JValue(true),
+                ReloadRequired = true
+            };
+            definition.Tracks.Nodes["optional-node"] = new FuseNode();
+            definition.Tracks.Segments["optional-segment"] = new FuseSegment();
+            definition.World.Scenery["optional-scenery"] = new FuseScenery();
+            definition.World.Scenery["always-scenery"] = new FuseScenery();
+            definition.Operations.Industries["yard"] = new FuseIndustry
+            {
+                Components = new Dictionary<string, FuseIndustryComponent>
+                {
+                    ["optional-component"] = new FuseIndustryComponent()
+                }
+            };
+            definition.FeatureRules["optional"] = new FuseFeatureRule
+            {
+                Setting = "enabled",
+                Value = new JValue(true),
+                Targets = new FuseFeatureTargets
+                {
+                    TrackNodes = new[] { "optional-node" },
+                    TrackSegments = new[] { "optional-segment" },
+                    Scenery = new[] { "optional-scenery" },
+                    IndustryComponents = new[] { "yard/optional-component" }
+                }
+            };
+            return definition;
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseIndustryComponentOwnershipTests.cs
+++ b/FUSE.Tests/Loading/FuseIndustryComponentOwnershipTests.cs
@@ -1,0 +1,53 @@
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseIndustryComponentOwnershipTests
+    {
+        [Fact]
+        public void ClaimId_MatchesEquivalentDestinationsAcrossDifferentIndustryIds()
+        {
+            var first = new FuseIndustryComponent
+            {
+                Type = "consumer",
+                Name = "Whittier Saw Mill MP1",
+                TrackSpanIds = new[] { "R3", "R2" }
+            };
+            var second = new FuseIndustryComponent
+            {
+                Type = "consumer",
+                Name = "Whittier Saw Mill MP1",
+                TrackSpanPatch = new FuseStringListPatch
+                {
+                    Replace = new[] { "r2", "r3" }
+                }
+            };
+
+            var firstId = FuseModLoader.BuildIndustryComponentClaimId(
+                "bjorn-sawmill",
+                "mp1",
+                first);
+            var secondId = FuseModLoader.BuildIndustryComponentClaimId(
+                "appy-sawmill",
+                "main-product-one",
+                second);
+
+            Assert.Equal(firstId, secondId, ignoreCase: true);
+            Assert.Contains("Whittier Saw Mill MP1", firstId);
+            Assert.Contains("spans=R2,R3", firstId);
+        }
+
+        [Fact]
+        public void ClaimId_FallsBackToExactComponentForPartialPatchWithoutSemanticData()
+        {
+            var id = FuseModLoader.BuildIndustryComponentClaimId(
+                "sylva-paperboard",
+                "R2-R3",
+                new FuseIndustryComponent { Partial = true });
+
+            Assert.Equal("component:sylva-paperboard.R2-R3", id);
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseInstalledDependencyCatalogTests.cs
+++ b/FUSE.Tests/Loading/FuseInstalledDependencyCatalogTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FUSE.Interface.MenuWindow;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseInstalledDependencyCatalogTests
+    {
+        [Fact]
+        public void UmmEquipmentRequirement_ParsesPackageIdAndMinimumVersion()
+        {
+            using (var fixture = new CatalogFixture())
+            {
+                fixture.Write(
+                    "GP38ATSF/Info.json",
+                    "{\"Id\":\"GP38ATSF\",\"DisplayName\":\"ATSF GP38\",\"Version\":\"4.4.5\",\"Requirements\":[\"GP38SoundMod-4.4.1\"]}");
+                fixture.Write(
+                    "GP38ATSF/GP38/Definitions.json",
+                    "{\"objects\":[{\"definition\":{\"kind\":\"DieselLocomotive\"}}]}");
+                fixture.Write(
+                    "GP38SoundMod/Info.json",
+                    "{\"Id\":\"GP38SoundMod\",\"Version\":\"4.4.7\",\"EntryMethod\":\"Scripts.Load\"}");
+
+                var packages = FuseInstalledDependencyCatalog.DiscoverInstalledPackages(
+                    fixture.Root,
+                    Array.Empty<FusePackageManifestSnapshot>());
+                var equipment = Assert.Single(packages, package => package.Id == "GP38ATSF");
+                var requirement = Assert.Single(equipment.Requirements);
+
+                Assert.Equal("Equipment", equipment.Category);
+                Assert.True(equipment.HasAssetLoaderMetadata);
+                Assert.Equal("GP38SoundMod", requirement.Id);
+                Assert.Equal("4.4.1", requirement.NotBefore);
+                Assert.Equal("UMM Info.json", requirement.Source);
+                Assert.Contains(
+                    "READY 4.4.7",
+                    DependencyGraphPage.FormatDependencyEdge(requirement, packages, advisory: false));
+            }
+        }
+
+        [Fact]
+        public void LegacyObjectRequirement_PreservesVersionBounds()
+        {
+            using (var fixture = new CatalogFixture())
+            {
+                fixture.Write(
+                    "LegacyCar/Definition.json",
+                    "{\"manifestVersion\":7,\"id\":\"Legacy.Car\",\"requires\":[{\"id\":\"Truck.Library\",\"notBefore\":\"2.1.0\",\"notAfter\":\"3.0.0\"}]}");
+                fixture.Write("TruckLibrary/Info.json", "{\"Id\":\"Truck.Library\",\"Version\":\"2.5.0\"}");
+
+                var packages = FuseInstalledDependencyCatalog.DiscoverInstalledPackages(
+                    fixture.Root,
+                    Array.Empty<FusePackageManifestSnapshot>());
+                var package = Assert.Single(packages, candidate => candidate.Id == "Legacy.Car");
+                var requirement = Assert.Single(package.Requirements);
+
+                Assert.Equal("2.1.0", requirement.NotBefore);
+                Assert.Equal("3.0.0", requirement.NotAfter);
+                Assert.Contains(
+                    "(2.1.0 to 3.0.0) | <color=\"green\">READY 2.5.0",
+                    DependencyGraphPage.FormatDependencyEdge(requirement, packages, advisory: false));
+            }
+        }
+
+        [Fact]
+        public void NexusCache_FillsManifestGap_WithoutInventingInstalledProvider()
+        {
+            using (var fixture = new CatalogFixture())
+            {
+                fixture.Write("FreightCar/Info.json", "{\"Id\":\"Freight.Car\",\"Version\":\"1.0.0\"}");
+                fixture.Write(
+                    ".fuse-metadata/dependencies.json",
+                    "{\"schemaVersion\":1,\"packages\":[" +
+                    "{\"folder\":\"FreightCar\",\"id\":\"Freight.Car\",\"requirements\":[{\"id\":\"Shared.Script\",\"minimumVersion\":\"2.0.0\",\"source\":\"nexus\"}]}," +
+                    "{\"folder\":\"RemovedCar\",\"id\":\"Removed.Car\",\"requirements\":[{\"id\":\"Ghost.Dependency\"}]}]}");
+
+                var packages = FuseInstalledDependencyCatalog.DiscoverInstalledPackages(
+                    fixture.Root,
+                    Array.Empty<FusePackageManifestSnapshot>());
+                var package = Assert.Single(packages);
+                var requirement = Assert.Single(package.Requirements);
+
+                Assert.Equal("Shared.Script", requirement.Id);
+                Assert.Equal("2.0.0", requirement.NotBefore);
+                Assert.Equal("Nexus API cache", requirement.Source);
+                Assert.Contains(
+                    "MISSING",
+                    DependencyGraphPage.FormatDependencyEdge(requirement, packages, advisory: false));
+                Assert.DoesNotContain(packages, candidate => candidate.Id == "Removed.Car");
+            }
+        }
+
+        [Fact]
+        public void ExplicitLocalRequirement_WinsOverCachedNexusDuplicate()
+        {
+            using (var fixture = new CatalogFixture())
+            {
+                fixture.Write(
+                    "Car/Info.json",
+                    "{\"Id\":\"Car\",\"Requirements\":[\"Local.Library-3.0.0\"]}");
+                fixture.Write(
+                    ".fuse-metadata/dependencies.json",
+                    "{\"schemaVersion\":1,\"packages\":[{\"folder\":\"Car\",\"id\":\"Car\",\"requirements\":[{\"id\":\"Local.Library\",\"minimumVersion\":\"1.0.0\",\"source\":\"nexus\"}]}]}");
+
+                var packages = FuseInstalledDependencyCatalog.DiscoverInstalledPackages(
+                    fixture.Root,
+                    Array.Empty<FusePackageManifestSnapshot>());
+                var requirement = Assert.Single(Assert.Single(packages).Requirements);
+
+                Assert.Equal("3.0.0", requirement.NotBefore);
+                Assert.Equal("UMM Info.json", requirement.Source);
+            }
+        }
+
+        [Fact]
+        public void ExplicitLocalRequirements_IgnoreStaleCachedNexusEdges()
+        {
+            using (var fixture = new CatalogFixture())
+            {
+                fixture.Write(
+                    "Car/Info.json",
+                    "{\"Id\":\"Car\",\"Requirements\":[\"Current.Library-3.0.0\"]}");
+                fixture.Write(
+                    ".fuse-metadata/dependencies.json",
+                    "{\"schemaVersion\":1,\"packages\":[{\"folder\":\"Car\",\"id\":\"Car\",\"source\":{\"kind\":\"nexus\"},\"requirements\":[{\"id\":\"Retired.Library\",\"minimumVersion\":\"1.0.0\",\"source\":\"nexus\"}]}]}");
+
+                var packages = FuseInstalledDependencyCatalog.DiscoverInstalledPackages(
+                    fixture.Root,
+                    Array.Empty<FusePackageManifestSnapshot>());
+                var requirement = Assert.Single(Assert.Single(packages).Requirements);
+
+                Assert.Equal("Current.Library", requirement.Id);
+                Assert.Equal("UMM Info.json", requirement.Source);
+            }
+        }
+
+        [Fact]
+        public void NexusIdentity_MatchesInstalledProviderByHomepageInsteadOfDisplayName()
+        {
+            using (var fixture = new CatalogFixture())
+            {
+                fixture.Write("Car/Info.json", "{\"Id\":\"Car\"}");
+                fixture.Write(
+                    "Scripts/Info.json",
+                    "{\"Id\":\"Different.Local.Id\",\"Version\":\"2.3.0\",\"Homepage\":\"https://www.nexusmods.com/railroader/mods/712\"}");
+                fixture.Write(
+                    ".fuse-metadata/dependencies.json",
+                    "{\"schemaVersion\":1,\"packages\":[{\"folder\":\"Car\",\"id\":\"Car\",\"requirements\":[" +
+                    "{\"id\":\"nexus:railroader:712\",\"displayName\":\"Shared Scripts\",\"minimumVersion\":\"2.2.0\",\"nexusModId\":\"712\",\"source\":\"nexus\"}]}]}");
+
+                var packages = FuseInstalledDependencyCatalog.DiscoverInstalledPackages(
+                    fixture.Root,
+                    Array.Empty<FusePackageManifestSnapshot>());
+                var requirement = Assert.Single(Assert.Single(packages, item => item.Id == "Car").Requirements);
+                var formatted = DependencyGraphPage.FormatDependencyEdge(requirement, packages, advisory: false);
+
+                Assert.Contains("Shared Scripts", formatted);
+                Assert.Contains("READY 2.3.0", formatted);
+            }
+        }
+
+        private sealed class CatalogFixture : IDisposable
+        {
+            public CatalogFixture()
+            {
+                Root = Path.Combine(Path.GetTempPath(), "fuse-dependency-catalog-" + Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(Root);
+            }
+
+            public string Root { get; }
+
+            public void Write(string relativePath, string contents)
+            {
+                var path = Path.Combine(Root, relativePath.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                File.WriteAllText(path, contents);
+            }
+
+            public void Dispose()
+            {
+                if (Directory.Exists(Root))
+                {
+                    Directory.Delete(Root, recursive: true);
+                }
+            }
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseLegacyAssemblyOrderingTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyAssemblyOrderingTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using FUSE.Loading;
+using Railloader;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseLegacyAssemblyOrderingTests
+    {
+        [Fact]
+        public void LoadAfter_orders_hosted_plugin_after_referenced_package()
+        {
+            var extension = Manifest("Extension.Mod", "A-Extension");
+            extension.LoadAfter = new[] { new ModReference { Id = "Base.Mod" } };
+            var @base = Manifest("Base.Mod", "Z-Base");
+
+            var ordered = FuseLegacyAssemblyHost.OrderLegacyManifestsForHosting(new[] { extension, @base });
+
+            Assert.Equal(new[] { "Base.Mod", "Extension.Mod" }, ordered.Select(item => item.Id));
+        }
+
+        [Fact]
+        public void LoadBefore_orders_hosted_plugin_before_referenced_package_alias()
+        {
+            var extension = Manifest("Extension.Mod.FUSE", "A-Extension");
+            var @base = Manifest("Base.Mod", "Z-Base");
+            @base.LoadBefore = new[] { "Extension.Mod" };
+
+            var ordered = FuseLegacyAssemblyHost.OrderLegacyManifestsForHosting(new[] { extension, @base });
+
+            Assert.Equal(new[] { "Base.Mod", "Extension.Mod.FUSE" }, ordered.Select(item => item.Id));
+        }
+
+        [Fact]
+        public void Required_reference_also_orders_dependency_before_hosted_plugin()
+        {
+            var extension = Manifest("Extension.Mod", "A-Extension");
+            extension.RequiredReferences = new[] { new ModReference { Id = "Base.Mod" } };
+            var @base = Manifest("Base.Mod", "Z-Base");
+
+            var ordered = FuseLegacyAssemblyHost.OrderLegacyManifestsForHosting(new[] { extension, @base });
+
+            Assert.Equal(new[] { "Base.Mod", "Extension.Mod" }, ordered.Select(item => item.Id));
+        }
+
+        [Fact]
+        public void Missing_advisory_reference_does_not_drop_package()
+        {
+            var package = Manifest("Only.Mod", "Only");
+            package.LoadAfter = new[] { new ModReference { Id = "Not.Installed" } };
+
+            Assert.Same(package, Assert.Single(FuseLegacyAssemblyHost.OrderLegacyManifestsForHosting(new[] { package })));
+        }
+
+        [Fact]
+        public void Load_order_cycle_keeps_every_package_in_deterministic_folder_order()
+        {
+            var first = Manifest("First.Mod", "A-First");
+            var second = Manifest("Second.Mod", "B-Second");
+            first.LoadAfter = new[] { new ModReference { Id = second.Id } };
+            second.LoadAfter = new[] { new ModReference { Id = first.Id } };
+
+            var ordered = FuseLegacyAssemblyHost.OrderLegacyManifestsForHosting(new[] { second, first });
+
+            Assert.Equal(new[] { "First.Mod", "Second.Mod" }, ordered.Select(item => item.Id));
+        }
+
+        private static FuseLegacyAssemblyManifest Manifest(string id, string folder)
+        {
+            return new FuseLegacyAssemblyManifest
+            {
+                Id = id,
+                Name = id,
+                Version = "1.0",
+                FolderPath = "C:\\Railroader\\Mods\\" + folder,
+                Assemblies = Array.Empty<string>()
+            };
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseLegacyCapabilityActivationTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyCapabilityActivationTests.cs
@@ -1,0 +1,47 @@
+using System;
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseLegacyCapabilityActivationTests
+    {
+        [Fact]
+        public void BuildRequestedIds_includes_enabled_package_and_dependency_ids()
+        {
+            var requested = FuseLegacyCapabilityActivation.BuildRequestedIds(new[]
+            {
+                new FusePackageManifestSnapshot
+                {
+                    Id = "Consumer.FUSE",
+                    RequiredPackageIds = new[] { "Zamu.SomeKindOfMadness.FUSE" },
+                },
+            });
+
+            Assert.Contains("Consumer", requested);
+            Assert.Contains("Zamu.SomeKindOfMadness", requested);
+        }
+
+        [Fact]
+        public void BuildRequestedIds_excludes_disabled_packages_and_their_dependencies()
+        {
+            var requested = FuseLegacyCapabilityActivation.BuildRequestedIds(new[]
+            {
+                new FusePackageManifestSnapshot
+                {
+                    Id = "Disabled.Consumer",
+                    Disabled = true,
+                    RequiredPackageIds = new[] { "Zamu.AbsoluteMadness" },
+                },
+            });
+
+            Assert.Empty(requested);
+        }
+
+        [Fact]
+        public void BuildRequestedIds_accepts_a_null_snapshot_sequence()
+        {
+            Assert.Empty(FuseLegacyCapabilityActivation.BuildRequestedIds(null));
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseLegacyEditorHelperSceneryTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyEditorHelperSceneryTests.cs
@@ -1,0 +1,76 @@
+using FUSE.Loading;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public class FuseLegacyEditorHelperSceneryTests
+    {
+        [Theory]
+        [InlineData("TurntableMeasurementTool", true)]
+        [InlineData("scenery://TurntableMeasurementTool", true)]
+        [InlineData("SCENERY://turntablemeasurementtool", true)]
+        [InlineData("30m Turntable", false)]
+        [InlineData("TurntableMeasurementTool Shed", false)]
+        [InlineData(null, false)]
+        public void EditorHelperDetection_IsExact(string assetIdentifier, bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseLegacyDataConverter.IsLegacyEditorOnlySceneryAsset(assetIdentifier));
+        }
+
+        [Fact]
+        public void StrykerBrysonMeasurementOverlay_IsNotMaterializedBesideRealTurntable()
+        {
+            var source = new JObject
+            {
+                ["scenery"] = new JObject
+                {
+                    ["TTPlaceholder"] = new JObject
+                    {
+                        ["modelIdentifier"] = "TurntableMeasurementTool",
+                        ["position"] = new JObject
+                        {
+                            ["x"] = 4278.08,
+                            ["y"] = 529.0,
+                            ["z"] = 5371.88
+                        }
+                    },
+                    ["RealBuilding"] = new JObject
+                    {
+                        ["modelIdentifier"] = "ALWHouses_CabooseHouse"
+                    }
+                },
+                ["splineys"] = new JObject
+                {
+                    ["Bryson_new_TT"] = new JObject
+                    {
+                        ["handler"] = "AlinasMapMod.Turntable.TurntableBuilder",
+                        ["position"] = new JObject
+                        {
+                            ["x"] = 4278.08,
+                            ["y"] = 529.0,
+                            ["z"] = 5371.88
+                        },
+                        ["rotation"] = new JObject { ["y"] = 2.5 }
+                    }
+                }
+            };
+            var manifest = new FuseLegacyPackageManifest
+            {
+                PackageId = "StrykerBryson.FUSE",
+                DisplayName = "Stryker's Bryson",
+                Version = "1.1"
+            };
+            var root = FuseLegacyDataConverter.CreateSkeleton(manifest, "brysonttplaceholder");
+
+            FuseLegacyDataConverter.ConvertSource(source, root, manifest);
+
+            var scenery = (JObject)root["world"]["scenery"];
+            Assert.Null(scenery["TTPlaceholder"]);
+            Assert.NotNull(scenery["RealBuilding"]);
+            Assert.NotNull(root["operations"]["turntables"]["Bryson_new_TT"]);
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyIndustryConverterTests.cs
@@ -42,6 +42,135 @@ namespace FUSE.Tests.Loading
         public class TopLevelPartialPatch
         {
             [Fact]
+            public void AreaUsedOnlyAsIndustryNamespace_DoesNotEmitBaseAreaMutation()
+            {
+                // ARC Whittier and KWIX use areas.whittier only to reach the
+                // industry dictionary. It must not become an area definition at
+                // position zero, which moves the base Whittier operations root.
+                var source = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["whittier"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["whittier-sawmill"] = new JObject
+                                {
+                                    ["components"] = new JObject
+                                    {
+                                        ["logs"] = new JObject
+                                        {
+                                            ["trackSpans"] = new JObject
+                                            {
+                                                ["$replace"] = new JArray("R1", "R2", "R3")
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+
+                Assert.Null(root["tracks"]?["areas"]?["whittier"]);
+                Assert.Equal("whittier", (string)industries["whittier-sawmill"]?["areaId"]);
+                Assert.Equal(
+                    new[] { "R1", "R2", "R3" },
+                    industries["whittier-sawmill"]?["components"]?["logs"]?
+                        ["trackSpanPatch"]?["replace"]?.Values<string>());
+            }
+
+            [Fact]
+            public void ExplicitAreaMetadata_StillEmitsAreaWithoutInventingMissingFields()
+            {
+                var source = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["new-yard"] = new JObject
+                        {
+                            ["position"] = new JObject
+                            {
+                                ["x"] = 12f,
+                                ["y"] = 3f,
+                                ["z"] = -8f
+                            },
+                            ["radius"] = 250f
+                        }
+                    }
+                };
+
+                var (root, _) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+                var area = root["tracks"]?["areas"]?["new-yard"];
+
+                Assert.NotNull(area);
+                Assert.False(((JObject)area).TryGetValue("name", out _), area.ToString());
+                Assert.Equal(12f, area["position"].Value<float>("x"));
+                Assert.Equal(250f, area.Value<float>("radius"));
+            }
+
+            [Fact]
+            public void RootLevelSpansAndAreas_ConvertTogether_ForKwixStyleFragments()
+            {
+                // Regression for issue #210. KWIX keeps each industry's spans at
+                // the document root beside the area/industry patch. Dropping the
+                // root-level spans leaves a valid-looking loader whose runtime
+                // TrackSpans array is empty, which later breaks EOD processing.
+                var source = new JObject
+                {
+                    ["spans"] = new JObject
+                    {
+                        ["KWIX_Bottling_GB-A"] = new JObject
+                        {
+                            ["upper"] = new JObject
+                            {
+                                ["segmentId"] = "SKWIX_IND_vm6e",
+                                ["distance"] = 0,
+                                ["end"] = "Start"
+                            },
+                            ["lower"] = new JObject
+                            {
+                                ["segmentId"] = "SKWIX_IND_vm6e",
+                                ["distance"] = 0,
+                                ["end"] = "End"
+                            }
+                        }
+                    },
+                    ["areas"] = new JObject
+                    {
+                        ["whittier"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["kwix-bottling"] = new JObject
+                                {
+                                    ["components"] = new JObject
+                                    {
+                                        ["kwix-bottling_GB-A"] = new JObject
+                                        {
+                                            ["type"] = "Model.Ops.IndustryLoader",
+                                            ["trackSpans"] = new JArray("KWIX_Bottling_GB-A"),
+                                            ["loadId"] = "glass-bottles"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(source);
+
+                Assert.NotNull(root["tracks"]?["spans"]?["KWIX_Bottling_GB-A"]);
+                Assert.Equal(
+                    "KWIX_Bottling_GB-A",
+                    (string)industries["kwix-bottling"]?["components"]?["kwix-bottling_GB-A"]?["trackSpanIds"]?[0]);
+            }
+
+            [Fact]
             public void NoAreaIdNoPositionNoRotation_ConverterOmitsTransformDirectives()
             {
                 var source = new JObject
@@ -332,6 +461,162 @@ namespace FUSE.Tests.Loading
 
         public class ReplaceDirectives
         {
+            [Fact]
+            public void Dw5WhittierSawmill_MultipleAdds_PreserveBaseUnloaderAndAllAddedTracks()
+            {
+                // Issue #236's DW5 Whittier Saw Mill package patches the existing
+                // `logs` unloader with three one-value $add instructions. Treating
+                // this array as a replacement leaves only one unloading area.
+                var patch = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["whittier"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["whittier-sawmill"] = new JObject
+                                {
+                                    ["components"] = new JObject
+                                    {
+                                        ["logs"] = new JObject
+                                        {
+                                            ["name"] = "Whittier Saw Mill R1/R2/R3",
+                                            ["trackSpans"] = new JArray(
+                                                new JObject { ["$add"] = "R2" },
+                                                new JObject { ["$add"] = "R3" },
+                                                new JObject { ["$add"] = "R4" }),
+                                            ["maxStorage"] = 220.0
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+                var state = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["whittier"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["whittier-sawmill"] = new JObject
+                                {
+                                    ["components"] = new JObject
+                                    {
+                                        ["logs"] = new JObject
+                                        {
+                                            ["type"] = "Model.Ops.IndustryUnloader",
+                                            ["trackSpans"] = new JArray("R1"),
+                                            ["loadId"] = "logs"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                FuseLegacyJsonPatch.Apply(state, patch, "DW5SawMill.json");
+                var expandedSlice = FuseLegacyGameGraphCompatibility.BuildPatchSlice(state, patch);
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(expandedSlice);
+                var converted = industries["whittier-sawmill"]?["components"]?["logs"];
+
+                Assert.True(converted.Value<bool>("partial"));
+                Assert.Null(converted["type"]);
+                Assert.Equal(
+                    new[] { "R2", "R3", "R4" },
+                    converted["trackSpanPatch"]?["append"]?.Values<string>());
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                var component = definition.Operations.Industries["whittier-sawmill"].Components["logs"];
+                Assert.True(component.Partial);
+                Assert.Equal(new[] { "R2", "R3", "R4" }, component.TrackSpanPatch.Append);
+                Assert.Null(component.TrackSpanPatch.Replace);
+            }
+
+            [Fact]
+            public void SylvaIndustriesBoosted_ArrayWrappedAdd_PreservesBaseSpanAndAddsR3()
+            {
+                // Sylva Industries Boosted 0.9 uses the Strange Customs form
+                //   "trackSpans": [ { "$add": "Piei" } ]
+                // for both lime and salt. This is a patch program: retain the
+                // vanilla P3z2 span (R2) and append the re-authored Piei span
+                // (R3). Flattening it to a one-item replacement makes only one
+                // track highlight and prevents cars on the other track from
+                // being accepted at EOD.
+                var patch = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["sylva"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["sylva-paperboard"] = new JObject
+                                {
+                                    ["components"] = new JObject
+                                    {
+                                        ["lime"] = new JObject
+                                        {
+                                            ["type"] = "Model.Ops.IndustryUnloader",
+                                            ["name"] = "Sylva Paperboard R2 & R3",
+                                            ["trackSpans"] = new JArray(
+                                                new JObject { ["$add"] = "Piei" }),
+                                            ["loadId"] = "lime"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+                var state = new JObject
+                {
+                    ["areas"] = new JObject
+                    {
+                        ["sylva"] = new JObject
+                        {
+                            ["industries"] = new JObject
+                            {
+                                ["sylva-paperboard"] = new JObject
+                                {
+                                    ["components"] = new JObject
+                                    {
+                                        ["lime"] = new JObject
+                                        {
+                                            ["type"] = "Model.Ops.IndustryUnloader",
+                                            ["trackSpans"] = new JArray("P3z2"),
+                                            ["loadId"] = "lime"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                FuseLegacyJsonPatch.Apply(state, patch, "SylvaIndustriesBoosted.json");
+                var expandedSlice = FuseLegacyGameGraphCompatibility.BuildPatchSlice(state, patch);
+                var preservedDirective = expandedSlice["areas"]?["sylva"]?["industries"]?
+                    ["sylva-paperboard"]?["components"]?["lime"]?["trackSpans"]?[0];
+                Assert.Equal("Piei", (string)preservedDirective?["$add"]);
+
+                var (root, industries) = FuseLegacyIndustryConverterTests.ConvertIndustries(expandedSlice);
+                var converted = industries["sylva-paperboard"]?["components"]?["lime"];
+                Assert.True(converted.Value<bool>("partial"));
+                Assert.Null(converted["type"]);
+                Assert.Equal(new[] { "Piei" }, converted["trackSpanPatch"]?["append"]?.Values<string>());
+
+                var definition = FuseSerializer.FromJson(root.ToString());
+                var component = definition.Operations.Industries["sylva-paperboard"].Components["lime"];
+                Assert.True(component.Partial);
+                Assert.Equal(new[] { "Piei" }, component.TrackSpanPatch.Append);
+                Assert.Null(component.TrackSpanPatch.Replace);
+            }
+
             [Fact]
             public void TrackSpanReplace_RoundTripsAsReplacementPatch()
             {

--- a/FUSE.Tests/Loading/FuseLegacyManifestSourceDetectionTests.cs
+++ b/FUSE.Tests/Loading/FuseLegacyManifestSourceDetectionTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using FUSE.Loading;
+using FUSE.Authoring.Data;
 using Xunit;
 
 namespace FUSE.Tests.Loading
@@ -64,6 +65,60 @@ namespace FUSE.Tests.Loading
             var found = FuseLegacyDataConverter.TryReadLegacyManifest(folder, out _);
 
             Assert.False(found);
+        }
+
+        [Fact]
+        public void ConditionalMixintoRequirement_IsAdvisoryLoadAfter_NotHardRequirement()
+        {
+            var folder = Path.Combine(_root, "Conditional.Mixinto");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(
+                Path.Combine(folder, "Definition.json"),
+                "{\"id\":\"Conditional.Mixinto\",\"mixintos\":{\"game-graph\":{" +
+                "\"mixinto\":\"file(optional.json)\",\"requires\":[\"Optional.Base\"]}}}");
+            File.WriteAllText(
+                Path.Combine(folder, "optional.json"),
+                "{\"nodes\":{\"N1\":{\"position\":{\"x\":1,\"y\":2,\"z\":3}}}}");
+
+            var found = FuseLegacyDataConverter.TryReadLegacyManifest(folder, out var manifest);
+
+            Assert.True(found);
+            Assert.Empty(manifest.RequiredPackageIds);
+            Assert.Contains("Optional.Base.FUSE", manifest.LoadAfter);
+        }
+
+        [Fact]
+        public void LegacyConflictsWith_PreservesVersionBounds()
+        {
+            var folder = Path.Combine(_root, "Legacy.Conflict");
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(
+                Path.Combine(folder, "Definition.json"),
+                "{\"id\":\"Legacy.Conflict\",\"conflictsWith\":[{" +
+                "\"id\":\"Other.Route\",\"notBefore\":\"2.0\",\"notAfter\":\"3.0\"}]}");
+            File.WriteAllText(
+                Path.Combine(folder, "game-graph.json"),
+                "{\"nodes\":{\"N1\":{\"position\":{\"x\":1,\"y\":2,\"z\":3}}}}");
+
+            Assert.True(FuseLegacyDataConverter.TryReadLegacyManifest(folder, out var manifest));
+
+            var conflict = Assert.Single(manifest.ConflictsWith);
+            Assert.Equal("Other.Route", conflict.Id);
+            Assert.Equal("2.0", conflict.NotBefore);
+            Assert.Equal("3.0", conflict.NotAfter);
+        }
+
+        [Fact]
+        public void SyntheticMapTileDefinition_IsNotTreatedAsGameGraphPatch()
+        {
+            var definition = new FuseModDefinition
+            {
+                Id = "Legacy.MapTiles",
+                Tags = new[] { "legacy-converted" }
+            };
+            var loaded = new FuseLoadedMod(_root, "legacy://map-tiles", definition);
+
+            Assert.False(FuseLegacyGameGraphCompatibility.ShouldExpand(loaded));
         }
 
         private string CreatePackage(string id, string graphJson)

--- a/FUSE.Tests/Loading/FuseLoadReportModExceptionsTests.cs
+++ b/FUSE.Tests/Loading/FuseLoadReportModExceptionsTests.cs
@@ -12,10 +12,9 @@ namespace FUSE.Tests.Loading
 {
     /// <summary>
     /// Pins the report surfaces for the third-party exception registry: the
-    /// summary's <c>modErrors</c> segment sits between <c>orphans</c> and the
-    /// <c>/fuse.report</c> suffix, the details section names each mod, the
-    /// JSON block rides beside <c>runtimeGuards</c>, and HasProblems only
-    /// flips for repeated faults (episodes >= 3 or count >= 10 per mod).
+    /// exception counts stay out of the readiness summary while the details
+    /// and structured JSON retain the complete diagnostic evidence. Runtime
+    /// exception observations never change package readiness.
     /// Uses the internal Build*ForTests seams against a hand-built snapshot
     /// so no live capture registries are touched. The exception registry is
     /// static session-cumulative state shared with
@@ -77,11 +76,12 @@ namespace FUSE.Tests.Loading
         }
 
         [Fact]
-        public void Summary_CarriesModErrorsSegment_BetweenOrphansAndReportSuffix_EvenWhenIdle()
+        public void Summary_OmitsRuntimeExceptionNoise()
         {
             var summary = FuseLoadReport.BuildSummaryForTests(CreateEmptySnapshot());
 
-            Assert.Contains("orphans 0 | modErrors 0 | /fuse.report", summary);
+            Assert.Contains("orphans 0 | /fuse.report", summary);
+            Assert.DoesNotContain("modErrors", summary);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace FUSE.Tests.Loading
             var snapshot = CreateEmptySnapshot();
 
             var summary = FuseLoadReport.BuildSummaryForTests(snapshot);
-            Assert.Contains($"modErrors {FuseModExceptionRegistry.GrandTotal} | /fuse.report", summary);
+            Assert.DoesNotContain("modErrors", summary);
 
             var details = FuseLoadReport.BuildDetailsForTests(snapshot);
             Assert.Contains("Third-party mod exceptions observed this session:", details);
@@ -146,7 +146,7 @@ namespace FUSE.Tests.Loading
         }
 
         [Fact]
-        public void HasProblems_IgnoresOneOffException_ButTripsOnRepeats()
+        public void HasProblems_IgnoresOneOffAndRepeatingRuntimeExceptions()
         {
             RecordMapEnhancerStyleException();
             Assert.False(CreateEmptySnapshot().HasProblems);
@@ -158,7 +158,8 @@ namespace FUSE.Tests.Loading
                 RecordMapEnhancerStyleException();
             }
 
-            Assert.True(CreateEmptySnapshot().HasProblems);
+            Assert.False(CreateEmptySnapshot().HasProblems);
+            Assert.True(CreateEmptySnapshot().HasModExceptionProblem);
         }
 
         [Fact]
@@ -199,6 +200,91 @@ namespace FUSE.Tests.Loading
             var json = JObject.Parse(FuseLoadReport.BuildJsonForTests(snapshot));
             Assert.True((bool)json["hasProblems"]);
             Assert.Equal(1, (int)json["counts"]["blockingNotices"]);
+        }
+
+        [Fact]
+        public void PackageFaultLocation_RendersInHumanAndStructuredReports()
+        {
+            var snapshot = CreateEmptySnapshot();
+            snapshot.Faults = new[]
+            {
+                new FusePackageFault(
+                    "Broken.Track",
+                    "schema validation",
+                    "Segment is missing an endpoint.",
+                    "validator details",
+                    @"C:\Railroader\Mods\Broken.Track",
+                    @"C:\Railroader\Mods\Broken.Track\track.fuse.json",
+                    "track.segments.bad.a",
+                    42,
+                    17,
+                    "Add endpoint node a.")
+            };
+
+            var details = FuseLoadReport.BuildDetailsForTests(snapshot);
+            Assert.Contains(@"file: C:\Railroader\Mods\Broken.Track\track.fuse.json", details);
+            Assert.Contains("relative file: track.fuse.json", details);
+            Assert.Contains("JSON location: track.segments.bad.a line 42, position 17", details);
+            Assert.Contains("action: Add endpoint node a.", details);
+
+            var json = JObject.Parse(FuseLoadReport.BuildJsonForTests(snapshot));
+            var fault = (JObject)json["packages"]["faults"][0];
+            Assert.Equal(@"C:\Railroader\Mods\Broken.Track\track.fuse.json", (string)fault["sourceFile"]);
+            Assert.Equal("track.fuse.json", (string)fault["relativeSourceFile"]);
+            Assert.Equal("Broken.Track", (string)fault["packageName"]);
+            Assert.Equal("track.segments.bad.a", (string)fault["jsonPath"]);
+            Assert.Equal(42, (int)fault["lineNumber"]);
+            Assert.Equal("validator details", (string)fault["details"]);
+        }
+
+        [Fact]
+        public void Shared_extension_merge_does_not_inflate_conflicts_or_health()
+        {
+            var snapshot = CreateEmptySnapshot();
+            snapshot.Conflicts = new[]
+            {
+                new FuseRegistryConflict
+                {
+                    Kind = FuseClaimKind.Industry,
+                    Id = "destination:type=teleportLoading,name=Kirkland Valley Coal",
+                    OwnerPackageId = "CF.AndrewsCoalPower.FUSE.patch",
+                    AttemptedPackageId = "Katers.TuckasegeeSteelWorks.FUSE.kirklandcoal",
+                    Resolution = "shared industry destination overlap; definitions merged into the same runtime location"
+                }
+            };
+
+            Assert.Equal(0, snapshot.ActionableConflictCount);
+            Assert.Equal(1, snapshot.CooperativeConflictCount);
+            Assert.False(snapshot.HasProblems);
+
+            var details = FuseLoadReport.BuildDetailsForTests(snapshot);
+            Assert.Contains("Ownership conflicts requiring attention: 0", details);
+            Assert.Contains("shared extension targets merged successfully: 1", details);
+
+            var json = JObject.Parse(FuseLoadReport.BuildJsonForTests(snapshot));
+            Assert.Equal(0, (int)json["counts"]["conflicts"]);
+            Assert.Equal(1, (int)json["counts"]["sharedExtensionOverlaps"]);
+            Assert.Equal("shared-extension", (string)json["conflicts"][0]["classification"]);
+        }
+
+        [Fact]
+        public void Optional_mixinto_skips_are_reported_as_inactive_fragments()
+        {
+            var snapshot = CreateEmptySnapshot();
+            snapshot.AppliedPackageIds = new[] { "Author.Package.base" };
+            snapshot.SkippedPackages = new Dictionary<string, string>
+            {
+                ["Author.Package.optional"] = "mixinto dependency missing id='Optional.Companion'"
+            };
+
+            Assert.False(snapshot.HasProblems);
+            Assert.Empty(snapshot.ActionableSkippedPackages);
+            Assert.Single(snapshot.OptionalSkippedPackages);
+
+            var details = FuseLoadReport.BuildDetailsForTests(snapshot);
+            Assert.Contains("Runtime definitions: resident=0; applied=1; actionable skips=0; optional fragments inactive=1.", details);
+            Assert.Contains("Optional conditional fragments inactive:", details);
+            Assert.DoesNotContain("Skipped packages:", details);
         }
     }
 }

--- a/FUSE.Tests/Loading/FuseLoadReportModExceptionsTests.cs
+++ b/FUSE.Tests/Loading/FuseLoadReportModExceptionsTests.cs
@@ -274,7 +274,9 @@ namespace FUSE.Tests.Loading
             snapshot.AppliedPackageIds = new[] { "Author.Package.base" };
             snapshot.SkippedPackages = new Dictionary<string, string>
             {
-                ["Author.Package.optional"] = "mixinto dependency missing id='Optional.Companion'"
+                ["Author.Package.optional"] =
+                    "package='Author.Package.optional' mixinto dependency missing id='Optional.Companion' " +
+                    "target='game-graph' folder='C:\\Mods\\AuthorPackage' sourceFile='legacy://optional.json'"
             };
 
             Assert.False(snapshot.HasProblems);

--- a/FUSE.Tests/Loading/FuseModRequirementResolverTests.cs
+++ b/FUSE.Tests/Loading/FuseModRequirementResolverTests.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using FUSE.Authoring.Data;
 using FUSE.Loading;
 using Xunit;
@@ -7,6 +10,212 @@ namespace FUSE.Tests.Loading
 {
     public class FuseModRequirementResolverTests
     {
+        [Fact]
+        public void MissingMixintoDependency_IdentifiesPackageFolderFileAndAction()
+        {
+            var dependencyId = "missing." + Guid.NewGuid().ToString("N");
+            var folder = Path.Combine(Path.GetTempPath(), "fuse-requirement-source");
+            var definitionPath = Path.Combine(folder, "track.fuse.json");
+            var loaded = new FuseLoadedMod(
+                folder,
+                definitionPath,
+                new FuseModDefinition
+                {
+                    Id = "author.sample",
+                    Mixinto = new FuseMixintoDefinition
+                    {
+                        Target = "railroader",
+                        Requires = new[] { new FuseModRequirement { Id = dependencyId } }
+                    }
+                });
+
+            var shouldApply = FuseModRequirementResolver.ShouldApply(loaded, out var reason);
+
+            Assert.False(shouldApply);
+            Assert.Contains("package='author.sample'", reason);
+            Assert.Contains($"id='{dependencyId}'", reason);
+            Assert.Contains($"folder='{folder}'", reason);
+            Assert.Contains($"sourceFile='{definitionPath}'", reason);
+            Assert.Contains("action='Install and enable", reason);
+        }
+
+        [Theory]
+        [InlineData("Zamu.StrangeCustoms", "99.0.0")]
+        [InlineData("AlinaNova21.AlinasMapMod", "99.0.0")]
+        [InlineData("AssetLoader", "99.0.0")]
+        public void Replacement_capability_satisfies_mixinto_requirement_without_legacy_version_comparison(
+            string dependencyId,
+            string legacyMinimumVersion)
+        {
+            var loaded = new FuseLoadedMod(
+                "C:\\Mods\\Extension",
+                "C:\\Mods\\Extension\\track.fuse.json",
+                new FuseModDefinition
+                {
+                    Id = "author.extension",
+                    Mixinto = new FuseMixintoDefinition
+                    {
+                        Target = "game-graph",
+                        Requires = new[]
+                        {
+                            new FuseModRequirement { Id = dependencyId, NotBefore = legacyMinimumVersion }
+                        }
+                    }
+                });
+
+            Assert.True(FuseModRequirementResolver.ShouldApply(loaded, out var reason));
+            Assert.Contains("requirements satisfied", reason);
+        }
+
+        [Fact]
+        public void Mixinto_conflictsWith_replacement_capability_skips_only_the_fragment()
+        {
+            var loaded = new FuseLoadedMod(
+                "C:\\Mods\\Conditional",
+                "C:\\Mods\\Conditional\\track.fuse.json",
+                new FuseModDefinition
+                {
+                    Id = "author.conditional",
+                    Mixinto = new FuseMixintoDefinition
+                    {
+                        Target = "game-graph",
+                        ConflictsWith = new[]
+                        {
+                            new FuseModRequirement { Id = "Zamu.StrangeCustoms", NotBefore = "99.0.0" }
+                        }
+                    }
+                });
+
+            Assert.False(FuseModRequirementResolver.ShouldApply(loaded, out var reason));
+            Assert.Contains("mixinto conflict matched", reason);
+            Assert.Contains("intentionally inactive", reason);
+        }
+
+        [Theory]
+        [InlineData("Route.Base", "Route.Base.FUSE", "1.5", "1.0", "2.0", false, true)]
+        [InlineData("Route.Base", "Route.Base.FUSE", "3.0", "1.0", "2.0", false, false)]
+        [InlineData("Route.Base", "Route.Other.FUSE", "1.5", null, null, false, false)]
+        [InlineData("Route.Base", "Route.Base.FUSE", "1.5", null, null, true, false)]
+        public void Declared_package_conflict_matches_alias_version_and_enabled_state(
+            string conflictId,
+            string targetId,
+            string targetVersion,
+            string notBefore,
+            string notAfter,
+            bool disabled,
+            bool expected)
+        {
+            var reference = new FuseModRequirement
+            {
+                Id = conflictId,
+                NotBefore = notBefore,
+                NotAfter = notAfter
+            };
+
+            Assert.Equal(expected, FuseDataPackageDiscovery.IsDeclaredConflictMatch(
+                reference,
+                targetId,
+                targetVersion,
+                disabled));
+        }
+
+        [Theory]
+        [InlineData("1.5", "1.0", "2.0", false, true)]
+        [InlineData("3.0", "1.0", "2.0", false, false)]
+        [InlineData("0.0", "99.0", null, true, true)]
+        public void Top_level_declared_conflict_matches_code_or_asset_package_inventory(
+            string installedVersion,
+            string notBefore,
+            string notAfter,
+            bool replacementCapability,
+            bool expected)
+        {
+            var installed = new FuseModRequirementResolver.InstalledMod
+            {
+                Id = "External.CodeMod",
+                Version = installedVersion,
+                Source = replacementCapability ? "FUSE replacement capability" : "Info.json",
+                IsReplacementCapability = replacementCapability,
+                FolderPath = "C:\\Railroader\\Mods\\ExternalCodeMod"
+            };
+            var inventory = new Dictionary<string, FuseModRequirementResolver.InstalledMod>(StringComparer.OrdinalIgnoreCase)
+            {
+                [installed.Id] = installed
+            };
+
+            var matched = FuseDataPackageDiscovery.TryMatchInstalledConflict(
+                "Author.Package",
+                "C:\\Railroader\\Mods\\AuthorPackage",
+                new FuseModRequirement
+                {
+                    Id = installed.Id,
+                    NotBefore = notBefore,
+                    NotAfter = notAfter
+                },
+                inventory,
+                out var result);
+
+            Assert.Equal(expected, matched);
+            Assert.Equal(expected ? installed : null, result);
+        }
+
+        [Fact]
+        public void Top_level_declared_conflict_does_not_match_declaring_folder_alias()
+        {
+            var installed = new FuseModRequirementResolver.InstalledMod
+            {
+                Id = "Author.Package.Alias",
+                Version = "1.0",
+                Source = "Info.json",
+                FolderPath = "C:\\Railroader\\Mods\\AuthorPackage"
+            };
+            var inventory = new Dictionary<string, FuseModRequirementResolver.InstalledMod>(StringComparer.OrdinalIgnoreCase)
+            {
+                [installed.Id] = installed
+            };
+
+            Assert.False(FuseDataPackageDiscovery.TryMatchInstalledConflict(
+                "Author.Package",
+                "C:\\Railroader\\Mods\\AuthorPackage\\",
+                new FuseModRequirement { Id = installed.Id },
+                inventory,
+                out _));
+        }
+
+        [Fact]
+        public void LegacyContextMods_IncludesInstalledManifestAndFuseReplacementCapabilities()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "fuse-legacy-mods-" + Guid.NewGuid().ToString("N"));
+            var package = Path.Combine(root, "Some Hosted Package");
+            var companion = Path.Combine(root, "Some Kind Of Madness");
+            Directory.CreateDirectory(package);
+            Directory.CreateDirectory(companion);
+            try
+            {
+                File.WriteAllText(
+                    Path.Combine(package, "Definition.json"),
+                    "{ \"id\": \"Joo.Sample\", \"name\": \"Sample\", \"version\": \"2.1\" }");
+                File.WriteAllText(
+                    Path.Combine(companion, "Definition.json"),
+                    "{ \"id\": \"Zamu.SomeKindOfMadness\", \"name\": \"Some Kind Of Madness\", \"version\": \"1.0\" }");
+
+                var mods = FuseLegacyAssemblyHost.EnumerateInstalledMods(root, (_, __) => true);
+
+                Assert.Contains(mods, mod => mod.Id == "Joo.Sample" && mod.IsEnabled && mod.IsLoaded);
+                Assert.Contains(mods, mod => mod.Id == "Zamu.SomeKindOfMadness" && mod.IsEnabled && mod.IsLoaded);
+                Assert.Contains(mods, mod => mod.Id == "Zamu.StrangeCustoms" && mod.IsEnabled && mod.IsLoaded);
+                Assert.Contains(mods, mod => mod.Id == "FUSE" && mod.IsEnabled && mod.IsLoaded);
+                Assert.Equal(mods.Count, mods.Select(mod => mod.Id).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, true);
+                }
+            }
+        }
+
         public class TryParseVersionTests
         {
             [Theory]

--- a/FUSE.Tests/Loading/FusePackageFaultRegistryTests.cs
+++ b/FUSE.Tests/Loading/FusePackageFaultRegistryTests.cs
@@ -177,6 +177,7 @@ namespace FUSE.Tests.Loading
         [Theory]
         [InlineData("mixinto dependency missing id='foo'", true)]
         [InlineData("MIXINTO DEPENDENCY MISSING something", true)]
+        [InlineData("package='Author.Optional' mixinto dependency missing id='Companion.Mod' target='game-graph'", true)]
         [InlineData("some other reason", false)]
         [InlineData("", false)]
         [InlineData(null, false)]

--- a/FUSE.Tests/Loading/FusePackageFaultRegistryTests.cs
+++ b/FUSE.Tests/Loading/FusePackageFaultRegistryTests.cs
@@ -166,6 +166,17 @@ namespace FUSE.Tests.Loading
         }
 
         [Fact]
+        public void MarkDisabled_DoesNotMakePackageAnActionableSkip()
+        {
+            FusePackageFaultRegistry.MarkDisabled("pkg", "disabled by active FUSE mod set");
+
+            Assert.Empty(FusePackageFaultRegistry.GetSkippedPackages());
+            Assert.Equal(
+                "disabled by active FUSE mod set",
+                FusePackageFaultRegistry.GetDisabledPackages()["pkg"]);
+        }
+
+        [Fact]
         public void MarkSkipped_BlankReason_DefaultsTo_Skipped()
         {
             FusePackageFaultRegistry.MarkSkipped("pkg", "   ");

--- a/FUSE.Tests/Loading/FusePackageFaultRegistryTests.cs
+++ b/FUSE.Tests/Loading/FusePackageFaultRegistryTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using FUSE.Loading;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace FUSE.Tests.Loading
@@ -97,6 +98,62 @@ namespace FUSE.Tests.Loading
 
             var fault = Assert.Single(FusePackageFaultRegistry.GetFaults());
             Assert.Contains("inner-detail", fault.Details);
+        }
+
+        [Fact]
+        public void RecordFault_ExtractsJsonLocationAndSourceFile()
+        {
+            Exception exception = null;
+            try
+            {
+                JObject.Parse("{\"track\": [ }");
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            var source = @"C:\Railroader\Mods\BrokenTrack\track.fuse.json";
+            FusePackageFaultRegistry.RecordFault(
+                "BrokenTrack",
+                "JSON deserialization",
+                "Invalid JSON",
+                exception,
+                @"C:\Railroader\Mods\BrokenTrack",
+                source);
+
+            var fault = Assert.Single(FusePackageFaultRegistry.GetFaults());
+            Assert.Equal(source, fault.SourceFile);
+            Assert.Equal("BrokenTrack", fault.PackageName);
+            Assert.Equal("track.fuse.json", fault.RelativeSourceFile);
+            Assert.Equal("track", fault.JsonPath);
+            Assert.True(fault.LineNumber > 0);
+            Assert.Contains("Valid JSON", fault.ExpectedShape);
+            Assert.Contains("Unexpected character", fault.ReceivedValue);
+            Assert.Contains("Correct the JSON", fault.SuggestedAction);
+        }
+
+        [Fact]
+        public void RecordFault_PreservesSchemaExpectationCodeAndReceivedValue()
+        {
+            FusePackageFaultRegistry.RecordFault(
+                "pkg",
+                "schema validation",
+                "Number expected.",
+                folderPath: @"C:\Railroader\Mods\Pretty Folder",
+                sourceFile: @"C:\Railroader\Mods\Pretty Folder\map.fuse.json",
+                jsonPath: "operations.loaders.loader.rate",
+                packageName: "Pretty Package",
+                validationCode: "fuse.number",
+                expectedShape: "A finite number greater than zero.",
+                receivedValue: "fast");
+
+            var fault = Assert.Single(FusePackageFaultRegistry.GetFaults());
+            Assert.Equal("Pretty Package", fault.PackageName);
+            Assert.Equal("map.fuse.json", fault.RelativeSourceFile);
+            Assert.Equal("fuse.number", fault.ValidationCode);
+            Assert.Equal("A finite number greater than zero.", fault.ExpectedShape);
+            Assert.Equal("fast", fault.ReceivedValue);
         }
 
         [Fact]

--- a/FUSE.Tests/Loading/FuseReplacementCapabilityCatalogTests.cs
+++ b/FUSE.Tests/Loading/FuseReplacementCapabilityCatalogTests.cs
@@ -1,0 +1,41 @@
+using FUSE.Loading;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseReplacementCapabilityCatalogTests
+    {
+        [Theory]
+        [InlineData("Zamu.StrangeCustoms")]
+        [InlineData("Zamu.ConfusingSupplements.FUSE")]
+        [InlineData("Zamu.C1CD")]
+        [InlineData("C1CD.FUSE")]
+        [InlineData("Zamu.FallFromGrace")]
+        [InlineData("FallFromGrace.FUSE")]
+        [InlineData("Zamu.AbsoluteMadness")]
+        [InlineData("AbsoluteMadness.FUSE")]
+        [InlineData("Zamu.SomeKindOfMadness")]
+        [InlineData("SomeKindOfMadness.FUSE")]
+        [InlineData("Zamu.Interchange2Interchange")]
+        [InlineData("Interchange2Interchange.FUSE")]
+        [InlineData("AlinaNova21.AlinasMapMod")]
+        [InlineData("AssetLoader")]
+        [InlineData("Railloader.Injector")]
+        [InlineData("Railloader.Interchange.FUSE")]
+        public void IsProvided_accepts_only_declared_replacement_families(string packageId)
+        {
+            Assert.True(FuseReplacementCapabilityCatalog.IsProvided(packageId));
+        }
+
+        [Theory]
+        [InlineData("AlinaNova21.AlinasMapExpansionSW")]
+        [InlineData("Joo.SignalsEverywhere")]
+        [InlineData("C_L_B.DKW")]
+        [InlineData("Embedded.BuildingBlocks")]
+        [InlineData("Zamu.SerialTrafficControl")]
+        public void IsProvided_does_not_waive_real_content_dependencies(string packageId)
+        {
+            Assert.False(FuseReplacementCapabilityCatalog.IsProvided(packageId));
+        }
+    }
+}

--- a/FUSE.Tests/Loading/FuseRmroc451CompatibilityTests.cs
+++ b/FUSE.Tests/Loading/FuseRmroc451CompatibilityTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection;
+using FUSE.Compatibility;
+using FUSE.Loading;
+using HarmonyLib;
+using Railloader;
+using Xunit;
+
+#pragma warning disable CS0618 // This test intentionally exercises the legacy shim.
+
+namespace FUSE.Tests.Loading
+{
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class FuseRmroc451CompatibilityCollection
+    {
+        public const string Name = "RMROC451 real legacy assembly compatibility";
+    }
+
+    /// <summary>
+    /// Opt-in field harness for issue #198. This loads the real third-party
+    /// assembly, resolves its Railloader.Interchange reference through FUSE,
+    /// constructs the plugin with FUSE's independent context, and resolves the
+    /// plugin's real Harmony targets against the installed Railroader API. The
+    /// test host does not patch Unity ECall methods because they require Unity's
+    /// native runtime; successful target resolution is the safe compatibility
+    /// gate available under the net48 xUnit runner.
+    /// </summary>
+    [Collection(FuseRmroc451CompatibilityCollection.Name)]
+    public sealed class FuseRmroc451CompatibilityTests
+    {
+        [Rmroc451RealAssemblyFact]
+        public void Real_plugin_resolves_hosts_and_patches_with_fuse_shim()
+        {
+            var archivePath = Environment.GetEnvironmentVariable("FUSE_TEST_RMROC451_ZIP");
+            var gameDirectory = Environment.GetEnvironmentVariable("FUSE_TEST_GAME_DIR");
+            var managedDirectory = Path.Combine(gameDirectory, "Railroader_Data", "Managed");
+            var extractionRoot = Path.Combine(
+                Path.GetTempPath(),
+                "fuse-rmroc451-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(extractionRoot);
+
+            PluginBase plugin = null;
+            ResolveEventHandler gameAssemblyResolver = (_, args) =>
+            {
+                var requested = new AssemblyName(args.Name).Name;
+                var candidate = Path.Combine(managedDirectory, requested + ".dll");
+                return File.Exists(candidate) ? Assembly.LoadFrom(candidate) : null;
+            };
+            FuseLegacySupportAssemblyShim.Initialize();
+            AppDomain.CurrentDomain.AssemblyResolve += gameAssemblyResolver;
+            try
+            {
+                ZipFile.ExtractToDirectory(archivePath, extractionRoot);
+                var assemblyPath = Directory.GetFiles(
+                        extractionRoot,
+                        "RMROC451.TweaksAndThings.dll",
+                        SearchOption.AllDirectories)
+                    .Single();
+                var packageFolder = Path.GetDirectoryName(assemblyPath);
+                var modsRoot = Directory.GetParent(packageFolder)?.FullName
+                               ?? extractionRoot;
+                var manifest = new FuseLegacyAssemblyManifest
+                {
+                    Id = "RMROC451.TweaksAndThings",
+                    Name = "RMROC451's Tweaks and Things",
+                    Version = "2.1.7",
+                    FolderPath = packageFolder,
+                    Assemblies = new[] { "RMROC451.TweaksAndThings" }
+                };
+                var definition = new FuseLegacyModDefinition(manifest);
+                var context = new FuseLegacyModdingContext(modsRoot);
+                var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+                var pluginType = assembly.GetType(
+                    "RMROC451.TweaksAndThings.TweaksAndThingsPlugin",
+                    throwOnError: true);
+
+                Assert.True(typeof(PluginBase).IsAssignableFrom(pluginType));
+                Assert.True(typeof(IUpdateHandler).IsAssignableFrom(pluginType));
+                Assert.True(typeof(IModTabHandler).IsAssignableFrom(pluginType));
+
+                plugin = (PluginBase)Activator.CreateInstance(
+                    pluginType,
+                    context,
+                    definition);
+                AssertHarmonyTargetsResolve(
+                    assembly,
+                    "RMROC451TweaksAndThings");
+            }
+            finally
+            {
+                AppDomain.CurrentDomain.AssemblyResolve -= gameAssemblyResolver;
+                FuseLegacySupportAssemblyShim.Shutdown();
+                try
+                {
+                    Directory.Delete(extractionRoot, recursive: true);
+                }
+                catch (IOException ex)
+                {
+                    // Assembly.Load(byte[]) normally leaves the extraction
+                    // unlocked. If an old CLR probes a sidecar from this folder,
+                    // the operating system will reclaim the temp folder later.
+                    System.Diagnostics.Trace.TraceWarning(
+                        $"RMROC451 compatibility harness could not remove temporary folder '{extractionRoot}': {ex.Message}");
+                }
+            }
+        }
+
+        private static void AssertHarmonyTargetsResolve(
+            Assembly assembly,
+            string category)
+        {
+            var harmony = new Harmony("FUSE.Tests.RMROC451.TargetAudit");
+            var processorType = typeof(PatchClassProcessor);
+            var getBulkMethods = processorType.GetMethod(
+                "GetBulkMethods",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            var patchMethodsField = processorType.GetField(
+                "patchMethods",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            var getOriginalMethod = typeof(Harmony).Assembly
+                .GetType("HarmonyLib.PatchTools", throwOnError: false)?
+                .GetMethod(
+                    "GetOriginalMethod",
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
+                    null,
+                    new[] { typeof(HarmonyMethod) },
+                    null);
+            Assert.NotNull(getBulkMethods);
+            Assert.NotNull(patchMethodsField);
+            Assert.NotNull(getOriginalMethod);
+
+            var patchClassCount = 0;
+            var resolvedTargetCount = 0;
+            foreach (var type in assembly.GetTypes())
+            {
+                var processor = new PatchClassProcessor(harmony, type);
+                if (!string.Equals(
+                        processor.Category,
+                        category,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                patchClassCount++;
+                var bulkMethods = (System.Collections.IEnumerable)
+                    getBulkMethods.Invoke(processor, null);
+                var bulkCount = 0;
+                foreach (var target in bulkMethods)
+                {
+                    Assert.NotNull(target);
+                    bulkCount++;
+                    resolvedTargetCount++;
+                }
+                if (bulkCount > 0)
+                {
+                    continue;
+                }
+
+                var patchMethods = (System.Collections.IEnumerable)
+                    patchMethodsField.GetValue(processor);
+                foreach (var patch in patchMethods)
+                {
+                    var info = (HarmonyMethod)patch.GetType()
+                        .GetField("info", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                        .GetValue(patch);
+                    Assert.NotNull(info.method);
+                    Assert.NotNull(getOriginalMethod.Invoke(null, new object[] { info }));
+                    resolvedTargetCount++;
+                }
+            }
+
+            Assert.True(patchClassCount > 0, "No RMROC451 Harmony patch classes were discovered.");
+            Assert.True(resolvedTargetCount > 0, "No RMROC451 Harmony targets resolved against the installed game.");
+        }
+    }
+
+    internal sealed class Rmroc451RealAssemblyFactAttribute : FactAttribute
+    {
+        public Rmroc451RealAssemblyFactAttribute()
+        {
+            var archivePath = Environment.GetEnvironmentVariable("FUSE_TEST_RMROC451_ZIP");
+            if (string.IsNullOrWhiteSpace(archivePath) || !File.Exists(archivePath))
+            {
+                Skip = "Opt-in real RMROC451 harness: set FUSE_TEST_RMROC451_ZIP to RMROC451.TweaksAndThings.zip.";
+                return;
+            }
+
+            var gameDirectory = Environment.GetEnvironmentVariable("FUSE_TEST_GAME_DIR");
+            if (string.IsNullOrWhiteSpace(gameDirectory) ||
+                !File.Exists(Path.Combine(gameDirectory, "Railroader_Data", "Managed", "Serilog.dll")))
+            {
+                Skip = "Opt-in real RMROC451 harness: set FUSE_TEST_GAME_DIR to a Railroader installation.";
+            }
+        }
+    }
+}
+
+#pragma warning restore CS0618

--- a/FUSE.Tests/Loading/FuseSpatialTrackConflictDetectorTests.cs
+++ b/FUSE.Tests/Loading/FuseSpatialTrackConflictDetectorTests.cs
@@ -1,0 +1,92 @@
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using System.Collections.Generic;
+using UnityEngine;
+using Xunit;
+
+namespace FUSE.Tests.Loading
+{
+    public sealed class FuseSpatialTrackConflictDetectorTests
+    {
+        [Fact]
+        public void Detect_reports_two_independent_track_layouts_with_multiple_nearby_nodes()
+        {
+            var conflicts = FuseSpatialTrackConflictDetector.Detect(new[]
+            {
+                Package("yard-a", "C:\\Mods\\YardA", ("a1", 100f, 200f), ("a2", 130f, 230f)),
+                Package("yard-b", "C:\\Mods\\YardB", ("b1", 105f, 203f), ("b2", 138f, 235f))
+            });
+
+            var conflict = Assert.Single(conflicts);
+            Assert.StartsWith("spatial-overlap:", conflict.Id);
+            Assert.Contains("both packages retained", conflict.Resolution);
+            Assert.Equal("yard-a", conflict.OwnerPackageId);
+            Assert.Equal("yard-b", conflict.AttemptedPackageId);
+        }
+
+        [Fact]
+        public void Detect_ignores_a_single_shared_connection_point()
+        {
+            var conflicts = FuseSpatialTrackConflictDetector.Detect(new[]
+            {
+                Package("extension-a", "C:\\Mods\\A", ("a1", 100f, 200f), ("a2", 130f, 230f)),
+                Package("extension-b", "C:\\Mods\\B", ("b1", 105f, 203f), ("b2", 500f, 600f))
+            });
+
+            Assert.Empty(conflicts);
+        }
+
+        [Fact]
+        public void Detect_ignores_definition_fragments_from_the_same_package_folder()
+        {
+            var conflicts = FuseSpatialTrackConflictDetector.Detect(new[]
+            {
+                Package("package.track", "C:\\Mods\\OnePackage", ("a1", 100f, 200f), ("a2", 130f, 230f)),
+                Package("package.spans", "C:\\Mods\\OnePackage", ("b1", 105f, 203f), ("b2", 138f, 235f))
+            });
+
+            Assert.Empty(conflicts);
+        }
+
+        [Fact]
+        public void Detect_ignores_declared_base_and_extension_layering()
+        {
+            var basePackage = Package(
+                "Katers.SylvaInterchange.FUSE",
+                "C:\\Mods\\SylvaBase",
+                ("a1", 100f, 200f),
+                ("a2", 130f, 230f));
+            var extension = Package(
+                "Katers.SylvaInterchangeHYSpans.FUSE",
+                "C:\\Mods\\SylvaHYSpans",
+                ("b1", 105f, 203f),
+                ("b2", 138f, 235f));
+            extension.RequiredPackageIds = new[] { "Katers.SylvaInterchange" };
+
+            var conflicts = FuseSpatialTrackConflictDetector.Detect(new[] { basePackage, extension });
+
+            Assert.Empty(conflicts);
+        }
+
+        private static FuseSpatialTrackPackage Package(
+            string id,
+            string folder,
+            params (string id, float x, float z)[] nodes)
+        {
+            var tracks = new FuseTrackDefinition();
+            foreach (var node in nodes)
+            {
+                tracks.Nodes[node.id] = new FuseNode { Position = new Vector3(node.x, 500f, node.z) };
+            }
+
+            tracks.Segments["segment-1"] = new FuseSegment();
+            tracks.Segments["segment-2"] = new FuseSegment();
+            return new FuseSpatialTrackPackage
+            {
+                PackageId = id,
+                FolderPath = folder,
+                TrackDefinitions = new[] { tracks }
+            };
+        }
+    }
+}

--- a/FUSE.Tests/Migrations/FuseMigrationTests.cs
+++ b/FUSE.Tests/Migrations/FuseMigrationTests.cs
@@ -179,6 +179,19 @@ namespace FUSE.Tests.Migrations
             }
 
             [Fact]
+            public void Initializes_NullWaterSurfaceContainers()
+            {
+                var definition = new FuseModDefinition();
+                definition.World.WaterSurfaces = null;
+                definition.World.Removals.WaterSurfaces = null;
+
+                FuseMigration.Normalize(definition);
+
+                Assert.NotNull(definition.World.WaterSurfaces);
+                Assert.NotNull(definition.World.Removals.WaterSurfaces);
+            }
+
+            [Fact]
             public void IsIdempotent_RunningTwiceProducesSameResult()
             {
                 var definition = new FuseModDefinition

--- a/FUSE.Tests/Patches/FuseAlinasUtilitiesCompatibilityTests.cs
+++ b/FUSE.Tests/Patches/FuseAlinasUtilitiesCompatibilityTests.cs
@@ -27,7 +27,7 @@ namespace FUSE.Tests.Patches
             var current = new object();
             var umm = new object();
 
-            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettingsForTests(
+            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettings(
                 current,
                 umm,
                 () => new object());
@@ -41,7 +41,7 @@ namespace FUSE.Tests.Patches
             var umm = new object();
             var created = false;
 
-            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettingsForTests(
+            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettings(
                 null,
                 umm,
                 () =>
@@ -59,7 +59,7 @@ namespace FUSE.Tests.Patches
         {
             var fallback = new object();
 
-            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettingsForTests(
+            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettings(
                 null,
                 null,
                 () => fallback);

--- a/FUSE.Tests/Patches/FuseAlinasUtilitiesCompatibilityTests.cs
+++ b/FUSE.Tests/Patches/FuseAlinasUtilitiesCompatibilityTests.cs
@@ -1,0 +1,70 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public class FuseAlinasUtilitiesCompatibilityTests
+    {
+        [Theory]
+        [InlineData("AlinasUtils", true)]
+        [InlineData("AlinasUtils1", true)]
+        [InlineData("alinasutils-recovered", true)]
+        [InlineData("Utilities", false)]
+        [InlineData("AlinasMapMod", false)]
+        [InlineData(null, false)]
+        public void AssemblyMatch_AcceptsRecoveredAlinasUtilitiesIdentities(
+            string assemblyName,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseAlinasUtilitiesCompatibility.IsTargetAssemblyName(assemblyName));
+        }
+
+        [Fact]
+        public void SettingsResolution_PreservesCurrentInstance()
+        {
+            var current = new object();
+            var umm = new object();
+
+            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettingsForTests(
+                current,
+                umm,
+                () => new object());
+
+            Assert.Same(current, resolved);
+        }
+
+        [Fact]
+        public void SettingsResolution_UsesUmmSettingsBeforeDefault()
+        {
+            var umm = new object();
+            var created = false;
+
+            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettingsForTests(
+                null,
+                umm,
+                () =>
+                {
+                    created = true;
+                    return new object();
+                });
+
+            Assert.Same(umm, resolved);
+            Assert.False(created);
+        }
+
+        [Fact]
+        public void SettingsResolution_CreatesDefaultAsLastResort()
+        {
+            var fallback = new object();
+
+            var resolved = FuseAlinasUtilitiesCompatibility.ResolveSettingsForTests(
+                null,
+                null,
+                () => fallback);
+
+            Assert.Same(fallback, resolved);
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseAssetLoaderReplacementCompatibilityTests.cs
+++ b/FUSE.Tests/Patches/FuseAssetLoaderReplacementCompatibilityTests.cs
@@ -1,0 +1,20 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public class FuseAssetLoaderReplacementCompatibilityTests
+    {
+        [Theory]
+        [InlineData("AssetLoader", true)]
+        [InlineData("assetloader", true)]
+        [InlineData("FUSE", false)]
+        [InlineData("SomeAssetPack", false)]
+        [InlineData(null, false)]
+        public void AssemblyMatch_IsExactAndCaseInsensitive(string assemblyName, bool expected)
+        {
+            Assert.Equal(expected,
+                FuseAssetLoaderReplacementCompatibility.IsTargetAssemblyName(assemblyName));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseC1CdCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseC1CdCompatibilityPatchTests.cs
@@ -1,0 +1,58 @@
+using FUSE.Patches;
+using Game;
+using HarmonyLib;
+using Model.Ops;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseC1CdCompatibilityPatchTests
+    {
+        [Theory]
+        [InlineData(0, 8f, 150, 0f, 24f, 0, 10.5f)]
+        [InlineData(0, 4f, 30, 6f, 18f, 0, 6f)]
+        [InlineData(0, 17f, 120, 6f, 18f, 1, 6f)]
+        [InlineData(0, 12f, 30, 22f, 6f, 0, 22f)]
+        [InlineData(0, 23f, 30, 22f, 6f, 0, 23.5f)]
+        public void Schedule_policy_respects_interval_and_service_window(
+            int day,
+            float hour,
+            int interval,
+            float notBefore,
+            float notAfter,
+            int expectedDay,
+            float expectedHour)
+        {
+            var actual = FuseC1CdSchedulePolicy.CalculateNextServiceTime(
+                new GameDateTime(day, hour),
+                interval,
+                notBefore,
+                notAfter);
+
+            Assert.Equal(expectedDay, actual.Day);
+            Assert.Equal(expectedHour, actual.Hours, 3);
+        }
+
+        [Fact]
+        public void Schedule_policy_rejects_non_positive_interval_without_hanging()
+        {
+            var actual = FuseC1CdSchedulePolicy.CalculateNextServiceTime(
+                new GameDateTime(2, 8f),
+                0,
+                0f,
+                24f);
+
+            Assert.Equal(2, actual.Day);
+            Assert.Equal(10.5f, actual.Hours, 3);
+        }
+
+        [Fact]
+        public void Patch_targets_current_static_service_method()
+        {
+            Assert.NotNull(AccessTools.Method(
+                typeof(Interchange),
+                nameof(Interchange.NextAvailableServiceTime),
+                new[] { typeof(GameDateTime) }));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseC1CdCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseC1CdCompatibilityPatchTests.cs
@@ -1,3 +1,4 @@
+using FUSE.Infrastructure;
 using FUSE.Patches;
 using Game;
 using HarmonyLib;

--- a/FUSE.Tests/Patches/FuseC1CdCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseC1CdCompatibilityPatchTests.cs
@@ -36,14 +36,17 @@ namespace FUSE.Tests.Patches
         [Fact]
         public void Schedule_policy_rejects_non_positive_interval_without_hanging()
         {
+            var expected = new GameDateTime(2, 8f)
+                .AddingMinutes(FuseSettings.NormalizeInterchangeServiceIntervalMinutes(0))
+                .RoundingMinutes(5);
             var actual = FuseC1CdSchedulePolicy.CalculateNextServiceTime(
                 new GameDateTime(2, 8f),
                 0,
                 0f,
                 24f);
 
-            Assert.Equal(2, actual.Day);
-            Assert.Equal(10.5f, actual.Hours, 3);
+            Assert.Equal(expected.Day, actual.Day);
+            Assert.Equal(expected.Hours, actual.Hours, 3);
         }
 
         [Fact]

--- a/FUSE.Tests/Patches/FuseCompanyStarterPlacementPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseCompanyStarterPlacementPatchTests.cs
@@ -1,0 +1,63 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseCompanyStarterPlacementPatchTests
+    {
+        [Fact]
+        public void StarterPool_RequiresAppalachianWhittierStartDefinition()
+        {
+            Assert.False(
+                FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
+                    "ewh-company",
+                    new[] { "FUSE", "Some.Other.Mod" }));
+            Assert.True(
+                FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
+                    "ewh-company",
+                    new[]
+                    {
+                        "FUSE",
+                        "KingG.Appalachian-Railway.start-whit",
+                    }));
+        }
+
+        [Fact]
+        public void StarterPool_DoesNotAffectOtherCompanyStarts()
+        {
+            var loaded = new[]
+            {
+                "KingG.Appalachian-Railway.start-whit",
+            };
+
+            Assert.False(
+                FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
+                    "ela-company",
+                    loaded));
+            Assert.False(
+                FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
+                    "",
+                    loaded));
+        }
+
+        [Theory]
+        [InlineData(false, 3, 0, false)]
+        [InlineData(true, 3, 0, false)]
+        [InlineData(true, 3, 2, false)]
+        [InlineData(true, 3, 3, true)]
+        [InlineData(true, 0, 0, false)]
+        public void StarterPool_ConsumesCutOnlyAfterConfirmedCompletePlacement(
+            bool callbackReportedPlaced,
+            int expectedCarCount,
+            int placedCarCount,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseCompanyStarterPlacementPatch.WasPlacementCommitted(
+                    callbackReportedPlaced,
+                    expectedCarCount,
+                    placedCarCount));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseCompanyStarterPlacementPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseCompanyStarterPlacementPatchTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using FUSE.Patches;
 using Xunit;
 
@@ -38,6 +39,29 @@ namespace FUSE.Tests.Patches
                 FuseCompanyStarterPlacementPatch.ShouldQueueStarterSetup(
                     "",
                     loaded));
+        }
+
+        [Theory]
+        [InlineData(false, false, false, 1)]
+        [InlineData(true, true, false, 1)]
+        [InlineData(true, false, true, 0)]
+        public void StarterPool_PreparesQueueOnlyForEligibleInactiveSetup(
+            bool shouldQueue,
+            bool presentationActive,
+            bool expectedPrepared,
+            int expectedRemaining)
+        {
+            var pending = new Queue<string>();
+            pending.Enqueue("retained-cut");
+
+            var prepared =
+                FuseCompanyStarterPlacementPatch.TryPrepareStarterQueue(
+                    pending,
+                    shouldQueue,
+                    presentationActive);
+
+            Assert.Equal(expectedPrepared, prepared);
+            Assert.Equal(expectedRemaining, pending.Count);
         }
 
         [Theory]

--- a/FUSE.Tests/Patches/FuseCompanyStarterPlacementPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseCompanyStarterPlacementPatchTests.cs
@@ -83,5 +83,28 @@ namespace FUSE.Tests.Patches
                     expectedCarCount,
                     placedCarCount));
         }
+
+        [Theory]
+        [InlineData(false, 0, false, 1)]
+        [InlineData(true, 0, true, 0)]
+        [InlineData(true, 1, false, 1)]
+        public void StarterPool_DiscardsOnlySuccessfullyPreparedEmptyCuts(
+            bool preparationSucceeded,
+            int descriptorCount,
+            bool expectedConsumed,
+            int expectedRemaining)
+        {
+            var pending = new Queue<string>();
+            pending.Enqueue("retained-cut");
+
+            var consumed =
+                FuseCompanyStarterPlacementPatch.TryConsumeConfirmedEmpty(
+                    pending,
+                    preparationSucceeded,
+                    descriptorCount);
+
+            Assert.Equal(expectedConsumed, consumed);
+            Assert.Equal(expectedRemaining, pending.Count);
+        }
     }
 }

--- a/FUSE.Tests/Patches/FuseCustomIndustryTitlePatchTests.cs
+++ b/FUSE.Tests/Patches/FuseCustomIndustryTitlePatchTests.cs
@@ -1,6 +1,4 @@
-using System.Runtime.Serialization;
 using FUSE.Patches;
-using Model.Ops;
 using StrangeCustoms.Tracks.Industries;
 using Xunit;
 
@@ -15,29 +13,38 @@ namespace FUSE.Tests.Patches
         }
 
         [Fact]
-        public void Prefix_UsesLegacyCustomIndustryTitleContract()
+        public void TryGetCustomTitle_UsesLegacyCustomIndustryTitleContract()
         {
-            var component = (FakeTitledComponent)FormatterServices
-                .GetUninitializedObject(typeof(FakeTitledComponent));
-            var result = string.Empty;
+            var component = new FakeTitledComponent("Acquire coal at test depot");
 
-            var runOriginal = FuseCustomIndustryTitlePatch.Prefix(component, ref result);
+            var found = FuseCustomIndustryTitlePatch.TryGetCustomTitle(component, out var title);
 
-            Assert.False(runOriginal);
-            Assert.Equal("Acquire coal at test depot", result);
+            Assert.True(found);
+            Assert.Equal("Acquire coal at test depot", title);
         }
 
-        private sealed class FakeTitledComponent : IndustryComponent, ICustomIndustryTitle
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void TryGetCustomTitle_RejectsMissingTitle(string value)
         {
-            public string Title => "Acquire coal at test depot";
+            var component = new FakeTitledComponent(value);
 
-            public override void OrderCars(IIndustryContext ctx)
+            var found = FuseCustomIndustryTitlePatch.TryGetCustomTitle(component, out var title);
+
+            Assert.False(found);
+            Assert.Equal(value, title);
+        }
+
+        private sealed class FakeTitledComponent : ICustomIndustryTitle
+        {
+            internal FakeTitledComponent(string title)
             {
+                Title = title;
             }
 
-            public override void Service(IIndustryContext ctx)
-            {
-            }
+            public string Title { get; }
         }
     }
 }

--- a/FUSE.Tests/Patches/FuseCustomIndustryTitlePatchTests.cs
+++ b/FUSE.Tests/Patches/FuseCustomIndustryTitlePatchTests.cs
@@ -1,0 +1,43 @@
+using System.Runtime.Serialization;
+using FUSE.Patches;
+using Model.Ops;
+using StrangeCustoms.Tracks.Industries;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseCustomIndustryTitlePatchTests
+    {
+        [Fact]
+        public void TargetMethod_ResolvesCurrentGamePickerTitleMethod()
+        {
+            Assert.NotNull(FuseCustomIndustryTitlePatch.TargetMethod());
+        }
+
+        [Fact]
+        public void Prefix_UsesLegacyCustomIndustryTitleContract()
+        {
+            var component = (FakeTitledComponent)FormatterServices
+                .GetUninitializedObject(typeof(FakeTitledComponent));
+            var result = string.Empty;
+
+            var runOriginal = FuseCustomIndustryTitlePatch.Prefix(component, ref result);
+
+            Assert.False(runOriginal);
+            Assert.Equal("Acquire coal at test depot", result);
+        }
+
+        private sealed class FakeTitledComponent : IndustryComponent, ICustomIndustryTitle
+        {
+            public string Title => "Acquire coal at test depot";
+
+            public override void OrderCars(IIndustryContext ctx)
+            {
+            }
+
+            public override void Service(IIndustryContext ctx)
+            {
+            }
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseFallFromGraceCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseFallFromGraceCompatibilityPatchTests.cs
@@ -15,6 +15,7 @@ namespace FUSE.Tests.Patches
         [InlineData(2, 0, 2, 1, 5)]
         [InlineData(0, 3, 1, 0, 3)]
         [InlineData(2, 0, int.MaxValue, int.MaxValue, int.MaxValue)]
+        [InlineData(int.MaxValue, int.MinValue, -2, 0, int.MinValue)]
         public void Grace_adjustment_is_identity_configurable_and_overflow_safe(
             int baseDays,
             int minimum,

--- a/FUSE.Tests/Patches/FuseFallFromGraceCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseFallFromGraceCompatibilityPatchTests.cs
@@ -1,0 +1,52 @@
+using FUSE.Patches;
+using HarmonyLib;
+using Model.Ops;
+using Track;
+using UI.Builder;
+using UI.CarInspector;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseFallFromGraceCompatibilityPatchTests
+    {
+        [Theory]
+        [InlineData(0, 0, 1, 0, 0)]
+        [InlineData(2, 0, 2, 1, 5)]
+        [InlineData(0, 3, 1, 0, 3)]
+        [InlineData(2, 0, int.MaxValue, int.MaxValue, int.MaxValue)]
+        public void Grace_adjustment_is_identity_configurable_and_overflow_safe(
+            int baseDays,
+            int minimum,
+            int multiplier,
+            int added,
+            int expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseFallFromGraceCalculationPatch.AdjustGraceDays(baseDays, minimum, multiplier, added));
+        }
+
+        [Fact]
+        public void Grace_patch_targets_the_location_overload()
+        {
+            var target = AccessTools.Method(
+                typeof(OpsController),
+                "CalculateGraceDays",
+                new[] { typeof(Location), typeof(Location) });
+
+            Assert.NotNull(target);
+        }
+
+        [Fact]
+        public void Inspector_patch_targets_the_waybill_panel_overload()
+        {
+            var target = AccessTools.Method(
+                typeof(CarInspector),
+                "PopulateWaybillPanel",
+                new[] { typeof(UIPanelBuilder), typeof(Waybill) });
+
+            Assert.NotNull(target);
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseForYourConvenienceCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseForYourConvenienceCompatibilityPatchTests.cs
@@ -1,0 +1,64 @@
+using FUSE.Patches;
+using HarmonyLib;
+using Model;
+using UI.Map;
+using UI.Tags;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseForYourConvenienceCompatibilityPatchTests
+    {
+        [Theory]
+        [InlineData(0f, "0.0 MPH")]
+        [InlineData(10f, "22.4 MPH")]
+        [InlineData(-10f, "22.4 MPH")]
+        public void Speed_is_displayed_as_absolute_mph(float metersPerSecond, string expected)
+        {
+            Assert.Equal(expected, FuseForYourConveniencePolicy.FormatSpeed(metersPerSecond));
+        }
+
+        [Theory]
+        [InlineData(5f, 10f, "Coal", "50% Coal")]
+        [InlineData(50f, 10f, "Coal", "100% Coal")]
+        [InlineData(5f, 0f, null, "0% Unknown load")]
+        public void Load_summary_is_bounded_and_handles_bad_capacity(
+            float quantity,
+            float capacity,
+            string description,
+            string expected)
+        {
+            Assert.Equal(expected,
+                FuseForYourConveniencePolicy.FormatLoad(quantity, capacity, description));
+        }
+
+        [Theory]
+        [InlineData("Whittier", "whittier", null, true)]
+        [InlineData("Whittier Station", "WHITTIER_AREA", null, true)]
+        [InlineData("Bryson Depot", null, "bryson-depot", true)]
+        [InlineData("Whittier Saw Mill", "whittier", null, false)]
+        [InlineData("Whittier Saw Mill", "bryson", "bryson-depot", false)]
+        [InlineData("R1", "r1", null, false)]
+        public void Station_actions_require_a_matching_named_icon(
+            string iconIdentity,
+            string areaId,
+            string passengerStopId,
+            bool expected)
+        {
+            Assert.Equal(
+                expected,
+                FuseForYourConvenienceStationMapPatch.IsStationIdentityMatch(
+                    iconIdentity,
+                    areaId,
+                    passengerStopId));
+        }
+
+        [Fact]
+        public void Harmony_targets_match_the_installed_game_contract()
+        {
+            Assert.NotNull(AccessTools.Method(typeof(Car), nameof(Car.Setup)));
+            Assert.NotNull(AccessTools.Method(typeof(TagController), "UpdateTag"));
+            Assert.NotNull(AccessTools.Method(typeof(MapBuilder), nameof(MapBuilder.Rebuild)));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseInterchangeToInterchangeCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseInterchangeToInterchangeCompatibilityPatchTests.cs
@@ -14,7 +14,10 @@ namespace FUSE.Tests.Patches
         [InlineData(30, 2f, 60)]
         [InlineData(30, 0f, 0)]
         [InlineData(-1, 1f, 0)]
-        [InlineData(200, 2f, 200)]
+        [InlineData(
+            FuseSettings.InterchangeToInterchangeMaximumCarsLimit,
+            2f,
+            FuseSettings.InterchangeToInterchangeMaximumCarsLimit)]
         public void Maximum_cut_policy_is_bounded(
             int configured,
             float multiplier,
@@ -27,7 +30,7 @@ namespace FUSE.Tests.Patches
         [Theory]
         [InlineData(-1, 0)]
         [InlineData(30, 30)]
-        [InlineData(999, 200)]
+        [InlineData(999, FuseSettings.InterchangeToInterchangeMaximumCarsLimit)]
         public void User_setting_is_bounded(int value, int expected)
         {
             Assert.Equal(expected, FuseSettings.ClampInterchangeToInterchangeMaximumCars(value));

--- a/FUSE.Tests/Patches/FuseInterchangeToInterchangeCompatibilityPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseInterchangeToInterchangeCompatibilityPatchTests.cs
@@ -1,0 +1,43 @@
+using FUSE.Infrastructure;
+using FUSE.Patches;
+using HarmonyLib;
+using Model.Ops;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseInterchangeToInterchangeCompatibilityPatchTests
+    {
+        [Theory]
+        [InlineData(30, 1f, 30)]
+        [InlineData(30, 0.5f, 15)]
+        [InlineData(30, 2f, 60)]
+        [InlineData(30, 0f, 0)]
+        [InlineData(-1, 1f, 0)]
+        [InlineData(200, 2f, 200)]
+        public void Maximum_cut_policy_is_bounded(
+            int configured,
+            float multiplier,
+            int expected)
+        {
+            Assert.Equal(expected,
+                FuseInterchangeToInterchangePolicy.ScaleMaximumCars(configured, multiplier));
+        }
+
+        [Theory]
+        [InlineData(-1, 0)]
+        [InlineData(30, 30)]
+        [InlineData(999, 200)]
+        public void User_setting_is_bounded(int value, int expected)
+        {
+            Assert.Equal(expected, FuseSettings.ClampInterchangeToInterchangeMaximumCars(value));
+        }
+
+        [Fact]
+        public void Harmony_targets_match_the_installed_game_contract()
+        {
+            Assert.NotNull(AccessTools.Method(typeof(Interchange), nameof(Interchange.OrderCars)));
+            Assert.NotNull(AccessTools.Method(typeof(OpsController), "RebuildCollections"));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseLegosLibraryCompatibilityTests.cs
+++ b/FUSE.Tests/Patches/FuseLegosLibraryCompatibilityTests.cs
@@ -1,4 +1,6 @@
 using FUSE.Patches;
+using Model.Definition;
+using System.Collections.Generic;
 using Xunit;
 
 namespace FUSE.Tests.Patches
@@ -20,6 +22,28 @@ namespace FUSE.Tests.Patches
         {
             Assert.False(FuseLegosLibraryCompatibility.IsCompletedIteratorState(null));
             Assert.False(FuseLegosLibraryCompatibility.IsCompletedIteratorState("-2"));
+        }
+
+        [Fact]
+        public void Container_fast_path_skips_unrelated_definition_stores()
+        {
+            var container = new Container();
+            container.Objects.Add(new ContainerItem { Identifier = "unrelated-car" });
+
+            Assert.False(FuseLegosLibraryCompatibility.ContainerMayContainEditedDefinition(
+                container,
+                new HashSet<string> { "edited-car" }));
+        }
+
+        [Fact]
+        public void Container_fast_path_preserves_stores_targeted_by_lego_edits()
+        {
+            var container = new Container();
+            container.Objects.Add(new ContainerItem { Identifier = "edited-car" });
+
+            Assert.True(FuseLegosLibraryCompatibility.ContainerMayContainEditedDefinition(
+                container,
+                new HashSet<string> { "edited-car" }));
         }
     }
 }

--- a/FUSE.Tests/Patches/FuseLegosLibraryCompatibilityTests.cs
+++ b/FUSE.Tests/Patches/FuseLegosLibraryCompatibilityTests.cs
@@ -1,0 +1,25 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public class FuseLegosLibraryCompatibilityTests
+    {
+        [Theory]
+        [InlineData(-2, true)]
+        [InlineData(-1, false)]
+        [InlineData(0, false)]
+        [InlineData(1, false)]
+        public void Detail_model_refresh_runs_only_after_iterator_completion(int state, bool expected)
+        {
+            Assert.Equal(expected, FuseLegosLibraryCompatibility.IsCompletedIteratorState(state));
+        }
+
+        [Fact]
+        public void Detail_model_refresh_rejects_missing_or_unexpected_state_values()
+        {
+            Assert.False(FuseLegosLibraryCompatibility.IsCompletedIteratorState(null));
+            Assert.False(FuseLegosLibraryCompatibility.IsCompletedIteratorState("-2"));
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseLocationPickerDeduplicationPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseLocationPickerDeduplicationPatchTests.cs
@@ -34,6 +34,32 @@ namespace FUSE.Tests.Patches
         }
 
         [Fact]
+        public void DeduplicateByKey_PreservesSourceWhenKeySelectorIsNull()
+        {
+            var source = new[] { "sawmill-mp1", "sawmill-mp2" };
+
+            var removed = FuseLocationPickerDeduplicationPatch.DeduplicateByKey(
+                source,
+                null,
+                out var result);
+
+            Assert.Equal(0, removed);
+            Assert.Equal(source, result);
+        }
+
+        [Fact]
+        public void DeduplicateByKey_ReturnsEmptyResultForNullSource()
+        {
+            var removed = FuseLocationPickerDeduplicationPatch.DeduplicateByKey<string>(
+                null,
+                value => value,
+                out var result);
+
+            Assert.Equal(0, removed);
+            Assert.Empty(result);
+        }
+
+        [Fact]
         public void ResolveCanonicalByKey_ReturnsRetainedEquivalentInstance()
         {
             var retained = new Item("sawmill-mp1", 1);

--- a/FUSE.Tests/Patches/FuseLocationPickerDeduplicationPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseLocationPickerDeduplicationPatchTests.cs
@@ -1,0 +1,62 @@
+using FUSE.Patches;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseLocationPickerDeduplicationPatchTests
+    {
+        [Fact]
+        public void DeduplicateByKey_CollapsesEquivalentKeysAndPreservesOrder()
+        {
+            var source = new[] { "sawmill-mp1", "SAWMILL-MP1", "sawmill-mp2" };
+
+            var removed = FuseLocationPickerDeduplicationPatch.DeduplicateByKey(
+                source,
+                value => value,
+                out var result);
+
+            Assert.Equal(1, removed);
+            Assert.Equal(new[] { "sawmill-mp1", "sawmill-mp2" }, result);
+        }
+
+        [Fact]
+        public void DeduplicateByKey_PreservesRowsWhoseIdentityCannotBeResolved()
+        {
+            var source = new[] { "broken-one", "broken-two" };
+
+            var removed = FuseLocationPickerDeduplicationPatch.DeduplicateByKey(
+                source,
+                _ => null,
+                out var result);
+
+            Assert.Equal(0, removed);
+            Assert.Equal(source, result);
+        }
+
+        [Fact]
+        public void ResolveCanonicalByKey_ReturnsRetainedEquivalentInstance()
+        {
+            var retained = new Item("sawmill-mp1", 1);
+            var duplicate = new Item("SAWMILL-MP1", 2);
+
+            var selected = FuseLocationPickerDeduplicationPatch.ResolveCanonicalByKey(
+                duplicate,
+                new[] { retained },
+                item => item.Id);
+
+            Assert.Same(retained, selected);
+        }
+
+        private sealed class Item
+        {
+            internal Item(string id, int instance)
+            {
+                Id = id;
+                Instance = instance;
+            }
+
+            internal string Id { get; }
+            internal int Instance { get; }
+        }
+    }
+}

--- a/FUSE.Tests/Patches/FuseMessengerIsolationPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseMessengerIsolationPatchTests.cs
@@ -6,6 +6,7 @@ using FUSE.Patches;
 using GalaSoft.MvvmLight.Helpers;
 using Game.Events;
 using HarmonyLib;
+using Railloader.Events;
 using Xunit;
 
 namespace FUSE.Tests.Patches
@@ -64,9 +65,10 @@ namespace FUSE.Tests.Patches
         }
 
         [Fact]
-        public void TargetMethods_CoverAllFourLifecycleEvents_WithBothDispatchEntries()
+        public void TargetMethods_CoverLifecycleAndLegacyDebugEvents_WithBothDispatchEntries()
         {
-            // Full expected surface: four lifecycle structs, two dispatch
+            // Full expected surface: four lifecycle structs plus the legacy
+            // debug-report contribution event, two dispatch
             // entries each. Compile-time typeofs again so any single
             // event going missing or changing shape raises an alarm here
             // instead of a runtime "stays unguarded" warning nobody reads.
@@ -75,7 +77,8 @@ namespace FUSE.Tests.Patches
                 typeof(MapWillLoadEvent),
                 typeof(MapDidLoadEvent),
                 typeof(MapWillUnloadEvent),
-                typeof(MapDidUnloadEvent)
+                typeof(MapDidUnloadEvent),
+                typeof(WillCopyDebugInformation)
             };
 
             var expected = new HashSet<MethodBase>();

--- a/FUSE.Tests/Patches/FuseOutboundIndustryRoutingPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseOutboundIndustryRoutingPatchTests.cs
@@ -64,6 +64,10 @@ namespace FUSE.Tests.Patches
         [Fact]
         public void Settings_clamp_untrusted_routing_values()
         {
+            Assert.Equal(0f, FuseSettings.ClampOutboundIndustryRerouteChance(-5f));
+            Assert.Equal(1f, FuseSettings.ClampOutboundIndustryRerouteChance(99f));
+            Assert.Equal(FuseSettings.DefaultOutboundIndustryRerouteChance,
+                FuseSettings.ClampOutboundIndustryRerouteChance(float.NaN));
             Assert.Equal(0.1f, FuseSettings.ClampOutboundIndustryFillFactor(-5f));
             Assert.Equal(3f, FuseSettings.ClampOutboundIndustryFillFactor(99f));
             Assert.Equal(FuseSettings.DefaultOutboundIndustryFillFactor,

--- a/FUSE.Tests/Patches/FuseOutboundIndustryRoutingPatchTests.cs
+++ b/FUSE.Tests/Patches/FuseOutboundIndustryRoutingPatchTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Infrastructure;
+using FUSE.Patches;
+using HarmonyLib;
+using Model.Ops;
+using Xunit;
+
+namespace FUSE.Tests.Patches
+{
+    public sealed class FuseOutboundIndustryRoutingPatchTests
+    {
+        [Theory]
+        [InlineData(false, false, false, 0)]
+        [InlineData(false, true, false, 1)]
+        [InlineData(false, false, true, 2)]
+        [InlineData(false, true, true, 2)]
+        [InlineData(true, false, false, 2)]
+        public void ResolveMode_preserves_opt_in_and_legacy_precedence(
+            bool explicitOptIn,
+            bool absolute,
+            bool configurable,
+            int expected)
+        {
+            Assert.Equal(expected, (int)FuseOutboundIndustryRoutingPatch.ResolveMode(
+                explicitOptIn,
+                absolute,
+                configurable));
+        }
+
+        [Theory]
+        [InlineData(0f, 0)]
+        [InlineData(0.24f, 0)]
+        [InlineData(0.25f, 0)]
+        [InlineData(0.26f, 1)]
+        [InlineData(0.99f, 1)]
+        public void Weighted_selection_uses_remaining_capacity(float sample, int expected)
+        {
+            Assert.Equal(expected, FuseOutboundIndustryRoutingPatch.SelectWeightedIndex(
+                new[] { 1f, 3f },
+                sample));
+        }
+
+        [Fact]
+        public void Weighted_selection_handles_empty_and_zero_weight_sets()
+        {
+            Assert.Equal(-1, FuseOutboundIndustryRoutingPatch.SelectWeightedIndex(Array.Empty<float>(), 0.5f));
+            Assert.Equal(1, FuseOutboundIndustryRoutingPatch.SelectWeightedIndex(new[] { 0f, 0f }, 0.75f));
+        }
+
+        [Fact]
+        public void Shuffle_is_deterministic_with_a_supplied_random_source()
+        {
+            var first = new List<int> { 1, 2, 3, 4, 5 };
+            var second = new List<int> { 1, 2, 3, 4, 5 };
+
+            FuseOutboundIndustryBlockingPatch.Shuffle(first, new Random(19));
+            FuseOutboundIndustryBlockingPatch.Shuffle(second, new Random(19));
+
+            Assert.Equal(first, second);
+            Assert.NotEqual(new[] { 1, 2, 3, 4, 5 }, first);
+        }
+
+        [Fact]
+        public void Settings_clamp_untrusted_routing_values()
+        {
+            Assert.Equal(0.1f, FuseSettings.ClampOutboundIndustryFillFactor(-5f));
+            Assert.Equal(3f, FuseSettings.ClampOutboundIndustryFillFactor(99f));
+            Assert.Equal(FuseSettings.DefaultOutboundIndustryFillFactor,
+                FuseSettings.ClampOutboundIndustryFillFactor(float.NaN));
+            Assert.Equal(0f, FuseSettings.ClampOutboundIndustryPaymentMultiplier(-5f));
+            Assert.Equal(10f, FuseSettings.ClampOutboundIndustryPaymentMultiplier(99f));
+        }
+
+        [Fact]
+        public void Harmony_targets_match_the_installed_game_contract()
+        {
+            Assert.NotNull(AccessTools.Method(typeof(OpsController), nameof(OpsController.AddOrderForOutboundEmptyCar)));
+            Assert.NotNull(AccessTools.Method(typeof(OpsController), nameof(OpsController.AddOrderForOutboundLoadedCar)));
+            Assert.NotNull(AccessTools.Method(typeof(IndustryContext), "AddOrderedCars"));
+        }
+    }
+}

--- a/FUSE.Tests/Registry/FuseRegistryTests.cs
+++ b/FUSE.Tests/Registry/FuseRegistryTests.cs
@@ -63,6 +63,44 @@ namespace FUSE.Tests.Registry
             Assert.Empty(FuseRegistry.Conflicts);
         }
 
+        [Fact]
+        public void RecordPlannedConflict_ReportsDeleteVersusDefinitionWithoutCreatingAClaim()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Node,
+                "node-removed",
+                "route-a.graph",
+                "route-b.patch",
+                "later package removal won; earlier package definition suppressed");
+
+            var conflict = Assert.Single(FuseRegistry.Conflicts);
+            Assert.Equal(FuseClaimKind.Node, conflict.Kind);
+            Assert.Equal("node-removed", conflict.Id);
+            Assert.Equal("route-a.graph", conflict.OwnerPackageId);
+            Assert.Equal("route-b.patch", conflict.AttemptedPackageId);
+            Assert.Contains("removal won", conflict.Resolution);
+            Assert.Equal(0, FuseRegistry.ExclusiveClaimCount);
+        }
+
+        [Fact]
+        public void RecordPlannedConflict_DeduplicatesTheSamePackagePairAcrossReapplyOrder()
+        {
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Industry,
+                "destination:type=consumer;name=MP1;spans=R2,R3",
+                "pkg-a",
+                "pkg-b",
+                "shared industry destination overlap");
+            FuseRegistry.RecordPlannedConflict(
+                FuseClaimKind.Industry,
+                "destination:type=consumer;name=MP1;spans=R2,R3",
+                "pkg-b",
+                "pkg-a",
+                "shared industry destination overlap");
+
+            Assert.Single(FuseRegistry.Conflicts);
+        }
+
         [Theory]
         [InlineData(null, "pkg")]
         [InlineData("", "pkg")]

--- a/FUSE.Tests/Runtime/API/FuseObjectLineLayoutTests.cs
+++ b/FUSE.Tests/Runtime/API/FuseObjectLineLayoutTests.cs
@@ -1,0 +1,98 @@
+using System;
+using FUSE.Authoring.Data;
+using FUSE.Runtime.API;
+using UnityEngine;
+using Xunit;
+
+namespace FUSE.Tests.Runtime.API
+{
+    public sealed class FuseObjectLineLayoutTests
+    {
+        [Fact]
+        public void UniformSpacingIncludesFinalEndpointWhenRequested()
+        {
+            var placements = FuseObjectLineLayout.Build(
+                new[]
+                {
+                    Point(0f, 0f),
+                    Point(10f, 0f),
+                },
+                4f,
+                true,
+                10);
+
+            Assert.Collection(
+                placements,
+                placement => Assert.Equal(0f, placement.Position.x, 3),
+                placement => Assert.Equal(4f, placement.Position.x, 3),
+                placement => Assert.Equal(8f, placement.Position.x, 3),
+                placement => Assert.Equal(10f, placement.Position.x, 3));
+            Assert.All(placements, placement => Assert.Equal(Vector3.right, placement.Forward));
+        }
+
+        [Fact]
+        public void SpacingContinuesAcrossPolylineCorners()
+        {
+            var placements = FuseObjectLineLayout.Build(
+                new[]
+                {
+                    Point(0f, 0f),
+                    Point(5f, 0f),
+                    Point(5f, 5f),
+                },
+                4f,
+                true,
+                10);
+
+            Assert.Equal(4, placements.Count);
+            Assert.Equal(new Vector3(0f, 0f, 0f), placements[0].Position);
+            Assert.Equal(new Vector3(4f, 0f, 0f), placements[1].Position);
+            Assert.Equal(new Vector3(5f, 0f, 3f), placements[2].Position);
+            Assert.Equal(new Vector3(5f, 0f, 5f), placements[3].Position);
+            Assert.Equal(Vector3.forward, placements[2].Forward);
+        }
+
+        [Fact]
+        public void SafetyLimitRejectsAccidentalInstanceExplosion()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                FuseObjectLineLayout.Build(
+                    new[]
+                    {
+                        Point(0f, 0f),
+                        Point(100f, 0f),
+                    },
+                    1f,
+                    true,
+                    20));
+
+            Assert.Contains("20 instance safety limit", exception.Message);
+            Assert.Contains("Increase spacing", exception.Message);
+        }
+
+        [Fact]
+        public void DuplicateOnlyPathIsRejected()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                FuseObjectLineLayout.Build(
+                    new[]
+                    {
+                        Point(2f, 3f),
+                        Point(2f, 3f),
+                    },
+                    5f,
+                    true,
+                    20));
+
+            Assert.Contains("non-zero path", exception.Message);
+        }
+
+        private static FuseSplineyPoint Point(float x, float z)
+        {
+            return new FuseSplineyPoint
+            {
+                Position = new Vector3(x, 0f, z),
+            };
+        }
+    }
+}

--- a/FUSE.Tests/Runtime/API/FuseRuntimeDefinitionCacheTests.cs
+++ b/FUSE.Tests/Runtime/API/FuseRuntimeDefinitionCacheTests.cs
@@ -1,0 +1,62 @@
+using System;
+using FUSE.Authoring.Data;
+using FUSE.Authoring.Data.Common;
+using FUSE.Runtime.API;
+using UnityEngine;
+using Xunit;
+
+namespace FUSE.Tests.Runtime.API
+{
+    public sealed class FuseRuntimeDefinitionCacheTests
+    {
+        [Fact]
+        public void Span_reads_are_deep_clones_and_cannot_erase_cached_endpoints()
+        {
+            var id = "span-cache-test-" + Guid.NewGuid().ToString("N");
+            var source = new FuseSpan
+            {
+                Upper = new FuseTrackLocation { SegmentId = "upper-segment", Normalized = 0.25f },
+                Lower = new FuseTrackLocation { SegmentId = "lower-segment", Distance = 12.5f },
+                Normalize = false,
+                GroupId = "test-group",
+            };
+
+            FuseRuntimeDefinitionCache.Store(FuseDefinitionKind.TrackSpan, id, source);
+            Assert.True(FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.TrackSpan, id, out FuseSpan first));
+
+            first.Upper.SegmentId = "mutated";
+            first.Lower = null;
+            first.GroupId = "mutated-group";
+
+            Assert.True(FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.TrackSpan, id, out FuseSpan second));
+            Assert.Equal("upper-segment", second.Upper.SegmentId);
+            Assert.Equal(0.25f, second.Upper.Normalized);
+            Assert.Equal("lower-segment", second.Lower.SegmentId);
+            Assert.Equal(12.5f, second.Lower.Distance);
+            Assert.False(second.Normalize);
+            Assert.Equal("test-group", second.GroupId);
+
+            FuseRuntimeDefinitionCache.Remove(FuseDefinitionKind.TrackSpan, id);
+        }
+
+        [Fact]
+        public void Water_surface_reads_clone_boundary_points()
+        {
+            var id = "water-cache-test-" + Guid.NewGuid().ToString("N");
+            var source = new FuseWaterSurface
+            {
+                Points = new[] { Vector3.zero, Vector3.right, Vector3.forward },
+                MaterialName = "Stock Water",
+            };
+
+            FuseRuntimeDefinitionCache.Store(FuseDefinitionKind.WaterSurface, id, source);
+            Assert.True(FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.WaterSurface, id, out FuseWaterSurface first));
+            first.Points[0] = Vector3.one;
+
+            Assert.True(FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.WaterSurface, id, out FuseWaterSurface second));
+            Assert.Equal(Vector3.zero, second.Points[0]);
+            Assert.Equal("Stock Water", second.MaterialName);
+            FuseRuntimeDefinitionCache.Remove(FuseDefinitionKind.WaterSurface, id);
+        }
+    }
+}

--- a/FUSE.Tests/Runtime/API/WaterSurfaceApiProfileTests.cs
+++ b/FUSE.Tests/Runtime/API/WaterSurfaceApiProfileTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using FUSE.Runtime.API;
+using UnityEngine;
+using UnityEngine.Rendering;
+using Xunit;
+
+namespace FUSE.Tests.Runtime.API
+{
+    public sealed class WaterSurfaceApiProfileTests
+    {
+        [Fact]
+        public void SourceLakeProfileCopiesRenderingFlowAndTerrainSnapControls()
+        {
+            var source = UninitializedLake();
+            source.distSmooth = 7.5f;
+            source.terrainSmoothMultiplier = 2.5f;
+            source.overrideLakeRender = true;
+            source.receiveShadows = true;
+            source.shadowCastingMode = ShadowCastingMode.TwoSided;
+            source.automaticFlowMapScale = 0.65f;
+            source.noiseflowMap = true;
+            source.noiseMultiplierflowMap = 1.7f;
+            source.noiseSizeXflowMap = 0.15f;
+            source.noiseSizeZflowMap = 0.35f;
+            source.floatSpeed = 12f;
+            source.flowSpeed = 3f;
+            source.flowDirection = 42f;
+            source.normalFromRaycast = true;
+            source.snapMask = 123;
+
+            var target = UninitializedLake();
+            InvokeApplySourceProfile(source, target);
+
+            Assert.Equal(source.distSmooth, target.distSmooth);
+            Assert.Equal(source.terrainSmoothMultiplier, target.terrainSmoothMultiplier);
+            Assert.Equal(source.overrideLakeRender, target.overrideLakeRender);
+            Assert.Equal(source.receiveShadows, target.receiveShadows);
+            Assert.Equal(source.shadowCastingMode, target.shadowCastingMode);
+            Assert.Equal(source.automaticFlowMapScale, target.automaticFlowMapScale);
+            Assert.Equal(source.noiseflowMap, target.noiseflowMap);
+            Assert.Equal(source.noiseMultiplierflowMap, target.noiseMultiplierflowMap);
+            Assert.Equal(source.noiseSizeXflowMap, target.noiseSizeXflowMap);
+            Assert.Equal(source.noiseSizeZflowMap, target.noiseSizeZflowMap);
+            Assert.Equal(source.floatSpeed, target.floatSpeed);
+            Assert.Equal(source.flowSpeed, target.flowSpeed);
+            Assert.Equal(source.flowDirection, target.flowDirection);
+            Assert.Equal(source.normalFromRaycast, target.normalFromRaycast);
+            Assert.Equal(source.snapMask.value, target.snapMask.value);
+        }
+
+        [Fact]
+        public void MissingSourceUsesNonShadowedSafeDefaults()
+        {
+            var target = UninitializedLake();
+            target.receiveShadows = true;
+            target.shadowCastingMode = ShadowCastingMode.TwoSided;
+
+            InvokeApplySourceProfile(null, target);
+
+            Assert.Null(target.currentProfile);
+            Assert.False(target.receiveShadows);
+            Assert.Equal(ShadowCastingMode.Off, target.shadowCastingMode);
+        }
+
+        private static LakePolygon UninitializedLake()
+        {
+#pragma warning disable SYSLIB0050
+            return (LakePolygon)FormatterServices.GetUninitializedObject(typeof(LakePolygon));
+#pragma warning restore SYSLIB0050
+        }
+
+        private static void InvokeApplySourceProfile(LakePolygon source, LakePolygon target)
+        {
+            var method = typeof(WaterSurfaceAPI).GetMethod(
+                "ApplySourceLakeProfile",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var exception = Record.Exception(() => method.Invoke(null, new object[] { source, target }));
+            if (exception is TargetInvocationException invocation && invocation.InnerException != null)
+                throw invocation.InnerException;
+            Assert.Null(exception);
+        }
+    }
+}

--- a/FUSE.Tests/Runtime/Lifecycle/FuseMainThreadWorkTrackerTests.cs
+++ b/FUSE.Tests/Runtime/Lifecycle/FuseMainThreadWorkTrackerTests.cs
@@ -1,0 +1,54 @@
+using FUSE.Runtime.Lifecycle;
+using Xunit;
+
+namespace FUSE.Tests.Runtime.Lifecycle
+{
+    public sealed class FuseMainThreadWorkTrackerTests
+    {
+        public FuseMainThreadWorkTrackerTests()
+        {
+            FuseMainThreadWorkTracker.Reset();
+        }
+
+        [Fact]
+        public void RecordElapsedRetainsSlowestPhaseForFrame()
+        {
+            FuseMainThreadWorkTracker.RecordElapsed(10, "first", 2d);
+            FuseMainThreadWorkTracker.RecordElapsed(10, "slowest", 5d);
+            FuseMainThreadWorkTracker.RecordElapsed(10, "later", 3d);
+
+            Assert.True(FuseMainThreadWorkTracker.TryGet(10, out var phase, out var milliseconds));
+            Assert.Equal("slowest", phase);
+            Assert.Equal(5d, milliseconds);
+        }
+
+        [Fact]
+        public void RecordElapsedKeepsPreviousFrameUntilNextFrameArrives()
+        {
+            FuseMainThreadWorkTracker.RecordElapsed(10, "ten", 4d);
+            FuseMainThreadWorkTracker.RecordElapsed(11, "eleven", 6d);
+
+            Assert.True(FuseMainThreadWorkTracker.TryGet(10, out var previous, out var previousMs));
+            Assert.Equal("ten", previous);
+            Assert.Equal(4d, previousMs);
+            Assert.True(FuseMainThreadWorkTracker.TryGet(11, out var current, out var currentMs));
+            Assert.Equal("eleven", current);
+            Assert.Equal(6d, currentMs);
+
+            FuseMainThreadWorkTracker.RecordElapsed(12, "twelve", 1d);
+            Assert.False(FuseMainThreadWorkTracker.TryGet(10, out _, out _));
+        }
+
+        [Fact]
+        public void ResetClearsBothFrames()
+        {
+            FuseMainThreadWorkTracker.RecordElapsed(10, "ten", 4d);
+            FuseMainThreadWorkTracker.RecordElapsed(11, "eleven", 6d);
+
+            FuseMainThreadWorkTracker.Reset();
+
+            Assert.False(FuseMainThreadWorkTracker.TryGet(10, out _, out _));
+            Assert.False(FuseMainThreadWorkTracker.TryGet(11, out _, out _));
+        }
+    }
+}

--- a/FUSE.Tests/Serialization/FuseJsonSchemaContractTests.cs
+++ b/FUSE.Tests/Serialization/FuseJsonSchemaContractTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Serialization
+{
+    public sealed class FuseJsonSchemaContractTests
+    {
+        [Fact]
+        public void Gauge_IsSegmentMetadata_WithAllEditorAuthoredValues()
+        {
+            var schemaPath = Path.Combine(
+                AppContext.BaseDirectory,
+                "fuse-mod.schema.json");
+            var schema = JObject.Parse(File.ReadAllText(schemaPath));
+            var definitions = Assert.IsType<JObject>(schema["$defs"]);
+            var node = Assert.IsType<JObject>(definitions["trackNode"]);
+            var segment = Assert.IsType<JObject>(definitions["trackSegment"]);
+            var nodeProperties = Assert.IsType<JObject>(node["properties"]);
+            var segmentProperties = Assert.IsType<JObject>(
+                segment["properties"]);
+
+            Assert.Null(nodeProperties["gauge"]);
+            var gauge = Assert.IsType<JObject>(segmentProperties["gauge"]);
+            var values = Assert.IsType<JArray>(gauge["enum"])
+                .Values<string>()
+                .ToArray();
+
+            Assert.Contains("Standard", values);
+            Assert.Contains("Narrow", values);
+            Assert.Contains("DualGauge", values);
+            Assert.Contains("DualGauge_L", values);
+            Assert.Contains("DualGauge_R", values);
+            Assert.Contains("DualGauge_T", values);
+        }
+
+        [Fact]
+        public void TrackStructureContract_IncludesDiamondAndFlagsEraMetadata()
+        {
+            var schemaPath = Path.Combine(AppContext.BaseDirectory, "fuse-mod.schema.json");
+            var schema = JObject.Parse(File.ReadAllText(schemaPath));
+            var definitions = Assert.IsType<JObject>(schema["$defs"]);
+            var nodeProperties = Assert.IsType<JObject>(definitions["trackNode"]?["properties"]);
+            var segmentProperties = Assert.IsType<JObject>(definitions["trackSegment"]?["properties"]);
+
+            Assert.Equal("boolean", nodeProperties["isDiamond"]?["type"]?.Value<string>());
+            Assert.Equal("boolean", segmentProperties["bridgeSupportsSteel"]?["type"]?.Value<string>());
+            Assert.Equal("boolean", segmentProperties["yard"]?["type"]?.Value<string>());
+            Assert.NotNull(segmentProperties["preserveBridgeSupportsSteel"]);
+            Assert.NotNull(segmentProperties["preserveYard"]);
+        }
+
+        [Fact]
+        public void UriContract_IncludesDocumentedFuseScheme()
+        {
+            var schemaPath = Path.Combine(
+                AppContext.BaseDirectory,
+                "fuse-mod.schema.json");
+            var schema = JObject.Parse(File.ReadAllText(schemaPath));
+            var definitions = Assert.IsType<JObject>(schema["$defs"]);
+            var uri = Assert.IsType<JObject>(definitions["uri"]);
+            var pattern = Assert.IsType<JValue>(uri["pattern"])
+                .Value<string>();
+
+            Assert.Contains("fuse", pattern, StringComparison.Ordinal);
+        }
+    }
+}

--- a/FUSE.Tests/Serialization/FuseJsonSchemaContractTests.cs
+++ b/FUSE.Tests/Serialization/FuseJsonSchemaContractTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -28,12 +29,22 @@ namespace FUSE.Tests.Serialization
                 .Values<string>()
                 .ToArray();
 
-            Assert.Contains("Standard", values);
-            Assert.Contains("Narrow", values);
-            Assert.Contains("DualGauge", values);
-            Assert.Contains("DualGauge_L", values);
-            Assert.Contains("DualGauge_R", values);
-            Assert.Contains("DualGauge_T", values);
+            Assert.Equal(new[]
+            {
+                "Standard",
+                "Narrow",
+                "3ft",
+                "3 ft",
+                "ThreeFoot",
+                "Three Foot",
+                "DualGauge",
+                "DualGauge_L",
+                "DualGauge_R",
+                "DualGauge_T",
+                "Dual",
+                "Mixed",
+                "MixedGauge"
+            }, values);
         }
 
         [Fact]
@@ -64,7 +75,37 @@ namespace FUSE.Tests.Serialization
             var pattern = Assert.IsType<JValue>(uri["pattern"])
                 .Value<string>();
 
-            Assert.Contains("fuse", pattern, StringComparison.Ordinal);
+            var regex = new Regex(pattern, RegexOptions.CultureInvariant);
+            Assert.True(regex.IsMatch("fuse://example-package/object"));
+            Assert.True(regex.IsMatch("path://scene/World/Example"));
+            Assert.False(regex.IsMatch("https://example.invalid/fuse"));
+            Assert.False(regex.IsMatch("not-fuse://example-package/object"));
+        }
+
+        [Fact]
+        public void SplineyContract_IncludesRuntimeObjectLineKindsAndUriPrefab()
+        {
+            var schemaPath = Path.Combine(AppContext.BaseDirectory, "fuse-mod.schema.json");
+            var schema = JObject.Parse(File.ReadAllText(schemaPath));
+            var definitions = Assert.IsType<JObject>(schema["$defs"]);
+            var properties = Assert.IsType<JObject>(definitions["spliney"]?["properties"]);
+            var kinds = Assert.IsType<JArray>(properties["type"]?["enum"])
+                .Values<string>()
+                .ToArray();
+
+            Assert.Equal(new[]
+            {
+                "river",
+                "road",
+                "terrainRoad",
+                "trestle",
+                "waterfall",
+                "objectLine",
+                "object-line",
+                "fence",
+                "retainingWall"
+            }, kinds);
+            Assert.Equal("#/$defs/uri", properties["prefab"]?["$ref"]?.Value<string>());
         }
     }
 }

--- a/FUSE.Tests/Validation/FuseDefinitionValidatorDeeperTests.World.cs
+++ b/FUSE.Tests/Validation/FuseDefinitionValidatorDeeperTests.World.cs
@@ -107,6 +107,45 @@ namespace FUSE.Tests.Validation
         public class WorldSplineyAndTelegraphRules
         {
             [Fact]
+            public void WaterSurface_WithInvalidGeometry_EmitsActionableErrors()
+            {
+                var definition = MinimalValid();
+                definition.World.WaterSurfaces["lake"] = new FuseWaterSurface
+                {
+                    Points = new[] { Vector3.zero, Vector3.one },
+                    TriangleDensity = 0f,
+                    MaximumTriangleArea = 0f,
+                    UvScale = 0f,
+                };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.Contains(result.Errors, e => e.Code == "fuse.waterSurface.points");
+                Assert.Contains(result.Errors, e => e.Code == "fuse.waterSurface.triangleDensity");
+                Assert.Contains(result.Errors, e => e.Code == "fuse.waterSurface.maximumTriangleArea");
+                Assert.Contains(result.Errors, e => e.Code == "fuse.waterSurface.uvScale");
+            }
+
+            [Fact]
+            public void WaterSurface_WithThreePointsAndSafeTessellation_IsAccepted()
+            {
+                var definition = MinimalValid();
+                definition.World.WaterSurfaces["lake"] = new FuseWaterSurface
+                {
+                    Points = new[]
+                    {
+                        Vector3.zero,
+                        new Vector3(20f, 0f, 0f),
+                        new Vector3(0f, 0f, 20f),
+                    },
+                };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.DoesNotContain(result.Errors, e => e.Field.StartsWith("world.waterSurfaces.lake", StringComparison.Ordinal));
+            }
+
+            [Fact]
             public void Spliney_WithFewerThanTwoPoints_EmitsError()
             {
                 var definition = MinimalValid();
@@ -134,6 +173,57 @@ namespace FUSE.Tests.Validation
                 var result = NewValidator().Validate(definition);
 
                 Assert.Contains(result.Errors, e => e.Field == "world.splineys.wires.type" && e.Code == "fuse.required");
+            }
+
+            [Fact]
+            public void ObjectLine_RequiresOneSourceAndSafeLayoutLimits()
+            {
+                var definition = MinimalValid();
+                definition.World.Splineys["fence"] = new FuseSpliney
+                {
+                    Type = "objectLine",
+                    AssetIdentifier = "fence-panel",
+                    Prefab = "path://scene/World/Fence",
+                    Spacing = 0f,
+                    MaximumInstances = 5000,
+                    Points = new[]
+                    {
+                        new FuseSplineyPoint { Position = Vector3.zero },
+                        new FuseSplineyPoint { Position = Vector3.right },
+                    },
+                };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.Contains(result.Errors, error => error.Code == "fuse.spliney.objectLine.source");
+                Assert.Contains(result.Errors, error => error.Code == "fuse.spliney.objectLine.spacing");
+                Assert.Contains(result.Errors, error => error.Code == "fuse.spliney.objectLine.maximumInstances");
+            }
+
+            [Fact]
+            public void ObjectLine_WithOneAssetSourceAndSafeLimits_IsAccepted()
+            {
+                var definition = MinimalValid();
+                definition.World.Splineys["fence"] = new FuseSpliney
+                {
+                    Type = "objectLine",
+                    AssetIdentifier = "fence-panel",
+                    Spacing = 3f,
+                    MaximumInstances = 200,
+                    Points = new[]
+                    {
+                        new FuseSplineyPoint { Position = Vector3.zero },
+                        new FuseSplineyPoint { Position = Vector3.right * 20f },
+                    },
+                };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.DoesNotContain(
+                    result.Errors,
+                    error => error.Field.StartsWith(
+                        "world.splineys.fence",
+                        StringComparison.Ordinal));
             }
 
             [Fact]
@@ -363,6 +453,21 @@ namespace FUSE.Tests.Validation
                 var result = NewValidator().Validate(definition);
 
                 Assert.Contains(result.Errors, e => e.Code == "fuse.world.removal.conflict");
+            }
+
+            [Fact]
+            public void WaterSurfaceRemoval_AlsoDefined_EmitsConflictError()
+            {
+                var definition = MinimalValid();
+                definition.World.WaterSurfaces["lake"] = new FuseWaterSurface
+                {
+                    Points = new[] { Vector3.zero, Vector3.right, Vector3.forward },
+                };
+                definition.World.Removals.WaterSurfaces = new[] { "lake" };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.Contains(result.Errors, e => e.Field == "world.removals.waterSurfaces[0]" && e.Code == "fuse.world.removal.conflict");
             }
 
             [Fact]

--- a/FUSE.Tests/Validation/FuseDefinitionValidatorTests.cs
+++ b/FUSE.Tests/Validation/FuseDefinitionValidatorTests.cs
@@ -173,6 +173,24 @@ namespace FUSE.Tests.Validation
 
                 Assert.Contains(result.Warnings, w => w.Field == "mixinto.requires[0].id" && w.Code == "fuse.mixinto.requirement.id.blank");
             }
+
+            [Fact]
+            public void BlankConflictId_EmitsWarning()
+            {
+                var definition = MinimalValid();
+                definition.Mixinto = new FuseMixintoDefinition
+                {
+                    Target = "game-graph",
+                    SourceFile = "src.json",
+                    ConflictsWith = new[] { new FuseModRequirement { Id = "   " } }
+                };
+
+                var result = NewValidator().Validate(definition);
+
+                Assert.Contains(result.Warnings, warning =>
+                    warning.Field == "mixinto.conflictsWith[0].id" &&
+                    warning.Code == "fuse.mixinto.conflict.id.blank");
+            }
         }
 
         public class SettingsRules

--- a/FUSE.Tests/Validation/FuseFeatureRuleValidationTests.cs
+++ b/FUSE.Tests/Validation/FuseFeatureRuleValidationTests.cs
@@ -1,0 +1,87 @@
+using FUSE.Authoring.Data;
+using FUSE.Authoring.Validation;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace FUSE.Tests.Validation
+{
+    public sealed class FuseFeatureRuleValidationTests
+    {
+        [Fact]
+        public void ValidRule_PassesValidation()
+        {
+            var definition = ValidDefinition();
+
+            var result = new FuseDefinitionValidator().Validate(definition);
+
+            Assert.DoesNotContain(result.Errors, error => error.Field.StartsWith("featureRules."));
+        }
+
+        [Fact]
+        public void MissingSetting_IsActionableError()
+        {
+            var definition = ValidDefinition();
+            definition.FeatureRules["optional"].Setting = "missing";
+
+            var result = new FuseDefinitionValidator().Validate(definition);
+
+            Assert.Contains(result.Errors, error => error.Code == "fuse.featureRule.setting.missing");
+        }
+
+        [Fact]
+        public void UnknownTarget_IsActionableError()
+        {
+            var definition = ValidDefinition();
+            definition.FeatureRules["optional"].Targets.Scenery = new[] { "not-authored-here" };
+
+            var result = new FuseDefinitionValidator().Validate(definition);
+
+            Assert.Contains(result.Errors, error => error.Code == "fuse.featureRule.target.missing" && error.Field.Contains("scenery"));
+        }
+
+        [Fact]
+        public void NumericOperator_OnBooleanSetting_IsRejected()
+        {
+            var definition = ValidDefinition();
+            definition.FeatureRules["optional"].Operator = "greaterThan";
+
+            var result = new FuseDefinitionValidator().Validate(definition);
+
+            Assert.Contains(result.Errors, error => error.Code == "fuse.featureRule.operator.type");
+        }
+
+        [Fact]
+        public void EmptyTargets_AreRejected()
+        {
+            var definition = ValidDefinition();
+            definition.FeatureRules["optional"].Targets = new FuseFeatureTargets();
+
+            var result = new FuseDefinitionValidator().Validate(definition);
+
+            Assert.Contains(result.Errors, error => error.Code == "fuse.featureRule.targets.empty");
+        }
+
+        private static FuseModDefinition ValidDefinition()
+        {
+            var definition = new FuseModDefinition
+            {
+                Id = "feature-test",
+                Name = "Feature Test"
+            };
+            definition.Settings["enabled"] = new FuseModSettingDefinition
+            {
+                Type = "bool",
+                Default = new JValue(true),
+                ReloadRequired = true
+            };
+            definition.World.Scenery["optional-scenery"] = new FuseScenery();
+            definition.FeatureRules["optional"] = new FuseFeatureRule
+            {
+                Setting = "enabled",
+                Value = new JValue(true),
+                Targets = new FuseFeatureTargets { Scenery = new[] { "optional-scenery" } }
+            };
+            return definition;
+        }
+    }
+}

--- a/FUSE.Tests/Validation/FuseFeatureRuleValidationTests.cs
+++ b/FUSE.Tests/Validation/FuseFeatureRuleValidationTests.cs
@@ -14,7 +14,7 @@ namespace FUSE.Tests.Validation
 
             var result = new FuseDefinitionValidator().Validate(definition);
 
-            Assert.DoesNotContain(result.Errors, error => error.Field.StartsWith("featureRules."));
+            Assert.True(result.IsValid);
         }
 
         [Fact]
@@ -74,7 +74,10 @@ namespace FUSE.Tests.Validation
                 Default = new JValue(true),
                 ReloadRequired = true
             };
-            definition.World.Scenery["optional-scenery"] = new FuseScenery();
+            definition.World.Scenery["optional-scenery"] = new FuseScenery
+            {
+                AssetIdentifier = "vanilla://optional-scenery"
+            };
             definition.FeatureRules["optional"] = new FuseFeatureRule
             {
                 Setting = "enabled",

--- a/FUSE/Authoring/Data/FuseModDefinition.cs
+++ b/FUSE/Authoring/Data/FuseModDefinition.cs
@@ -26,6 +26,7 @@ namespace FUSE.Authoring.Data
         public FuseAudioRoot Audio { get; set; } = new FuseAudioRoot();
         public FuseProgressionRoot Progression { get; set; } = new FuseProgressionRoot();
         public Dictionary<string, FuseModSettingDefinition> Settings { get; set; } = new Dictionary<string, FuseModSettingDefinition>();
+        public Dictionary<string, FuseFeatureRule> FeatureRules { get; set; } = new Dictionary<string, FuseFeatureRule>();
         public FuseEditorState Editor { get; set; }
         public Dictionary<string, object> Extensions { get; set; } = new Dictionary<string, object>();
     }
@@ -50,6 +51,12 @@ namespace FUSE.Authoring.Data
         /// instead of treating it as a package fault.
         /// </summary>
         public FuseModRequirement[] Requires { get; set; }
+
+        /// <summary>
+        /// Optional legacy incompatibility references. If any matching package
+        /// is enabled, only this conditional fragment is skipped.
+        /// </summary>
+        public FuseModRequirement[] ConflictsWith { get; set; }
     }
 
     public sealed class FuseModRequirement

--- a/FUSE/Authoring/Data/FuseModSettingsDefinition.cs
+++ b/FUSE/Authoring/Data/FuseModSettingsDefinition.cs
@@ -20,4 +20,45 @@ namespace FUSE.Authoring.Data
         public bool Advanced { get; set; }
         public bool ReloadRequired { get; set; }
     }
+
+    /// <summary>
+    /// Conditionally includes a named set of authored objects based on one
+    /// package setting. Rules are evaluated after schema validation and before
+    /// the definition becomes resident; changing the setting therefore takes
+    /// effect on the next map/package reload.
+    /// </summary>
+    public sealed class FuseFeatureRule
+    {
+        public string Setting { get; set; }
+        public string Operator { get; set; } = "equals";
+        public JToken Value { get; set; }
+        public FuseFeatureTargets Targets { get; set; } = new FuseFeatureTargets();
+    }
+
+    public sealed class FuseFeatureTargets
+    {
+        public string[] TrackNodes { get; set; } = Array.Empty<string>();
+        public string[] TrackSegments { get; set; } = Array.Empty<string>();
+        public string[] TrackSpans { get; set; } = Array.Empty<string>();
+        public string[] TrackAreas { get; set; } = Array.Empty<string>();
+        public string[] Loads { get; set; } = Array.Empty<string>();
+        public string[] Industries { get; set; } = Array.Empty<string>();
+        public string[] IndustryComponents { get; set; } = Array.Empty<string>();
+        public string[] Loaders { get; set; } = Array.Empty<string>();
+        public string[] Turntables { get; set; } = Array.Empty<string>();
+        public string[] Stations { get; set; } = Array.Empty<string>();
+        public string[] Scenery { get; set; } = Array.Empty<string>();
+        public string[] Splineys { get; set; } = Array.Empty<string>();
+        public string[] WaterSurfaces { get; set; } = Array.Empty<string>();
+        public string[] TelegraphPoles { get; set; } = Array.Empty<string>();
+        public string[] MapLabels { get; set; } = Array.Empty<string>();
+        public string[] MapMasks { get; set; } = Array.Empty<string>();
+        public string[] MapTiles { get; set; } = Array.Empty<string>();
+        public string[] SceneClones { get; set; } = Array.Empty<string>();
+        public string[] Progressions { get; set; } = Array.Empty<string>();
+        public string[] MapFeatures { get; set; } = Array.Empty<string>();
+        public string[] Whistles { get; set; } = Array.Empty<string>();
+        public string[] Horns { get; set; } = Array.Empty<string>();
+        public string[] Bells { get; set; } = Array.Empty<string>();
+    }
 }

--- a/FUSE/Authoring/Data/Operations/FuseIndustryComponentTypes.cs
+++ b/FUSE/Authoring/Data/Operations/FuseIndustryComponentTypes.cs
@@ -99,6 +99,7 @@ namespace FUSE.Authoring.Data
                 { "pay-for-resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
                 { "confusingsupplements.pay4resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
                 { "confusingsupplements.industrycomponents.pay4resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
+                { "adrfdr.pay4resource", "ConfusingSupplements.IndustryComponents.Pay4Resource" },
                 { "confusingsupplements.empty", "ConfusingSupplements.IndustryComponents.Empty" },
                 { "confusingsupplements.industrycomponents.empty", "ConfusingSupplements.IndustryComponents.Empty" }
             };

--- a/FUSE/Authoring/Data/Tracks/FuseRemovedTrackSnapshots.cs
+++ b/FUSE/Authoring/Data/Tracks/FuseRemovedTrackSnapshots.cs
@@ -6,7 +6,7 @@ namespace FUSE.Authoring.Data
     /// <summary>
     /// Serializable node snapshot used to restore base-game track removed by a
     /// FUSE package. Preserved fields: id, transform, switch stand flip, thrown
-    /// state, and public CTC flags. Lossy fields: turntable links, private CTC
+    /// state, diamond-crossing state, and public CTC flags. Lossy fields: turntable links, private CTC
     /// display state, event delegates, and runtime cache state.
     /// </summary>
     public sealed class FuseRemovedNodeSnapshot
@@ -15,6 +15,7 @@ namespace FUSE.Authoring.Data
         public Vector3 Position { get; set; }
         public Vector3 Rotation { get; set; }
         public bool FlipSwitchStand { get; set; }
+        public bool IsDiamond { get; set; }
         public bool IsThrown { get; set; }
         public bool IsCtcSwitch { get; set; }
         public bool IsCtcSwitchUnlocked { get; set; }
@@ -22,7 +23,7 @@ namespace FUSE.Authoring.Data
 
     /// <summary>
     /// Serializable segment snapshot used to restore base-game track removed by a
-    /// FUSE package. Preserved fields: id, endpoints, style, class, group,
+    /// FUSE package. Preserved fields: id, endpoints, style/structure flags, class, group,
     /// priority, speed limit, availability flags, endpoint transforms, and
     /// measured length. Lossy fields: private Bezier caches, turntable links,
     /// editor gizmo state, and generated mesh state.
@@ -33,6 +34,7 @@ namespace FUSE.Authoring.Data
         public string StartNodeId { get; set; }
         public string EndNodeId { get; set; }
         public string Style { get; set; }
+        public int StructureFlags { get; set; }
         public string TrackClass { get; set; }
         public string GroupId { get; set; }
         public int Priority { get; set; }

--- a/FUSE/Authoring/Data/Tracks/FuseTrackDefinition.cs
+++ b/FUSE/Authoring/Data/Tracks/FuseTrackDefinition.cs
@@ -26,6 +26,7 @@ namespace FUSE.Authoring.Data
         public Vector3 Position { get; set; }
         public Vector3 Rotation { get; set; }
         public bool FlipSwitchStand { get; set; }
+        public bool IsDiamond { get; set; }
         public string GroupId { get; set; }
         public string[] Tags { get; set; }
     }
@@ -41,8 +42,12 @@ namespace FUSE.Authoring.Data
         public string GroupId { get; set; }
         public string[] Tags { get; set; }
         public string Gauge { get; set; }
+        public bool BridgeSupportsSteel { get; set; }
+        public bool Yard { get; set; }
         public bool Partial { get; set; }
         public bool PreserveStyle { get; set; }
+        public bool PreserveBridgeSupportsSteel { get; set; }
+        public bool PreserveYard { get; set; }
         public bool PreserveTrackClass { get; set; }
         public bool PreserveSpeedLimit { get; set; }
         public bool PreservePriority { get; set; }

--- a/FUSE/Authoring/Data/World/FuseWorldDefinition.cs
+++ b/FUSE/Authoring/Data/World/FuseWorldDefinition.cs
@@ -9,6 +9,7 @@ namespace FUSE.Authoring.Data
         public Dictionary<string, FuseScenery> Scenery { get; set; } = new Dictionary<string, FuseScenery>();
         public FuseSpawnPoint[] SpawnPoints { get; set; } = Array.Empty<FuseSpawnPoint>();
         public Dictionary<string, FuseSpliney> Splineys { get; set; } = new Dictionary<string, FuseSpliney>();
+        public Dictionary<string, FuseWaterSurface> WaterSurfaces { get; set; } = new Dictionary<string, FuseWaterSurface>();
         public Dictionary<string, FuseTelegraphPoles> TelegraphPoles { get; set; } = new Dictionary<string, FuseTelegraphPoles>();
         public FuseTelegraphPoleMovement[] TelegraphPoleMovements { get; set; } = Array.Empty<FuseTelegraphPoleMovement>();
         public Dictionary<string, FuseMapLabel> MapLabels { get; set; } = new Dictionary<string, FuseMapLabel>();
@@ -36,6 +37,7 @@ namespace FUSE.Authoring.Data
     {
         public string[] Scenery { get; set; } = Array.Empty<string>();
         public string[] Splineys { get; set; } = Array.Empty<string>();
+        public string[] WaterSurfaces { get; set; } = Array.Empty<string>();
         public string[] TelegraphPoles { get; set; } = Array.Empty<string>();
         public string[] MapLabels { get; set; } = Array.Empty<string>();
         public string[] MapMasks { get; set; } = Array.Empty<string>();
@@ -95,6 +97,17 @@ namespace FUSE.Authoring.Data
         public float OffsetY { get; set; }
         public string HeadStyle { get; set; }
         public string TailStyle { get; set; }
+        public string AssetIdentifier { get; set; }
+        public string Prefab { get; set; }
+        public float Spacing { get; set; } = 5f;
+        public Vector3 InstanceScale { get; set; } = Vector3.one;
+        public Vector3 RotationOffset { get; set; }
+        public float LateralOffset { get; set; }
+        public float VerticalOffset { get; set; }
+        public bool SnapToTerrain { get; set; }
+        public bool AlignToSlope { get; set; }
+        public bool PlaceAtEnd { get; set; } = true;
+        public int MaximumInstances { get; set; } = 1024;
         public FuseSplineyPoint[] Points { get; set; }
     }
 
@@ -103,6 +116,25 @@ namespace FUSE.Authoring.Data
         public Vector3 Position { get; set; }
         public Vector3 Rotation { get; set; }
         public float? Width { get; set; }
+    }
+
+    /// <summary>
+    /// A flat or terrain-following lake polygon. Points are authored in world
+    /// coordinates. FUSE reuses a loaded Railroader water material/profile so
+    /// native map packages do not need to copy game assets.
+    /// </summary>
+    public sealed class FuseWaterSurface
+    {
+        public Vector3[] Points { get; set; } = Array.Empty<Vector3>();
+        public string SourceLakePath { get; set; }
+        public string MaterialName { get; set; }
+        public bool LockHeight { get; set; } = true;
+        public bool SnapToTerrain { get; set; }
+        public bool EnableCollider { get; set; } = true;
+        public float UvScale { get; set; } = 1f;
+        public float TriangleDensity { get; set; } = 0.2f;
+        public float MaximumTriangleArea { get; set; } = 50f;
+        public float YOffset { get; set; }
     }
 
     public sealed class FuseTelegraphPoles

--- a/FUSE/Authoring/Entities/FuseSceneryEntity.cs
+++ b/FUSE/Authoring/Entities/FuseSceneryEntity.cs
@@ -34,6 +34,9 @@ namespace FUSE.Authoring.Entities
         [FuseHidden]
         public SceneryAssetInstance RuntimeScenery { get; private set; }
 
+        [FuseHidden]
+        public bool AllowUnverifiedLegacyAsset { get; set; }
+
         [FuseEditable("Anchor Spans", Group = "Scenery", Order = 12)]
         public string[] AnchorSpanIds { get; set; } = System.Array.Empty<string>();
 
@@ -108,11 +111,15 @@ namespace FUSE.Authoring.Entities
                 // recompute had no readers, and the per-item
                 // GetComponentsInChildren scan sat inside the post-load
                 // activation wave for nothing.
-                RuntimeScenery = SceneryAPI.AddScenery(Id, definition);
+                RuntimeScenery = SceneryAPI.AddScenery(
+                    Id,
+                    definition,
+                    onDeferredActivated: null,
+                    allowUnverifiedLegacyAsset: AllowUnverifiedLegacyAsset);
             }
             else
             {
-                SceneryAPI.UpdateScenery(Id, definition);
+                SceneryAPI.UpdateScenery(Id, definition, AllowUnverifiedLegacyAsset);
                 RuntimeScenery = SceneryAPI.GetScenery(Id);
             }
 

--- a/FUSE/Authoring/Migrations/FuseMigration.cs
+++ b/FUSE/Authoring/Migrations/FuseMigration.cs
@@ -70,6 +70,7 @@ namespace FUSE.Authoring.Migrations
             definition.Audio = definition.Audio ?? new FuseAudioRoot();
             definition.Progression = definition.Progression ?? new FuseProgressionRoot();
             definition.Settings = definition.Settings ?? new Dictionary<string, FuseModSettingDefinition>();
+            definition.FeatureRules = definition.FeatureRules ?? new Dictionary<string, FuseFeatureRule>();
             definition.Extensions = definition.Extensions ?? new Dictionary<string, object>();
 
             foreach (var setting in definition.Settings.Values.Where(setting => setting != null))
@@ -78,6 +79,7 @@ namespace FUSE.Authoring.Migrations
                 setting.Scope = string.IsNullOrWhiteSpace(setting.Scope) ? "user" : setting.Scope.Trim();
                 setting.Values = setting.Values ?? Array.Empty<string>();
             }
+            NormalizeFeatureRules(definition.FeatureRules);
 
             definition.Tracks.Nodes = definition.Tracks.Nodes ?? new Dictionary<string, FuseNode>();
             definition.Tracks.Segments = definition.Tracks.Segments ?? new Dictionary<string, FuseSegment>();
@@ -301,7 +303,49 @@ namespace FUSE.Authoring.Migrations
             mixinto.Target = string.IsNullOrWhiteSpace(mixinto.Target) ? null : mixinto.Target.Trim();
             mixinto.SourceFile = string.IsNullOrWhiteSpace(mixinto.SourceFile) ? null : mixinto.SourceFile.Trim();
             mixinto.Requires = mixinto.Requires ?? Array.Empty<FuseModRequirement>();
-            foreach (var requirement in mixinto.Requires)
+            mixinto.ConflictsWith = mixinto.ConflictsWith ?? Array.Empty<FuseModRequirement>();
+            NormalizeModReferences(mixinto.Requires);
+            NormalizeModReferences(mixinto.ConflictsWith);
+        }
+
+        private static void NormalizeFeatureRules(IDictionary<string, FuseFeatureRule> rules)
+        {
+            if (rules == null)
+                return;
+            foreach (var rule in rules.Values.Where(rule => rule != null))
+            {
+                rule.Operator = string.IsNullOrWhiteSpace(rule.Operator) ? "equals" : rule.Operator.Trim();
+                rule.Targets = rule.Targets ?? new FuseFeatureTargets();
+                var targets = rule.Targets;
+                targets.TrackNodes = targets.TrackNodes ?? Array.Empty<string>();
+                targets.TrackSegments = targets.TrackSegments ?? Array.Empty<string>();
+                targets.TrackSpans = targets.TrackSpans ?? Array.Empty<string>();
+                targets.TrackAreas = targets.TrackAreas ?? Array.Empty<string>();
+                targets.Loads = targets.Loads ?? Array.Empty<string>();
+                targets.Industries = targets.Industries ?? Array.Empty<string>();
+                targets.IndustryComponents = targets.IndustryComponents ?? Array.Empty<string>();
+                targets.Loaders = targets.Loaders ?? Array.Empty<string>();
+                targets.Turntables = targets.Turntables ?? Array.Empty<string>();
+                targets.Stations = targets.Stations ?? Array.Empty<string>();
+                targets.Scenery = targets.Scenery ?? Array.Empty<string>();
+                targets.Splineys = targets.Splineys ?? Array.Empty<string>();
+                targets.WaterSurfaces = targets.WaterSurfaces ?? Array.Empty<string>();
+                targets.TelegraphPoles = targets.TelegraphPoles ?? Array.Empty<string>();
+                targets.MapLabels = targets.MapLabels ?? Array.Empty<string>();
+                targets.MapMasks = targets.MapMasks ?? Array.Empty<string>();
+                targets.MapTiles = targets.MapTiles ?? Array.Empty<string>();
+                targets.SceneClones = targets.SceneClones ?? Array.Empty<string>();
+                targets.Progressions = targets.Progressions ?? Array.Empty<string>();
+                targets.MapFeatures = targets.MapFeatures ?? Array.Empty<string>();
+                targets.Whistles = targets.Whistles ?? Array.Empty<string>();
+                targets.Horns = targets.Horns ?? Array.Empty<string>();
+                targets.Bells = targets.Bells ?? Array.Empty<string>();
+            }
+        }
+
+        private static void NormalizeModReferences(FuseModRequirement[] references)
+        {
+            foreach (var requirement in references ?? Array.Empty<FuseModRequirement>())
             {
                 if (requirement == null)
                 {

--- a/FUSE/Authoring/Migrations/FuseMigration.cs
+++ b/FUSE/Authoring/Migrations/FuseMigration.cs
@@ -99,6 +99,7 @@ namespace FUSE.Authoring.Migrations
             definition.World.Scenery = definition.World.Scenery ?? new Dictionary<string, FuseScenery>();
             definition.World.SpawnPoints = definition.World.SpawnPoints ?? Array.Empty<FuseSpawnPoint>();
             definition.World.Splineys = definition.World.Splineys ?? new Dictionary<string, FuseSpliney>();
+            definition.World.WaterSurfaces = definition.World.WaterSurfaces ?? new Dictionary<string, FuseWaterSurface>();
             definition.World.TelegraphPoles = definition.World.TelegraphPoles ?? new Dictionary<string, FuseTelegraphPoles>();
             definition.World.TelegraphPoleMovements = definition.World.TelegraphPoleMovements ?? Array.Empty<FuseTelegraphPoleMovement>();
             definition.World.MapLabels = definition.World.MapLabels ?? new Dictionary<string, FuseMapLabel>();
@@ -114,6 +115,7 @@ namespace FUSE.Authoring.Migrations
             definition.World.Removals = definition.World.Removals ?? new FuseWorldRemovals();
             definition.World.Removals.Scenery = definition.World.Removals.Scenery ?? Array.Empty<string>();
             definition.World.Removals.Splineys = definition.World.Removals.Splineys ?? Array.Empty<string>();
+            definition.World.Removals.WaterSurfaces = definition.World.Removals.WaterSurfaces ?? Array.Empty<string>();
             definition.World.Removals.TelegraphPoles = definition.World.Removals.TelegraphPoles ?? Array.Empty<string>();
             definition.World.Removals.MapLabels = definition.World.Removals.MapLabels ?? Array.Empty<string>();
             definition.World.Removals.MapMasks = definition.World.Removals.MapMasks ?? Array.Empty<string>();

--- a/FUSE/Authoring/Validation/FuseDefinitionValidator.cs
+++ b/FUSE/Authoring/Validation/FuseDefinitionValidator.cs
@@ -12,6 +12,13 @@ namespace FUSE.Authoring.Validation
 {
     public sealed class FuseDefinitionValidator : IValidator<FuseModDefinition>
     {
+        private static readonly HashSet<string> ValidFeatureRuleOperators =
+            new HashSet<string>(new[]
+            {
+                "equals", "notEquals", "greaterThan", "greaterThanOrEqual",
+                "lessThan", "lessThanOrEqual"
+            }, StringComparer.OrdinalIgnoreCase);
+
         public ValidationResult Validate(FuseModDefinition value)
         {
             var result = new ValidationResult();
@@ -49,6 +56,7 @@ namespace FUSE.Authoring.Validation
             ValidateAudio(result, value.Audio);
             ValidateProgression(result, value.Progression);
             ValidateSettings(result, value.Settings);
+            ValidateFeatureRules(result, value);
             return result;
         }
 
@@ -97,20 +105,30 @@ namespace FUSE.Authoring.Validation
                 result.AddWarning("mixinto.sourceFile", "Mixinto sourceFile is blank; conversion provenance will be less clear.", "fuse.mixinto.sourceFile.blank");
             }
 
-            var requirements = mixinto.Requires ?? Array.Empty<FuseModRequirement>();
-            for (var index = 0; index < requirements.Length; index++)
+            ValidateMixintoReferences(result, mixinto.Requires, "requires", "requirement");
+            ValidateMixintoReferences(result, mixinto.ConflictsWith, "conflictsWith", "conflict");
+        }
+
+        private static void ValidateMixintoReferences(
+            ValidationResult result,
+            FuseModRequirement[] references,
+            string propertyName,
+            string kind)
+        {
+            var materialized = references ?? Array.Empty<FuseModRequirement>();
+            for (var index = 0; index < materialized.Length; index++)
             {
-                var requirement = requirements[index];
-                var path = $"mixinto.requires[{index}]";
+                var requirement = materialized[index];
+                var path = $"mixinto.{propertyName}[{index}]";
                 if (requirement == null)
                 {
-                    result.AddWarning(path, "Null mixinto requirement will be ignored.", "fuse.mixinto.requirement.null");
+                    result.AddWarning(path, $"Null mixinto {kind} will be ignored.", $"fuse.mixinto.{kind}.null");
                     continue;
                 }
 
                 if (string.IsNullOrWhiteSpace(requirement.Id))
                 {
-                    result.AddWarning($"{path}.id", "Mixinto requirement id is blank and will be ignored.", "fuse.mixinto.requirement.id.blank");
+                    result.AddWarning($"{path}.id", $"Mixinto {kind} id is blank and will be ignored.", $"fuse.mixinto.{kind}.id.blank");
                 }
             }
         }
@@ -160,6 +178,111 @@ namespace FUSE.Authoring.Validation
                     result.AddWarning(path, "Server-scoped reload-required settings should be documented for multiplayer profile sharing.", "fuse.settings.server.reloadRequired", pair.Key);
                 }
             }
+        }
+
+        private static void ValidateFeatureRules(ValidationResult result, FuseModDefinition definition)
+        {
+            var rules = definition.FeatureRules;
+            if (rules == null)
+                return;
+            foreach (var pair in rules)
+            {
+                var path = $"featureRules.{pair.Key}";
+                if (string.IsNullOrWhiteSpace(pair.Key))
+                {
+                    result.AddError("featureRules", "Feature rule IDs must not be blank.", "fuse.featureRule.id.blank");
+                    continue;
+                }
+                var rule = pair.Value;
+                if (rule == null)
+                {
+                    result.AddError(path, "Feature rule definition is required.", "fuse.featureRule.required");
+                    continue;
+                }
+                if (string.IsNullOrWhiteSpace(rule.Setting) ||
+                    !definition.Settings.TryGetValue(rule.Setting, out var setting) || setting == null)
+                {
+                    result.AddError($"{path}.setting", "Feature rule must reference a setting declared by this definition.", "fuse.featureRule.setting.missing", rule.Setting);
+                }
+                else
+                {
+                    var normalizedOperator = (rule.Operator ?? "equals").Trim();
+                    if ((normalizedOperator.Equals("greaterThan", StringComparison.OrdinalIgnoreCase) ||
+                         normalizedOperator.Equals("greaterThanOrEqual", StringComparison.OrdinalIgnoreCase) ||
+                         normalizedOperator.Equals("lessThan", StringComparison.OrdinalIgnoreCase) ||
+                         normalizedOperator.Equals("lessThanOrEqual", StringComparison.OrdinalIgnoreCase)) &&
+                        FuseModSettingsStore.NormalizeType(setting.Type) != "number")
+                    {
+                        result.AddError($"{path}.operator", "Numeric feature-rule comparisons require a number setting.", "fuse.featureRule.operator.type", rule.Operator);
+                    }
+                    if (!setting.ReloadRequired)
+                    {
+                        result.AddWarning($"settings.{rule.Setting}.reloadRequired", "Settings used by feature rules take effect on map reload; set reloadRequired to true so players are told clearly.", "fuse.featureRule.setting.reloadRequired", rule.Setting);
+                    }
+                }
+                if (!ValidFeatureRuleOperators.Contains((rule.Operator ?? "equals").Trim()))
+                    result.AddError($"{path}.operator", "Feature rule operator is not supported.", "fuse.featureRule.operator", rule.Operator);
+                if (rule.Value == null)
+                    result.AddError($"{path}.value", "Feature rule comparison value is required.", "fuse.featureRule.value.required");
+                ValidateFeatureTargets(result, definition, path, rule.Targets);
+            }
+        }
+
+        private static void ValidateFeatureTargets(ValidationResult result, FuseModDefinition definition, string path, FuseFeatureTargets targets)
+        {
+            if (targets == null)
+            {
+                result.AddError($"{path}.targets", "Feature rule targets are required.", "fuse.featureRule.targets.required");
+                return;
+            }
+            var componentIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var industry in definition.Operations.Industries)
+                foreach (var component in industry.Value?.Components ?? new Dictionary<string, FuseIndustryComponent>())
+                    componentIds.Add(industry.Key + "/" + component.Key);
+            var count = 0;
+            count += ValidateFeatureTargetIds(result, path, "trackNodes", targets.TrackNodes, definition.Tracks.Nodes.Keys);
+            count += ValidateFeatureTargetIds(result, path, "trackSegments", targets.TrackSegments, definition.Tracks.Segments.Keys);
+            count += ValidateFeatureTargetIds(result, path, "trackSpans", targets.TrackSpans, definition.Tracks.Spans.Keys);
+            count += ValidateFeatureTargetIds(result, path, "trackAreas", targets.TrackAreas, definition.Tracks.Areas.Keys);
+            count += ValidateFeatureTargetIds(result, path, "loads", targets.Loads, definition.Operations.Loads.Keys);
+            count += ValidateFeatureTargetIds(result, path, "industries", targets.Industries, definition.Operations.Industries.Keys);
+            count += ValidateFeatureTargetIds(result, path, "industryComponents", targets.IndustryComponents, componentIds);
+            count += ValidateFeatureTargetIds(result, path, "loaders", targets.Loaders, definition.Operations.Loaders.Keys);
+            count += ValidateFeatureTargetIds(result, path, "turntables", targets.Turntables, definition.Operations.Turntables.Keys);
+            count += ValidateFeatureTargetIds(result, path, "stations", targets.Stations, definition.Operations.Stations.Keys);
+            count += ValidateFeatureTargetIds(result, path, "scenery", targets.Scenery, definition.World.Scenery.Keys);
+            count += ValidateFeatureTargetIds(result, path, "splineys", targets.Splineys, definition.World.Splineys.Keys);
+            count += ValidateFeatureTargetIds(result, path, "waterSurfaces", targets.WaterSurfaces, definition.World.WaterSurfaces.Keys);
+            count += ValidateFeatureTargetIds(result, path, "telegraphPoles", targets.TelegraphPoles, definition.World.TelegraphPoles.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapLabels", targets.MapLabels, definition.World.MapLabels.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapMasks", targets.MapMasks, definition.World.MapMasks.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapTiles", targets.MapTiles, definition.World.MapTiles.Keys);
+            count += ValidateFeatureTargetIds(result, path, "sceneClones", targets.SceneClones, definition.World.SceneClones.Keys);
+            count += ValidateFeatureTargetIds(result, path, "progressions", targets.Progressions, definition.Progression.Progressions.Keys);
+            count += ValidateFeatureTargetIds(result, path, "mapFeatures", targets.MapFeatures, definition.Progression.MapFeatures.Keys);
+            count += ValidateFeatureTargetIds(result, path, "whistles", targets.Whistles, definition.Audio.Whistles.Keys);
+            count += ValidateFeatureTargetIds(result, path, "horns", targets.Horns, definition.Audio.Horns.Keys);
+            count += ValidateFeatureTargetIds(result, path, "bells", targets.Bells, definition.Audio.Bells.Keys);
+            if (count == 0)
+                result.AddError($"{path}.targets", "Feature rule must target at least one authored object.", "fuse.featureRule.targets.empty");
+        }
+
+        private static int ValidateFeatureTargetIds(ValidationResult result, string path, string property, IEnumerable<string> values, IEnumerable<string> defined)
+        {
+            var ids = (values ?? Array.Empty<string>()).ToArray();
+            var known = new HashSet<string>(defined ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var index = 0; index < ids.Length; index++)
+            {
+                var id = ids[index];
+                if (string.IsNullOrWhiteSpace(id))
+                    result.AddError($"{path}.targets.{property}[{index}]", "Feature target ID must not be blank.", "fuse.featureRule.target.blank");
+                else if (!known.Contains(id))
+                    result.AddError($"{path}.targets.{property}[{index}]", "Feature target must name an object authored in this definition.", "fuse.featureRule.target.missing", id);
+                else if (!seen.Add(id))
+                    result.AddWarning($"{path}.targets.{property}[{index}]", "Feature target is listed more than once in this rule.", "fuse.featureRule.target.duplicate", id);
+            }
+            return ids.Length;
         }
 
         private static void ValidateTrack(ValidationResult result, FuseTrackDefinition tracks, FuseOperationsDefinition operations)
@@ -546,6 +669,7 @@ namespace FUSE.Authoring.Validation
             {
                 ValidateWorldRemovalTargets(result, "world.removals.scenery", world.Removals.Scenery, world.Scenery.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.splineys", world.Removals.Splineys, world.Splineys.Keys);
+                ValidateWorldRemovalTargets(result, "world.removals.waterSurfaces", world.Removals.WaterSurfaces, world.WaterSurfaces.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.telegraphPoles", world.Removals.TelegraphPoles, world.TelegraphPoles.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.mapLabels", world.Removals.MapLabels, world.MapLabels.Keys);
                 ValidateWorldRemovalTargets(result, "world.removals.mapMasks", world.Removals.MapMasks, world.MapMasks.Keys);
@@ -596,11 +720,52 @@ namespace FUSE.Authoring.Validation
 
             foreach (var spliney in world.Splineys)
             {
-                Required(result, $"world.splineys.{spliney.Key}.type", spliney.Value.Type);
-                if (spliney.Value.Points == null || spliney.Value.Points.Length < 2)
+                var path = $"world.splineys.{spliney.Key}";
+                var value = spliney.Value;
+                if (value == null)
                 {
-                    result.AddError($"world.splineys.{spliney.Key}.points", "Spliney objects require at least two points.", "fuse.spliney.points");
+                    result.AddError(path, "Spliney definition is required.", "fuse.spliney.required");
+                    continue;
                 }
+                Required(result, $"{path}.type", value.Type);
+                if (value.Points == null || value.Points.Length < 2)
+                {
+                    result.AddError($"{path}.points", "Spliney objects require at least two points.", "fuse.spliney.points");
+                }
+                if (IsObjectLine(value.Type))
+                {
+                    if (string.IsNullOrWhiteSpace(value.AssetIdentifier)
+                        == string.IsNullOrWhiteSpace(value.Prefab))
+                    {
+                        result.AddError(
+                            path,
+                            "Object-line splineys require exactly one of assetIdentifier or prefab.",
+                            "fuse.spliney.objectLine.source");
+                    }
+                    if (value.Spacing <= 0f)
+                        result.AddError($"{path}.spacing", "Object-line spacing must be greater than 0.", "fuse.spliney.objectLine.spacing", value.Spacing);
+                    if (value.MaximumInstances < 1 || value.MaximumInstances > 4096)
+                        result.AddError($"{path}.maximumInstances", "Object-line maximumInstances must be between 1 and 4096.", "fuse.spliney.objectLine.maximumInstances", value.MaximumInstances);
+                }
+            }
+
+            foreach (var waterSurface in world.WaterSurfaces)
+            {
+                var path = $"world.waterSurfaces.{waterSurface.Key}";
+                var value = waterSurface.Value;
+                if (value == null)
+                {
+                    result.AddError(path, "Water surface definition is required.", "fuse.waterSurface.required");
+                    continue;
+                }
+                if (value.Points == null || value.Points.Length < 3)
+                    result.AddError($"{path}.points", "Water surfaces require at least three boundary points.", "fuse.waterSurface.points");
+                if (value.TriangleDensity <= 0f || value.TriangleDensity > 1f)
+                    result.AddError($"{path}.triangleDensity", "Triangle density must be greater than 0 and at most 1.", "fuse.waterSurface.triangleDensity", value.TriangleDensity);
+                if (value.MaximumTriangleArea <= 0f)
+                    result.AddError($"{path}.maximumTriangleArea", "Maximum triangle area must be greater than 0.", "fuse.waterSurface.maximumTriangleArea", value.MaximumTriangleArea);
+                if (value.UvScale <= 0f)
+                    result.AddError($"{path}.uvScale", "UV scale must be greater than 0.", "fuse.waterSurface.uvScale", value.UvScale);
             }
 
             foreach (var telegraph in world.TelegraphPoles)
@@ -703,6 +868,14 @@ namespace FUSE.Authoring.Validation
 
                 Required(result, $"world.sceneClones.{sceneClone.Key}.targetPath", sceneClone.Value.TargetPath);
             }
+        }
+
+        private static bool IsObjectLine(string type)
+        {
+            return string.Equals(type, "objectLine", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(type, "object-line", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(type, "fence", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(type, "retainingWall", StringComparison.OrdinalIgnoreCase);
         }
 
         private static void ValidateWorldRemovalTargets(ValidationResult result, string path, IEnumerable<string> removals, IEnumerable<string> definitions)

--- a/FUSE/Compatibility/FuseConfusingSupplementsBodygroups.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsBodygroups.cs
@@ -69,8 +69,10 @@ namespace FUSE.Compatibility
                 var group = groupEntry.Value;
                 if (string.IsNullOrWhiteSpace(groupId) || group?.Options == null || group.Options.Count == 0)
                 {
+                    var rejectedGroupId = string.IsNullOrWhiteSpace(groupId) ? "<blank>" : groupId;
                     FuseLog.Warning(
-                        $"FUSE ignored an empty legacy bodygroup on '{context.ObjectName ?? "<unknown car>"}'.");
+                        $"FUSE ignored legacy bodygroup '{rejectedGroupId}' on " +
+                        $"'{context.ObjectName ?? "<unknown car>"}' because its id is blank or it has no options.");
                     continue;
                 }
 

--- a/FUSE/Compatibility/FuseConfusingSupplementsBodygroups.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsBodygroups.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Infrastructure;
+using Game.Messages;
+using Game.State;
+using HarmonyLib;
+using KeyValue.Runtime;
+using Model;
+using Model.Definition;
+using Model.Definition.Data;
+using Railloader.Extensions;
+using UI.Builder;
+using UnityEngine;
+
+namespace FUSE.Compatibility
+{
+    /// <summary>
+    /// FUSE-owned implementation of the rolling-stock body-group component used by
+    /// legacy Confusing Supplements asset packs. The implementation deliberately
+    /// lives in FUSE's namespace: FUSE reproduces the data contract and behavior
+    /// without loading or redistributing the retired library assembly.
+    /// </summary>
+    internal sealed class FuseConfusingSupplementsBodygroupsComponent : Model.Definition.Component
+    {
+        internal const string ComponentKind = "ConfusingSupplements.Bodygroups";
+
+        public override string Kind => ComponentKind;
+
+        public Dictionary<string, FuseConfusingSupplementsBodygroup> Groups { get; set; } =
+            new Dictionary<string, FuseConfusingSupplementsBodygroup>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal sealed class FuseConfusingSupplementsBodygroup
+    {
+        public string Name { get; set; }
+
+        public Dictionary<string, FuseConfusingSupplementsBodygroupOption> Options { get; set; } =
+            new Dictionary<string, FuseConfusingSupplementsBodygroupOption>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal sealed class FuseConfusingSupplementsBodygroupOption
+    {
+        public string Name { get; set; }
+
+        public string[] Path { get; set; }
+    }
+
+    internal sealed class FuseConfusingSupplementsBodygroupsBuilder : ComponentBuilder<FuseConfusingSupplementsBodygroupsComponent>
+    {
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsBodygroupsComponent component)
+        {
+            var car = context.GameObject?.GetComponentInParent<Car>();
+            var modelRoot = car?.BodyTransform;
+            if (car == null || modelRoot == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not attach legacy bodygroups to '{context.ObjectName ?? "<unknown car>"}' " +
+                    "because its car body was unavailable.");
+                return;
+            }
+
+            foreach (var groupEntry in component?.Groups ??
+                         Enumerable.Empty<KeyValuePair<string, FuseConfusingSupplementsBodygroup>>())
+            {
+                var groupId = groupEntry.Key?.Trim();
+                var group = groupEntry.Value;
+                if (string.IsNullOrWhiteSpace(groupId) || group?.Options == null || group.Options.Count == 0)
+                {
+                    FuseLog.Warning(
+                        $"FUSE ignored an empty legacy bodygroup on '{context.ObjectName ?? "<unknown car>"}'.");
+                    continue;
+                }
+
+                var propertyKey = "cs.bodygroups." + groupId;
+                var options = group.Options.ToArray();
+                context.ObserveProperty(propertyKey, value => ApplySelection(
+                    context.ObjectName,
+                    modelRoot,
+                    groupId,
+                    options,
+                    ReadSelectedOption(value, options)));
+            }
+        }
+
+        internal static string ReadSelectedOption(
+            Value value,
+            IReadOnlyList<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>> options)
+        {
+            var selected = value.StringValue;
+            return string.IsNullOrWhiteSpace(selected) && options != null && options.Count > 0
+                ? options[0].Key
+                : selected;
+        }
+
+        private static void ApplySelection(
+            string objectName,
+            Transform modelRoot,
+            string groupId,
+            IEnumerable<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>> options,
+            string selectedId)
+        {
+            foreach (var optionEntry in options)
+            {
+                var path = optionEntry.Value?.Path;
+                if (path == null || path.Length == 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var target = modelRoot.ResolveTransform(
+                        new TransformReference { Path = path },
+                        defaultReturnsReceiver: false);
+                    if (target == null)
+                    {
+                        FuseLog.Warning(
+                            $"FUSE legacy bodygroup '{groupId}' on '{objectName ?? "<unknown car>"}' " +
+                            $"could not resolve option '{optionEntry.Key}' path '{string.Join("/", path)}'.");
+                        continue;
+                    }
+
+                    target.gameObject.SetActive(
+                        string.Equals(optionEntry.Key, selectedId, StringComparison.OrdinalIgnoreCase));
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE contained a malformed legacy bodygroup path for '{objectName ?? "<unknown car>"}', " +
+                        $"group '{groupId}', option '{optionEntry.Key}': {ex.GetBaseException().Message}");
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(UI.CarCustomizeWindow.CarCustomizeWindow), "BuildColorTab")]
+    internal static class FuseConfusingSupplementsBodygroupsCustomizePatch
+    {
+        private static void Postfix(UIPanelBuilder builder, Car ____car)
+        {
+            if (____car?.Definition?.Components == null)
+            {
+                return;
+            }
+
+            var components = ____car.Definition.Components
+                .OfType<FuseConfusingSupplementsBodygroupsComponent>()
+                .Where(component => component.Groups != null && component.Groups.Count > 0)
+                .ToArray();
+            if (components.Length == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                builder.AddSection("Bodygroups", section =>
+                {
+                    foreach (var component in components)
+                    {
+                        AddGroups(section, ____car, component);
+                    }
+                }, 0f);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a legacy bodygroup Customize-window error; " +
+                    $"the rest of the window remains usable: {ex.GetBaseException().Message}");
+            }
+        }
+
+        private static void AddGroups(
+            UIPanelBuilder builder,
+            Car car,
+            FuseConfusingSupplementsBodygroupsComponent component)
+        {
+            foreach (var groupEntry in component.Groups)
+            {
+                var groupId = groupEntry.Key?.Trim();
+                var group = groupEntry.Value;
+                if (string.IsNullOrWhiteSpace(groupId) || group?.Options == null || group.Options.Count == 0)
+                {
+                    continue;
+                }
+
+                var optionEntries = group.Options.ToArray();
+                var optionIds = optionEntries.Select(entry => entry.Key).ToArray();
+                var optionNames = optionEntries
+                    .Select(entry => string.IsNullOrWhiteSpace(entry.Value?.Name) ? entry.Key : entry.Value.Name)
+                    .ToList();
+                var propertyKey = "cs.bodygroups." + groupId;
+                var current = car.KeyValueObject == null
+                    ? null
+                    : car.KeyValueObject[propertyKey].StringValue;
+                var selectedIndex = Array.FindIndex(
+                    optionIds,
+                    optionId => string.Equals(optionId, current, StringComparison.OrdinalIgnoreCase));
+                if (selectedIndex < 0)
+                {
+                    selectedIndex = 0;
+                }
+
+                var fieldName = string.IsNullOrWhiteSpace(group.Name) ? groupId : group.Name;
+                builder.AddField(fieldName, builder.AddDropdown(optionNames, selectedIndex, index =>
+                {
+                    if (index < 0 || index >= optionIds.Length)
+                    {
+                        return;
+                    }
+
+                    StateManager.ApplyLocal(new PropertyChange(
+                        car.id,
+                        propertyKey,
+                        new StringPropertyValue(optionIds[index])));
+                }));
+            }
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsBodygroups.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsBodygroups.cs
@@ -78,12 +78,29 @@ namespace FUSE.Compatibility
 
                 var propertyKey = "cs.bodygroups." + groupId;
                 var options = group.Options.ToArray();
-                context.ObserveProperty(propertyKey, value => ApplySelection(
-                    context.ObjectName,
-                    modelRoot,
-                    groupId,
-                    options,
-                    ReadSelectedOption(value, options)));
+                context.ObserveProperty(propertyKey, value =>
+                {
+                    var savedSelection = value.StringValue;
+                    var selectedOption = ReadSelectedOption(value, options);
+                    if (!string.IsNullOrWhiteSpace(savedSelection) &&
+                        !options.Any(option => string.Equals(
+                            option.Key,
+                            savedSelection,
+                            StringComparison.OrdinalIgnoreCase)))
+                    {
+                        FuseLog.Warning(
+                            $"FUSE legacy bodygroup '{groupId}' on " +
+                            $"'{context.ObjectName ?? "<unknown car>"}' no longer has saved option " +
+                            $"'{savedSelection}'; using '{selectedOption}' instead.");
+                    }
+
+                    ApplySelection(
+                        context.ObjectName,
+                        modelRoot,
+                        groupId,
+                        options,
+                        selectedOption);
+                });
             }
         }
 
@@ -92,7 +109,16 @@ namespace FUSE.Compatibility
             IReadOnlyList<KeyValuePair<string, FuseConfusingSupplementsBodygroupOption>> options)
         {
             var selected = value.StringValue;
-            return string.IsNullOrWhiteSpace(selected) && options != null && options.Count > 0
+            if (options == null || options.Count == 0)
+            {
+                return selected;
+            }
+
+            return string.IsNullOrWhiteSpace(selected) ||
+                   !options.Any(option => string.Equals(
+                       option.Key,
+                       selected,
+                       StringComparison.OrdinalIgnoreCase))
                 ? options[0].Key
                 : selected;
         }

--- a/FUSE/Compatibility/FuseConfusingSupplementsCompatibility.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsCompatibility.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FUSE.Infrastructure;
+using Model;
+
+namespace FUSE.Compatibility
+{
+    /// <summary>
+    /// Owns the legacy component discriminator and saved-property contracts that
+    /// FUSE replaces when the retired Confusing Supplements package is suppressed.
+    /// </summary>
+    internal static class FuseConfusingSupplementsCompatibility
+    {
+        private static readonly object Gate = new object();
+        private static bool _initialized;
+
+        internal static IReadOnlyList<string> ImplementedComponentKinds { get; } = new[]
+        {
+            FuseConfusingSupplementsBodygroupsComponent.ComponentKind,
+            FuseConfusingSupplementsDestinationSignComponent.ComponentKind,
+            FuseConfusingSupplementsLabelPrinterComponent.ComponentKind,
+            FuseConfusingSupplementsLiveryComponent.ComponentKind,
+            FuseConfusingSupplementsRefillerComponent.ComponentKind
+        };
+
+        internal static void Initialize()
+        {
+            lock (Gate)
+            {
+                if (_initialized)
+                {
+                    return;
+                }
+
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsBodygroupsComponent),
+                    typeof(FuseConfusingSupplementsBodygroupsBuilder),
+                    FuseConfusingSupplementsBodygroupsComponent.ComponentKind);
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsDestinationSignComponent),
+                    typeof(FuseConfusingSupplementsDestinationSignBuilder),
+                    FuseConfusingSupplementsDestinationSignComponent.ComponentKind);
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsLabelPrinterComponent),
+                    typeof(FuseConfusingSupplementsLabelPrinterBuilder),
+                    FuseConfusingSupplementsLabelPrinterComponent.ComponentKind);
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsLiveryComponent),
+                    typeof(FuseConfusingSupplementsLiveryBuilder),
+                    FuseConfusingSupplementsLiveryComponent.ComponentKind);
+                RegisterComponent(
+                    typeof(FuseConfusingSupplementsRefillerComponent),
+                    typeof(FuseConfusingSupplementsRefillerBuilder),
+                    FuseConfusingSupplementsRefillerComponent.ComponentKind);
+                AppendTrainmasterPrefixes("cs.bodygroups.", "cs.labelprinter.", "cs.livery");
+                _initialized = true;
+            }
+        }
+
+        private static void RegisterComponent(Type componentType, Type builderType, string kind)
+        {
+            try
+            {
+                FuseLegacyTypeRegistry.RegisterComponent(componentType, builderType, kind);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not register its replacement for legacy component '{kind}': " +
+                    $"{ex.GetBaseException().GetType().Name}: {ex.GetBaseException().Message}");
+            }
+        }
+
+        private static void AppendTrainmasterPrefixes(params string[] requiredPrefixes)
+        {
+            try
+            {
+                var field = typeof(Car).GetField(
+                    "TrainmasterPrefixes",
+                    BindingFlags.Static | BindingFlags.NonPublic);
+                var current = field?.GetValue(null) as string[];
+                if (field == null || current == null)
+                {
+                    FuseLog.Warning(
+                        "FUSE could not extend the car property access list for legacy Confusing Supplements customization.");
+                    return;
+                }
+
+                var merged = current
+                    .Concat(requiredPrefixes ?? Array.Empty<string>())
+                    .Where(prefix => !string.IsNullOrWhiteSpace(prefix))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                if (merged.Length != current.Length)
+                {
+                    field.SetValue(null, merged);
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not extend the car property access list for legacy Confusing Supplements " +
+                    $"customization: {ex.GetBaseException().Message}");
+            }
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsCompatibility.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsCompatibility.cs
@@ -79,7 +79,7 @@ namespace FUSE.Compatibility
             {
                 var field = typeof(Car).GetField(
                     "TrainmasterPrefixes",
-                    BindingFlags.Static | BindingFlags.NonPublic);
+                    BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
                 var current = field?.GetValue(null) as string[];
                 if (field == null || current == null)
                 {

--- a/FUSE/Compatibility/FuseConfusingSupplementsDestinationSign.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsDestinationSign.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AssetPack.Runtime;
+using Effects.Decals;
+using FUSE.Infrastructure;
+using Helpers;
+using Helpers.Culling;
+using Model;
+using Model.Definition.Data;
+using Railloader.Extensions;
+using UnityEngine;
+using UnityEngine.Rendering.Universal;
+
+namespace FUSE.Compatibility
+{
+    internal sealed class FuseConfusingSupplementsDestinationSignComponent : Model.Definition.Component
+    {
+        internal const string ComponentKind = "ConfusingSupplements.DestinationSign";
+
+        public override string Kind => ComponentKind;
+
+        public AssetReference Model { get; set; } = new AssetReference();
+
+        public Vector3 Size { get; set; } = Vector3.one;
+
+        public List<string> Destinations { get; set; } = new List<string>();
+    }
+
+    internal sealed class FuseConfusingSupplementsDestinationSignBuilder : ComponentBuilder<FuseConfusingSupplementsDestinationSignComponent>
+    {
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsDestinationSignComponent component)
+        {
+            if (context.GameObject == null || component == null)
+            {
+                return;
+            }
+
+            var controller = context.GameObject.AddComponent<FuseConfusingSupplementsDestinationSignController>();
+            controller.Configure(component);
+        }
+    }
+
+    internal sealed class FuseConfusingSupplementsDestinationSignController : MonoBehaviour,
+        IPickable,
+        CullingManager.ICullingEventHandler
+    {
+        private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
+        private LoadedAssetReference<GameObject> _loadedModel;
+        private CullingManager.Token _cullingToken;
+        private DecalProjectorHelper _decal;
+        private GameObject _modelInstance;
+        private GameObject _sign;
+        private string[] _destinations = Array.Empty<string>();
+        private int _selectedIndex = -1;
+
+        public float MaxPickDistance => _sign == null ? 0f : 5f;
+
+        public int Priority => 0;
+
+        public TooltipInfo TooltipInfo => new TooltipInfo("Change destination sign", "Primary: next; secondary: previous");
+
+        public PickableActivationFilter ActivationFilter => PickableActivationFilter.Any;
+
+        internal async void Configure(FuseConfusingSupplementsDestinationSignComponent component)
+        {
+            await ConfigureAsync(component);
+        }
+
+        private async Task ConfigureAsync(FuseConfusingSupplementsDestinationSignComponent component)
+        {
+            try
+            {
+                if (component?.Model == null || component.Model.IsEmpty)
+                {
+                    throw new ArgumentException("Destination-sign model reference is empty.");
+                }
+
+                _destinations = (component.Destinations ?? new List<string>())
+                    .Where(destination => !string.IsNullOrWhiteSpace(destination))
+                    .ToArray();
+                _loadedModel = await TrainController.Shared.PrefabStore.LoadAssetAsync<GameObject>(
+                    component.Model.AssetPackIdentifier,
+                    component.Model.AssetIdentifier,
+                    _cancellation.Token);
+                _cancellation.Token.ThrowIfCancellationRequested();
+
+                if (_loadedModel?.Asset == null)
+                {
+                    throw new InvalidOperationException($"Destination-sign model '{component.Model.AssetIdentifier}' did not load.");
+                }
+
+                _modelInstance = UnityEngine.Object.Instantiate(_loadedModel.Asset, transform, false);
+                _modelInstance.name = "FUSE Destination Sign";
+                _modelInstance.transform.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
+                _sign = _modelInstance.GetComponentsInChildren<Transform>(true)
+                    .FirstOrDefault(child => string.Equals(child.name, "Sign", StringComparison.OrdinalIgnoreCase))
+                    ?.gameObject;
+                if (_sign == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Destination-sign model '{component.Model.AssetIdentifier}' has no child named 'Sign'.");
+                }
+
+                var projectorObject = new GameObject("FUSE Destination Text");
+                projectorObject.SetActive(false);
+                projectorObject.transform.SetParent(_sign.transform, false);
+                projectorObject.transform.SetLocalPositionAndRotation(
+                    Vector3.forward * 0.1f,
+                    Quaternion.Euler(0f, 180f, 0f));
+
+                var projector = projectorObject.AddComponent<DecalProjector>();
+                projector.size = component.Size;
+                projector.pivot = Vector3.zero;
+                projector.drawDistance = Mathf.Max(
+                    600f,
+                    Mathf.Max(component.Size.x, component.Size.y) * 100f);
+
+                _decal = projectorObject.AddComponent<DecalProjectorHelper>();
+                _decal.decalRenderer = CanvasDecalRenderer.Shared;
+                _decal.templateName = "Tender";
+                _decal.text = string.Empty;
+                _decal.ForceColor(Color.black);
+                _decal.RenderDecal();
+                projectorObject.SetActive(true);
+
+                _cullingToken = CullingManager.Scenery?.AddSphere(transform, 10f, this);
+                _cullingToken?.RegisterFixedUpdate(transform);
+                RefreshSign();
+            }
+            catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not build a legacy destination sign: " +
+                    $"{ex.GetBaseException().GetType().Name}: {ex.GetBaseException().Message}");
+                CleanupRuntimeObjects();
+            }
+        }
+
+        public void Activate(PickableActivateEvent evt)
+        {
+            _selectedIndex = NextIndex(
+                _selectedIndex,
+                _destinations.Length,
+                evt.Activation == PickableActivation.Secondary);
+            RefreshSign();
+        }
+
+        public void Deactivate()
+        {
+        }
+
+        internal static int NextIndex(int current, int count, bool previous)
+        {
+            if (count <= 0)
+            {
+                return -1;
+            }
+
+            if (previous)
+            {
+                return current <= -1 ? count - 1 : current - 1;
+            }
+
+            return current >= count - 1 ? -1 : current + 1;
+        }
+
+        private void RefreshSign()
+        {
+            if (_sign == null)
+            {
+                return;
+            }
+
+            if (_selectedIndex < 0 || _selectedIndex >= _destinations.Length || _decal == null)
+            {
+                _sign.SetActive(false);
+                return;
+            }
+
+            _decal.text = _destinations[_selectedIndex];
+            _decal.RenderDecal();
+            _sign.SetActive(true);
+        }
+
+        public void CullingSphereStateChanged(bool isVisible, int distanceBand)
+        {
+            if (_modelInstance != null)
+            {
+                _modelInstance.SetActive(isVisible && distanceBand < 1);
+            }
+        }
+
+        public void RequestUpdateCullingPosition()
+        {
+            _cullingToken?.UpdatePosition(transform);
+        }
+
+        private void OnDestroy()
+        {
+            _cancellation.Cancel();
+            _cancellation.Dispose();
+            CleanupRuntimeObjects();
+        }
+
+        private void CleanupRuntimeObjects()
+        {
+            _cullingToken?.Dispose();
+            _cullingToken = null;
+            _loadedModel?.Dispose();
+            _loadedModel = null;
+            if (_modelInstance != null)
+            {
+                UnityEngine.Object.Destroy(_modelInstance);
+                _modelInstance = null;
+            }
+
+            _sign = null;
+            _decal = null;
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsDestinationSign.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsDestinationSign.cs
@@ -73,6 +73,7 @@ namespace FUSE.Compatibility
 
         private async Task ConfigureAsync(FuseConfusingSupplementsDestinationSignComponent component)
         {
+            var cancellationToken = _cancellation.Token;
             try
             {
                 if (component?.Model == null || component.Model.IsEmpty)
@@ -86,8 +87,8 @@ namespace FUSE.Compatibility
                 _loadedModel = await TrainController.Shared.PrefabStore.LoadAssetAsync<GameObject>(
                     component.Model.AssetPackIdentifier,
                     component.Model.AssetIdentifier,
-                    _cancellation.Token);
-                _cancellation.Token.ThrowIfCancellationRequested();
+                    cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
 
                 if (_loadedModel?.Asset == null)
                 {
@@ -132,8 +133,9 @@ namespace FUSE.Compatibility
                 _cullingToken?.RegisterFixedUpdate(transform);
                 RefreshSign();
             }
-            catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
+                CleanupRuntimeObjects();
                 return;
             }
             catch (Exception ex)

--- a/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
@@ -32,6 +32,9 @@ namespace FUSE.Compatibility
 
     internal sealed class FuseConfusingSupplementsLabelPrinterBuilder : ComponentBuilder<FuseConfusingSupplementsLabelPrinterComponent>
     {
+        private const string SavedPropertyPrefix = "cs.labelprinter.";
+        internal const string TextFieldName = "text";
+
         protected override void Build(
             ComponentBuilderContext context,
             FuseConfusingSupplementsLabelPrinterComponent component)
@@ -78,7 +81,7 @@ namespace FUSE.Compatibility
                 }
             }
 
-            context.ObserveProperty("cs.labelprinter." + savedPropertyId, value =>
+            context.ObserveProperty(SavedPropertyKey(savedPropertyId), value =>
             {
                 helper.text = ReadText(value);
                 helper.RenderDecal();
@@ -88,9 +91,14 @@ namespace FUSE.Compatibility
         internal static string ReadText(Value value)
         {
             var values = value.DictionaryValue;
-            return values != null && values.TryGetValue("text", out var text)
+            return values != null && values.TryGetValue(TextFieldName, out var text)
                 ? text.StringValue ?? string.Empty
                 : string.Empty;
+        }
+
+        internal static string SavedPropertyKey(string savedPropertyId)
+        {
+            return SavedPropertyPrefix + savedPropertyId;
         }
 
         private static bool TryGetTemplateName(DecalContent content, out string templateName)
@@ -169,7 +177,7 @@ namespace FUSE.Compatibility
             }
 
             return FuseConfusingSupplementsLabelPrinterBuilder.ReadText(
-                car.KeyValueObject["cs.labelprinter." + savedPropertyId]);
+                car.KeyValueObject[FuseConfusingSupplementsLabelPrinterBuilder.SavedPropertyKey(savedPropertyId)]);
         }
 
         private static void SetText(Car car, string savedPropertyId, string text)
@@ -179,11 +187,13 @@ namespace FUSE.Compatibility
                 return;
             }
 
-            car.KeyValueObject["cs.labelprinter." + savedPropertyId] = Value.Dictionary(
-                new Dictionary<string, Value>
-                {
-                    ["text"] = Value.String(text ?? string.Empty)
-                });
+            car.KeyValueObject[FuseConfusingSupplementsLabelPrinterBuilder.SavedPropertyKey(savedPropertyId)] =
+                Value.Dictionary(
+                    new Dictionary<string, Value>
+                    {
+                        [FuseConfusingSupplementsLabelPrinterBuilder.TextFieldName] =
+                            Value.String(text ?? string.Empty)
+                    });
         }
     }
 }

--- a/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
@@ -27,7 +27,7 @@ namespace FUSE.Compatibility
 
         [JsonIgnore]
         [DefinitionProperty(Hidden = true)]
-        public string SavedPropertyId => string.IsNullOrWhiteSpace(Group) ? Name : Group;
+        public string SavedPropertyId => (string.IsNullOrWhiteSpace(Group) ? Name : Group)?.Trim();
     }
 
     internal sealed class FuseConfusingSupplementsLabelPrinterBuilder : ComponentBuilder<FuseConfusingSupplementsLabelPrinterComponent>
@@ -41,7 +41,7 @@ namespace FUSE.Compatibility
                 return;
             }
 
-            var savedPropertyId = component.SavedPropertyId?.Trim();
+            var savedPropertyId = component.SavedPropertyId;
             if (string.IsNullOrWhiteSpace(savedPropertyId))
             {
                 FuseLog.Warning(

--- a/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
@@ -93,7 +93,7 @@ namespace FUSE.Compatibility
                 : string.Empty;
         }
 
-        internal static bool TryGetTemplateName(DecalContent content, out string templateName)
+        private static bool TryGetTemplateName(DecalContent content, out string templateName)
         {
             switch (content)
             {

--- a/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Effects.Decals;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Helpers;
+using KeyValue.Runtime;
+using Model;
+using Model.Definition;
+using Model.Definition.Components;
+using Newtonsoft.Json;
+using Railloader.Extensions;
+using UI.Builder;
+using UnityEngine;
+using UnityEngine.Rendering.Universal;
+
+namespace FUSE.Compatibility
+{
+    internal sealed class FuseConfusingSupplementsLabelPrinterComponent : DecalComponent
+    {
+        internal const string ComponentKind = "ConfusingSupplements.LabelPrinter";
+
+        public override string Kind => ComponentKind;
+
+        public string Group { get; set; }
+
+        [JsonIgnore]
+        [DefinitionProperty(Hidden = true)]
+        public string SavedPropertyId => string.IsNullOrWhiteSpace(Group) ? Name : Group;
+    }
+
+    internal sealed class FuseConfusingSupplementsLabelPrinterBuilder : ComponentBuilder<FuseConfusingSupplementsLabelPrinterComponent>
+    {
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsLabelPrinterComponent component)
+        {
+            if (context.GameObject == null || component == null)
+            {
+                return;
+            }
+
+            var savedPropertyId = component.SavedPropertyId?.Trim();
+            if (string.IsNullOrWhiteSpace(savedPropertyId))
+            {
+                FuseLog.Warning(
+                    $"FUSE ignored a legacy label-printer component on '{context.ObjectName ?? "<unknown car>"}' " +
+                    "because both name and group are empty.");
+                return;
+            }
+
+            var projector = context.GameObject.AddComponent<DecalProjector>();
+            projector.size = component.Size;
+            projector.pivot = Vector3.zero;
+            projector.drawDistance = Mathf.Max(
+                600f,
+                Mathf.Max(component.Size.x, component.Size.y) * 100f);
+
+            var helper = context.GameObject.AddComponent<DecalProjectorHelper>();
+            helper.decalRenderer = CanvasDecalRenderer.Shared;
+            helper.templateName = TemplateName(component.Content);
+            if (!string.IsNullOrWhiteSpace(component.ForceColor))
+            {
+                var color = ColorHelper.ColorFromHex(component.ForceColor);
+                if (color.HasValue)
+                {
+                    helper.ForceColor(color.Value);
+                }
+            }
+
+            context.ObserveProperty("cs.labelprinter." + savedPropertyId, value =>
+            {
+                helper.text = ReadText(value);
+                helper.RenderDecal();
+            });
+        }
+
+        internal static string ReadText(Value value)
+        {
+            var values = value.DictionaryValue;
+            return values != null && values.TryGetValue("text", out var text)
+                ? text.StringValue ?? string.Empty
+                : string.Empty;
+        }
+
+        private static string TemplateName(DecalContent content)
+        {
+            switch (content)
+            {
+                case DecalContent.RoadNumber:
+                    return "Number";
+                case DecalContent.Lettering:
+                    return "Tender";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(content), content, "Unsupported label-printer content type.");
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(UI.CarCustomizeWindow.CarCustomizeWindow), "BuildColorTab")]
+    internal static class FuseConfusingSupplementsLabelPrinterCustomizePatch
+    {
+        private static void Postfix(UIPanelBuilder builder, Car ____car)
+        {
+            if (____car?.Definition?.Components == null)
+            {
+                return;
+            }
+
+            var labels = ____car.Definition.Components
+                .OfType<FuseConfusingSupplementsLabelPrinterComponent>()
+                .Where(component => !string.IsNullOrWhiteSpace(component.SavedPropertyId))
+                .GroupBy(component => component.SavedPropertyId, StringComparer.OrdinalIgnoreCase)
+                .Select(group => new
+                {
+                    Id = group.Key,
+                    Name = group.Select(component => component.Name)
+                        .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name)) ?? group.Key
+                })
+                .OrderBy(label => label.Name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (labels.Length == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                builder.AddSection("Labels", section =>
+                {
+                    foreach (var label in labels)
+                    {
+                        section.AddField(
+                            label.Name,
+                            section.AddInputField(
+                                GetText(____car, label.Id),
+                                text => SetText(____car, label.Id, text),
+                                null,
+                                100));
+                    }
+                }, 0f);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a legacy label-printer Customize-window error; " +
+                    $"the rest of the window remains usable: {ex.GetBaseException().Message}");
+            }
+        }
+
+        internal static string GetText(Car car, string savedPropertyId)
+        {
+            if (car?.KeyValueObject == null || string.IsNullOrWhiteSpace(savedPropertyId))
+            {
+                return string.Empty;
+            }
+
+            return FuseConfusingSupplementsLabelPrinterBuilder.ReadText(
+                car.KeyValueObject["cs.labelprinter." + savedPropertyId]);
+        }
+
+        private static void SetText(Car car, string savedPropertyId, string text)
+        {
+            if (car?.KeyValueObject == null || string.IsNullOrWhiteSpace(savedPropertyId))
+            {
+                return;
+            }
+
+            car.KeyValueObject["cs.labelprinter." + savedPropertyId] = Value.Dictionary(
+                new Dictionary<string, Value>
+                {
+                    ["text"] = Value.String(text ?? string.Empty)
+                });
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsLabelPrinter.cs
@@ -50,6 +50,15 @@ namespace FUSE.Compatibility
                 return;
             }
 
+            if (!TryGetTemplateName(component.Content, out var templateName))
+            {
+                FuseLog.Warning(
+                    $"FUSE ignored legacy label-printer '{savedPropertyId}' on " +
+                    $"'{context.ObjectName ?? "<unknown car>"}' because decal content " +
+                    $"'{component.Content}' is unsupported.");
+                return;
+            }
+
             var projector = context.GameObject.AddComponent<DecalProjector>();
             projector.size = component.Size;
             projector.pivot = Vector3.zero;
@@ -59,7 +68,7 @@ namespace FUSE.Compatibility
 
             var helper = context.GameObject.AddComponent<DecalProjectorHelper>();
             helper.decalRenderer = CanvasDecalRenderer.Shared;
-            helper.templateName = TemplateName(component.Content);
+            helper.templateName = templateName;
             if (!string.IsNullOrWhiteSpace(component.ForceColor))
             {
                 var color = ColorHelper.ColorFromHex(component.ForceColor);
@@ -84,16 +93,19 @@ namespace FUSE.Compatibility
                 : string.Empty;
         }
 
-        private static string TemplateName(DecalContent content)
+        internal static bool TryGetTemplateName(DecalContent content, out string templateName)
         {
             switch (content)
             {
                 case DecalContent.RoadNumber:
-                    return "Number";
+                    templateName = "Number";
+                    return true;
                 case DecalContent.Lettering:
-                    return "Tender";
+                    templateName = "Tender";
+                    return true;
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(content), content, "Unsupported label-printer content type.");
+                    templateName = null;
+                    return false;
             }
         }
     }

--- a/FUSE/Compatibility/FuseConfusingSupplementsLivery.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsLivery.cs
@@ -1,0 +1,515 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using HarmonyLib;
+using KeyValue.Runtime;
+using Model;
+using Railloader.Extensions;
+using UI.Builder;
+using UnityEngine;
+
+namespace FUSE.Compatibility
+{
+    internal sealed class FuseConfusingSupplementsLiveryComponent : Model.Definition.Component
+    {
+        internal const string ComponentKind = "CS.LiverySwap";
+
+        public override string Kind => ComponentKind;
+    }
+
+    internal sealed class FuseConfusingSupplementsLiveryBuilder : ComponentBuilder<FuseConfusingSupplementsLiveryComponent>
+    {
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsLiveryComponent component)
+        {
+            var car = context.GameObject?.GetComponentInParent<Car>();
+            if (car == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not attach legacy livery support to '{context.ObjectName ?? "<unknown car>"}' " +
+                    "because its car object was unavailable.");
+                return;
+            }
+
+            var controller = car.GetComponent<FuseConfusingSupplementsLiveryController>() ??
+                             car.gameObject.AddComponent<FuseConfusingSupplementsLiveryController>();
+            controller.Configure(car);
+            context.ObserveProperty("cs.livery", controller.ApplySavedSelection);
+        }
+    }
+
+    internal sealed class FuseConfusingSupplementsLiveryController : MonoBehaviour
+    {
+        private readonly List<MaterialSnapshot> _materials = new List<MaterialSnapshot>();
+        private Car _car;
+        private string _carIdentifier;
+        private bool _configured;
+
+        internal void Configure(Car car)
+        {
+            if (_configured || car == null)
+            {
+                return;
+            }
+
+            _car = car;
+            _carIdentifier = car.DefinitionInfo.Identifier;
+            CaptureMaterials(car);
+            _configured = true;
+        }
+
+        internal void ApplySavedSelection(Value value)
+        {
+            if (!_configured)
+            {
+                return;
+            }
+
+            var selected = value.StringValue;
+            RestoreOriginalTextures();
+            if (string.IsNullOrWhiteSpace(selected))
+            {
+                return;
+            }
+
+            var choice = FuseConfusingSupplementsLiveryRegistry.GetChoices(_carIdentifier)
+                .FirstOrDefault(candidate => string.Equals(candidate.Id, selected, StringComparison.OrdinalIgnoreCase));
+            if (choice == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not find legacy livery '{selected}' for rolling stock '{_carIdentifier}'. " +
+                    "The standard textures remain active.");
+                return;
+            }
+
+            ApplyDirectory(choice.DirectoryPath);
+        }
+
+        internal string CarIdentifier => _carIdentifier ?? string.Empty;
+
+        internal string SelectedLiveryId
+        {
+            get
+            {
+                if (!_configured || _car?.KeyValueObject == null)
+                {
+                    return string.Empty;
+                }
+
+                return _car.KeyValueObject["cs.livery"].StringValue ?? string.Empty;
+            }
+        }
+
+        internal void RefreshFromSavedSelection()
+        {
+            if (!_configured)
+            {
+                return;
+            }
+
+            ApplySavedSelection(
+                _car?.KeyValueObject == null
+                    ? Value.Null()
+                    : _car.KeyValueObject["cs.livery"]);
+        }
+
+        private void CaptureMaterials(Car car)
+        {
+            var propertyIds = new List<int>();
+            foreach (var renderer in car.GetComponentsInChildren<Renderer>(true))
+            {
+                Material[] materials;
+                try
+                {
+                    // Renderer.materials creates per-renderer instances. This keeps a
+                    // livery chosen on one car from repainting every car that shares
+                    // the asset pack's source material.
+                    materials = renderer.materials;
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not isolate livery materials on '{_carIdentifier}': {ex.GetBaseException().Message}");
+                    continue;
+                }
+
+                foreach (var material in materials.Where(material => material != null))
+                {
+                    propertyIds.Clear();
+                    material.GetTexturePropertyNameIDs(propertyIds);
+                    foreach (var propertyId in propertyIds)
+                    {
+                        var texture = material.GetTexture(propertyId);
+                        if (texture == null)
+                        {
+                            continue;
+                        }
+
+                        _materials.Add(new MaterialSnapshot(
+                            material,
+                            propertyId,
+                            texture,
+                            texture.name ?? string.Empty));
+                    }
+                }
+            }
+        }
+
+        private void RestoreOriginalTextures()
+        {
+            foreach (var snapshot in _materials)
+            {
+                if (snapshot.Material != null)
+                {
+                    snapshot.Material.SetTexture(snapshot.PropertyId, snapshot.OriginalTexture);
+                }
+            }
+        }
+
+        private void ApplyDirectory(string directoryPath)
+        {
+            var files = FuseConfusingSupplementsLiveryRegistry.IndexTextureFiles(directoryPath);
+            if (files.Count == 0)
+            {
+                FuseLog.Warning(
+                    $"FUSE legacy livery folder '{directoryPath}' has no PNG or JPEG texture files.");
+                return;
+            }
+
+            var replacements = 0;
+            foreach (var snapshot in _materials)
+            {
+                if (snapshot.Material == null || string.IsNullOrWhiteSpace(snapshot.OriginalTextureName) ||
+                    !files.TryGetValue(snapshot.OriginalTextureName, out var texturePath))
+                {
+                    continue;
+                }
+
+                var texture = FuseConfusingSupplementsLiveryRegistry.LoadTexture(texturePath);
+                if (texture == null)
+                {
+                    continue;
+                }
+
+                snapshot.Material.SetTexture(snapshot.PropertyId, texture);
+                replacements++;
+            }
+
+            if (replacements == 0)
+            {
+                FuseLog.Warning(
+                    $"FUSE legacy livery folder '{directoryPath}' did not match any source texture names on " +
+                    $"rolling stock '{_carIdentifier}'.");
+            }
+        }
+
+        private sealed class MaterialSnapshot
+        {
+            internal MaterialSnapshot(
+                Material material,
+                int propertyId,
+                Texture originalTexture,
+                string originalTextureName)
+            {
+                Material = material;
+                PropertyId = propertyId;
+                OriginalTexture = originalTexture;
+                OriginalTextureName = originalTextureName;
+            }
+
+            internal Material Material { get; }
+            internal int PropertyId { get; }
+            internal Texture OriginalTexture { get; }
+            internal string OriginalTextureName { get; }
+        }
+    }
+
+    internal static class FuseConfusingSupplementsLiveryRegistry
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<string, Texture2D> Textures =
+            new Dictionary<string, Texture2D>(StringComparer.OrdinalIgnoreCase);
+
+        internal static int CachedTextureCount
+        {
+            get
+            {
+                lock (Gate)
+                {
+                    return Textures.Count(pair => pair.Value != null);
+                }
+            }
+        }
+
+        internal static int RefreshLiveCars()
+        {
+            ClearTextureCache();
+
+            var controllers = Resources
+                .FindObjectsOfTypeAll<FuseConfusingSupplementsLiveryController>()
+                .Where(IsLiveController)
+                .ToArray();
+            foreach (var controller in controllers)
+            {
+                try
+                {
+                    controller.RefreshFromSavedSelection();
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not refresh the legacy livery on '{controller.CarIdentifier}': " +
+                        ex.GetBaseException().Message);
+                }
+            }
+
+            return controllers.Length;
+        }
+
+        internal static string BuildDiagnosticReport()
+        {
+            var controllers = Resources
+                .FindObjectsOfTypeAll<FuseConfusingSupplementsLiveryController>()
+                .Where(IsLiveController)
+                .OrderBy(controller => controller.CarIdentifier, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(controller => controller.GetInstanceID())
+                .ToArray();
+            var report = new StringBuilder();
+            report.Append("FUSE livery diagnostics: cars=")
+                .Append(controllers.Length)
+                .Append(" cachedTextures=")
+                .Append(CachedTextureCount);
+
+            foreach (var controller in controllers)
+            {
+                var choices = GetChoices(controller.CarIdentifier);
+                report.AppendLine()
+                    .Append("- car=")
+                    .Append(string.IsNullOrWhiteSpace(controller.CarIdentifier)
+                        ? "<unknown>"
+                        : controller.CarIdentifier)
+                    .Append(" selected=")
+                    .Append(string.IsNullOrWhiteSpace(controller.SelectedLiveryId)
+                        ? "<standard>"
+                        : controller.SelectedLiveryId)
+                    .Append(" choices=")
+                    .Append(choices.Count);
+                if (choices.Count > 0)
+                {
+                    report.Append(" [")
+                        .Append(string.Join(", ", choices.Select(choice => choice.Id)))
+                        .Append(']');
+                }
+            }
+
+            return report.ToString();
+        }
+
+        private static void ClearTextureCache()
+        {
+            lock (Gate)
+            {
+                foreach (var texture in Textures.Values.Where(texture => texture != null))
+                {
+                    UnityEngine.Object.Destroy(texture);
+                }
+
+                Textures.Clear();
+            }
+        }
+
+        private static bool IsLiveController(
+            FuseConfusingSupplementsLiveryController controller)
+        {
+            return controller != null
+                   && controller.gameObject != null
+                   && controller.gameObject.scene.IsValid();
+        }
+
+        internal static IReadOnlyList<FuseConfusingSupplementsLiveryChoice> GetChoices(string carIdentifier)
+        {
+            if (string.IsNullOrWhiteSpace(carIdentifier))
+            {
+                return Array.Empty<FuseConfusingSupplementsLiveryChoice>();
+            }
+
+            var choices = new Dictionary<string, FuseConfusingSupplementsLiveryChoice>(StringComparer.OrdinalIgnoreCase);
+            foreach (var mixinto in FuseLegacyAssemblyHost.EnumerateMixintos("livery:" + carIdentifier))
+            {
+                var path = mixinto.Mixinto;
+                if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+                {
+                    FuseLog.Warning(
+                        $"FUSE ignored legacy livery entry '{path ?? "<empty>"}' for '{carIdentifier}' " +
+                        "because it is not an existing directory.");
+                    continue;
+                }
+
+                var id = Path.GetFileName(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                if (string.IsNullOrWhiteSpace(id))
+                {
+                    continue;
+                }
+
+                if (choices.ContainsKey(id))
+                {
+                    FuseLog.Warning(
+                        $"FUSE found more than one legacy livery named '{id}' for '{carIdentifier}'. " +
+                        $"The first folder wins; ignored '{path}'.");
+                    continue;
+                }
+
+                choices[id] = new FuseConfusingSupplementsLiveryChoice(id, path);
+            }
+
+            return choices.Values.OrderBy(choice => choice.Id, StringComparer.OrdinalIgnoreCase).ToArray();
+        }
+
+        internal static Dictionary<string, string> IndexTextureFiles(string directoryPath)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(directoryPath) || !Directory.Exists(directoryPath))
+            {
+                return result;
+            }
+
+            foreach (var path in Directory.EnumerateFiles(directoryPath))
+            {
+                if (!IsTextureFile(path))
+                {
+                    continue;
+                }
+
+                result[Path.GetFileNameWithoutExtension(path)] = path;
+            }
+
+            return result;
+        }
+
+        internal static bool IsTextureFile(string path)
+        {
+            var extension = Path.GetExtension(path);
+            return string.Equals(extension, ".png", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(extension, ".jpg", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(extension, ".jpeg", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static Texture2D LoadTexture(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                return null;
+            }
+
+            lock (Gate)
+            {
+                if (Textures.TryGetValue(path, out var cached) && cached != null)
+                {
+                    return cached;
+                }
+
+                try
+                {
+                    var texture = new Texture2D(2, 2, TextureFormat.RGBA32, true)
+                    {
+                        name = Path.GetFileNameWithoutExtension(path)
+                    };
+                    if (!ImageConversion.LoadImage(texture, File.ReadAllBytes(path)))
+                    {
+                        UnityEngine.Object.Destroy(texture);
+                        return null;
+                    }
+
+                    Textures[path] = texture;
+                    return texture;
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not load legacy livery texture '{path}': {ex.GetBaseException().Message}");
+                    return null;
+                }
+            }
+        }
+    }
+
+    internal sealed class FuseConfusingSupplementsLiveryChoice
+    {
+        internal FuseConfusingSupplementsLiveryChoice(string id, string directoryPath)
+        {
+            Id = id;
+            DirectoryPath = directoryPath;
+        }
+
+        internal string Id { get; }
+        internal string DirectoryPath { get; }
+    }
+
+    [HarmonyPatch(typeof(UI.CarCustomizeWindow.CarCustomizeWindow), "BuildColorTab")]
+    internal static class FuseConfusingSupplementsLiveryCustomizePatch
+    {
+        private static readonly string[] StandardLiveryIds = { string.Empty };
+        private static readonly string[] StandardLiveryNames = { "Standard" };
+
+        private static void Postfix(UIPanelBuilder builder, Car ____car)
+        {
+            if (____car?.Definition?.Components == null ||
+                !____car.Definition.Components.OfType<FuseConfusingSupplementsLiveryComponent>().Any())
+            {
+                return;
+            }
+
+            try
+            {
+                var choices = FuseConfusingSupplementsLiveryRegistry
+                    .GetChoices(____car.DefinitionInfo.Identifier)
+                    .ToArray();
+                builder.AddSection("Livery", section =>
+                {
+                    if (choices.Length == 0)
+                    {
+                        section.AddLabel(
+                            $"No compatible liveries found for {____car.DefinitionInfo.Identifier}.");
+                        return;
+                    }
+
+                    var ids = StandardLiveryIds.Concat(choices.Select(choice => choice.Id)).ToArray();
+                    var names = StandardLiveryNames.Concat(choices.Select(choice => choice.Id)).ToList();
+                    var current = ____car.KeyValueObject == null
+                        ? null
+                        : ____car.KeyValueObject["cs.livery"].StringValue;
+                    var selected = Array.FindIndex(
+                        ids,
+                        id => string.Equals(id, current, StringComparison.OrdinalIgnoreCase));
+                    if (selected < 0)
+                    {
+                        selected = 0;
+                    }
+
+                    section.AddField("Livery", section.AddDropdown(names, selected, index =>
+                    {
+                        if (____car.KeyValueObject == null || index < 0 || index >= ids.Length)
+                        {
+                            return;
+                        }
+
+                        ____car.KeyValueObject["cs.livery"] = string.IsNullOrWhiteSpace(ids[index])
+                            ? Value.Null()
+                            : Value.String(ids[index]);
+                    }));
+                }, 0f);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a legacy livery Customize-window error; " +
+                    $"the rest of the window remains usable: {ex.GetBaseException().Message}");
+            }
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsRefiller.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsRefiller.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FUSE.Infrastructure;
 using Game.State;
@@ -42,8 +43,25 @@ namespace FUSE.Compatibility
         }
     }
 
-    internal static class FuseConfusingSupplementsRefillerTransferPolicy
+    internal static class FuseConfusingSupplementsRefillerPolicy
     {
+        internal static bool CanTargetReceiveFromSource(
+            IEnumerable<string> sourceLoadIdentifiers,
+            IEnumerable<string> targetLoadIdentifiers)
+        {
+            if (sourceLoadIdentifiers == null || targetLoadIdentifiers == null)
+            {
+                return false;
+            }
+
+            return targetLoadIdentifiers.Any(targetIdentifier =>
+                !string.IsNullOrWhiteSpace(targetIdentifier) &&
+                sourceLoadIdentifiers.Any(sourceIdentifier => string.Equals(
+                    sourceIdentifier,
+                    targetIdentifier,
+                    StringComparison.OrdinalIgnoreCase)));
+        }
+
         internal static float Take(
             ref float remainingTransfer,
             float availableCapacity,
@@ -94,19 +112,11 @@ namespace FUSE.Compatibility
             }
         }
 
-        internal static bool CanReceiveFrom(CarDefinition source, CarDefinition target)
+        private static bool CanTargetReceiveFromSource(CarDefinition source, CarDefinition target)
         {
-            if (source?.LoadSlots == null || target?.LoadSlots == null)
-            {
-                return false;
-            }
-
-            return target.LoadSlots.Any(targetSlot =>
-                !string.IsNullOrWhiteSpace(targetSlot?.RequiredLoadIdentifier) &&
-                source.LoadSlots.Any(sourceSlot => string.Equals(
-                    sourceSlot?.RequiredLoadIdentifier,
-                    targetSlot.RequiredLoadIdentifier,
-                    StringComparison.OrdinalIgnoreCase)));
+            return FuseConfusingSupplementsRefillerPolicy.CanTargetReceiveFromSource(
+                source?.LoadSlots?.Select(slot => slot?.RequiredLoadIdentifier),
+                target?.LoadSlots?.Select(slot => slot?.RequiredLoadIdentifier));
         }
 
         private static Car FindNearestCompatibleCar(Car source, Car.LogicalEnd end)
@@ -137,7 +147,8 @@ namespace FUSE.Compatibility
                     continue;
                 }
 
-                if (IsSupportedTarget(candidate) && CanReceiveFrom(source.Definition, candidate.Definition))
+                if (IsSupportedTarget(candidate) &&
+                    CanTargetReceiveFromSource(source.Definition, candidate.Definition))
                 {
                     return candidate;
                 }
@@ -193,7 +204,7 @@ namespace FUSE.Compatibility
 
                 var targetLoad = target.GetLoadInfo(targetIndex);
                 var targetQuantity = targetLoad?.Quantity ?? 0f;
-                var quantity = FuseConfusingSupplementsRefillerTransferPolicy.Take(
+                var quantity = FuseConfusingSupplementsRefillerPolicy.Take(
                     ref remainingTransfer,
                     targetSlot.MaximumCapacity - targetQuantity,
                     sourceLoad.Value.Quantity);

--- a/FUSE/Compatibility/FuseConfusingSupplementsRefiller.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsRefiller.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using FUSE.Infrastructure;
 using Game.State;
 using Model;
@@ -54,12 +53,26 @@ namespace FUSE.Compatibility
                 return false;
             }
 
-            return targetLoadIdentifiers.Any(targetIdentifier =>
-                !string.IsNullOrWhiteSpace(targetIdentifier) &&
-                sourceLoadIdentifiers.Any(sourceIdentifier => string.Equals(
-                    sourceIdentifier,
-                    targetIdentifier,
-                    StringComparison.OrdinalIgnoreCase)));
+            foreach (var targetIdentifier in targetLoadIdentifiers)
+            {
+                if (string.IsNullOrWhiteSpace(targetIdentifier))
+                {
+                    continue;
+                }
+
+                foreach (var sourceIdentifier in sourceLoadIdentifiers)
+                {
+                    if (string.Equals(
+                            sourceIdentifier,
+                            targetIdentifier,
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         internal static float Take(
@@ -114,9 +127,42 @@ namespace FUSE.Compatibility
 
         private static bool CanTargetReceiveFromSource(CarDefinition source, CarDefinition target)
         {
-            return FuseConfusingSupplementsRefillerPolicy.CanTargetReceiveFromSource(
-                source?.LoadSlots?.Select(slot => slot?.RequiredLoadIdentifier),
-                target?.LoadSlots?.Select(slot => slot?.RequiredLoadIdentifier));
+            if (source?.LoadSlots == null || target?.LoadSlots == null)
+            {
+                return false;
+            }
+
+            for (var targetIndex = 0; targetIndex < target.LoadSlots.Count; targetIndex++)
+            {
+                var targetIdentifier = target.LoadSlots[targetIndex]?.RequiredLoadIdentifier;
+                if (FindLoadSlot(source, targetIdentifier) >= 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static int FindLoadSlot(CarDefinition definition, string requiredLoadIdentifier)
+        {
+            if (definition?.LoadSlots == null || string.IsNullOrWhiteSpace(requiredLoadIdentifier))
+            {
+                return -1;
+            }
+
+            for (var index = 0; index < definition.LoadSlots.Count; index++)
+            {
+                if (string.Equals(
+                        definition.LoadSlots[index]?.RequiredLoadIdentifier,
+                        requiredLoadIdentifier,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return index;
+                }
+            }
+
+            return -1;
         }
 
         private static Car FindNearestCompatibleCar(Car source, Car.LogicalEnd end)
@@ -187,10 +233,7 @@ namespace FUSE.Compatibility
                     continue;
                 }
 
-                var sourceIndex = source.Definition.LoadSlots.FindIndex(slot => string.Equals(
-                    slot?.RequiredLoadIdentifier,
-                    loadId,
-                    StringComparison.OrdinalIgnoreCase));
+                var sourceIndex = FindLoadSlot(source.Definition, loadId);
                 if (sourceIndex < 0)
                 {
                     continue;

--- a/FUSE/Compatibility/FuseConfusingSupplementsRefiller.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsRefiller.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Linq;
+using FUSE.Infrastructure;
+using Game.State;
+using Model;
+using Model.Definition;
+using Model.Definition.Data;
+using Model.Ops;
+using Model.Physics;
+using Railloader.Extensions;
+using UnityEngine;
+
+namespace FUSE.Compatibility
+{
+    internal sealed class FuseConfusingSupplementsRefillerComponent : Model.Definition.Component
+    {
+        internal const string ComponentKind = "ConfusingSupplements.Refiller";
+
+        public override string Kind => ComponentKind;
+
+        public int TransferRate { get; set; } = 36000;
+    }
+
+    internal sealed class FuseConfusingSupplementsRefillerBuilder : ComponentBuilder<FuseConfusingSupplementsRefillerComponent>
+    {
+        protected override void Build(
+            ComponentBuilderContext context,
+            FuseConfusingSupplementsRefillerComponent component)
+        {
+            var car = context.GameObject?.GetComponentInParent<Car>();
+            if (car == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not attach a legacy refiller to '{context.ObjectName ?? "<unknown car>"}' " +
+                    "because its car object was unavailable.");
+                return;
+            }
+
+            var runtime = car.GetComponent<FuseConfusingSupplementsRefillerRuntime>() ??
+                          car.gameObject.AddComponent<FuseConfusingSupplementsRefillerRuntime>();
+            runtime.TransferPerSecond = Mathf.Max(0f, (component?.TransferRate ?? 0) / 3600f);
+        }
+    }
+
+    internal sealed class FuseConfusingSupplementsRefillerRuntime : MonoBehaviour
+    {
+        internal float TransferPerSecond { get; set; }
+
+        private Car _source;
+        private float _nextUpdate;
+
+        private void Awake()
+        {
+            _source = GetComponent<Car>();
+        }
+
+        private void Update()
+        {
+            if (!StateManager.IsHost || _source == null || Time.time < _nextUpdate)
+            {
+                return;
+            }
+
+            _nextUpdate = Time.time + 1f;
+            try
+            {
+                var target = FindNearestCompatibleCar(_source, Car.LogicalEnd.A) ??
+                             FindNearestCompatibleCar(_source, Car.LogicalEnd.B);
+                if (target != null)
+                {
+                    TransferLoads(_source, target, TransferPerSecond);
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE contained a rolling-stock refiller error on '{_source.DisplayName ?? _source.id}': " +
+                    ex.GetBaseException().Message);
+            }
+        }
+
+        internal static bool CanReceiveFrom(CarDefinition source, CarDefinition target)
+        {
+            if (source?.LoadSlots == null || target?.LoadSlots == null)
+            {
+                return false;
+            }
+
+            return target.LoadSlots.Any(targetSlot =>
+                !string.IsNullOrWhiteSpace(targetSlot?.RequiredLoadIdentifier) &&
+                source.LoadSlots.Any(sourceSlot => string.Equals(
+                    sourceSlot?.RequiredLoadIdentifier,
+                    targetSlot.RequiredLoadIdentifier,
+                    StringComparison.OrdinalIgnoreCase)));
+        }
+
+        private static Car FindNearestCompatibleCar(Car source, Car.LogicalEnd end)
+        {
+            var set = source.set;
+            var index = set?.IndexOfCar(source);
+            if (!index.HasValue)
+            {
+                return null;
+            }
+
+            var cursor = index.Value;
+            var stop = false;
+            while (!stop)
+            {
+                var candidate = set.NextCarConnected(
+                    ref cursor,
+                    end,
+                    IntegrationSet.EnumerationCondition.AirConnected,
+                    out stop);
+                if (candidate == null)
+                {
+                    break;
+                }
+
+                if (candidate == source)
+                {
+                    continue;
+                }
+
+                if (IsSupportedTarget(candidate) && CanReceiveFrom(source.Definition, candidate.Definition))
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsSupportedTarget(Car car)
+        {
+            return car != null &&
+                   (car.Archetype == CarArchetype.LocomotiveDiesel ||
+                    car.Archetype == CarArchetype.LocomotiveSteam ||
+                    car.Archetype == CarArchetype.Tender);
+        }
+
+        private static void TransferLoads(Car source, Car target, float maximumTransfer)
+        {
+            if (maximumTransfer <= 0f || source?.Definition?.LoadSlots == null || target?.Definition?.LoadSlots == null)
+            {
+                return;
+            }
+
+            for (var targetIndex = 0; targetIndex < target.Definition.LoadSlots.Count; targetIndex++)
+            {
+                var targetSlot = target.Definition.LoadSlots[targetIndex];
+                var loadId = targetSlot?.RequiredLoadIdentifier;
+                if (string.IsNullOrWhiteSpace(loadId))
+                {
+                    continue;
+                }
+
+                var sourceIndex = source.Definition.LoadSlots.FindIndex(slot => string.Equals(
+                    slot?.RequiredLoadIdentifier,
+                    loadId,
+                    StringComparison.OrdinalIgnoreCase));
+                if (sourceIndex < 0)
+                {
+                    continue;
+                }
+
+                var sourceLoad = source.GetLoadInfo(sourceIndex);
+                if (!sourceLoad.HasValue || sourceLoad.Value.Quantity <= 0f)
+                {
+                    continue;
+                }
+
+                var targetLoad = target.GetLoadInfo(targetIndex);
+                var targetQuantity = targetLoad?.Quantity ?? 0f;
+                var availableCapacity = Mathf.Max(0f, targetSlot.MaximumCapacity - targetQuantity);
+                var quantity = Mathf.Min(maximumTransfer, Mathf.Min(availableCapacity, sourceLoad.Value.Quantity));
+                if (quantity <= 0f)
+                {
+                    continue;
+                }
+
+                var remainingSource = sourceLoad.Value;
+                remainingSource.Quantity -= quantity;
+                target.SetLoadInfo(targetIndex, new CarLoadInfo(loadId, targetQuantity + quantity));
+                source.SetLoadInfo(sourceIndex, remainingSource);
+            }
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseConfusingSupplementsRefiller.cs
+++ b/FUSE/Compatibility/FuseConfusingSupplementsRefiller.cs
@@ -42,6 +42,21 @@ namespace FUSE.Compatibility
         }
     }
 
+    internal static class FuseConfusingSupplementsRefillerTransferPolicy
+    {
+        internal static float Take(
+            ref float remainingTransfer,
+            float availableCapacity,
+            float availableSource)
+        {
+            var quantity = Math.Min(
+                Math.Max(0f, remainingTransfer),
+                Math.Min(Math.Max(0f, availableCapacity), Math.Max(0f, availableSource)));
+            remainingTransfer -= quantity;
+            return quantity;
+        }
+    }
+
     internal sealed class FuseConfusingSupplementsRefillerRuntime : MonoBehaviour
     {
         internal float TransferPerSecond { get; set; }
@@ -146,8 +161,14 @@ namespace FUSE.Compatibility
                 return;
             }
 
+            var remainingTransfer = maximumTransfer;
             for (var targetIndex = 0; targetIndex < target.Definition.LoadSlots.Count; targetIndex++)
             {
+                if (remainingTransfer <= 0f)
+                {
+                    break;
+                }
+
                 var targetSlot = target.Definition.LoadSlots[targetIndex];
                 var loadId = targetSlot?.RequiredLoadIdentifier;
                 if (string.IsNullOrWhiteSpace(loadId))
@@ -172,8 +193,10 @@ namespace FUSE.Compatibility
 
                 var targetLoad = target.GetLoadInfo(targetIndex);
                 var targetQuantity = targetLoad?.Quantity ?? 0f;
-                var availableCapacity = Mathf.Max(0f, targetSlot.MaximumCapacity - targetQuantity);
-                var quantity = Mathf.Min(maximumTransfer, Mathf.Min(availableCapacity, sourceLoad.Value.Quantity));
+                var quantity = FuseConfusingSupplementsRefillerTransferPolicy.Take(
+                    ref remainingTransfer,
+                    targetSlot.MaximumCapacity - targetQuantity,
+                    sourceLoad.Value.Quantity);
                 if (quantity <= 0f)
                 {
                     continue;

--- a/FUSE/Compatibility/FuseLegacyDebugInformation.cs
+++ b/FUSE/Compatibility/FuseLegacyDebugInformation.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using FUSE.Infrastructure;
+using GalaSoft.MvvmLight.Messaging;
+using Railloader.Events;
+
+namespace FUSE.Compatibility
+{
+    internal static class FuseLegacyDebugInformation
+    {
+        internal const int MaximumLines = 1000;
+        internal const int MaximumCharacters = 131072;
+        private const int MaximumLineCharacters = 4096;
+        private static readonly char[] NewLineSeparator = { '\n' };
+
+        internal static IReadOnlyList<string> Collect()
+        {
+            return Collect(Messenger.Default);
+        }
+
+        internal static IReadOnlyList<string> Collect(IMessenger messenger)
+        {
+            return Collect(message => messenger?.Send(message));
+        }
+
+        internal static IReadOnlyList<string> Collect(
+            Action<WillCopyDebugInformation> dispatch)
+        {
+            var lines = new List<string>();
+            var characterCount = 0;
+            var truncated = false;
+
+            void AppendLine(string value)
+            {
+                if (truncated || value == null)
+                {
+                    return;
+                }
+
+                var normalized = value.Replace("\r\n", "\n").Replace('\r', '\n');
+                foreach (var candidate in normalized.Split(NewLineSeparator, StringSplitOptions.None))
+                {
+                    var line = candidate.Length > MaximumLineCharacters
+                        ? candidate.Substring(0, MaximumLineCharacters) + " …"
+                        : candidate;
+                    if (lines.Count >= MaximumLines
+                        || characterCount + line.Length > MaximumCharacters)
+                    {
+                        truncated = true;
+                        break;
+                    }
+
+                    lines.Add(line);
+                    characterCount += line.Length;
+                }
+            }
+
+            try
+            {
+                dispatch?.Invoke(new WillCopyDebugInformation(AppendLine));
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a legacy debug-report listener failure: " +
+                    ex.GetBaseException().Message);
+            }
+
+            if (truncated)
+            {
+                lines.Add(
+                    $"[FUSE truncated legacy debug information at {MaximumLines} lines or " +
+                    $"{MaximumCharacters} characters.]");
+            }
+
+            return lines;
+        }
+
+        internal static string AppendToReport(string report)
+        {
+            var lines = Collect();
+            if (lines.Count == 0)
+            {
+                return report ?? string.Empty;
+            }
+
+            var builder = new StringBuilder(report ?? string.Empty);
+            if (builder.Length > 0 && builder[builder.Length - 1] != '\n')
+            {
+                builder.AppendLine();
+            }
+
+            builder.AppendLine("Legacy mod diagnostic contributions:");
+            foreach (var line in lines)
+            {
+                builder.Append("  ").AppendLine(line);
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseLegacyInstallDetector.cs
+++ b/FUSE/Compatibility/FuseLegacyInstallDetector.cs
@@ -8,7 +8,8 @@ using UnityEngine;
 namespace FUSE.Compatibility
 {
     // Detects when the legacy Railloader install is left in place alongside
-    // FUSE. The bad state is Railloader.dll and/or Railloader.Interchange.dll
+    // FUSE. The bad state is Railloader.dll, Railloader.Injector.dll, and/or
+    // Railloader.Interchange.dll
     // sitting in Railroader_Data\Managed\: Unity's assembly loader resolves
     // them before FuseLegacySupportAssemblyShim's AssemblyResolve hook fires,
     // so legacy mod IL binds to the real old-loader types instead of FUSE's
@@ -17,7 +18,9 @@ namespace FUSE.Compatibility
     internal static class FuseLegacyInstallDetector
     {
         private const string LegacyRailloaderDll = "Railloader.dll";
+        private const string LegacyInjectorDll = "Railloader.Injector.dll";
         private const string LegacyInterchangeDll = "Railloader.Interchange.dll";
+        private const string LegacyStrangeCustomsDll = "StrangeCustoms.dll";
 
         internal static IReadOnlyList<string> DetectConflictingFiles()
         {
@@ -39,7 +42,9 @@ namespace FUSE.Compatibility
 
                 var managedDir = Path.Combine(dataPath, "Managed");
                 AddIfFileExists(results, Path.Combine(managedDir, LegacyRailloaderDll));
+                AddIfFileExists(results, Path.Combine(managedDir, LegacyInjectorDll));
                 AddIfFileExists(results, Path.Combine(managedDir, LegacyInterchangeDll));
+                AddIfFileExists(results, Path.Combine(managedDir, LegacyStrangeCustomsDll));
             }
             catch (Exception ex)
             {
@@ -120,17 +125,9 @@ namespace FUSE.Compatibility
             }
         }
 
-        private static bool IsLegacyLoaderAssemblyName(string assemblyName)
+        internal static bool IsLegacyLoaderAssemblyName(string assemblyName)
         {
             if (string.IsNullOrWhiteSpace(assemblyName))
-            {
-                return false;
-            }
-
-            // Railloader.Injector is the Doorstop-style native-side hook that
-            // ships with the standard FUSE-compatible install — it is NOT the
-            // legacy managed loader API and must not be flagged as a conflict.
-            if (assemblyName.Equals("Railloader.Injector", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/FUSE/Compatibility/FuseLegacyTypeRegistry.cs
+++ b/FUSE/Compatibility/FuseLegacyTypeRegistry.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model;
+
+namespace FUSE.Compatibility
+{
+    /// <summary>
+    /// Runtime registry used by the RailLoader compatibility context. Legacy library
+    /// mods register JSON discriminator values and component builders during startup;
+    /// FUSE forwards those registrations into the live game instead of merely allowing
+    /// the plugin assembly to load.
+    /// </summary>
+    internal static class FuseLegacyTypeRegistry
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<Type, Dictionary<string, Type>> Registrations =
+            new Dictionary<Type, Dictionary<string, Type>>();
+
+        internal static void RegisterSubType(Type baseType, string identifier, Type implementationType)
+        {
+            if (baseType == null)
+            {
+                throw new ArgumentNullException(nameof(baseType));
+            }
+
+            if (string.IsNullOrWhiteSpace(identifier))
+            {
+                throw new ArgumentException("A legacy subtype identifier is required.", nameof(identifier));
+            }
+
+            if (implementationType == null)
+            {
+                throw new ArgumentNullException(nameof(implementationType));
+            }
+
+            if (!baseType.IsAssignableFrom(implementationType))
+            {
+                throw new ArgumentException(
+                    $"Legacy subtype '{implementationType.FullName}' is not assignable to '{baseType.FullName}'.",
+                    nameof(implementationType));
+            }
+
+            Type replaced = null;
+            lock (Gate)
+            {
+                if (!Registrations.TryGetValue(baseType, out var byIdentifier))
+                {
+                    byIdentifier = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+                    Registrations[baseType] = byIdentifier;
+                }
+
+                byIdentifier.TryGetValue(identifier.Trim(), out replaced);
+                byIdentifier[identifier.Trim()] = implementationType;
+            }
+
+            if (replaced != null && replaced != implementationType)
+            {
+                FuseLog.Warning(
+                    $"FUSE legacy subtype '{identifier}' for '{baseType.FullName}' was re-registered from " +
+                    $"'{replaced.FullName}' to '{implementationType.FullName}'. The latest registration will be used.");
+            }
+            else
+            {
+                FuseLog.Info(
+                    $"FUSE registered legacy subtype '{identifier}' for '{baseType.FullName}' as " +
+                    $"'{implementationType.FullName}'.");
+            }
+        }
+
+        internal static void RegisterComponent(Type componentType, Type builderType, string kind)
+        {
+            if (componentType == null)
+            {
+                throw new ArgumentNullException(nameof(componentType));
+            }
+
+            if (!typeof(Model.Definition.Component).IsAssignableFrom(componentType))
+            {
+                throw new ArgumentException(
+                    $"Legacy component '{componentType.FullName}' does not derive from Model.Definition.Component.",
+                    nameof(componentType));
+            }
+
+            if (builderType == null)
+            {
+                throw new ArgumentNullException(nameof(builderType));
+            }
+
+            if (!typeof(IComponentBuilder).IsAssignableFrom(builderType))
+            {
+                throw new ArgumentException(
+                    $"Legacy component builder '{builderType.FullName}' does not implement Model.IComponentBuilder.",
+                    nameof(builderType));
+            }
+
+            var builder = Activator.CreateInstance(builderType);
+            if (!(builder is IComponentBuilder typedBuilder))
+            {
+                throw new InvalidOperationException(
+                    $"Legacy component builder '{builderType.FullName}' could not be created as Model.IComponentBuilder.");
+            }
+
+            var prepare = AccessTools.Method(typeof(ComponentFactory), "PrepareBuildersIfNeeded");
+            var buildersField = AccessTools.Field(typeof(ComponentFactory), "_builders");
+            if (prepare == null || buildersField == null)
+            {
+                throw new MissingMemberException(
+                    typeof(ComponentFactory).FullName,
+                    "PrepareBuildersIfNeeded/_builders");
+            }
+
+            prepare.Invoke(null, null);
+            var builders = buildersField.GetValue(null) as IDictionary;
+            if (builders == null)
+            {
+                throw new InvalidOperationException("The game's component-builder registry was unavailable after initialization.");
+            }
+
+            builders[componentType] = typedBuilder;
+            RegisterSubType(typeof(Model.Definition.Component), kind, componentType);
+            Loading.FuseAssetPackRegistry.OnLegacyComponentKindRegistered(kind);
+            FuseLog.Info(
+                $"FUSE registered legacy component kind '{kind}' with builder '{builderType.FullName}'.");
+        }
+
+        internal static IReadOnlyList<KeyValuePair<string, Type>> Snapshot(Type baseType)
+        {
+            if (baseType == null)
+            {
+                return Array.Empty<KeyValuePair<string, Type>>();
+            }
+
+            lock (Gate)
+            {
+                if (!Registrations.TryGetValue(baseType, out var byIdentifier))
+                {
+                    return Array.Empty<KeyValuePair<string, Type>>();
+                }
+
+                return byIdentifier.ToArray();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds compatibility registrations to JsonSubTypes at lookup time. Keeping the
+    /// dynamic entries outside JsonSubTypes' private cache means registrations made by
+    /// a late-starting hosted plugin become visible immediately.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FuseLegacyJsonSubtypeRegistryPatch
+    {
+        private static Type _knownSubTypeAttributeType;
+        private static ConstructorInfo _knownSubTypeConstructor;
+
+        private static MethodInfo TargetMethod()
+        {
+            var jsonSubtypes =
+                AccessTools.TypeByName("JsonSubTypes.JsonSubtypes") ??
+                Type.GetType("JsonSubTypes.JsonSubtypes, JsonSubTypes", throwOnError: false);
+            if (jsonSubtypes == null)
+            {
+                return null;
+            }
+
+            _knownSubTypeAttributeType = jsonSubtypes.GetNestedType(
+                "KnownSubTypeAttribute",
+                BindingFlags.Public | BindingFlags.NonPublic);
+            _knownSubTypeConstructor = _knownSubTypeAttributeType?.GetConstructor(new[] { typeof(Type), typeof(object) });
+            // JsonSubTypes exposes both GetAttributes(Type) and
+            // GetAttributes<T>(Type). AccessTools.Method sees the identical
+            // parameter lists as ambiguous, so select the non-generic method
+            // explicitly. An ambiguous target makes Harmony detach the patch
+            // even though the runtime DLL is otherwise compatible.
+            return jsonSubtypes
+                .GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)
+                .SingleOrDefault(method =>
+                    string.Equals(method.Name, "GetAttributes", StringComparison.Ordinal) &&
+                    !method.IsGenericMethodDefinition &&
+                    method.GetParameters().Length == 1 &&
+                    method.GetParameters()[0].ParameterType == typeof(Type));
+        }
+
+        private static void Postfix(Type typeInfo, ref IEnumerable<object> __result)
+        {
+            var registrations = FuseLegacyTypeRegistry.Snapshot(typeInfo);
+            if (registrations.Count == 0 || _knownSubTypeConstructor == null)
+            {
+                return;
+            }
+
+            var replacementIds = new HashSet<string>(
+                registrations.Select(pair => pair.Key),
+                StringComparer.OrdinalIgnoreCase);
+            var combined = (__result ?? Enumerable.Empty<object>())
+                .Where(attribute => !IsReplacedKnownSubType(attribute, replacementIds))
+                .ToList();
+
+            foreach (var registration in registrations)
+            {
+                combined.Add(_knownSubTypeConstructor.Invoke(new object[]
+                {
+                    registration.Value,
+                    registration.Key
+                }));
+            }
+
+            __result = combined;
+        }
+
+        private static bool IsReplacedKnownSubType(object attribute, HashSet<string> replacementIds)
+        {
+            if (attribute == null || _knownSubTypeAttributeType == null ||
+                !_knownSubTypeAttributeType.IsInstanceOfType(attribute))
+            {
+                return false;
+            }
+
+            var associatedValue = _knownSubTypeAttributeType
+                .GetProperty("AssociatedValue", BindingFlags.Instance | BindingFlags.Public)
+                ?.GetValue(attribute, null) as string;
+            return associatedValue != null && replacementIds.Contains(associatedValue);
+        }
+    }
+}

--- a/FUSE/Compatibility/FuseNarrowGaugePerformanceCompatibility.cs
+++ b/FUSE/Compatibility/FuseNarrowGaugePerformanceCompatibility.cs
@@ -39,6 +39,8 @@ namespace FUSE.Compatibility
         private const float CurveOverlapToleranceMeters = 0.085f;
 
         private static readonly object Gate = new object();
+        [ThreadStatic]
+        private static List<LineSegment> _curveSegments;
         private static Harmony _harmony;
         private static bool _installed;
         private static bool _attempted;
@@ -330,51 +332,70 @@ namespace FUSE.Compatibility
             }
 
             // NarrowGauge's original DistancePointToCurve enumerates a.Segments
-            // through LINQ Min for every 0.1m endpoint. The segment sequence is
-            // immutable for this calculation, so materialize it once while
-            // preserving the exact sampling grid, distance formula, and tolerance.
-            var segments = a.Segments.Select(item => item.Item2).ToArray();
-            if (segments.Length == 0)
+            // through LINQ Min for every 0.1m endpoint. Reuse one list per thread
+            // so every pairwise overlap test does not allocate another iterator,
+            // closure, and segment array.
+            var segments = _curveSegments;
+            if (segments == null)
             {
-                throw new InvalidOperationException(
-                    "Cannot measure overlap against a curve with no segments.");
+                segments = new List<LineSegment>(64);
+                _curveSegments = segments;
             }
 
-            var length = b.Length;
-            var overlap = 0f;
-            var count = Mathf.Max(
-                2,
-                Mathf.CeilToInt(length / CurveOverlapSampleSpacingMeters) + 1);
-            for (var index = 0; index + 1 < count; index++)
+            segments.Clear();
+            try
             {
-                var startDistance = Mathf.Min(
-                    length,
-                    index * CurveOverlapSampleSpacingMeters);
-                var endDistance = index == count - 2
-                    ? length
-                    : Mathf.Min(
-                        length,
-                        (index + 1) * CurveOverlapSampleSpacingMeters);
-                if (DistancePointToSegments(
-                        b.LinePointAtDistance(startDistance).point,
-                        segments) <= CurveOverlapToleranceMeters &&
-                    DistancePointToSegments(
-                        b.LinePointAtDistance(endDistance).point,
-                        segments) <= CurveOverlapToleranceMeters)
+                foreach (var item in a.Segments)
                 {
-                    overlap += endDistance - startDistance;
+                    segments.Add(item.Item2);
                 }
-            }
 
-            return overlap;
+                if (segments.Count == 0)
+                {
+                    throw new InvalidOperationException(
+                        "Cannot measure overlap against a curve with no segments.");
+                }
+
+                var length = b.Length;
+                var overlap = 0f;
+                var count = Mathf.Max(
+                    2,
+                    Mathf.CeilToInt(length / CurveOverlapSampleSpacingMeters) + 1);
+                for (var index = 0; index + 1 < count; index++)
+                {
+                    var startDistance = Mathf.Min(
+                        length,
+                        index * CurveOverlapSampleSpacingMeters);
+                    var endDistance = index == count - 2
+                        ? length
+                        : Mathf.Min(
+                            length,
+                            (index + 1) * CurveOverlapSampleSpacingMeters);
+                    if (DistancePointToSegments(
+                            b.LinePointAtDistance(startDistance).point,
+                            segments) <= CurveOverlapToleranceMeters &&
+                        DistancePointToSegments(
+                            b.LinePointAtDistance(endDistance).point,
+                            segments) <= CurveOverlapToleranceMeters)
+                    {
+                        overlap += endDistance - startDistance;
+                    }
+                }
+
+                return overlap;
+            }
+            finally
+            {
+                segments.Clear();
+            }
         }
 
         private static float DistancePointToSegments(
             Vector3 point,
-            LineSegment[] segments)
+            List<LineSegment> segments)
         {
             var minimum = float.MaxValue;
-            for (var index = 0; index < segments.Length; index++)
+            for (var index = 0; index < segments.Count; index++)
             {
                 var segment = segments[index];
                 var start = segment.a.point;

--- a/FUSE/Compatibility/RailloaderLegacySupport.cs
+++ b/FUSE/Compatibility/RailloaderLegacySupport.cs
@@ -6,6 +6,9 @@ using UI.Builder;
 using UI.Common;
 using UI.Console;
 using UnityEngine;
+using LegacyComponent = Model.Definition.Component;
+using LegacyComponentBuilderContext = Model.ComponentBuilderContext;
+using LegacyComponentBuilder = Model.IComponentBuilder;
 
 // Legacy support surface for assemblies compiled against the previous loader API.
 // This file reproduces the public surface of the legacy Railloader.Interchange API
@@ -112,8 +115,8 @@ namespace Railloader
         /// Preserves the legacy component-builder registration contract so plugin types can load under FUSE.
         /// </summary>
         void RegisterComponent<TComponent, TComponentBuilder>(string kind)
-            where TComponent : Component
-            where TComponentBuilder : IComponentBuilder;
+            where TComponent : LegacyComponent
+            where TComponentBuilder : LegacyComponentBuilder;
     }
 
     [Obsolete(LegacyShim.Message)]
@@ -383,14 +386,14 @@ namespace Railloader
 namespace Railloader.Extensions
 {
     [Obsolete(LegacyShim.Message)]
-    public abstract class ComponentBuilder<T> : IComponentBuilder where T : Component
+    public abstract class ComponentBuilder<T> : LegacyComponentBuilder where T : LegacyComponent
     {
         public System.Type ComponentType => typeof(T);
 
         /// <summary>
         /// Preserves the legacy non-generic dispatch entry point and forwards it to the typed builder contract.
         /// </summary>
-        public void Build(ComponentBuilderContext ctx, Component component)
+        public void Build(LegacyComponentBuilderContext ctx, LegacyComponent component)
         {
             Build(ctx, (T)(object)component);
         }
@@ -398,7 +401,7 @@ namespace Railloader.Extensions
         /// <summary>
         /// Preserves the typed legacy component-build override implemented by existing plugin binaries.
         /// </summary>
-        protected abstract void Build(ComponentBuilderContext ctx, T component);
+        protected abstract void Build(LegacyComponentBuilderContext ctx, T component);
     }
 }
 

--- a/FUSE/Compatibility/RailroaderTrackContract.cs
+++ b/FUSE/Compatibility/RailroaderTrackContract.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Reflection;
+using Track;
+
+namespace FUSE.Compatibility
+{
+    /// <summary>
+    /// Bridges the released TrackSegment.Style representation and the newer
+    /// flags-based graph contract without taking a compile-time dependency on
+    /// fields that are absent from either game generation.
+    /// </summary>
+    internal static class RailroaderTrackContract
+    {
+        private const int BridgeFlag = 2;
+        private const int BridgeSupportsSteelFlag = 4;
+        private const int TunnelFlag = 8;
+        private const int YardFlag = 16;
+
+        private static readonly FieldInfo SegmentStyleField =
+            typeof(TrackSegment).GetField("style", BindingFlags.Instance | BindingFlags.Public);
+        private static readonly FieldInfo SegmentFlagsField =
+            typeof(TrackSegment).GetField("flags", BindingFlags.Instance | BindingFlags.Public);
+        private static readonly PropertyInfo NodeDiamondProperty =
+            typeof(TrackNode).GetProperty("IsDiamond", BindingFlags.Instance | BindingFlags.Public);
+        private static readonly FieldInfo NodeDiamondField =
+            typeof(TrackNode).GetField("isDiamond", BindingFlags.Instance | BindingFlags.Public);
+        private static readonly MethodInfo GraphSetNodeIsDiamondMethod =
+            typeof(Graph).GetMethod(
+                "SetNodeIsDiamond",
+                BindingFlags.Instance | BindingFlags.Public,
+                null,
+                new[] { typeof(TrackNode), typeof(bool) },
+                null);
+
+        internal static bool GetNodeIsDiamond(TrackNode node)
+        {
+            if (node == null)
+            {
+                return false;
+            }
+
+            if (NodeDiamondProperty?.CanRead == true)
+            {
+                return Convert.ToBoolean(NodeDiamondProperty.GetValue(node, null));
+            }
+
+            return NodeDiamondField != null && Convert.ToBoolean(NodeDiamondField.GetValue(node));
+        }
+
+        internal static void SetNodeIsDiamond(TrackNode node, bool value)
+        {
+            if (node == null)
+            {
+                return;
+            }
+
+            if (GraphSetNodeIsDiamondMethod != null && Graph.Shared != null)
+            {
+                GraphSetNodeIsDiamondMethod.Invoke(Graph.Shared, new object[] { node, value });
+            }
+            else if (NodeDiamondProperty?.CanWrite == true)
+            {
+                NodeDiamondProperty.SetValue(node, value, null);
+            }
+            else
+            {
+                NodeDiamondField?.SetValue(node, value);
+            }
+        }
+
+        internal static int GetStructureFlags(TrackSegment segment)
+        {
+            if (segment == null)
+            {
+                return 0;
+            }
+
+            if (SegmentFlagsField != null)
+            {
+                return Convert.ToInt32(SegmentFlagsField.GetValue(segment));
+            }
+
+            return StyleNameToFlags(SegmentStyleField?.GetValue(segment)?.ToString());
+        }
+
+        internal static string GetStyleName(TrackSegment segment)
+        {
+            if (segment == null)
+            {
+                return "Standard";
+            }
+
+            if (SegmentStyleField != null)
+            {
+                return SegmentStyleField.GetValue(segment)?.ToString() ?? "Standard";
+            }
+
+            var flags = GetStructureFlags(segment);
+            if ((flags & TunnelFlag) != 0)
+            {
+                return "Tunnel";
+            }
+
+            if ((flags & BridgeFlag) != 0)
+            {
+                return "Bridge";
+            }
+
+            if ((flags & YardFlag) != 0)
+            {
+                return "Yard";
+            }
+
+            return "Standard";
+        }
+
+        internal static bool GetBridgeSupportsSteel(TrackSegment segment)
+        {
+            return (GetStructureFlags(segment) & BridgeSupportsSteelFlag) != 0;
+        }
+
+        internal static bool GetYard(TrackSegment segment)
+        {
+            return (GetStructureFlags(segment) & YardFlag) != 0;
+        }
+
+        internal static void ApplyStructure(
+            TrackSegment segment,
+            string style,
+            bool bridgeSupportsSteel,
+            bool yard)
+        {
+            if (segment == null)
+            {
+                return;
+            }
+
+            if (SegmentFlagsField != null)
+            {
+                var flags = StyleNameToFlags(style);
+                if (bridgeSupportsSteel)
+                {
+                    flags |= BridgeFlag | BridgeSupportsSteelFlag;
+                }
+
+                if (yard)
+                {
+                    flags |= YardFlag;
+                }
+
+                SegmentFlagsField.SetValue(segment, Enum.ToObject(SegmentFlagsField.FieldType, flags));
+                return;
+            }
+
+            if (SegmentStyleField == null)
+            {
+                return;
+            }
+
+            var releasedStyle = style;
+            if (yard && string.Equals(releasedStyle, "standard", StringComparison.OrdinalIgnoreCase))
+            {
+                releasedStyle = "Yard";
+            }
+
+            SegmentStyleField.SetValue(
+                segment,
+                Enum.Parse(SegmentStyleField.FieldType, releasedStyle ?? "Standard", true));
+        }
+
+        internal static int StyleNameToFlags(string style)
+        {
+            if (string.Equals(style, "bridge", StringComparison.OrdinalIgnoreCase))
+            {
+                return BridgeFlag;
+            }
+
+            if (string.Equals(style, "tunnel", StringComparison.OrdinalIgnoreCase))
+            {
+                return TunnelFlag;
+            }
+
+            if (string.Equals(style, "yard", StringComparison.OrdinalIgnoreCase))
+            {
+                return YardFlag;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/FUSE/Compatibility/StrangeCustomsLegacySupport.cs
+++ b/FUSE/Compatibility/StrangeCustomsLegacySupport.cs
@@ -1,7 +1,12 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
+using FUSE.Infrastructure;
+using FUSE.Authoring.Data;
+using FUSE.Loading;
+using FUSE.Runtime.API;
 using Helpers;
 using Model;
 using Model.Definition.Data;
@@ -14,6 +19,7 @@ using Track;
 using UI.Builder;
 using UI.Console;
 using UnityEngine;
+using UnityEngine.Networking;
 
 // Interop declarations matching the StrangeCustoms public-API shape that the
 // old-loader plugin ecosystem (DKW, ModularScenery, Alina's Map Mod, etc.) was
@@ -69,10 +75,10 @@ namespace StrangeCustoms
     }
 
     /// <summary>
-    /// File-cache shape that legacy plugins use to fetch external assets at
-    /// runtime. The shim declares the surface so plugin IL JITs cleanly;
-    /// FUSE's asset pipeline does not populate <see cref="Instance"/>, so any
-    /// runtime call goes through the no-op bodies below.
+    /// FUSE-owned implementation of the loose-file cache used by legacy
+    /// Strange Customs consumers. It preserves the public ABI while keeping
+    /// cache ownership, loading, invalidation, and callback containment inside
+    /// FUSE.
     /// </summary>
     [Obsolete(LegacyShim.Message)]
     public class FileCache : MonoBehaviour
@@ -97,7 +103,8 @@ namespace StrangeCustoms
                 {
                     try
                     {
-                        return File.GetLastWriteTime(FileName) >= LastUpdate;
+                        return !File.Exists(FileName)
+                               || File.GetLastWriteTimeUtc(FileName) > LastUpdate;
                     }
                     catch
                     {
@@ -135,12 +142,31 @@ namespace StrangeCustoms
             public void Set(T value)
             {
                 Value = value;
-                LastUpdate = DateTime.UtcNow;
+                LastUpdate = File.Exists(FileName)
+                    ? File.GetLastWriteTimeUtc(FileName)
+                    : DateTime.UtcNow;
                 IsValid = true;
                 IsLoading = false;
                 var handler = Loaded;
                 Loaded = null;
-                handler?.Invoke(value);
+                if (handler == null)
+                {
+                    return;
+                }
+
+                foreach (Action<T> callback in handler.GetInvocationList())
+                {
+                    try
+                    {
+                        callback(value);
+                    }
+                    catch (Exception ex)
+                    {
+                        FuseLog.Warning(
+                            $"FUSE contained a Strange Customs file-cache callback error for '{FileName}': " +
+                            ex.GetBaseException().Message);
+                    }
+                }
             }
 
             /// <summary>
@@ -192,31 +218,294 @@ namespace StrangeCustoms
 
         public static FileCache Instance { get; private set; }
 
-        /// <summary>
-        /// Retains the legacy audio-load signature so plugin IL resolves; FUSE does not run that cache pipeline.
-        /// </summary>
-        public void LoadAudioClip(string fileName, Action<AudioClip> callback)
+        private readonly Dictionary<string, CacheEntry> _entries =
+            new Dictionary<string, CacheEntry>(StringComparer.OrdinalIgnoreCase);
+
+        internal static void EnsureInstance()
         {
-            // FUSE does not run the legacy file-cache pipeline. The callback is
-            // never invoked under FUSE; the method exists for interop only.
+            if (Instance != null)
+            {
+                return;
+            }
+
+            var host = new GameObject("FUSE Strange Customs File Cache");
+            UnityEngine.Object.DontDestroyOnLoad(host);
+            Instance = host.AddComponent<FileCache>();
+        }
+
+        internal static void Shutdown()
+        {
+            if (Instance == null)
+            {
+                return;
+            }
+
+            var host = Instance.gameObject;
+            Instance.Clear();
+            Instance = null;
+            if (host != null)
+            {
+                UnityEngine.Object.Destroy(host);
+            }
+        }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                UnityEngine.Object.Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+            {
+                Clear();
+                Instance = null;
+            }
         }
 
         /// <summary>
-        /// Retains the legacy texture-load signature and reports an uncached miss because FUSE does not service it.
+        /// Loads a loose audio file asynchronously and invokes every waiting
+        /// callback exactly once, including failures (with a null clip).
+        /// </summary>
+        public void LoadAudioClip(string fileName, Action<AudioClip> callback)
+        {
+            var fullPath = NormalizePath(fileName);
+            if (fullPath.Length == 0)
+            {
+                InvokeSafely(callback, null, fileName);
+                return;
+            }
+
+            if (_entries.TryGetValue(fullPath, out var rawEntry)
+                && rawEntry is CacheEntry<AudioClip> cached)
+            {
+                if (cached.IsValid && !cached.IsExpired && cached.Value != null)
+                {
+                    InvokeSafely(callback, cached.Value, fullPath);
+                    return;
+                }
+
+                cached.Register(callback);
+                if (cached.IsLoading)
+                {
+                    return;
+                }
+
+                DestroyCachedObject(cached.Value);
+                cached.Invalidate();
+                cached.IsLoading = true;
+                StartCoroutine(LoadAudioClipCoroutine(fullPath, cached));
+                return;
+            }
+
+            var entry = new CacheEntry<AudioClip>(fullPath)
+            {
+                IsLoading = true
+            };
+            entry.Register(callback);
+            _entries[fullPath] = entry;
+            StartCoroutine(LoadAudioClipCoroutine(fullPath, entry));
+        }
+
+        /// <summary>
+        /// Loads a PNG/JPEG texture immediately, reusing it until the source
+        /// file changes.
         /// </summary>
         public Texture2D LoadTexture(string fileName, out bool wasCached)
         {
             wasCached = false;
-            return null;
+            var fullPath = NormalizePath(fileName);
+            if (fullPath.Length == 0)
+            {
+                return null;
+            }
+
+            CacheEntry<Texture2D> cached = null;
+            if (_entries.TryGetValue(fullPath, out var rawEntry)
+                && (cached = rawEntry as CacheEntry<Texture2D>) != null)
+            {
+                if (cached.IsValid && !cached.IsExpired && cached.Value != null)
+                {
+                    wasCached = true;
+                    return cached.Value;
+                }
+
+                DestroyCachedObject(cached.Value);
+                cached.Invalidate();
+            }
+
+            if (!File.Exists(fullPath))
+            {
+                FuseLog.Warning(
+                    $"FUSE Strange Customs file cache could not find texture '{fullPath}'.");
+                return null;
+            }
+
+            try
+            {
+                var texture = new Texture2D(2, 2, TextureFormat.RGBA32, true)
+                {
+                    name = Path.GetFileNameWithoutExtension(fullPath)
+                };
+                if (!ImageConversion.LoadImage(texture, File.ReadAllBytes(fullPath)))
+                {
+                    UnityEngine.Object.Destroy(texture);
+                    FuseLog.Warning(
+                        $"FUSE Strange Customs file cache could not decode texture '{fullPath}'.");
+                    return null;
+                }
+
+                var entry = cached ?? new CacheEntry<Texture2D>(fullPath);
+                entry.Set(texture);
+                _entries[fullPath] = entry;
+                return texture;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE Strange Customs file cache could not load texture '{fullPath}': " +
+                    ex.GetBaseException().Message);
+                return null;
+            }
         }
 
         /// <summary>
-        /// Retains the legacy cache-lookup signature and reports a miss because FUSE does not populate this cache.
+        /// Returns the typed cache entry when one exists. Callers can inspect
+        /// validity/loading state or register for an in-flight completion.
         /// </summary>
         public bool TryGetValue<T>(string fileName, out CacheEntry<T> value)
         {
+            var fullPath = NormalizePath(fileName);
+            if (fullPath.Length > 0
+                && _entries.TryGetValue(fullPath, out var entry)
+                && entry is CacheEntry<T> typed)
+            {
+                value = typed;
+                return true;
+            }
+
             value = null;
             return false;
+        }
+
+        private IEnumerator LoadAudioClipCoroutine(
+            string fullPath,
+            CacheEntry<AudioClip> entry)
+        {
+            AudioClip clip = null;
+            if (!File.Exists(fullPath))
+            {
+                FuseLog.Warning(
+                    $"FUSE Strange Customs file cache could not find audio '{fullPath}'.");
+            }
+            else
+            {
+                var uri = new Uri(fullPath).AbsoluteUri;
+                using (var request = UnityWebRequestMultimedia.GetAudioClip(
+                           uri,
+                           AudioTypeForPath(fullPath)))
+                {
+                    yield return request.SendWebRequest();
+                    if (request.isNetworkError || request.isHttpError)
+                    {
+                        FuseLog.Warning(
+                            $"FUSE Strange Customs file cache could not load audio '{fullPath}': " +
+                            request.error);
+                    }
+                    else
+                    {
+                        clip = DownloadHandlerAudioClip.GetContent(request);
+                        if (clip != null)
+                        {
+                            clip.name = Path.GetFileNameWithoutExtension(fullPath);
+                        }
+                    }
+                }
+            }
+
+            entry.Set(clip);
+            if (clip == null)
+            {
+                entry.Invalidate();
+            }
+        }
+
+        private static AudioType AudioTypeForPath(string path)
+        {
+            switch ((Path.GetExtension(path) ?? string.Empty).ToLowerInvariant())
+            {
+                case ".mp3": return AudioType.MPEG;
+                case ".ogg": return AudioType.OGGVORBIS;
+                case ".wav": return AudioType.WAV;
+                case ".aif":
+                case ".aiff": return AudioType.AIFF;
+                default: return AudioType.UNKNOWN;
+            }
+        }
+
+        internal static string NormalizePath(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                return Path.GetFullPath(fileName.Trim());
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static void InvokeSafely<T>(
+            Action<T> callback,
+            T value,
+            string fileName)
+        {
+            if (callback == null)
+            {
+                return;
+            }
+
+            try
+            {
+                callback(value);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE contained a Strange Customs file-cache callback error for '{fileName}': " +
+                    ex.GetBaseException().Message);
+            }
+        }
+
+        private void Clear()
+        {
+            foreach (var entry in _entries.Values)
+            {
+                var valueProperty = entry?.GetType().GetProperty("Value");
+                DestroyCachedObject(valueProperty?.GetValue(entry, null) as UnityEngine.Object);
+                entry?.Invalidate();
+            }
+
+            _entries.Clear();
+        }
+
+        private static void DestroyCachedObject(UnityEngine.Object value)
+        {
+            if (value != null)
+            {
+                UnityEngine.Object.Destroy(value);
+            }
         }
     }
 
@@ -242,9 +531,8 @@ namespace StrangeCustoms
     }
 
     /// <summary>
-    /// Default spliney builder for "flowy" splines. FUSE does not own the
-    /// rendering, so the build method returns null; the type exists so plugin
-    /// IL that references it JITs.
+    /// Default legacy flowy-spline builder backed by FUSE's native spliney
+    /// conversion and runtime API.
     /// </summary>
     [Obsolete(LegacyShim.Message)]
     public class FlowyThingBuilder : ISplineyBuilder
@@ -254,7 +542,50 @@ namespace StrangeCustoms
         /// </summary>
         public GameObject BuildSpliney(string id, Transform parentTransform, JObject data)
         {
-            return null;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("A spliney id is required.", nameof(id));
+            }
+
+            var definition = ConvertDefinition(data);
+            GameObject root;
+            if (SplineyAPI.GetSpliney(id) == null)
+            {
+                root = SplineyAPI.AddSpliney(id, definition);
+            }
+            else
+            {
+                SplineyAPI.UpdateSpliney(id, definition);
+                root = SplineyAPI.GetSpliney(id);
+            }
+
+            if (root != null
+                && parentTransform != null
+                && root.transform.parent != parentTransform)
+            {
+                root.transform.SetParent(parentTransform, true);
+            }
+
+            return root;
+        }
+
+        internal static FuseSpliney ConvertDefinition(JObject data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            var converted = FuseLegacyDataConverter
+                .ConvertSplineyForCompatibility(data);
+            var definition = converted.ToObject<FuseSpliney>();
+            if (definition == null)
+            {
+                throw new InvalidOperationException(
+                    "The legacy flowy-spline definition could not be converted.");
+            }
+
+            return definition;
         }
     }
 
@@ -585,12 +916,18 @@ namespace StrangeCustoms.Tracks
 
             var upper = trackSpan.upper;
             var lower = trackSpan.lower;
-            Upper = upper.HasValue
+            Upper = upper.HasValue && upper.Value.IsValid
                 ? new SerializedLocation(upper.Value.Serializable())
                 : null;
-            Lower = lower.HasValue
+            Lower = lower.HasValue && lower.Value.IsValid
                 ? new SerializedLocation(lower.Value.Serializable())
                 : null;
+            if (Upper == null || Lower == null)
+            {
+                FuseLog.Warning(
+                    $"FUSE omitted invalid endpoint data while projecting legacy track span " +
+                    $"'{trackSpan.id ?? "<unknown>"}'. A conflicting package removed one of its segments.");
+            }
         }
 
         /// <summary>

--- a/FUSE/FUSE.csproj
+++ b/FUSE/FUSE.csproj
@@ -158,6 +158,10 @@
       <HintPath>$(UnityManagedDir)\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="Unity.RenderPipelines.Universal.Runtime" Condition="Exists('$(UnityManagedDir)\Unity.RenderPipelines.Universal.Runtime.dll')">
+      <HintPath>$(UnityManagedDir)\Unity.RenderPipelines.Universal.Runtime.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
     <Reference Include="UnityEngine.UI" Condition="Exists('$(UnityManagedDir)\UnityEngine.UI.dll')">
       <HintPath>$(UnityManagedDir)\UnityEngine.UI.dll</HintPath>
       <Private>false</Private>

--- a/FUSE/FusePlugin.cs
+++ b/FUSE/FusePlugin.cs
@@ -65,7 +65,6 @@ namespace FUSE
             try
             {
                 FuseLegacySupportAssemblyShim.Initialize();
-                FuseLegacyUmmRecovery.RecoverFailedEntries();
                 WarnIfLegacyRailloaderInstallPresent();
                 LogStartupVersions(modEntry);
                 FuseSettings.Load(modEntry);
@@ -75,6 +74,8 @@ namespace FUSE
 
                 _harmony = new Harmony(HarmonyId);
                 FusePatchResilience.ApplyAll(_harmony, Assembly.GetExecutingAssembly());
+                FuseConfusingSupplementsCompatibility.Initialize();
+                StrangeCustoms.FileCache.EnsureInstance();
                 FuseNarrowGaugePerformanceCompatibility.Initialize(_harmony);
                 FuseEarlyLoader.SetPatchAvailable(FusePatchResilience.Applied.Any(patch =>
                     string.Equals(patch.TypeName, "FUSE.Patches.FuseEarlyLoaderSceneManagerPatch", StringComparison.Ordinal)));
@@ -258,6 +259,7 @@ namespace FUSE
             FuseSceneryLoadFailurePatch.Shutdown();
             FuseModExceptionLogHook.Shutdown();
             FuseLegacyAssemblyHost.Shutdown();
+            StrangeCustoms.FileCache.Shutdown();
             FuseLegacySupportAssemblyShim.Shutdown();
             FuseLegacyUmmRecovery.Reset();
             FuseRuntimeRebindService.Shutdown();

--- a/FUSE/FusePlugin.cs
+++ b/FUSE/FusePlugin.cs
@@ -227,6 +227,7 @@ namespace FUSE
                 try
                 {
                     _harmony.UnpatchAll(HarmonyId);
+                    FuseLegosLibraryCompatibility.ResetAfterSuccessfulUnpatch();
                 }
                 catch (Exception ex)
                 {

--- a/FUSE/Info.json
+++ b/FUSE/Info.json
@@ -23,6 +23,24 @@
     "FrameSpikeThresholdMs": 100,
     "ForceConstrainedVramMode": false,
     "EnableNativeLeakStackTraces": false,
-    "EnableUpdateCheck": true
+    "EnableUpdateCheck": true,
+    "GraceMinimumDays": 0,
+    "GraceMultiplier": 1,
+    "GraceAddedDays": 0,
+    "InterchangeServiceIntervalMinutes": 150,
+    "InterchangeContinuousService": false,
+    "InterchangeNotBeforeHour": 0,
+    "InterchangeNotAfterHour": 24,
+    "EnableOutboundIndustryRerouting": false,
+    "OutboundIndustryRerouteChance": 0.25,
+    "OutboundIndustryFillFactor": 1,
+    "OutboundIndustryPaymentMultiplier": 1,
+    "OutboundIndustryAllowShortTrips": false,
+    "OutboundIndustryIgnoreOrigin": false,
+    "OutboundIndustryPreventBlocking": false,
+    "InterchangeToInterchangeMaximumCars": 30,
+    "ForYourConvenienceShowCabooseIcons": false,
+    "ForYourConvenienceShowCarTagMph": false,
+    "ForYourConvenienceShowCarTagLoads": false
   }
 }

--- a/FUSE/Infrastructure/FuseLiveConsole.cs
+++ b/FUSE/Infrastructure/FuseLiveConsole.cs
@@ -1,0 +1,222 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace FUSE.Infrastructure
+{
+    /// <summary>
+    /// Optional Windows console mirror for authors who want a RailLoader-style
+    /// live FUSE log on another screen. FUSE detaches only a console it allocated
+    /// itself; an existing --console/parent console is never freed.
+    /// </summary>
+    internal static class FuseLiveConsole
+    {
+        private const string Kernel32 = "kernel32.dll";
+        private const string User32 = "user32.dll";
+        private const uint ScClose = 0xF060;
+        private const uint MfByCommand = 0x00000000;
+        private static readonly object Gate = new object();
+
+        private static bool _enabled;
+        private static bool _allocatedByFuse;
+        private static TextWriter _previousOut;
+        private static TextWriter _consoleWriter;
+
+        internal static bool IsEnabled
+        {
+            get
+            {
+                lock (Gate)
+                {
+                    return _enabled;
+                }
+            }
+        }
+
+        internal static string Enable()
+        {
+            lock (Gate)
+            {
+                if (_enabled)
+                {
+                    return "The FUSE live console is already open.";
+                }
+
+                if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+                {
+                    return "The separate live console is available on Windows only. Use the in-game log viewer on this platform.";
+                }
+
+                try
+                {
+                    _allocatedByFuse = GetConsoleOutputCP() == 0;
+                    if (_allocatedByFuse && !AllocConsole())
+                    {
+                        _allocatedByFuse = false;
+                        return "Windows could not open a console for FUSE.";
+                    }
+
+                    SetConsoleTitleW("FUSE Live Diagnostics");
+                    if (_allocatedByFuse)
+                    {
+                        DisableWindowCloseCommand();
+                    }
+                    _previousOut = System.Console.Out;
+                    var stream = System.Console.OpenStandardOutput();
+                    _consoleWriter = new StreamWriter(stream) { AutoFlush = true };
+                    System.Console.SetOut(_consoleWriter);
+                    _enabled = true;
+
+                    System.Console.WriteLine("FUSE live diagnostics console");
+                    System.Console.WriteLine("This mirrors FUSE.log. Close it from FUSE > Tools > Live Diagnostics.");
+                    foreach (var entry in FuseLiveLogBuffer.Snapshot("All", string.Empty, 120))
+                    {
+                        System.Console.WriteLine(entry.FormatLine());
+                    }
+
+                    return _allocatedByFuse
+                        ? "Opened the FUSE live diagnostics console."
+                        : "FUSE is now mirroring to the existing console.";
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is InvalidOperationException)
+                {
+                    RestoreConsoleOutput();
+                    if (_allocatedByFuse)
+                    {
+                        FreeConsole();
+                        _allocatedByFuse = false;
+                    }
+
+                    return "FUSE could not open the live console: " + ex.GetBaseException().Message;
+                }
+            }
+        }
+
+        internal static string Disable()
+        {
+            lock (Gate)
+            {
+                if (!_enabled)
+                {
+                    return "The FUSE live console is not open.";
+                }
+
+                var detached = _allocatedByFuse;
+                RestoreConsoleOutput();
+                if (_allocatedByFuse)
+                {
+                    FreeConsole();
+                }
+
+                _allocatedByFuse = false;
+                return detached
+                    ? "Closed the FUSE live diagnostics console."
+                    : "Stopped mirroring FUSE logs to the existing console.";
+            }
+        }
+
+        internal static void WriteLine(string line)
+        {
+            lock (Gate)
+            {
+                if (!_enabled)
+                {
+                    return;
+                }
+
+                try
+                {
+                    System.Console.WriteLine(line ?? string.Empty);
+                }
+                catch (Exception ex) when (ex is IOException || ex is ObjectDisposedException || ex is InvalidOperationException)
+                {
+                    var detachOwnedConsole = _allocatedByFuse;
+                    RestoreConsoleOutput();
+                    if (detachOwnedConsole)
+                    {
+                        FreeConsole();
+                    }
+
+                    _allocatedByFuse = false;
+                }
+            }
+        }
+
+        private static void DisableWindowCloseCommand()
+        {
+            // Closing an AllocConsole window through its title-bar X can deliver
+            // CTRL_CLOSE_EVENT to the game process. Keep this optional diagnostics
+            // surface non-destructive; the Tools page owns the explicit detach.
+            var consoleWindow = GetConsoleWindow();
+            if (consoleWindow == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var systemMenu = GetSystemMenu(consoleWindow, false);
+            if (systemMenu == IntPtr.Zero)
+            {
+                return;
+            }
+
+            if (DeleteMenu(systemMenu, ScClose, MfByCommand))
+            {
+                DrawMenuBar(consoleWindow);
+            }
+        }
+
+        private static void RestoreConsoleOutput()
+        {
+            _enabled = false;
+            if (_previousOut != null)
+            {
+                System.Console.SetOut(_previousOut);
+            }
+
+            try
+            {
+                _consoleWriter?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                // Do not route this through FuseLog: this cleanup can itself be
+                // running because the console-backed FuseLog mirror failed, and
+                // logging there would recurse into the same broken stream.
+                System.Diagnostics.Debug.WriteLine(
+                    "FUSE could not release its optional diagnostics console: " + ex.Message);
+            }
+
+            _consoleWriter = null;
+            _previousOut = null;
+        }
+
+        [DllImport(Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool AllocConsole();
+
+        [DllImport(Kernel32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool FreeConsole();
+
+        [DllImport(Kernel32)]
+        private static extern uint GetConsoleOutputCP();
+
+        [DllImport(Kernel32)]
+        private static extern IntPtr GetConsoleWindow();
+
+        [DllImport(Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetConsoleTitleW([MarshalAs(UnmanagedType.LPWStr)] string title);
+
+        [DllImport(User32, SetLastError = true)]
+        private static extern IntPtr GetSystemMenu(IntPtr window, [MarshalAs(UnmanagedType.Bool)] bool revert);
+
+        [DllImport(User32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool DeleteMenu(IntPtr menu, uint position, uint flags);
+
+        [DllImport(User32, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool DrawMenuBar(IntPtr window);
+    }
+}

--- a/FUSE/Infrastructure/FuseLiveLogBuffer.cs
+++ b/FUSE/Infrastructure/FuseLiveLogBuffer.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FUSE.Infrastructure
+{
+    internal sealed class FuseLiveLogEntry
+    {
+        public long Sequence { get; set; }
+        public DateTime Timestamp { get; set; }
+        public string Level { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+
+        public string FormatLine() =>
+            $"[{Timestamp:HH:mm:ss.fff}] [{Level}] {Message}";
+    }
+
+    /// <summary>
+    /// A bounded, thread-safe copy of the current session's FUSE log. The disk
+    /// writer remains the durable source; this buffer exists so the Tools page
+    /// and optional live console never need to repeatedly reread FUSE.log.
+    /// </summary>
+    internal static class FuseLiveLogBuffer
+    {
+        internal const int Capacity = 1000;
+
+        private static readonly object Gate = new object();
+        private static readonly Queue<FuseLiveLogEntry> Entries =
+            new Queue<FuseLiveLogEntry>(Capacity);
+
+        private static long _nextSequence;
+
+        internal static void Append(DateTime timestamp, string level, string message)
+        {
+            lock (Gate)
+            {
+                while (Entries.Count >= Capacity)
+                {
+                    Entries.Dequeue();
+                }
+
+                Entries.Enqueue(new FuseLiveLogEntry
+                {
+                    Sequence = ++_nextSequence,
+                    Timestamp = timestamp,
+                    Level = NormalizeLevel(level),
+                    Message = message ?? string.Empty
+                });
+            }
+        }
+
+        internal static FuseLiveLogEntry[] Snapshot(string levelFilter, string search, int maximum)
+        {
+            maximum = Math.Max(1, maximum);
+            var normalizedLevel = (levelFilter ?? string.Empty).Trim();
+            var normalizedSearch = (search ?? string.Empty).Trim();
+
+            lock (Gate)
+            {
+                return Entries
+                    .Where(entry => MatchesLevel(entry.Level, normalizedLevel))
+                    .Where(entry => string.IsNullOrEmpty(normalizedSearch) ||
+                                    entry.Message.IndexOf(normalizedSearch, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                                    entry.Level.IndexOf(normalizedSearch, StringComparison.OrdinalIgnoreCase) >= 0)
+                    .Reverse()
+                    .Take(maximum)
+                    .Reverse()
+                    .Select(Clone)
+                    .ToArray();
+            }
+        }
+
+        internal static int Count
+        {
+            get
+            {
+                lock (Gate)
+                {
+                    return Entries.Count;
+                }
+            }
+        }
+
+        private static FuseLiveLogEntry Clone(FuseLiveLogEntry entry) =>
+            new FuseLiveLogEntry
+            {
+                Sequence = entry.Sequence,
+                Timestamp = entry.Timestamp,
+                Level = entry.Level,
+                Message = entry.Message
+            };
+
+        private static bool MatchesLevel(string actual, string filter)
+        {
+            if (string.IsNullOrEmpty(filter) || string.Equals(filter, "All", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (string.Equals(filter, "Warnings + Errors", StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Equals(actual, "WARN", StringComparison.OrdinalIgnoreCase) ||
+                       string.Equals(actual, "ERROR", StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (string.Equals(filter, "Errors", StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Equals(actual, "ERROR", StringComparison.OrdinalIgnoreCase);
+            }
+
+            return string.Equals(actual, filter, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string NormalizeLevel(string level)
+        {
+            var value = (level ?? string.Empty).Trim().ToUpperInvariant();
+            return string.IsNullOrEmpty(value) ? "INFO" : value;
+        }
+
+        internal static void ResetForTests()
+        {
+            lock (Gate)
+            {
+                Entries.Clear();
+                _nextSequence = 0;
+            }
+        }
+    }
+}

--- a/FUSE/Infrastructure/FuseLog.cs
+++ b/FUSE/Infrastructure/FuseLog.cs
@@ -215,6 +215,12 @@ namespace FUSE.Infrastructure
 
         private static void WriteFile(string level, string message)
         {
+            var timestamp = DateTime.Now;
+            var normalizedMessage = message ?? string.Empty;
+            var line = $"[{timestamp:HH:mm:ss.fff}] [{level}] {normalizedMessage}";
+            FuseLiveLogBuffer.Append(timestamp, level, normalizedMessage);
+            FuseLiveConsole.WriteLine(line);
+
             if (!_fileLoggingAvailable)
             {
                 return;
@@ -232,7 +238,7 @@ namespace FUSE.Infrastructure
             // no file I/O runs on the caller.
             try
             {
-                queue.Add($"[{DateTime.Now:HH:mm:ss.fff}] [{level}] {message ?? string.Empty}");
+                queue.Add(line);
             }
             catch (InvalidOperationException)
             {

--- a/FUSE/Infrastructure/FuseModSetService.cs
+++ b/FUSE/Infrastructure/FuseModSetService.cs
@@ -15,7 +15,7 @@ namespace FUSE.Infrastructure
     {
         private static readonly object Sync = new object();
         private static FuseModSetStore _store;
-        private static string _lastStatus = "No mod set is loaded. All UMM-active FUSE packages are enabled.";
+        private static string _lastStatus = "No mod set is loaded. All UMM-active and FUSE-managed packages are enabled.";
 
         public static string LastStatus
         {
@@ -48,7 +48,7 @@ namespace FUSE.Infrastructure
                 {
                     EnsureLoaded();
                     var set = FindSet(_store.ActiveSetId);
-                    return set == null ? "None - all UMM-active packages enabled" : set.Name;
+                    return set == null ? "None - all available packages enabled" : set.Name;
                 }
             }
         }
@@ -73,9 +73,100 @@ namespace FUSE.Infrastructure
                 .ToArray();
         }
 
-        public static IReadOnlyList<FuseUmmModInfo> GetEnabledVisibleUmmMods()
+        public static IReadOnlyList<FuseUmmModInfo> GetVisibleProfileMods()
         {
-            return GetVisibleUmmMods()
+            return MergeVisibleProfileMods(
+                FuseUmmState.GetActiveMods(includeFuse: false),
+                FuseDataPackageDiscovery.GetPackageManifestSnapshots());
+        }
+
+        internal static IReadOnlyList<FuseUmmModInfo> MergeVisibleProfileMods(
+            IEnumerable<FuseUmmModInfo> activeUmmMods,
+            IEnumerable<FusePackageManifestSnapshot> dataPackages)
+        {
+            var result = (activeUmmMods ?? Enumerable.Empty<FuseUmmModInfo>())
+                .Where(mod => mod != null)
+                .Select(mod => new FuseUmmModInfo
+                {
+                    Id = mod.Id ?? string.Empty,
+                    DisplayName = mod.DisplayName ?? string.Empty,
+                    Version = mod.Version ?? string.Empty,
+                    FolderName = mod.FolderName ?? string.Empty,
+                    Path = mod.Path ?? string.Empty,
+                    Enabled = mod.Enabled,
+                    IsFuseDataPackage = mod.IsFuseDataPackage,
+                    IsLegacyConverted = mod.IsLegacyConverted,
+                    ProfileSource = string.IsNullOrWhiteSpace(mod.ProfileSource) ? "UMM-active" : mod.ProfileSource
+                })
+                .ToList();
+
+            foreach (var package in dataPackages ?? Enumerable.Empty<FusePackageManifestSnapshot>())
+            {
+                if (package == null ||
+                    string.Equals(package.Id, "FUSE", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(package.FolderName, "FUSE", StringComparison.OrdinalIgnoreCase) ||
+                    (package.Disabled && !IsDisabledByFuseProfile(package.DisabledReason)))
+                {
+                    continue;
+                }
+
+                var existing = result.FirstOrDefault(mod =>
+                    FuseDeclaredPackageRelationship.SamePackageId(mod.Id, package.Id) ||
+                    (!string.IsNullOrWhiteSpace(package.FolderName) &&
+                     string.Equals(mod.FolderName, package.FolderName, StringComparison.OrdinalIgnoreCase)));
+                var source = package.IsLegacyConverted ? "legacy converted data" : "FUSE data";
+                if (existing != null)
+                {
+                    existing.IsFuseDataPackage = true;
+                    existing.IsLegacyConverted = existing.IsLegacyConverted || package.IsLegacyConverted;
+                    if (existing.ProfileSource.IndexOf(source, StringComparison.OrdinalIgnoreCase) < 0)
+                    {
+                        existing.ProfileSource += " + " + source;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(existing.DisplayName))
+                    {
+                        existing.DisplayName = package.DisplayName;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(existing.Version))
+                    {
+                        existing.Version = package.Version;
+                    }
+
+                    continue;
+                }
+
+                result.Add(new FuseUmmModInfo
+                {
+                    Id = package.Id ?? string.Empty,
+                    DisplayName = string.IsNullOrWhiteSpace(package.DisplayName) ? package.Id : package.DisplayName,
+                    Version = package.Version ?? string.Empty,
+                    FolderName = package.FolderName ?? string.Empty,
+                    Path = package.FolderPath ?? string.Empty,
+                    Enabled = !package.Disabled,
+                    IsFuseDataPackage = true,
+                    IsLegacyConverted = package.IsLegacyConverted,
+                    ProfileSource = source
+                });
+            }
+
+            return result
+                .Where(mod => !string.IsNullOrWhiteSpace(mod.Id) || !string.IsNullOrWhiteSpace(mod.FolderName))
+                .OrderBy(mod => mod.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(mod => mod.Id, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        private static bool IsDisabledByFuseProfile(string reason)
+        {
+            return !string.IsNullOrWhiteSpace(reason) &&
+                   reason.IndexOf("disabled by active FUSE mod set", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        public static IReadOnlyList<FuseUmmModInfo> GetEnabledVisibleProfileMods()
+        {
+            return GetVisibleProfileMods()
                 .Where(IsModEnabledInActiveSet)
                 .OrderBy(mod => mod.DisplayName, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(mod => mod.Id, StringComparer.OrdinalIgnoreCase)
@@ -84,7 +175,7 @@ namespace FUSE.Infrastructure
 
         public static string GetActiveSetFingerprint()
         {
-            var mods = GetEnabledVisibleUmmMods();
+            var mods = GetEnabledVisibleProfileMods();
             var input = string.Join(
                 "\n",
                 mods.Select(mod => $"{mod.Id}|{mod.Version}|{mod.FolderName}").ToArray());
@@ -107,9 +198,9 @@ namespace FUSE.Infrastructure
 
         public static string GetSetPackageSummary(FuseModSet set)
         {
-            var visible = GetVisibleUmmMods();
+            var visible = GetVisibleProfileMods();
             var enabled = visible.Count(m => IsModEnabledInSet(set, m));
-            return $"{enabled}/{visible.Count} UMM-active mod(s) enabled by FUSE profile";
+            return $"{enabled}/{visible.Count} available package(s) enabled by FUSE profile";
         }
 
         public static string ExportActiveManifest()
@@ -118,13 +209,14 @@ namespace FUSE.Infrastructure
             {
                 EnsureLoaded();
                 var path = Path.Combine(Path.GetDirectoryName(GetStorePath()) ?? Application.persistentDataPath, "active-mod-set-manifest.json");
-                var mods = GetEnabledVisibleUmmMods()
+                var mods = GetEnabledVisibleProfileMods()
                     .Select(mod => new
                     {
                         mod.Id,
                         mod.DisplayName,
                         mod.Version,
-                        mod.FolderName
+                        mod.FolderName,
+                        mod.ProfileSource
                     })
                     .ToArray();
                 var manifest = new
@@ -132,7 +224,7 @@ namespace FUSE.Infrastructure
                     exportedUtc = DateTime.UtcNow.ToString("O"),
                     activeSet = ActiveSetName,
                     fingerprint = GetActiveSetFingerprint(),
-                    policy = "UMM-disabled mods are excluded before FUSE mod-set filtering.",
+                    policy = "UMM-disabled mods are excluded before FUSE profile filtering; non-UMM FUSE and converted legacy data packages remain profile-selectable.",
                     mods
                 };
                 Directory.CreateDirectory(Path.GetDirectoryName(path) ?? string.Empty);
@@ -181,7 +273,7 @@ namespace FUSE.Infrastructure
                 EnsureLoaded();
                 _store.ActiveSetId = string.Empty;
                 Save();
-                _lastStatus = "No mod set is loaded. All UMM-active FUSE packages are enabled.";
+                _lastStatus = "No mod set is loaded. All UMM-active and FUSE-managed packages are enabled.";
             }
         }
 
@@ -233,37 +325,61 @@ namespace FUSE.Infrastructure
             lock (Sync)
             {
                 EnsureLoaded();
-
-                var ids = ToMutableSet(set.EnabledModIds);
-                var folders = ToMutableSet(set.EnabledFolderNames);
-                var currentlyEnabled = IsModEnabledInSet(set, mod);
-                if (currentlyEnabled)
+                var storedSet = FindSet(set.Id);
+                if (storedSet == null)
                 {
-                    ids.Remove(mod.Id ?? string.Empty);
-                    folders.Remove(mod.FolderName ?? string.Empty);
-                    _lastStatus = $"Turned off '{mod.DisplayName}' in mod set '{set.Name}'.";
-                }
-                else
-                {
-                    if (!string.IsNullOrWhiteSpace(mod.Id))
-                    {
-                        ids.Add(mod.Id);
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(mod.FolderName))
-                    {
-                        folders.Add(mod.FolderName);
-                    }
-
-                    _lastStatus = $"Turned on '{mod.DisplayName}' in mod set '{set.Name}'.";
+                    _lastStatus = $"Could not update mod set '{set.Name}' because it no longer exists.";
+                    return false;
                 }
 
-                set.EnabledModIds = ids.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToArray();
-                set.EnabledFolderNames = folders.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToArray();
-                set.UpdatedUtc = DateTime.UtcNow.ToString("O");
+                var nowEnabled = ToggleModMembership(storedSet, mod);
+                if (!ReferenceEquals(storedSet, set))
+                {
+                    set.EnabledModIds = storedSet.EnabledModIds.ToArray();
+                    set.EnabledFolderNames = storedSet.EnabledFolderNames.ToArray();
+                    set.UpdatedUtc = storedSet.UpdatedUtc;
+                }
+
+                _lastStatus = nowEnabled
+                    ? $"Turned on '{mod.DisplayName}' in mod set '{storedSet.Name}'."
+                    : $"Turned off '{mod.DisplayName}' in mod set '{storedSet.Name}'.";
                 Save();
                 return true;
             }
+        }
+
+        internal static bool ToggleModMembership(FuseModSet set, FuseUmmModInfo mod)
+        {
+            if (set == null || mod == null)
+            {
+                return false;
+            }
+
+            var ids = ToMutableSet(set.EnabledModIds);
+            var folders = ToMutableSet(set.EnabledFolderNames);
+            var currentlyEnabled = IsModEnabledInSet(set, mod);
+            if (currentlyEnabled)
+            {
+                ids.Remove(mod.Id ?? string.Empty);
+                folders.Remove(mod.FolderName ?? string.Empty);
+            }
+            else
+            {
+                if (!string.IsNullOrWhiteSpace(mod.Id))
+                {
+                    ids.Add(mod.Id);
+                }
+
+                if (!string.IsNullOrWhiteSpace(mod.FolderName))
+                {
+                    folders.Add(mod.FolderName);
+                }
+            }
+
+            set.EnabledModIds = ids.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToArray();
+            set.EnabledFolderNames = folders.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToArray();
+            set.UpdatedUtc = DateTime.UtcNow.ToString("O");
+            return !currentlyEnabled;
         }
 
         public static bool HasActiveSet
@@ -299,8 +415,13 @@ namespace FUSE.Infrastructure
                     return true;
                 }
 
-                return IsPackageMatched(set, packageId, folderPath);
+                return IsPackageEnabledInSet(set, packageId, folderPath);
             }
+        }
+
+        internal static bool IsPackageEnabledInSet(FuseModSet set, string packageId, string folderPath)
+        {
+            return set == null || IsPackageMatched(set, packageId, folderPath);
         }
 
         public static string GetPackageDisabledReason(string packageId, string folderPath)
@@ -367,29 +488,45 @@ namespace FUSE.Infrastructure
 
         private static FuseModSet CreateSetFromCurrentActiveModsNoLock()
         {
-            var mods = FuseUmmState.GetActiveMods(includeFuse: false).ToArray();
+            var mods = GetVisibleProfileMods().ToArray();
             var now = DateTime.UtcNow.ToString("O");
-            var set = new FuseModSet
-            {
-                Id = "set-" + DateTime.UtcNow.ToString("yyyyMMdd-HHmmss"),
-                Name = NextSetName(),
-                EnabledModIds = mods.Select(mod => mod.Id)
-                    .Where(value => !string.IsNullOrWhiteSpace(value))
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
-                    .ToArray(),
-                EnabledFolderNames = mods.Select(mod => mod.FolderName)
-                    .Where(value => !string.IsNullOrWhiteSpace(value))
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
-                    .ToArray(),
-                CreatedUtc = now,
-                UpdatedUtc = now
-            };
+            var set = CreateSetDefinition(
+                "set-" + DateTime.UtcNow.ToString("yyyyMMdd-HHmmss"),
+                NextSetName(),
+                mods,
+                now);
 
             _store.Sets.Add(set);
             _store.ActiveSetId = set.Id;
             return set;
+        }
+
+        internal static FuseModSet CreateSetDefinition(
+            string id,
+            string name,
+            IEnumerable<FuseUmmModInfo> mods,
+            string timestamp)
+        {
+            var candidates = (mods ?? Enumerable.Empty<FuseUmmModInfo>())
+                .Where(mod => mod != null)
+                .ToArray();
+            return new FuseModSet
+            {
+                Id = id ?? string.Empty,
+                Name = name ?? string.Empty,
+                EnabledModIds = candidates.Select(mod => mod.Id)
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+                    .ToArray(),
+                EnabledFolderNames = candidates.Select(mod => mod.FolderName)
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+                    .ToArray(),
+                CreatedUtc = timestamp ?? string.Empty,
+                UpdatedUtc = timestamp ?? string.Empty
+            };
         }
 
         private static string NextSetName()
@@ -410,7 +547,7 @@ namespace FUSE.Infrastructure
                 StringComparer.OrdinalIgnoreCase);
         }
 
-        private static bool IsModEnabledInSet(FuseModSet set, FuseUmmModInfo mod)
+        internal static bool IsModEnabledInSet(FuseModSet set, FuseUmmModInfo mod)
         {
             if (set == null || mod == null)
             {

--- a/FUSE/Infrastructure/FuseRuntimeGuardCounters.cs
+++ b/FUSE/Infrastructure/FuseRuntimeGuardCounters.cs
@@ -35,6 +35,7 @@ namespace FUSE.Infrastructure
         internal static long RebillAutoConfigSuppressed { get; private set; }
         internal static long BrssModMenuDeferred { get; private set; }
         internal static long TimeSyncMainThreadMarshaled { get; private set; }
+        internal static long PassengerStopSpansSanitized { get; private set; }
 
         internal static long FrameSpikes { get; private set; }
         internal static float FrameSpikeWorstMs { get; private set; }
@@ -66,7 +67,8 @@ namespace FUSE.Infrastructure
             MapEnhancerCullingGuarded +
             RebillAutoConfigSuppressed +
             BrssModMenuDeferred +
-            TimeSyncMainThreadMarshaled;
+            TimeSyncMainThreadMarshaled +
+            PassengerStopSpansSanitized;
 
         internal static bool AllIdle => GuardTotal == 0;
 
@@ -99,6 +101,8 @@ namespace FUSE.Infrastructure
         internal static long RecordBrssModMenuDeferred() => ++BrssModMenuDeferred;
 
         internal static long RecordTimeSyncMainThreadMarshaled() => ++TimeSyncMainThreadMarshaled;
+
+        internal static long RecordPassengerStopSpanSanitized() => ++PassengerStopSpansSanitized;
 
         internal static long RecordFrameSpike(float frameMs)
         {
@@ -133,6 +137,7 @@ namespace FUSE.Infrastructure
                 $"rebillAutoConfigSuppressed={RebillAutoConfigSuppressed} " +
                 $"brssModMenuDeferred={BrssModMenuDeferred} " +
                 $"timeSyncMainThread={TimeSyncMainThreadMarshaled} " +
+                $"passengerStopSpansSanitized={PassengerStopSpansSanitized} " +
                 $"flares={FlareSuppressed} switchRailsBackfilled={SwitchGeometryRailsBackfilled} " +
                 spikes;
         }
@@ -155,6 +160,7 @@ namespace FUSE.Infrastructure
             RebillAutoConfigSuppressed = 0;
             BrssModMenuDeferred = 0;
             TimeSyncMainThreadMarshaled = 0;
+            PassengerStopSpansSanitized = 0;
             FrameSpikes = 0;
             FrameSpikeWorstMs = 0f;
             SceneryLoadWatchAttached = 0;

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -86,6 +86,7 @@ namespace FUSE.Infrastructure
         public const bool DefaultOutboundIndustryIgnoreOrigin = false;
         public const bool DefaultOutboundIndustryPreventBlocking = false;
         public const int DefaultInterchangeToInterchangeMaximumCars = 30;
+        internal const int InterchangeToInterchangeMaximumCarsLimit = 200;
         public const bool DefaultForYourConvenienceShowCabooseIcons = false;
         public const bool DefaultForYourConvenienceShowCarTagMph = false;
         public const bool DefaultForYourConvenienceShowCarTagLoads = false;
@@ -854,7 +855,7 @@ namespace FUSE.Infrastructure
 
         internal static int ClampInterchangeToInterchangeMaximumCars(int value)
         {
-            return Mathf.Clamp(value, 0, 200);
+            return Mathf.Clamp(value, 0, InterchangeToInterchangeMaximumCarsLimit);
         }
 
         public static void SetForYourConvenienceShowCabooseIcons(bool enabled)

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -355,7 +355,7 @@ namespace FUSE.Infrastructure
                     ReadFloat(settings, "InterchangeNotAfterHour", DefaultInterchangeNotAfterHour));
                 EnableOutboundIndustryRerouting =
                     ReadBool(settings, "EnableOutboundIndustryRerouting", DefaultEnableOutboundIndustryRerouting);
-                OutboundIndustryRerouteChance = Mathf.Clamp01(
+                OutboundIndustryRerouteChance = ClampOutboundIndustryRerouteChance(
                     ReadFloat(settings, "OutboundIndustryRerouteChance", DefaultOutboundIndustryRerouteChance));
                 OutboundIndustryFillFactor = ClampOutboundIndustryFillFactor(
                     ReadFloat(settings, "OutboundIndustryFillFactor", DefaultOutboundIndustryFillFactor));
@@ -813,7 +813,7 @@ namespace FUSE.Infrastructure
 
         public static void SetOutboundIndustryRerouteChance(float value)
         {
-            OutboundIndustryRerouteChance = Mathf.Clamp01(value);
+            OutboundIndustryRerouteChance = ClampOutboundIndustryRerouteChance(value);
             SaveUserOverride(nameof(OutboundIndustryRerouteChance), OutboundIndustryRerouteChance);
         }
 
@@ -874,6 +874,11 @@ namespace FUSE.Infrastructure
         {
             ForYourConvenienceShowCarTagLoads = enabled;
             SaveUserOverride(nameof(ForYourConvenienceShowCarTagLoads), enabled);
+        }
+
+        internal static float ClampOutboundIndustryRerouteChance(float value)
+        {
+            return float.IsNaN(value) ? DefaultOutboundIndustryRerouteChance : Mathf.Clamp01(value);
         }
 
         internal static float ClampOutboundIndustryFillFactor(float value)
@@ -1152,7 +1157,7 @@ namespace FUSE.Infrastructure
                     ReadFloat(settings, nameof(InterchangeNotAfterHour), InterchangeNotAfterHour));
                 EnableOutboundIndustryRerouting =
                     ReadBool(settings, nameof(EnableOutboundIndustryRerouting), EnableOutboundIndustryRerouting);
-                OutboundIndustryRerouteChance = Mathf.Clamp01(
+                OutboundIndustryRerouteChance = ClampOutboundIndustryRerouteChance(
                     ReadFloat(settings, nameof(OutboundIndustryRerouteChance), OutboundIndustryRerouteChance));
                 OutboundIndustryFillFactor = ClampOutboundIndustryFillFactor(
                     ReadFloat(settings, nameof(OutboundIndustryFillFactor), OutboundIndustryFillFactor));

--- a/FUSE/Infrastructure/FuseSettings.cs
+++ b/FUSE/Infrastructure/FuseSettings.cs
@@ -68,6 +68,27 @@ namespace FUSE.Infrastructure
         // a newer stable FUSE release exists and, if so, surfaces a non-blocking
         // notice. On by default; one switch turns off all network access for it.
         public const bool DefaultEnableUpdateCheck = true;
+        // Native replacement for ZAMU FallFromGrace. The defaults preserve the
+        // base game's grace calculation exactly (minimum 0, x1, +0) while still
+        // enabling the useful due-date row in the car inspector.
+        public const int DefaultGraceMinimumDays = 0;
+        public const int DefaultGraceMultiplier = 1;
+        public const int DefaultGraceAddedDays = 0;
+        public const int DefaultInterchangeServiceIntervalMinutes = 150;
+        public const bool DefaultInterchangeContinuousService = false;
+        public const float DefaultInterchangeNotBeforeHour = 0f;
+        public const float DefaultInterchangeNotAfterHour = 24f;
+        public const bool DefaultEnableOutboundIndustryRerouting = false;
+        public const float DefaultOutboundIndustryRerouteChance = 0.25f;
+        public const float DefaultOutboundIndustryFillFactor = 1f;
+        public const float DefaultOutboundIndustryPaymentMultiplier = 1f;
+        public const bool DefaultOutboundIndustryAllowShortTrips = false;
+        public const bool DefaultOutboundIndustryIgnoreOrigin = false;
+        public const bool DefaultOutboundIndustryPreventBlocking = false;
+        public const int DefaultInterchangeToInterchangeMaximumCars = 30;
+        public const bool DefaultForYourConvenienceShowCabooseIcons = false;
+        public const bool DefaultForYourConvenienceShowCarTagMph = false;
+        public const bool DefaultForYourConvenienceShowCarTagLoads = false;
         // The cold load of a direct (fuseasset://) asset pack goes through the
         // game's public ContainerSerialization.Deserialize so old-loader
         // Harmony postfixes (LegosLibraryOfStuff clone/edit injection) apply
@@ -143,6 +164,57 @@ namespace FUSE.Infrastructure
 
         public static bool EnableUpdateCheck { get; private set; } = DefaultEnableUpdateCheck;
 
+        public static int GraceMinimumDays { get; private set; } = DefaultGraceMinimumDays;
+
+        public static int GraceMultiplier { get; private set; } = DefaultGraceMultiplier;
+
+        public static int GraceAddedDays { get; private set; } = DefaultGraceAddedDays;
+
+        public static int InterchangeServiceIntervalMinutes { get; private set; } =
+            DefaultInterchangeServiceIntervalMinutes;
+
+        public static bool InterchangeContinuousService { get; private set; } =
+            DefaultInterchangeContinuousService;
+
+        public static float InterchangeNotBeforeHour { get; private set; } =
+            DefaultInterchangeNotBeforeHour;
+
+        public static float InterchangeNotAfterHour { get; private set; } =
+            DefaultInterchangeNotAfterHour;
+
+        public static bool EnableOutboundIndustryRerouting { get; private set; } =
+            DefaultEnableOutboundIndustryRerouting;
+
+        public static float OutboundIndustryRerouteChance { get; private set; } =
+            DefaultOutboundIndustryRerouteChance;
+
+        public static float OutboundIndustryFillFactor { get; private set; } =
+            DefaultOutboundIndustryFillFactor;
+
+        public static float OutboundIndustryPaymentMultiplier { get; private set; } =
+            DefaultOutboundIndustryPaymentMultiplier;
+
+        public static bool OutboundIndustryAllowShortTrips { get; private set; } =
+            DefaultOutboundIndustryAllowShortTrips;
+
+        public static bool OutboundIndustryIgnoreOrigin { get; private set; } =
+            DefaultOutboundIndustryIgnoreOrigin;
+
+        public static bool OutboundIndustryPreventBlocking { get; private set; } =
+            DefaultOutboundIndustryPreventBlocking;
+
+        public static int InterchangeToInterchangeMaximumCars { get; private set; } =
+            DefaultInterchangeToInterchangeMaximumCars;
+
+        public static bool ForYourConvenienceShowCabooseIcons { get; private set; } =
+            DefaultForYourConvenienceShowCabooseIcons;
+
+        public static bool ForYourConvenienceShowCarTagMph { get; private set; } =
+            DefaultForYourConvenienceShowCarTagMph;
+
+        public static bool ForYourConvenienceShowCarTagLoads { get; private set; } =
+            DefaultForYourConvenienceShowCarTagLoads;
+
         public static bool DirectStoreNativeDeserialize { get; private set; } = DefaultDirectStoreNativeDeserialize;
 
         public static void Load(UnityModManager.ModEntry modEntry)
@@ -176,6 +248,24 @@ namespace FUSE.Infrastructure
             ForceConstrainedVramMode = DefaultForceConstrainedVramMode;
             EnableNativeLeakStackTraces = DefaultEnableNativeLeakStackTraces;
             EnableUpdateCheck = DefaultEnableUpdateCheck;
+            GraceMinimumDays = DefaultGraceMinimumDays;
+            GraceMultiplier = DefaultGraceMultiplier;
+            GraceAddedDays = DefaultGraceAddedDays;
+            InterchangeServiceIntervalMinutes = DefaultInterchangeServiceIntervalMinutes;
+            InterchangeContinuousService = DefaultInterchangeContinuousService;
+            InterchangeNotBeforeHour = DefaultInterchangeNotBeforeHour;
+            InterchangeNotAfterHour = DefaultInterchangeNotAfterHour;
+            EnableOutboundIndustryRerouting = DefaultEnableOutboundIndustryRerouting;
+            OutboundIndustryRerouteChance = DefaultOutboundIndustryRerouteChance;
+            OutboundIndustryFillFactor = DefaultOutboundIndustryFillFactor;
+            OutboundIndustryPaymentMultiplier = DefaultOutboundIndustryPaymentMultiplier;
+            OutboundIndustryAllowShortTrips = DefaultOutboundIndustryAllowShortTrips;
+            OutboundIndustryIgnoreOrigin = DefaultOutboundIndustryIgnoreOrigin;
+            OutboundIndustryPreventBlocking = DefaultOutboundIndustryPreventBlocking;
+            InterchangeToInterchangeMaximumCars = DefaultInterchangeToInterchangeMaximumCars;
+            ForYourConvenienceShowCabooseIcons = DefaultForYourConvenienceShowCabooseIcons;
+            ForYourConvenienceShowCarTagMph = DefaultForYourConvenienceShowCarTagMph;
+            ForYourConvenienceShowCarTagLoads = DefaultForYourConvenienceShowCarTagLoads;
             DirectStoreNativeDeserialize = DefaultDirectStoreNativeDeserialize;
             FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
 
@@ -248,6 +338,51 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, "EnableNativeLeakStackTraces", DefaultEnableNativeLeakStackTraces);
                 EnableUpdateCheck =
                     ReadBool(settings, "EnableUpdateCheck", DefaultEnableUpdateCheck);
+                GraceMinimumDays =
+                    ReadInt(settings, "GraceMinimumDays", DefaultGraceMinimumDays);
+                GraceMultiplier =
+                    ReadInt(settings, "GraceMultiplier", DefaultGraceMultiplier);
+                GraceAddedDays =
+                    ReadInt(settings, "GraceAddedDays", DefaultGraceAddedDays);
+                InterchangeServiceIntervalMinutes = NormalizeInterchangeServiceIntervalMinutes(
+                    ReadInt(settings, "InterchangeServiceIntervalMinutes", DefaultInterchangeServiceIntervalMinutes));
+                InterchangeContinuousService =
+                    ReadBool(settings, "InterchangeContinuousService", DefaultInterchangeContinuousService);
+                InterchangeNotBeforeHour = ClampInterchangeServiceHour(
+                    ReadFloat(settings, "InterchangeNotBeforeHour", DefaultInterchangeNotBeforeHour));
+                InterchangeNotAfterHour = ClampInterchangeServiceHour(
+                    ReadFloat(settings, "InterchangeNotAfterHour", DefaultInterchangeNotAfterHour));
+                EnableOutboundIndustryRerouting =
+                    ReadBool(settings, "EnableOutboundIndustryRerouting", DefaultEnableOutboundIndustryRerouting);
+                OutboundIndustryRerouteChance = Mathf.Clamp01(
+                    ReadFloat(settings, "OutboundIndustryRerouteChance", DefaultOutboundIndustryRerouteChance));
+                OutboundIndustryFillFactor = ClampOutboundIndustryFillFactor(
+                    ReadFloat(settings, "OutboundIndustryFillFactor", DefaultOutboundIndustryFillFactor));
+                OutboundIndustryPaymentMultiplier = ClampOutboundIndustryPaymentMultiplier(
+                    ReadFloat(settings, "OutboundIndustryPaymentMultiplier", DefaultOutboundIndustryPaymentMultiplier));
+                OutboundIndustryAllowShortTrips =
+                    ReadBool(settings, "OutboundIndustryAllowShortTrips", DefaultOutboundIndustryAllowShortTrips);
+                OutboundIndustryIgnoreOrigin =
+                    ReadBool(settings, "OutboundIndustryIgnoreOrigin", DefaultOutboundIndustryIgnoreOrigin);
+                OutboundIndustryPreventBlocking =
+                    ReadBool(settings, "OutboundIndustryPreventBlocking", DefaultOutboundIndustryPreventBlocking);
+                InterchangeToInterchangeMaximumCars = ClampInterchangeToInterchangeMaximumCars(
+                    ReadInt(
+                        settings,
+                        "InterchangeToInterchangeMaximumCars",
+                        DefaultInterchangeToInterchangeMaximumCars));
+                ForYourConvenienceShowCabooseIcons = ReadBool(
+                    settings,
+                    "ForYourConvenienceShowCabooseIcons",
+                    DefaultForYourConvenienceShowCabooseIcons);
+                ForYourConvenienceShowCarTagMph = ReadBool(
+                    settings,
+                    "ForYourConvenienceShowCarTagMph",
+                    DefaultForYourConvenienceShowCarTagMph);
+                ForYourConvenienceShowCarTagLoads = ReadBool(
+                    settings,
+                    "ForYourConvenienceShowCarTagLoads",
+                    DefaultForYourConvenienceShowCarTagLoads);
                 DirectStoreNativeDeserialize =
                     ReadBool(settings, "DirectStoreNativeDeserialize", DefaultDirectStoreNativeDeserialize);
                 ApplyUserOverrides();
@@ -284,6 +419,24 @@ namespace FUSE.Infrastructure
                     $"ForceConstrainedVramMode={ForceConstrainedVramMode} " +
                     $"EnableNativeLeakStackTraces={EnableNativeLeakStackTraces} " +
                     $"EnableUpdateCheck={EnableUpdateCheck} " +
+                    $"GraceMinimumDays={GraceMinimumDays} " +
+                    $"GraceMultiplier={GraceMultiplier} " +
+                    $"GraceAddedDays={GraceAddedDays} " +
+                    $"InterchangeServiceIntervalMinutes={InterchangeServiceIntervalMinutes} " +
+                    $"InterchangeContinuousService={InterchangeContinuousService} " +
+                    $"InterchangeNotBeforeHour={InterchangeNotBeforeHour} " +
+                    $"InterchangeNotAfterHour={InterchangeNotAfterHour} " +
+                    $"EnableOutboundIndustryRerouting={EnableOutboundIndustryRerouting} " +
+                    $"OutboundIndustryRerouteChance={OutboundIndustryRerouteChance} " +
+                    $"OutboundIndustryFillFactor={OutboundIndustryFillFactor} " +
+                    $"OutboundIndustryPaymentMultiplier={OutboundIndustryPaymentMultiplier} " +
+                    $"OutboundIndustryAllowShortTrips={OutboundIndustryAllowShortTrips} " +
+                    $"OutboundIndustryIgnoreOrigin={OutboundIndustryIgnoreOrigin} " +
+                    $"OutboundIndustryPreventBlocking={OutboundIndustryPreventBlocking} " +
+                    $"InterchangeToInterchangeMaximumCars={InterchangeToInterchangeMaximumCars} " +
+                    $"ForYourConvenienceShowCabooseIcons={ForYourConvenienceShowCabooseIcons} " +
+                    $"ForYourConvenienceShowCarTagMph={ForYourConvenienceShowCarTagMph} " +
+                    $"ForYourConvenienceShowCarTagLoads={ForYourConvenienceShowCarTagLoads} " +
                     $"DirectStoreNativeDeserialize={DirectStoreNativeDeserialize} " +
                     $"timeoutSeconds={ExperimentalEarlyScenePathSuppressionTimeoutSeconds}.");
             }
@@ -318,6 +471,24 @@ namespace FUSE.Infrastructure
                 ForceConstrainedVramMode = DefaultForceConstrainedVramMode;
                 EnableNativeLeakStackTraces = DefaultEnableNativeLeakStackTraces;
                 EnableUpdateCheck = DefaultEnableUpdateCheck;
+                GraceMinimumDays = DefaultGraceMinimumDays;
+                GraceMultiplier = DefaultGraceMultiplier;
+                GraceAddedDays = DefaultGraceAddedDays;
+                InterchangeServiceIntervalMinutes = DefaultInterchangeServiceIntervalMinutes;
+                InterchangeContinuousService = DefaultInterchangeContinuousService;
+                InterchangeNotBeforeHour = DefaultInterchangeNotBeforeHour;
+                InterchangeNotAfterHour = DefaultInterchangeNotAfterHour;
+                EnableOutboundIndustryRerouting = DefaultEnableOutboundIndustryRerouting;
+                OutboundIndustryRerouteChance = DefaultOutboundIndustryRerouteChance;
+                OutboundIndustryFillFactor = DefaultOutboundIndustryFillFactor;
+                OutboundIndustryPaymentMultiplier = DefaultOutboundIndustryPaymentMultiplier;
+                OutboundIndustryAllowShortTrips = DefaultOutboundIndustryAllowShortTrips;
+                OutboundIndustryIgnoreOrigin = DefaultOutboundIndustryIgnoreOrigin;
+                OutboundIndustryPreventBlocking = DefaultOutboundIndustryPreventBlocking;
+                InterchangeToInterchangeMaximumCars = DefaultInterchangeToInterchangeMaximumCars;
+                ForYourConvenienceShowCabooseIcons = DefaultForYourConvenienceShowCabooseIcons;
+                ForYourConvenienceShowCarTagMph = DefaultForYourConvenienceShowCarTagMph;
+                ForYourConvenienceShowCarTagLoads = DefaultForYourConvenienceShowCarTagLoads;
                 DirectStoreNativeDeserialize = DefaultDirectStoreNativeDeserialize;
                 FuseLog.MirrorInfoToPlayerLog = MirrorInfoToPlayerLog;
                 FuseLog.Exception($"FUSE failed to parse Info.json settings; experimental early scene-path suppression remains disabled", ex);
@@ -562,6 +733,158 @@ namespace FUSE.Infrastructure
                 "Takes effect on the next game start.");
         }
 
+        public static void SetGraceMinimumDays(int value)
+        {
+            GraceMinimumDays = value;
+            SaveUserOverride(nameof(GraceMinimumDays), value);
+            FuseLog.Info($"FUSE legacy gameplay setting changed: {nameof(GraceMinimumDays)}={value}.");
+        }
+
+        public static void SetGraceMultiplier(int value)
+        {
+            GraceMultiplier = value;
+            SaveUserOverride(nameof(GraceMultiplier), value);
+            FuseLog.Info($"FUSE legacy gameplay setting changed: {nameof(GraceMultiplier)}={value}.");
+        }
+
+        public static void SetGraceAddedDays(int value)
+        {
+            GraceAddedDays = value;
+            SaveUserOverride(nameof(GraceAddedDays), value);
+            FuseLog.Info($"FUSE legacy gameplay setting changed: {nameof(GraceAddedDays)}={value}.");
+        }
+
+        public static void SetInterchangeServiceIntervalMinutes(int value)
+        {
+            InterchangeServiceIntervalMinutes = NormalizeInterchangeServiceIntervalMinutes(value);
+            SaveUserOverride(nameof(InterchangeServiceIntervalMinutes), InterchangeServiceIntervalMinutes);
+            FuseLog.Info(
+                $"FUSE legacy gameplay setting changed: {nameof(InterchangeServiceIntervalMinutes)}=" +
+                $"{InterchangeServiceIntervalMinutes}.");
+        }
+
+        public static void SetInterchangeContinuousService(bool enabled)
+        {
+            InterchangeContinuousService = enabled;
+            SaveUserOverride(nameof(InterchangeContinuousService), enabled);
+            FuseLog.Info(
+                $"FUSE legacy gameplay setting changed: {nameof(InterchangeContinuousService)}={enabled}.");
+        }
+
+        public static void SetInterchangeNotBeforeHour(float value)
+        {
+            InterchangeNotBeforeHour = ClampInterchangeServiceHour(value);
+            SaveUserOverride(nameof(InterchangeNotBeforeHour), InterchangeNotBeforeHour);
+            FuseLog.Info(
+                $"FUSE legacy gameplay setting changed: {nameof(InterchangeNotBeforeHour)}=" +
+                $"{InterchangeNotBeforeHour:F2}.");
+        }
+
+        public static void SetInterchangeNotAfterHour(float value)
+        {
+            InterchangeNotAfterHour = ClampInterchangeServiceHour(value);
+            SaveUserOverride(nameof(InterchangeNotAfterHour), InterchangeNotAfterHour);
+            FuseLog.Info(
+                $"FUSE legacy gameplay setting changed: {nameof(InterchangeNotAfterHour)}=" +
+                $"{InterchangeNotAfterHour:F2}.");
+        }
+
+        internal static int NormalizeInterchangeServiceIntervalMinutes(int value)
+        {
+            return value <= 0 ? DefaultInterchangeServiceIntervalMinutes : Math.Min(value, 7 * 24 * 60);
+        }
+
+        internal static float ClampInterchangeServiceHour(float value)
+        {
+            if (float.IsNaN(value))
+            {
+                return 0f;
+            }
+
+            return Mathf.Clamp(value, 0f, 24f);
+        }
+
+        public static void SetEnableOutboundIndustryRerouting(bool enabled)
+        {
+            EnableOutboundIndustryRerouting = enabled;
+            SaveUserOverride(nameof(EnableOutboundIndustryRerouting), enabled);
+        }
+
+        public static void SetOutboundIndustryRerouteChance(float value)
+        {
+            OutboundIndustryRerouteChance = Mathf.Clamp01(value);
+            SaveUserOverride(nameof(OutboundIndustryRerouteChance), OutboundIndustryRerouteChance);
+        }
+
+        public static void SetOutboundIndustryFillFactor(float value)
+        {
+            OutboundIndustryFillFactor = ClampOutboundIndustryFillFactor(value);
+            SaveUserOverride(nameof(OutboundIndustryFillFactor), OutboundIndustryFillFactor);
+        }
+
+        public static void SetOutboundIndustryPaymentMultiplier(float value)
+        {
+            OutboundIndustryPaymentMultiplier = ClampOutboundIndustryPaymentMultiplier(value);
+            SaveUserOverride(nameof(OutboundIndustryPaymentMultiplier), OutboundIndustryPaymentMultiplier);
+        }
+
+        public static void SetOutboundIndustryAllowShortTrips(bool enabled)
+        {
+            OutboundIndustryAllowShortTrips = enabled;
+            SaveUserOverride(nameof(OutboundIndustryAllowShortTrips), enabled);
+        }
+
+        public static void SetOutboundIndustryIgnoreOrigin(bool enabled)
+        {
+            OutboundIndustryIgnoreOrigin = enabled;
+            SaveUserOverride(nameof(OutboundIndustryIgnoreOrigin), enabled);
+        }
+
+        public static void SetOutboundIndustryPreventBlocking(bool enabled)
+        {
+            OutboundIndustryPreventBlocking = enabled;
+            SaveUserOverride(nameof(OutboundIndustryPreventBlocking), enabled);
+        }
+
+        public static void SetInterchangeToInterchangeMaximumCars(int value)
+        {
+            InterchangeToInterchangeMaximumCars = ClampInterchangeToInterchangeMaximumCars(value);
+            SaveUserOverride(nameof(InterchangeToInterchangeMaximumCars), InterchangeToInterchangeMaximumCars);
+        }
+
+        internal static int ClampInterchangeToInterchangeMaximumCars(int value)
+        {
+            return Mathf.Clamp(value, 0, 200);
+        }
+
+        public static void SetForYourConvenienceShowCabooseIcons(bool enabled)
+        {
+            ForYourConvenienceShowCabooseIcons = enabled;
+            SaveUserOverride(nameof(ForYourConvenienceShowCabooseIcons), enabled);
+        }
+
+        public static void SetForYourConvenienceShowCarTagMph(bool enabled)
+        {
+            ForYourConvenienceShowCarTagMph = enabled;
+            SaveUserOverride(nameof(ForYourConvenienceShowCarTagMph), enabled);
+        }
+
+        public static void SetForYourConvenienceShowCarTagLoads(bool enabled)
+        {
+            ForYourConvenienceShowCarTagLoads = enabled;
+            SaveUserOverride(nameof(ForYourConvenienceShowCarTagLoads), enabled);
+        }
+
+        internal static float ClampOutboundIndustryFillFactor(float value)
+        {
+            return float.IsNaN(value) ? DefaultOutboundIndustryFillFactor : Mathf.Clamp(value, 0.1f, 3f);
+        }
+
+        internal static float ClampOutboundIndustryPaymentMultiplier(float value)
+        {
+            return float.IsNaN(value) ? DefaultOutboundIndustryPaymentMultiplier : Mathf.Clamp(value, 0f, 10f);
+        }
+
         public static string GetUserSettingsPath()
         {
             return Path.Combine(Application.persistentDataPath, "FUSE", "settings.json");
@@ -611,6 +934,34 @@ namespace FUSE.Infrastructure
             return float.TryParse(
                 token.ToString(),
                 System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out parsed)
+                ? parsed
+                : defaultValue;
+        }
+
+        internal static int ReadInt(JToken settings, string key, int defaultValue)
+        {
+            if (settings == null || string.IsNullOrWhiteSpace(key))
+            {
+                return defaultValue;
+            }
+
+            var token = settings[key];
+            if (token == null)
+            {
+                return defaultValue;
+            }
+
+            if (token.Type == JTokenType.Integer)
+            {
+                return token.Value<int>();
+            }
+
+            int parsed;
+            return int.TryParse(
+                token.ToString(),
+                System.Globalization.NumberStyles.Integer,
                 System.Globalization.CultureInfo.InvariantCulture,
                 out parsed)
                 ? parsed
@@ -781,6 +1132,57 @@ namespace FUSE.Infrastructure
                     ReadBool(settings, nameof(EnableNativeLeakStackTraces), EnableNativeLeakStackTraces);
                 EnableUpdateCheck =
                     ReadBool(settings, nameof(EnableUpdateCheck), EnableUpdateCheck);
+                GraceMinimumDays =
+                    ReadInt(settings, nameof(GraceMinimumDays), GraceMinimumDays);
+                GraceMultiplier =
+                    ReadInt(settings, nameof(GraceMultiplier), GraceMultiplier);
+                GraceAddedDays =
+                    ReadInt(settings, nameof(GraceAddedDays), GraceAddedDays);
+                InterchangeServiceIntervalMinutes = NormalizeInterchangeServiceIntervalMinutes(
+                    ReadInt(
+                        settings,
+                        nameof(InterchangeServiceIntervalMinutes),
+                        InterchangeServiceIntervalMinutes));
+                InterchangeContinuousService =
+                    ReadBool(settings, nameof(InterchangeContinuousService), InterchangeContinuousService);
+                InterchangeNotBeforeHour = ClampInterchangeServiceHour(
+                    ReadFloat(settings, nameof(InterchangeNotBeforeHour), InterchangeNotBeforeHour));
+                InterchangeNotAfterHour = ClampInterchangeServiceHour(
+                    ReadFloat(settings, nameof(InterchangeNotAfterHour), InterchangeNotAfterHour));
+                EnableOutboundIndustryRerouting =
+                    ReadBool(settings, nameof(EnableOutboundIndustryRerouting), EnableOutboundIndustryRerouting);
+                OutboundIndustryRerouteChance = Mathf.Clamp01(
+                    ReadFloat(settings, nameof(OutboundIndustryRerouteChance), OutboundIndustryRerouteChance));
+                OutboundIndustryFillFactor = ClampOutboundIndustryFillFactor(
+                    ReadFloat(settings, nameof(OutboundIndustryFillFactor), OutboundIndustryFillFactor));
+                OutboundIndustryPaymentMultiplier = ClampOutboundIndustryPaymentMultiplier(
+                    ReadFloat(
+                        settings,
+                        nameof(OutboundIndustryPaymentMultiplier),
+                        OutboundIndustryPaymentMultiplier));
+                OutboundIndustryAllowShortTrips =
+                    ReadBool(settings, nameof(OutboundIndustryAllowShortTrips), OutboundIndustryAllowShortTrips);
+                OutboundIndustryIgnoreOrigin =
+                    ReadBool(settings, nameof(OutboundIndustryIgnoreOrigin), OutboundIndustryIgnoreOrigin);
+                OutboundIndustryPreventBlocking =
+                    ReadBool(settings, nameof(OutboundIndustryPreventBlocking), OutboundIndustryPreventBlocking);
+                InterchangeToInterchangeMaximumCars = ClampInterchangeToInterchangeMaximumCars(
+                    ReadInt(
+                        settings,
+                        nameof(InterchangeToInterchangeMaximumCars),
+                        InterchangeToInterchangeMaximumCars));
+                ForYourConvenienceShowCabooseIcons = ReadBool(
+                    settings,
+                    nameof(ForYourConvenienceShowCabooseIcons),
+                    ForYourConvenienceShowCabooseIcons);
+                ForYourConvenienceShowCarTagMph = ReadBool(
+                    settings,
+                    nameof(ForYourConvenienceShowCarTagMph),
+                    ForYourConvenienceShowCarTagMph);
+                ForYourConvenienceShowCarTagLoads = ReadBool(
+                    settings,
+                    nameof(ForYourConvenienceShowCarTagLoads),
+                    ForYourConvenienceShowCarTagLoads);
                 DirectStoreNativeDeserialize =
                     ReadBool(settings, nameof(DirectStoreNativeDeserialize), DirectStoreNativeDeserialize);
                 FuseLog.Info($"FUSE user setting overrides loaded from '{path}'.");
@@ -797,6 +1199,11 @@ namespace FUSE.Infrastructure
         }
 
         private static void SaveUserOverride(string key, float value)
+        {
+            SaveUserOverride(key, new JValue(value));
+        }
+
+        private static void SaveUserOverride(string key, int value)
         {
             SaveUserOverride(key, new JValue(value));
         }

--- a/FUSE/Infrastructure/FuseUmmState.cs
+++ b/FUSE/Infrastructure/FuseUmmState.cs
@@ -16,6 +16,9 @@ namespace FUSE.Infrastructure
         public string FolderName { get; set; } = string.Empty;
         public string Path { get; set; } = string.Empty;
         public bool Enabled { get; set; }
+        public bool IsFuseDataPackage { get; set; }
+        public bool IsLegacyConverted { get; set; }
+        public string ProfileSource { get; set; } = "UMM-active";
     }
 
     internal static class FuseUmmState

--- a/FUSE/Infrastructure/FuseUmmState.cs
+++ b/FUSE/Infrastructure/FuseUmmState.cs
@@ -99,6 +99,71 @@ namespace FUSE.Infrastructure
             return false;
         }
 
+        /// <summary>
+        /// Returns true when Unity Mod Manager already owns an executable package's
+        /// active lifecycle. Dual-format mods can also contain a RailLoader
+        /// Definition.json; hosting that legacy plugin after UMM has started the
+        /// same assembly invokes its startup and Harmony patches twice.
+        /// </summary>
+        public static bool HasActiveRuntimeEntry(string folderPath, string packageId)
+        {
+            try
+            {
+                var entries = ModEntriesField?.GetValue(null) as IEnumerable;
+                if (entries == null)
+                {
+                    return false;
+                }
+
+                foreach (var value in entries)
+                {
+                    if (!(value is UnityModManager.ModEntry entry))
+                    {
+                        continue;
+                    }
+
+                    var infoId = entry.Info?.Id;
+                    var samePackage = SamePath(entry.Path, folderPath) ||
+                                      (!string.IsNullOrWhiteSpace(packageId) &&
+                                       string.Equals(infoId, packageId, StringComparison.OrdinalIgnoreCase));
+                    if (!samePackage || string.IsNullOrWhiteSpace(entry.Info?.EntryMethod))
+                    {
+                        continue;
+                    }
+
+                    if (IsActiveRuntimeState(
+                        entry.Enabled,
+                        entry.Started,
+                        entry.Loaded,
+                        entry.ErrorOnLoading))
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                if (!_loggedInspectionFailure)
+                {
+                    _loggedInspectionFailure = true;
+                    FuseLog.Warning(
+                        $"FUSE could not inspect Unity Mod Manager runtime ownership for packages: " +
+                        ex.GetBaseException().Message);
+                }
+            }
+
+            return false;
+        }
+
+        internal static bool IsActiveRuntimeState(
+            bool enabled,
+            bool started,
+            bool loaded,
+            bool errorOnLoading)
+        {
+            return enabled && started && loaded && !errorOnLoading;
+        }
+
         private static IEnumerable<FuseUmmModInfo> EnumerateModEntries()
         {
             var entries = ModEntriesField?.GetValue(null) as IEnumerable;

--- a/FUSE/Interface/Console/FuseConsoleCommands.cs
+++ b/FUSE/Interface/Console/FuseConsoleCommands.cs
@@ -168,6 +168,7 @@ namespace FUSE.Interface.Console
             }
             catch (Exception ex)
             {
+                FuseLog.Exception("FUSE livery refresh console command failed.", ex);
                 return "FUSE livery refresh failed: " + ex.GetBaseException().Message;
             }
         }
@@ -187,6 +188,7 @@ namespace FUSE.Interface.Console
             }
             catch (Exception ex)
             {
+                FuseLog.Exception("FUSE livery diagnostics console command failed.", ex);
                 return "FUSE livery diagnostics failed: " + ex.GetBaseException().Message;
             }
         }
@@ -772,8 +774,16 @@ namespace FUSE.Interface.Console
     {
         public string Execute(string[] components)
         {
-            return FuseCompanyStarterPlacementPatch
-                .ResumePendingPlacements();
+            try
+            {
+                return FuseCompanyStarterPlacementPatch
+                    .ResumePendingPlacements();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE starters console command failed.", ex);
+                return "FUSE starters failed: " + ex.GetBaseException().Message;
+            }
         }
     }
 

--- a/FUSE/Interface/Console/FuseConsoleCommands.cs
+++ b/FUSE/Interface/Console/FuseConsoleCommands.cs
@@ -31,6 +31,7 @@ namespace FUSE.Interface.Console
             {
                 new FuseReportCommand(),
                 new FuseLoadedCommand(),
+                new FuseStartersCommand(),
                 new FuseUpdateCommand(),
                 new FuseMapsCommand(),
                 new FuseMapLaunchCommand(),
@@ -38,6 +39,8 @@ namespace FUSE.Interface.Console
                 new FuseGraphCommand(),
                 new FuseProgressionsCommand(),
                 new FuseOperationsCommand(),
+                new FuseLiveryRefreshCommand(),
+                new FuseLiveryReportCommand(),
                 new FuseDumpGraphCommand(),
                 new FuseDumpRuntimeGraphCommand(),
                 new FuseDumpMandelasCommand(),
@@ -147,6 +150,45 @@ namespace FUSE.Interface.Console
             }
 
             return string.Join("/", names.ToArray());
+        }
+    }
+
+    [ConsoleCommand(
+        "/cs-livery-refresh",
+        "Reload Confusing Supplements-compatible livery textures and reapply each car's saved selection.")]
+    public sealed class FuseLiveryRefreshCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            try
+            {
+                var refreshed = Compatibility.FuseConfusingSupplementsLiveryRegistry
+                    .RefreshLiveCars();
+                return $"FUSE refreshed Confusing Supplements-compatible liveries on {refreshed} car(s).";
+            }
+            catch (Exception ex)
+            {
+                return "FUSE livery refresh failed: " + ex.GetBaseException().Message;
+            }
+        }
+    }
+
+    [ConsoleCommand(
+        "/fuse.liveries",
+        "Report Confusing Supplements-compatible livery selections, choices, and cached textures.")]
+    public sealed class FuseLiveryReportCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            try
+            {
+                return Compatibility.FuseConfusingSupplementsLiveryRegistry
+                    .BuildDiagnosticReport();
+            }
+            catch (Exception ex)
+            {
+                return "FUSE livery diagnostics failed: " + ex.GetBaseException().Message;
+            }
         }
     }
 
@@ -483,6 +525,20 @@ namespace FUSE.Interface.Console
                     sb.AppendLine("  " + folder);
                 }
 
+                var definitionOverrides = FuseAssetPackRegistry.GetLegacyDefinitionOverrides();
+                var overrideIssues = FuseAssetPackRegistry.GetLegacyDefinitionOverrideIssues();
+                sb.AppendLine($"Definition overrides: active={definitionOverrides.Length}; issues={overrideIssues.Length}.");
+                foreach (var definitionOverride in definitionOverrides)
+                {
+                    sb.AppendLine(
+                        $"  {definitionOverride.StoreIdentifier} <- {definitionOverride.DefinitionsPath} " +
+                        $"(package {definitionOverride.PackageId})");
+                }
+                foreach (var issue in overrideIssues)
+                {
+                    sb.AppendLine("  ISSUE: " + issue);
+                }
+
                 return sb.ToString();
             }
             catch (Exception ex)
@@ -706,6 +762,18 @@ namespace FUSE.Interface.Console
             }
 
             return FuseLoadReport.GetLastDetailReport();
+        }
+    }
+
+    [ConsoleCommand(
+        "/fuse.starters",
+        "Resume placement of retained Appalachian Railway starter equipment.")]
+    public sealed class FuseStartersCommand : IConsoleCommand
+    {
+        public string Execute(string[] components)
+        {
+            return FuseCompanyStarterPlacementPatch
+                .ResumePendingPlacements();
         }
     }
 
@@ -1182,14 +1250,17 @@ namespace FUSE.Interface.Console
         public string Execute(string[] components)
         {
             var conflicts = FuseRegistry.Conflicts;
+            var actionable = conflicts.Count(conflict => !conflict.IsCooperativeMerge);
+            var cooperative = conflicts.Count(conflict => conflict.IsCooperativeMerge);
             var sb = new StringBuilder();
             sb.AppendLine(
                 $"FUSE registry: exclusive={FuseRegistry.ExclusiveClaimCount} shared={FuseRegistry.SharedClaimCount} " +
-                $"conflicts={conflicts.Count}");
+                $"conflicts={actionable} sharedExtensionTargets={cooperative} records={conflicts.Count}");
             foreach (var conflict in conflicts.OrderByDescending(c => c.AtUtc))
             {
+                var classification = conflict.IsCooperativeMerge ? "shared-extension" : "actionable";
                 sb.AppendLine(
-                    $"  target='{conflict.Target ?? conflict.Kind.ToString()}' kind='{conflict.Kind}' id='{conflict.Id}': " +
+                    $"  [{classification}] target='{conflict.Target ?? conflict.Kind.ToString()}' kind='{conflict.Kind}' id='{conflict.Id}': " +
                     $"owner='{conflict.OwnerPackageId}' attempted='{conflict.AttemptedPackageId}' " +
                     $"resolution='{conflict.Resolution ?? "claim skipped"}' at={conflict.AtUtc:HH:mm:ss}Z");
             }

--- a/FUSE/Interface/FuseTrackDebugOverlay.cs
+++ b/FUSE/Interface/FuseTrackDebugOverlay.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using FUSE.Runtime.API;
 using FUSE.Infrastructure;
+using FUSE.Compatibility;
 using Model.Ops;
 using Track;
 using UnityEngine;
@@ -240,7 +241,7 @@ namespace FUSE.Interface
             string style;
             try
             {
-                style = segment.style.ToString();
+                style = RailroaderTrackContract.GetStyleName(segment);
             }
             catch
             {

--- a/FUSE/Interface/FuseWorldLabelsOverlay.cs
+++ b/FUSE/Interface/FuseWorldLabelsOverlay.cs
@@ -4,6 +4,7 @@ using FUSE.Runtime.API;
 using FUSE.Runtime.Cache;
 using FUSE.Infrastructure;
 using Track;
+using UI.Common;
 using UnityEngine;
 
 namespace FUSE.Interface
@@ -62,6 +63,7 @@ namespace FUSE.Interface
         public static readonly Color TrackSegmentColor = new Color(1.00f, 0.88f, 0.25f, 1f);   // yellow
 
         private static GameObject _host;
+        private static bool _windowInspectionWarningLogged;
 
         private readonly List<Label> _labels = new List<Label>(256);
         private GUIStyle _labelStyle;
@@ -89,6 +91,8 @@ namespace FUSE.Interface
                 Destroy(_host);
                 _host = null;
             }
+
+            _windowInspectionWarningLogged = false;
         }
 
         private void Update()
@@ -114,7 +118,10 @@ namespace FUSE.Interface
 
         private void OnGUI()
         {
-            if (!FuseSettings.ShowWorldLabelsOverlay)
+            if (!ShouldRender(
+                    FuseSettings.ShowWorldLabelsOverlay,
+                    Time.timeScale <= 0f,
+                    HasShownGameWindow()))
             {
                 return;
             }
@@ -182,6 +189,47 @@ namespace FUSE.Interface
                 GUI.Label(new Rect(rect.x + 4f, rect.y + 2f, rect.width - 8f, rect.height - 4f), content, _labelStyle);
                 painted++;
             }
+        }
+
+        internal static bool ShouldRender(bool enabled, bool gamePaused, bool hasShownGameWindow)
+        {
+            return enabled && !gamePaused && !hasShownGameWindow;
+        }
+
+        private static bool HasShownGameWindow()
+        {
+            var manager = WindowManager.Shared;
+            if (manager == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                var windows = manager.GetComponentsInChildren<Window>(true);
+                for (var index = 0; index < windows.Length; index++)
+                {
+                    if (windows[index] != null && windows[index].IsShown)
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // UI teardown can race OnGUI while returning to the main menu.
+                // Failing open keeps a transient manager state from disabling
+                // the overlay for the rest of the session.
+                if (!_windowInspectionWarningLogged)
+                {
+                    _windowInspectionWarningLogged = true;
+                    FuseLog.Warning(
+                        "FUSE world-labels overlay could not inspect game windows: " +
+                        ex.GetBaseException().Message);
+                }
+            }
+
+            return false;
         }
 
         private void OnDestroy()

--- a/FUSE/Interface/MenuWindow/AssetsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/AssetsToolPage.cs
@@ -2,6 +2,7 @@
 using FUSE.Loading;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -21,13 +22,19 @@ namespace FUSE.Interface.MenuWindow
             builder.AddLabel("This tool shows asset information and a list of any duplicate asset keys.");
 
             var diagnostics = FuseAssetPackRegistry.GetDiagnostics();
+            var duplicateGroups = GroupDuplicateAssets(diagnostics.DuplicateKeys);
             builder.AddSection("Asset Resolution");
             builder.AddField("Mode", AssetPackModeText());
             builder.AddField("Stores Scanned", diagnostics.StoreFolders.Length.ToString());
             builder.AddField("Runtime Stores", FusePerformanceMetrics.FormatCount("direct asset pack store count"));
             builder.AddField("Unique Asset Keys", diagnostics.UniqueAssetKeys.ToString());
-            builder.AddField("Duplicate Keys", diagnostics.DuplicateKeys.Length.ToString());
+            builder.AddField("Overlapping Asset Keys", diagnostics.DuplicateKeys.Length.ToString());
+            builder.AddField("Source Overlap Groups", duplicateGroups.Length.ToString());
+            builder.AddField("Identical Copies", diagnostics.DuplicateKeys.Count(item => !item.DefinitionsDiffer).ToString());
+            builder.AddField("Different Definitions", diagnostics.DuplicateKeys.Count(item => item.DefinitionsDiffer).ToString());
             builder.AddField("Failed Definitions", diagnostics.FailedDefinitionLoads.Length.ToString());
+            builder.AddField("Definition Overrides", diagnostics.LegacyDefinitionOverrides.Length.ToString());
+            builder.AddField("Override Issues", diagnostics.LegacyDefinitionOverrideIssues.Length.ToString());
             builder.AddField("Last Direct Mount", FusePerformanceMetrics.FormatTiming("direct asset pack stores"));
             AddWrappedField(
                 builder,
@@ -55,7 +62,8 @@ namespace FUSE.Interface.MenuWindow
 
             builder.Spacer(4f);
 
-            if (!FuseSettings.ShowAdvancedHealthDetails && diagnostics.DuplicateKeys.Length == 0 && diagnostics.FailedDefinitionLoads.Length == 0)
+            if (!FuseSettings.ShowAdvancedHealthDetails && diagnostics.DuplicateKeys.Length == 0 &&
+                diagnostics.FailedDefinitionLoads.Length == 0 && diagnostics.LegacyDefinitionOverrideIssues.Length == 0)
             {
                 builder.AddField("Status", "No asset issues detected");
             }
@@ -69,26 +77,26 @@ namespace FUSE.Interface.MenuWindow
             }
             else
             {
-                builder.AddSection("Duplicate Asset Keys");
+                builder.AddSection("Asset Source Overlaps");
                 if (diagnostics.DuplicateKeys.Length == 0)
                 {
                     builder.AddField("Status", "None detected");
                 }
                 else
                 {
-                    foreach (var duplicate in diagnostics.DuplicateKeys.Take(20))
+                    foreach (var group in duplicateGroups.Take(20))
                     {
-                        BuildDuplicateAssetPreview(builder, duplicate);
+                        BuildDuplicateAssetGroupPreview(builder, group);
                         builder.Spacer(4f);
                         builder.AddHRule();
                     }
 
-                    if (diagnostics.DuplicateKeys.Length > 20)
+                    if (duplicateGroups.Length > 20)
                     {
                         AddWrappedField(
                             builder,
                             "More",
-                            (diagnostics.DuplicateKeys.Length - 20) + " hidden. Export Asset Report for all duplicate keys.",
+                            (duplicateGroups.Length - 20) + " source group(s) hidden. Export Asset Report for every overlapping key.",
                             34f);
                     }
                 }
@@ -108,38 +116,103 @@ namespace FUSE.Interface.MenuWindow
                         (diagnostics.StoreFolders.Length - 40) + " hidden. Export Asset Report for all store paths.",
                         34f);
                 }
+
+                builder.Spacer(4f);
+                builder.AddSection("Definition Overrides");
+                if (diagnostics.LegacyDefinitionOverrides.Length == 0)
+                {
+                    builder.AddField("Status", "None detected");
+                }
+                else
+                {
+                    foreach (var definitionOverride in diagnostics.LegacyDefinitionOverrides.Take(20))
+                    {
+                        AddWrappedField(
+                            builder,
+                            definitionOverride.StoreIdentifier,
+                            definitionOverride.PackageId + " | " + definitionOverride.DefinitionsPath,
+                            44f);
+                    }
+                }
+
+                foreach (var issue in diagnostics.LegacyDefinitionOverrideIssues.Take(20))
+                {
+                    AddWrappedField(builder, "Override Issue", issue, 58f);
+                }
             }
 
             builder.Spacer(8f);
         }
 
-        private static string BuildAssetSummary(FuseAssetPackDiagnostics diagnostics)
+        internal static string BuildAssetSummary(FuseAssetPackDiagnostics diagnostics)
         {
+            diagnostics = diagnostics ?? new FuseAssetPackDiagnostics();
+            var duplicateGroups = GroupDuplicateAssets(diagnostics.DuplicateKeys);
             var builder = new StringBuilder();
             builder.AppendLine("FUSE Asset Summary");
             builder.AppendLine("Mode: " + AssetPackModeText());
             builder.AppendLine("Stores scanned: " + (diagnostics.StoreFolders?.Length ?? 0));
             builder.AppendLine("Unique asset keys: " + diagnostics.UniqueAssetKeys);
-            builder.AppendLine("Duplicate keys: " + (diagnostics.DuplicateKeys?.Length ?? 0));
+            builder.AppendLine("Overlapping asset keys: " + (diagnostics.DuplicateKeys?.Length ?? 0));
+            builder.AppendLine("Source overlap groups: " + duplicateGroups.Length);
+            builder.AppendLine("Identical duplicate definitions: " + (diagnostics.DuplicateKeys?.Count(item => !item.DefinitionsDiffer) ?? 0));
+            builder.AppendLine("Different duplicate definitions: " + (diagnostics.DuplicateKeys?.Count(item => item.DefinitionsDiffer) ?? 0));
             builder.AppendLine("Failed definitions: " + (diagnostics.FailedDefinitionLoads?.Length ?? 0));
+            builder.AppendLine("Definition overrides: " + (diagnostics.LegacyDefinitionOverrides?.Length ?? 0));
+            builder.AppendLine("Definition override issues: " + (diagnostics.LegacyDefinitionOverrideIssues?.Length ?? 0));
 
-            var duplicates = diagnostics.DuplicateKeys ?? Array.Empty<FuseDuplicateAssetKey>();
-            if (duplicates.Length > 0)
+            if (duplicateGroups.Length > 0)
             {
                 builder.AppendLine();
-                builder.AppendLine("Duplicate preview:");
-                foreach (var duplicate in duplicates.Take(10))
+                builder.AppendLine("Overlap group preview:");
+                foreach (var group in duplicateGroups.Take(10))
                 {
-                    builder.AppendLine("- " + BuildDuplicateAssetPreviewString(duplicate));
+                    builder.AppendLine("- " + BuildDuplicateAssetGroupPreviewString(group));
                 }
 
-                if (duplicates.Length > 10)
+                if (duplicateGroups.Length > 10)
                 {
-                    builder.AppendLine("- " + (duplicates.Length - 10) + " more duplicate key(s); export the asset report for the full list.");
+                    builder.AppendLine("- " + (duplicateGroups.Length - 10) + " more source overlap group(s); export the asset report for every key.");
                 }
             }
 
             return builder.ToString().TrimEnd();
+        }
+
+        internal static FuseDuplicateAssetGroup[] GroupDuplicateAssets(
+            IEnumerable<FuseDuplicateAssetKey> duplicates)
+        {
+            var grouped = new Dictionary<string, FuseDuplicateAssetGroup>(StringComparer.Ordinal);
+            foreach (var duplicate in duplicates ?? Enumerable.Empty<FuseDuplicateAssetKey>())
+            {
+                if (duplicate == null || string.IsNullOrWhiteSpace(duplicate.Key))
+                {
+                    continue;
+                }
+
+                var sources = (duplicate.Sources ?? Array.Empty<string>())
+                    .Where(source => !string.IsNullOrWhiteSpace(source))
+                    .ToArray();
+                var identity = (duplicate.DefinitionsDiffer ? "different" : "identical") +
+                               "\u001e" + string.Join("\u001f", sources);
+                if (!grouped.TryGetValue(identity, out var group))
+                {
+                    group = new FuseDuplicateAssetGroup
+                    {
+                        DefinitionsDiffer = duplicate.DefinitionsDiffer,
+                        Sources = sources
+                    };
+                    grouped.Add(identity, group);
+                }
+
+                group.Keys.Add(duplicate.Key);
+            }
+
+            return grouped.Values
+                .OrderByDescending(group => group.DefinitionsDiffer)
+                .ThenByDescending(group => group.Keys.Count)
+                .ThenBy(group => group.Keys.FirstOrDefault() ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
         }
 
         private static string AssetPackModeText()
@@ -165,11 +238,6 @@ namespace FUSE.Interface.MenuWindow
 
             var sources = duplicateAssetKey.Sources ?? [];
             var preview = sources
-                .Select(source =>
-                {
-                    var name = string.IsNullOrWhiteSpace(source) ? string.Empty : Path.GetFileName(source);
-                    return string.IsNullOrWhiteSpace(name) ? source : name;
-                })
                 .Where(source => !string.IsNullOrWhiteSpace(source))
                 .ToArray();
 
@@ -187,13 +255,17 @@ namespace FUSE.Interface.MenuWindow
             }
         }
 
-        private static void BuildDuplicateAssetPreview(UIPanelBuilder builder, FuseDuplicateAssetKey duplicate)
+        private static void BuildDuplicateAssetGroupPreview(UIPanelBuilder builder, FuseDuplicateAssetGroup group)
         {
-            if (duplicate == null) return;
+            if (group == null)
+            {
+                return;
+            }
 
-            GetDuplicateAssetInfo(duplicate, out string winner, out string[] overridden, out string suffix);
+            GetDuplicateAssetInfo(group.Sources, out string winner, out string[] overridden, out string suffix);
 
-            builder.AddField("Asset Key", duplicate.Key);
+            builder.AddField("Affected Keys", group.Keys.Count.ToString());
+            builder.AddField("Definition Match", group.DefinitionsDiffer ? "Different definitions (review)" : "Identical copies");
 
             if (string.IsNullOrWhiteSpace(winner))
             {
@@ -206,20 +278,53 @@ namespace FUSE.Interface.MenuWindow
             {
                 builder.AddField("Sources Overridden", string.Join(",", overridden) + suffix);
             }
+
+            AddWrappedField(
+                builder,
+                "Example Keys",
+                string.Join(", ", group.Keys.OrderBy(key => key, StringComparer.OrdinalIgnoreCase).Take(4)),
+                44f);
+            AddWrappedField(
+                builder,
+                "Impact",
+                group.DefinitionsDiffer
+                    ? "Definitions differ; FUSE uses the listed winner, so model or behavior can change with source order."
+                    : "Definitions are identical; this is redundant installed content, not a load failure.",
+                44f);
         }
 
-        private static string BuildDuplicateAssetPreviewString(FuseDuplicateAssetKey duplicate)
+        private static string BuildDuplicateAssetGroupPreviewString(FuseDuplicateAssetGroup group)
         {
-            if (duplicate == null)
+            if (group == null)
             {
                 return string.Empty;
             }
 
-            GetDuplicateAssetInfo(duplicate, out string winner, out string[] overridden, out string suffix);
+            GetDuplicateAssetInfo(group.Sources, out string winner, out string[] overridden, out string suffix);
+            var examples = string.Join(", ", group.Keys
+                .OrderBy(key => key, StringComparer.OrdinalIgnoreCase)
+                .Take(3)
+                .Select(InsertBreakHints));
+            var impact = group.DefinitionsDiffer
+                ? "different definitions; winner controls behavior"
+                : "identical copies; no behavior change";
 
             return overridden.Length == 0
-                ? $"{InsertBreakHints(duplicate.Key)} | winner {winner}{suffix}"
-                : $"{InsertBreakHints(duplicate.Key)} | winner {winner} | overridden {string.Join(", ", overridden)}{suffix}";
+                ? $"{group.Keys.Count} key(s) | winner {winner}{suffix} | {impact} | examples {examples}"
+                : $"{group.Keys.Count} key(s) | winner {winner} | overridden {string.Join(", ", overridden)}{suffix} | {impact} | examples {examples}";
+        }
+
+        private static void GetDuplicateAssetInfo(
+            string[] sources,
+            out string winner,
+            out string[] overridden,
+            out string suffix)
+        {
+            GetDuplicateAssetInfo(
+                new FuseDuplicateAssetKey { Sources = sources ?? Array.Empty<string>() },
+                out winner,
+                out overridden,
+                out suffix);
         }
 
         private static string ExportAssetDiagnostics(FuseAssetPackDiagnostics diagnostics, bool openFolder = true)
@@ -248,6 +353,7 @@ namespace FUSE.Interface.MenuWindow
                     duplicates.Add(new JObject
                     {
                         ["key"] = duplicate.Key ?? string.Empty,
+                        ["definitionsDiffer"] = duplicate.DefinitionsDiffer,
                         ["sourceCount"] = sources.Count,
                         ["winner"] = sources.Count > 0 ? sources[0] : string.Empty,
                         ["overridden"] = new JArray(sources.Skip(1)),
@@ -261,6 +367,26 @@ namespace FUSE.Interface.MenuWindow
                     failedDefinitions.Add(failure);
                 }
 
+                var definitionOverrides = new JArray();
+                foreach (var definitionOverride in diagnostics.LegacyDefinitionOverrides ??
+                         Array.Empty<FuseLegacyDefinitionOverrideRegistration>())
+                {
+                    definitionOverrides.Add(new JObject
+                    {
+                        ["storeIdentifier"] = definitionOverride.StoreIdentifier ?? string.Empty,
+                        ["definitionsPath"] = definitionOverride.DefinitionsPath ?? string.Empty,
+                        ["packageId"] = definitionOverride.PackageId ?? string.Empty,
+                        ["packagePath"] = definitionOverride.PackagePath ?? string.Empty,
+                        ["explicit"] = definitionOverride.Explicit
+                    });
+                }
+
+                var definitionOverrideIssues = new JArray();
+                foreach (var issue in diagnostics.LegacyDefinitionOverrideIssues ?? Array.Empty<string>())
+                {
+                    definitionOverrideIssues.Add(issue);
+                }
+
                 var report = new JObject
                 {
                     ["exportedUtc"] = DateTime.UtcNow.ToString("O"),
@@ -269,9 +395,13 @@ namespace FUSE.Interface.MenuWindow
                     ["uniqueAssetKeys"] = diagnostics.UniqueAssetKeys,
                     ["duplicateKeyCount"] = duplicates.Count,
                     ["failedDefinitionLoadCount"] = failedDefinitions.Count,
+                    ["definitionOverrideCount"] = definitionOverrides.Count,
+                    ["definitionOverrideIssueCount"] = definitionOverrideIssues.Count,
                     ["stores"] = stores,
                     ["duplicateKeys"] = duplicates,
-                    ["failedDefinitionLoads"] = failedDefinitions
+                    ["failedDefinitionLoads"] = failedDefinitions,
+                    ["definitionOverrides"] = definitionOverrides,
+                    ["definitionOverrideIssues"] = definitionOverrideIssues
                 };
 
                 File.WriteAllText(path, report.ToString(Newtonsoft.Json.Formatting.Indented));
@@ -291,5 +421,14 @@ namespace FUSE.Interface.MenuWindow
                 return message;
             }
         }
+    }
+
+    internal sealed class FuseDuplicateAssetGroup
+    {
+        internal bool DefinitionsDiffer { get; set; }
+
+        internal string[] Sources { get; set; } = Array.Empty<string>();
+
+        internal List<string> Keys { get; } = new List<string>();
     }
 }

--- a/FUSE/Interface/MenuWindow/AuditsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/AuditsToolPage.cs
@@ -145,13 +145,23 @@ namespace FUSE.Interface.MenuWindow
 
             foreach (var fault in report["packages"]?["faults"] as JArray ?? [])
             {
+                var faultDetail = ReadString(fault["message"], "Package failed during load/apply.") +
+                    " stage='" + ReadString(fault["stage"], "unknown") + "'" +
+                    " package='" + ReadString(fault["packageName"], ReadString(fault["packageId"], "unknown")) + "'" +
+                    " folder='" + ReadString(fault["folderPath"], "unknown") + "'" +
+                    " file='" + ReadString(fault["relativeSourceFile"], ReadString(fault["sourceFile"], "unknown")) + "'" +
+                    " jsonPath='" + ReadString(fault["jsonPath"], "<root>") + "'" +
+                    " expected='" + ReadString(fault["expectedShape"], "see validation message") + "'" +
+                    " received='" + ReadString(fault["receivedValue"], "not captured") + "'";
                 AddFinding(
                     findings,
-                    "Critical",
-                    "Package fault",
+                    "High",
+                    "Package isolated after apply fault",
                     ReadString(fault["packageId"], "(unknown package)"),
-                    ReadString(fault["message"], "Package failed during load/apply."),
-                    "Open Issues, inspect the package fault stage, then fix the source package or compatibility layer.");
+                    faultDetail,
+                    ReadString(
+                        fault["suggestedAction"],
+                        "Inspect the package fault stage, then fix the source package or compatibility layer."));
             }
 
             foreach (var asset in report["unknownSceneryAssets"] as JArray ?? [])
@@ -167,13 +177,17 @@ namespace FUSE.Interface.MenuWindow
 
             foreach (var issue in report["graphPostBindIssues"] as JArray ?? [])
             {
+                var detail = issue.ToString();
+                var isOwnedRemoval = detail.IndexOf(" was removed by '", StringComparison.OrdinalIgnoreCase) >= 0;
                 AddFinding(
                     findings,
-                    "High",
-                    "Graph post-bind issue",
+                    isOwnedRemoval ? "Medium" : "High",
+                    isOwnedRemoval ? "Track package collision" : "Graph post-bind issue",
                     "track graph",
-                    issue.ToString(),
-                    "Inspect the owning track package and verify deleted/replaced node, segment, and span ids.");
+                    detail,
+                    isOwnedRemoval
+                        ? "These packages edit the same route. Disable one package, choose a compatible option/patch, or have the authors coordinate the shared node/segment ownership."
+                        : "Inspect the owning track package and verify deleted/replaced node, segment, and span ids.");
             }
 
             foreach (var skip in report["progressionTransferSkips"] as JArray ?? [])
@@ -189,6 +203,14 @@ namespace FUSE.Interface.MenuWindow
 
             foreach (var conflict in report["conflicts"] as JArray ?? [])
             {
+                if (!ShouldAuditConflictRecord(ReadString(conflict["classification"], string.Empty)))
+                {
+                    // Successful shared industry merges are surfaced as
+                    // informational extension targets on the dedicated Mods
+                    // Fighting page. They are not audit failures.
+                    continue;
+                }
+
                 AddFinding(
                     findings,
                     "Medium",
@@ -226,13 +248,24 @@ namespace FUSE.Interface.MenuWindow
         {
             try
             {
-                foreach (var span in TrackAPI.GetAllSpans() ?? [])
+                foreach (var span in TrackAPI.GetRegisteredSpansForDiagnostics() ?? [])
                 {
                     var id = span?.id ?? "(blank span)";
+                    var owner = FuseRegistry.GetExclusiveOwner(FuseClaimKind.Span, id);
+                    if (!ShouldAuditTrackSpanOwner(owner))
+                    {
+                        // Railroader ships a number of registered placeholder or
+                        // progression spans whose serialized endpoints are empty
+                        // until the game activates them. They are base-game state,
+                        // not FUSE authoring failures. The graph post-bind audit
+                        // separately reports mod-owned spans lost during merging.
+                        continue;
+                    }
+
                     var definition = TrackAPI.GetDefinition(span);
                     if (definition?.Upper == null || definition.Lower == null)
                     {
-                        AddFinding(findings, "High", "Invalid track span", id, "Span definition has missing upper/lower location.", "Inspect the source span and repair or remove invalid endpoints.");
+                        AddFinding(findings, "High", "Invalid FUSE track span", id, $"Owner '{owner}' has a span with missing upper/lower location.", "Inspect the owning package source and repair or remove invalid endpoints.");
                         continue;
                     }
 
@@ -256,6 +289,19 @@ namespace FUSE.Interface.MenuWindow
             }
         }
 
+        internal static bool ShouldAuditConflictRecord(string classification)
+        {
+            return !string.Equals(
+                classification?.Trim(),
+                "shared-extension",
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static bool ShouldAuditTrackSpanOwner(string ownerPackageId)
+        {
+            return !string.IsNullOrWhiteSpace(ownerPackageId);
+        }
+
         private static void AddIndustryAuditFindings(List<AuditFinding> findings)
         {
             try
@@ -273,11 +319,13 @@ namespace FUSE.Interface.MenuWindow
                         AddFinding(findings, "Medium", "Industry missing identifier", id, GetGameObjectPath(industry.gameObject), "Assign a stable industry identifier or remove the orphan scene object.");
                     }
 
-                    var definition = IndustryAPI.GetDefinition(industry);
-                    if (definition == null || definition.Components == null || definition.Components.Count == 0)
-                    {
-                        AddFinding(findings, "Low", "Industry has no components", id, GetGameObjectPath(industry.gameObject), "Verify whether this is scenery-only, a disabled vanilla industry, or a broken industry component binding.");
-                    }
+                    // An Industry is also the game's location container. Base
+                    // depots, passenger/scenery-only locations, fictional
+                    // destinations, and intentionally disabled industries may
+                    // legitimately contain no IndustryComponent children.
+                    // Missing referenced components are already reported by
+                    // package apply/post-bind diagnostics, so emptiness alone
+                    // is not an actionable finding.
                 }
             }
             catch (Exception ex)

--- a/FUSE/Interface/MenuWindow/DependencyGraphPage.cs
+++ b/FUSE/Interface/MenuWindow/DependencyGraphPage.cs
@@ -14,37 +14,27 @@ namespace FUSE.Interface.MenuWindow
         {
             builder.AddTitle("Mod Dependency Graph", "");
 
-            builder.AddLabel("This page shows mod dependencies with load order requirements and any detected faults.");
+            builder.AddLabel("This page shows dependencies for FUSE data, UMM plugins, RailLoader packages, locomotives, railcars, and asset packs.");
             AddWrappedLabel(
                 builder,
                 "Legacy (converted) packages list soft load-order hints: a hint whose target is not installed is optional and does not block loading. " +
-                "Asset-only packs and code-only plugins satisfy a dependency without being FUSE data packages. Retired package IDs whose runtime capability is replaced by FUSE are labeled PROVIDED BY FUSE.",
-                48f);
+                "Local manifests are authoritative. Nexus requirements are cached by the installer for offline use and are labeled NEXUS CACHE. " +
+                "Retired package IDs whose runtime capability is replaced by FUSE are labeled PROVIDED BY FUSE.",
+                64f);
 
             builder.Spacer(24f);
 
-            var manifests = FuseDataPackageDiscovery.GetPackageManifestSnapshots();
-            if (manifests == null || manifests.Count == 0)
+            var packages = FuseInstalledDependencyCatalog.DiscoverInstalledPackages();
+            if (packages == null || packages.Count == 0)
             {
                 builder.AddField("Dependencies", "No packages discovered");
                 return;
             }
 
-            var byId = manifests
-                .GroupBy(manifest => manifest.Id, StringComparer.OrdinalIgnoreCase)
-                .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
-            // Resolve every edge target that is not a discovered data package
-            // against the Mods root once, so installed asset-only packs and
-            // hosted code-only plugins render as PRESENT rather than MISSING
-            // (issues #207, #223).
-            var undiscovered = manifests
-                .SelectMany(manifest => manifest.RequiredPackageIds.Concat(manifest.LoadAfter).Concat(manifest.LoadBefore))
-                .Where(id => !string.IsNullOrWhiteSpace(id) && !byId.ContainsKey(id));
-            var presentInModsRoot = FuseDataPackageDiscovery.ResolvePackagesPresentInModsRoot(undiscovered);
             var rows = 0;
-            foreach (var manifest in manifests)
+            foreach (var package in packages)
             {
-                var hasEdges = manifest.RequiredPackageIds.Length > 0 || manifest.LoadAfter.Length > 0 || manifest.LoadBefore.Length > 0 || manifest.Faults.Length > 0;
+                var hasEdges = package.HasEdges || package.Faults.Count > 0;
                 if (!hasEdges && !FuseSettings.ShowAdvancedHealthDetails)
                 {
                     continue;
@@ -56,26 +46,27 @@ namespace FUSE.Interface.MenuWindow
                 }
 
                 builder.FieldLabelWidth = 120f;
-                AddWrappedLabel(builder, InsertBreakHints(manifest.Id), 28f);
-                foreach (var dependencyId in manifest.RequiredPackageIds)
+                var heading = package.Id + "  <color=\"grey\">[" + package.Category + " / " + package.ManifestSource + "]";
+                AddWrappedLabel(builder, InsertBreakHints(heading), 28f);
+                foreach (var dependency in package.Requirements)
                 {
-                    builder.AddField("requires", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId, presentInModsRoot, advisory: false))));
+                    builder.AddField("requires", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependency, packages, advisory: false))));
                     rows++;
                 }
 
-                foreach (var dependencyId in manifest.LoadAfter)
+                foreach (var dependency in package.LoadAfter)
                 {
-                    builder.AddField("load after", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId, presentInModsRoot, manifest.IsLegacyConverted))));
+                    builder.AddField("load after", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependency, packages, package.IsLegacy))));
                     rows++;
                 }
 
-                foreach (var dependencyId in manifest.LoadBefore)
+                foreach (var dependency in package.LoadBefore)
                 {
-                    builder.AddField("load before", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId, presentInModsRoot, manifest.IsLegacyConverted))));
+                    builder.AddField("load before", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependency, packages, package.IsLegacy))));
                     rows++;
                 }
 
-                foreach (var fault in manifest.Faults)
+                foreach (var fault in package.Faults)
                 {
                     builder.AddField("fault detected", builder.AddLabelMarkup(InsertBreakHints(FormatFault(fault))));
                     rows++;
@@ -90,6 +81,81 @@ namespace FUSE.Interface.MenuWindow
             {
                 builder.AddField("Dependencies", "No package dependency edges in current profile");
             }
+        }
+
+        internal static string FormatDependencyEdge(
+            FuseInstalledDependencyEdge edge,
+            IEnumerable<FuseInstalledPackageDependencySnapshot> packages,
+            bool advisory)
+        {
+            if (edge == null || string.IsNullOrWhiteSpace(edge.Id))
+            {
+                return "(blank) | <color=\"red\">MISSING";
+            }
+
+            var dependencyId = edge.Id.Trim();
+            var dependencyLabel = string.IsNullOrWhiteSpace(edge.DisplayName)
+                ? dependencyId
+                : edge.DisplayName.Trim() + " (" + dependencyId + ")";
+            var versionRange = FormatVersionRange(edge);
+            var source = string.IsNullOrWhiteSpace(edge.Source) ? string.Empty : " <color=\"grey\">[" + edge.Source + "]";
+            var dependency = FuseInstalledDependencyCatalog.FindInstalled(packages, dependencyId);
+            if (dependency != null)
+            {
+                if (dependency.Disabled)
+                {
+                    return advisory
+                        ? dependencyLabel + versionRange + " | <color=\"grey\">DISABLED (optional hint)" + source
+                        : dependencyLabel + versionRange + " | <color=\"yellow\">DISABLED" + source;
+                }
+
+                var matches = FuseInstalledDependencyCatalog.VersionSatisfies(
+                    dependency.Version,
+                    edge.NotBefore,
+                    edge.NotAfter,
+                    out var versionReadable);
+                var installedVersion = string.IsNullOrWhiteSpace(dependency.Version) ? string.Empty : " " + dependency.Version;
+                if (!matches)
+                {
+                    if (!versionReadable && (!string.IsNullOrWhiteSpace(edge.NotBefore) || !string.IsNullOrWhiteSpace(edge.NotAfter)))
+                    {
+                        return dependencyLabel + versionRange + " | <color=\"yellow\">PRESENT; VERSION UNKNOWN" + source;
+                    }
+
+                    return dependencyLabel + versionRange + " | <color=\"red\">INCOMPATIBLE" + installedVersion + source;
+                }
+
+                return dependencyLabel + versionRange + " | <color=\"green\">READY" + installedVersion + source;
+            }
+
+            if (FuseReplacementCapabilityCatalog.IsProvided(dependencyId))
+            {
+                return dependencyLabel + versionRange + " | <color=\"green\">PROVIDED BY FUSE" + source;
+            }
+
+            return advisory
+                ? dependencyLabel + versionRange + " | <color=\"grey\">NOT INSTALLED (optional hint)" + source
+                : dependencyLabel + versionRange + " | <color=\"red\">MISSING" + source;
+        }
+
+        private static string FormatVersionRange(FuseInstalledDependencyEdge edge)
+        {
+            if (edge == null)
+            {
+                return string.Empty;
+            }
+
+            if (!string.IsNullOrWhiteSpace(edge.NotBefore) && !string.IsNullOrWhiteSpace(edge.NotAfter))
+            {
+                return " (" + edge.NotBefore + " to " + edge.NotAfter + ")";
+            }
+
+            if (!string.IsNullOrWhiteSpace(edge.NotBefore))
+            {
+                return " (>= " + edge.NotBefore + ")";
+            }
+
+            return string.IsNullOrWhiteSpace(edge.NotAfter) ? string.Empty : " (<= " + edge.NotAfter + ")";
         }
 
         internal static string FormatDependencyEdge(

--- a/FUSE/Interface/MenuWindow/DependencyGraphPage.cs
+++ b/FUSE/Interface/MenuWindow/DependencyGraphPage.cs
@@ -18,7 +18,7 @@ namespace FUSE.Interface.MenuWindow
             AddWrappedLabel(
                 builder,
                 "Legacy (converted) packages list soft load-order hints: a hint whose target is not installed is optional and does not block loading. " +
-                "Asset-only packs and code-only plugins satisfy a dependency without being FUSE data packages.",
+                "Asset-only packs and code-only plugins satisfy a dependency without being FUSE data packages. Retired package IDs whose runtime capability is replaced by FUSE are labeled PROVIDED BY FUSE.",
                 48f);
 
             builder.Spacer(24f);
@@ -38,13 +38,13 @@ namespace FUSE.Interface.MenuWindow
             // hosted code-only plugins render as PRESENT rather than MISSING
             // (issues #207, #223).
             var undiscovered = manifests
-                .SelectMany(manifest => manifest.LoadAfter.Concat(manifest.LoadBefore))
+                .SelectMany(manifest => manifest.RequiredPackageIds.Concat(manifest.LoadAfter).Concat(manifest.LoadBefore))
                 .Where(id => !string.IsNullOrWhiteSpace(id) && !byId.ContainsKey(id));
             var presentInModsRoot = FuseDataPackageDiscovery.ResolvePackagesPresentInModsRoot(undiscovered);
             var rows = 0;
             foreach (var manifest in manifests)
             {
-                var hasEdges = manifest.LoadAfter.Length > 0 || manifest.LoadBefore.Length > 0 || manifest.Faults.Length > 0;
+                var hasEdges = manifest.RequiredPackageIds.Length > 0 || manifest.LoadAfter.Length > 0 || manifest.LoadBefore.Length > 0 || manifest.Faults.Length > 0;
                 if (!hasEdges && !FuseSettings.ShowAdvancedHealthDetails)
                 {
                     continue;
@@ -57,6 +57,12 @@ namespace FUSE.Interface.MenuWindow
 
                 builder.FieldLabelWidth = 120f;
                 AddWrappedLabel(builder, InsertBreakHints(manifest.Id), 28f);
+                foreach (var dependencyId in manifest.RequiredPackageIds)
+                {
+                    builder.AddField("requires", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId, presentInModsRoot, advisory: false))));
+                    rows++;
+                }
+
                 foreach (var dependencyId in manifest.LoadAfter)
                 {
                     builder.AddField("load after", builder.AddLabelMarkup(InsertBreakHints(FormatDependencyEdge(dependencyId, byId, presentInModsRoot, manifest.IsLegacyConverted))));
@@ -97,7 +103,15 @@ namespace FUSE.Interface.MenuWindow
                 return "(blank) | <color=\"red\">MISSING";
             }
 
-            if (packages != null && packages.TryGetValue(dependencyId, out var dependency))
+            FusePackageManifestSnapshot dependency = null;
+            if (packages != null)
+            {
+                packages.TryGetValue(dependencyId, out dependency);
+                dependency = dependency ?? packages.Values.FirstOrDefault(candidate =>
+                    FuseDeclaredPackageRelationship.SamePackageId(candidate?.Id, dependencyId));
+            }
+
+            if (dependency != null)
             {
                 if (!dependency.Disabled)
                 {
@@ -107,6 +121,11 @@ namespace FUSE.Interface.MenuWindow
                 return advisory
                     ? dependencyId + " | <color=\"grey\">DISABLED (optional hint)"
                     : dependencyId + " | <color=\"yellow\">DISABLED";
+            }
+
+            if (FuseReplacementCapabilityCatalog.IsProvided(dependencyId))
+            {
+                return dependencyId + " | <color=\"green\">PROVIDED BY FUSE";
             }
 
             if (presentInModsRoot != null && presentInModsRoot.Contains(dependencyId))

--- a/FUSE/Interface/MenuWindow/FuseMenuWindow.cs
+++ b/FUSE/Interface/MenuWindow/FuseMenuWindow.cs
@@ -132,6 +132,14 @@ namespace FUSE.Interface.MenuWindow
             {
                 ModsPanelBuilder.CloseAllLegacyModTabs("legacy settings tab no longer visible");
             }
+
+            if (_window != null && _window.IsShown &&
+                _selectedTabState.Value == TabIdTools &&
+                _selectedToolItem.Value == "liveDiagnostics" &&
+                LiveDiagnosticsToolPage.ShouldAutoRefresh(Time.unscaledTime))
+            {
+                RebuildWindow();
+            }
         }
 
         private void BuildFuseMenu(UIPanelBuilder builder)
@@ -442,9 +450,47 @@ namespace FUSE.Interface.MenuWindow
             }
 
             var scrollRects = _window.contentRectTransform.GetComponentsInChildren<ScrollRect>(true);
-            return scrollRects == null || scrollRects.Length == 0
-                ? null
-                : scrollRects[scrollRects.Length - 1];
+            if (scrollRects == null || scrollRects.Length == 0)
+            {
+                return null;
+            }
+
+            // List/detail pages contain two ScrollRects: the navigation list on
+            // the left and the actual page on the right. Component traversal
+            // order is not a UI contract, so choosing the last component made
+            // auto-refresh preserve the left list while the visible page jumped
+            // back to the top. Select the right-most viewport instead; single-
+            // scroll pages naturally select their only viewport.
+            ScrollRect selected = null;
+            var selectedCenterX = float.NegativeInfinity;
+            var selectedArea = float.NegativeInfinity;
+            var corners = new Vector3[4];
+            foreach (var candidate in scrollRects)
+            {
+                if (candidate == null)
+                {
+                    continue;
+                }
+
+                var viewport = candidate.viewport ?? candidate.transform as RectTransform;
+                if (viewport == null)
+                {
+                    continue;
+                }
+
+                viewport.GetWorldCorners(corners);
+                var centerX = (corners[0].x + corners[2].x) * 0.5f;
+                var area = Mathf.Abs((corners[2].x - corners[0].x) * (corners[2].y - corners[0].y));
+                if (centerX > selectedCenterX + 0.01f ||
+                    (Mathf.Abs(centerX - selectedCenterX) <= 0.01f && area > selectedArea))
+                {
+                    selected = candidate;
+                    selectedCenterX = centerX;
+                    selectedArea = area;
+                }
+            }
+
+            return selected ?? scrollRects[0];
         }
 
         public void SetSelectedProfile(string id)

--- a/FUSE/Interface/MenuWindow/FuseMenuWindow.cs
+++ b/FUSE/Interface/MenuWindow/FuseMenuWindow.cs
@@ -133,13 +133,6 @@ namespace FUSE.Interface.MenuWindow
                 ModsPanelBuilder.CloseAllLegacyModTabs("legacy settings tab no longer visible");
             }
 
-            if (_window != null && _window.IsShown &&
-                _selectedTabState.Value == TabIdTools &&
-                _selectedToolItem.Value == "liveDiagnostics" &&
-                LiveDiagnosticsToolPage.ShouldAutoRefresh(Time.unscaledTime))
-            {
-                RebuildWindow();
-            }
         }
 
         private void BuildFuseMenu(UIPanelBuilder builder)

--- a/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/FuseSettingsPanelBuilder.cs
@@ -14,6 +14,7 @@ namespace FUSE.Interface.MenuWindow
         private enum PageId
         {
             General,
+            LegacyGameplay,
         }
 
         private sealed class Page(PageId id)
@@ -30,6 +31,7 @@ namespace FUSE.Interface.MenuWindow
 
             List<UIPanelBuilder.ListItem<Page>> list = [];
             list.Add(new UIPanelBuilder.ListItem<Page>("general", new Page(PageId.General), "Settings", "General"));
+            list.Add(new UIPanelBuilder.ListItem<Page>("legacy-gameplay", new Page(PageId.LegacyGameplay), "Settings", "Legacy Gameplay"));
 
             builder.AddListDetail(list, selectedItem, delegate (UIPanelBuilder builder, Page page)
             {
@@ -48,6 +50,9 @@ namespace FUSE.Interface.MenuWindow
                             case PageId.General:
                                 BuildGeneralSettingsPage(builder);
                                 break;
+                            case PageId.LegacyGameplay:
+                                BuildLegacyGameplaySettingsPage(builder);
+                                break;
                             default:
                                 builder.AddLabel("Unknown page.");
                                 break;
@@ -55,6 +60,249 @@ namespace FUSE.Interface.MenuWindow
                     }, new RectOffset(0, 4, 0, 0));
                 }
             });
+        }
+
+        private static void BuildLegacyGameplaySettingsPage(UIPanelBuilder builder)
+        {
+            builder.AddTitle("Legacy Gameplay Replacements", "");
+            builder.FieldLabelWidth = 200f;
+            builder.Spacing = 6f;
+
+            builder.AddLabel(
+                "FUSE owns these compatibility behaviors so legacy dependencies can be removed. " +
+                "Defaults preserve the base game unless a value below is changed.");
+
+            builder.AddSection("Fall From Grace");
+            builder.AddLabel(
+                "Grace days = max(Minimum, base-game days × Multiplier + Added). " +
+                "The 0 / 1 / 0 defaults are identical to the base game. FUSE also shows the due time in the car inspector.");
+
+            AddIntegerField(builder, "Minimum Days", FuseSettings.GraceMinimumDays, FuseSettings.SetGraceMinimumDays);
+            AddIntegerField(builder, "Multiplier", FuseSettings.GraceMultiplier, FuseSettings.SetGraceMultiplier);
+            AddIntegerField(builder, "Added Days", FuseSettings.GraceAddedDays, FuseSettings.SetGraceAddedDays);
+
+            builder.AddSection("Configurable Interchange Service");
+            builder.AddLabel(
+                "Replaces C1CD. Controls the extra-service interval and optional daily service window for all interchanges.");
+
+            var intervals = new[] { 5, 15, 30, 45, 60, 90, 120, 150, 180, 240, 300, 360, 480, 720, 1080 };
+            var selectedInterval = Array.IndexOf(intervals, FuseSettings.InterchangeServiceIntervalMinutes);
+            if (selectedInterval < 0)
+            {
+                selectedInterval = Array.FindIndex(
+                    intervals,
+                    value => value >= FuseSettings.InterchangeServiceIntervalMinutes);
+                if (selectedInterval < 0)
+                {
+                    selectedInterval = intervals.Length - 1;
+                }
+            }
+
+            builder.AddField(
+                "Serve Interval",
+                builder.AddDropdown(
+                    new List<string>(Array.ConvertAll(intervals, FormatServiceInterval)),
+                    selectedInterval,
+                    index =>
+                    {
+                        if (index >= 0 && index < intervals.Length)
+                        {
+                            FuseSettings.SetInterchangeServiceIntervalMinutes(intervals[index]);
+                        }
+                    }));
+
+            builder.AddField("Continuous Service", control: BuildToggleBoxWithButton(
+                builder,
+                FuseSettings.InterchangeContinuousService,
+                () =>
+                {
+                    FuseSettings.SetInterchangeContinuousService(!FuseSettings.InterchangeContinuousService);
+                    builder.Rebuild();
+                }));
+
+            builder.AddLabel(
+                "When enabled, FUSE schedules the next extra service after every interchange pass, even when no orders remain.");
+
+            builder.AddField("Not Before", control: builder.AddSliderQuantized(
+                () => FuseSettings.InterchangeNotBeforeHour,
+                () => FormatServiceHour(FuseSettings.InterchangeNotBeforeHour),
+                FuseSettings.SetInterchangeNotBeforeHour,
+                0.25f,
+                0f,
+                24f,
+                FuseSettings.SetInterchangeNotBeforeHour));
+
+            builder.AddField("Not After", control: builder.AddSliderQuantized(
+                () => FuseSettings.InterchangeNotAfterHour,
+                () => FormatServiceHour(FuseSettings.InterchangeNotAfterHour),
+                FuseSettings.SetInterchangeNotAfterHour,
+                0.25f,
+                0f,
+                24f,
+                FuseSettings.SetInterchangeNotAfterHour));
+
+            builder.AddLabel(
+                "Use 00:00–24:00 for all-day service. A start later than the end (for example 22:00–06:00) creates an overnight window.");
+
+            builder.AddSection("Outbound Industry Routing");
+            builder.AddLabel(
+                "Native replacement for AbsoluteMadness and SomeKindOfMadness. It activates automatically when an enabled package requests either legacy id. " +
+                "The switch below is an explicit opt-in for profiles that do not declare the old dependency.");
+
+            builder.AddField("Enable Routing", control: BuildToggleBoxWithButton(
+                builder,
+                FuseSettings.EnableOutboundIndustryRerouting,
+                () =>
+                {
+                    FuseSettings.SetEnableOutboundIndustryRerouting(!FuseSettings.EnableOutboundIndustryRerouting);
+                    builder.Rebuild();
+                }));
+
+            builder.AddField("Route Chance", control: builder.AddSliderQuantized(
+                () => FuseSettings.OutboundIndustryRerouteChance,
+                () => (FuseSettings.OutboundIndustryRerouteChance * 100f).ToString("0", System.Globalization.CultureInfo.InvariantCulture) + "%",
+                FuseSettings.SetOutboundIndustryRerouteChance,
+                0.05f,
+                0f,
+                1f,
+                FuseSettings.SetOutboundIndustryRerouteChance));
+
+            builder.AddField("Capacity Target", control: builder.AddSliderQuantized(
+                () => FuseSettings.OutboundIndustryFillFactor,
+                () => FuseSettings.OutboundIndustryFillFactor.ToString("0.0x", System.Globalization.CultureInfo.InvariantCulture),
+                FuseSettings.SetOutboundIndustryFillFactor,
+                0.1f,
+                0.1f,
+                3f,
+                FuseSettings.SetOutboundIndustryFillFactor));
+
+            builder.AddField("Payment", control: builder.AddSliderQuantized(
+                () => FuseSettings.OutboundIndustryPaymentMultiplier,
+                () => FuseSettings.OutboundIndustryPaymentMultiplier.ToString("0.0x", System.Globalization.CultureInfo.InvariantCulture),
+                FuseSettings.SetOutboundIndustryPaymentMultiplier,
+                0.1f,
+                0f,
+                10f,
+                FuseSettings.SetOutboundIndustryPaymentMultiplier));
+
+            AddOutboundRoutingToggle(
+                builder,
+                "Allow Short Trips",
+                FuseSettings.OutboundIndustryAllowShortTrips,
+                FuseSettings.SetOutboundIndustryAllowShortTrips);
+            AddOutboundRoutingToggle(
+                builder,
+                "Ignore Origin",
+                FuseSettings.OutboundIndustryIgnoreOrigin,
+                FuseSettings.SetOutboundIndustryIgnoreOrigin);
+            AddOutboundRoutingToggle(
+                builder,
+                "Shuffle Orders",
+                FuseSettings.OutboundIndustryPreventBlocking,
+                FuseSettings.SetOutboundIndustryPreventBlocking);
+
+            builder.AddLabel(
+                "If both old packages are requested, the configurable SomeKindOfMadness behavior wins. " +
+                "A routing extension can inspect or adjust candidates through FUSE's native outbound-routing event.");
+
+            builder.AddSection("Interchange-to-Interchange Traffic");
+            builder.AddLabel(
+                "Replaces Interchange2Interchange when an enabled package requests it. " +
+                "Each contracted source interchange can create a daily cut for every other enabled interchange.");
+            AddIntegerField(
+                builder,
+                "Maximum Cars / Cut",
+                FuseSettings.InterchangeToInterchangeMaximumCars,
+                FuseSettings.SetInterchangeToInterchangeMaximumCars);
+
+            builder.AddSection("For Your Convenience");
+            builder.AddLabel(
+                "These visual additions activate only when an enabled package requests ForYourConvenience. " +
+                "The live Industry Dashboard is always available under Tools, and station-map actions are attached without replacing existing icon actions.");
+            AddLegacyToggle(
+                builder,
+                "Caboose Map Icons",
+                FuseSettings.ForYourConvenienceShowCabooseIcons,
+                FuseSettings.SetForYourConvenienceShowCabooseIcons);
+            AddLegacyToggle(
+                builder,
+                "Car Tag Speed",
+                FuseSettings.ForYourConvenienceShowCarTagMph,
+                FuseSettings.SetForYourConvenienceShowCarTagMph);
+            AddLegacyToggle(
+                builder,
+                "Car Tag Loads",
+                FuseSettings.ForYourConvenienceShowCarTagLoads,
+                FuseSettings.SetForYourConvenienceShowCarTagLoads);
+
+            builder.Spacer(32f);
+        }
+
+        private static void AddOutboundRoutingToggle(
+            UIPanelBuilder builder,
+            string label,
+            bool enabled,
+            Action<bool> setter)
+        {
+            builder.AddField(label, control: BuildToggleBoxWithButton(
+                builder,
+                enabled,
+                () =>
+                {
+                    setter(!enabled);
+                    builder.Rebuild();
+                }));
+        }
+
+        private static void AddLegacyToggle(
+            UIPanelBuilder builder,
+            string label,
+            bool enabled,
+            Action<bool> setter)
+        {
+            builder.AddField(label, control: BuildToggleBoxWithButton(
+                builder,
+                enabled,
+                () =>
+                {
+                    setter(!enabled);
+                    builder.Rebuild();
+                }));
+        }
+
+        private static void AddIntegerField(UIPanelBuilder builder, string label, int value, Action<int> setter)
+        {
+            builder.AddField(
+                label,
+                builder.AddInputField(
+                    value.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    text =>
+                    {
+                        int parsed;
+                        if (int.TryParse(
+                            text,
+                            System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            out parsed))
+                        {
+                            setter(parsed);
+                        }
+                    }));
+        }
+
+        private static string FormatServiceInterval(int minutes)
+        {
+            return minutes < 60
+                ? minutes + " min"
+                : (minutes / 60f).ToString("0.#", System.Globalization.CultureInfo.InvariantCulture) + " h";
+        }
+
+        private static string FormatServiceHour(float hour)
+        {
+            var totalMinutes = (int)Math.Round(hour * 60f);
+            var displayHour = totalMinutes / 60;
+            var displayMinute = totalMinutes % 60;
+            return $"{displayHour:00}:{displayMinute:00}";
         }
 
         private static void BuildGeneralSettingsPage(UIPanelBuilder builder)

--- a/FUSE/Interface/MenuWindow/IndustryDashboardToolPage.cs
+++ b/FUSE/Interface/MenuWindow/IndustryDashboardToolPage.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using FUSE.Infrastructure;
+using Model.Ops;
+using UI.Builder;
+using static FUSE.Interface.InterfaceUtils;
+
+namespace FUSE.Interface.MenuWindow
+{
+    internal static class IndustryDashboardToolPage
+    {
+        public static void Build(UIPanelBuilder builder)
+        {
+            builder.AddTitle("Industry Dashboard", "");
+            AddWrappedLabel(
+                builder,
+                "A live, read-only view of the industries and component storage known to the game's operations controller. " +
+                "It remains useful for native FUSE packages and replaces the old ForYourConvenience dashboard when that dependency is requested.",
+                58f);
+
+            builder.HStack(row => row.AddButtonCompact("Refresh", builder.Rebuild), 6f).Height(32f);
+            builder.Spacer(8f);
+
+            var industries = OpsController.Shared?.AllIndustries?
+                .Where(industry => industry != null)
+                .OrderBy(industry => industry.ProgressionDisabled)
+                .ThenBy(industry => industry.name, StringComparer.OrdinalIgnoreCase)
+                .ToArray() ?? Array.Empty<Industry>();
+            builder.AddField("Industries", industries.Length.ToString());
+            if (industries.Length == 0)
+            {
+                builder.AddLabelEmptyState("No operations industries are available in the current scene.");
+                return;
+            }
+
+            foreach (var industry in industries)
+            {
+                BuildIndustry(builder, industry);
+            }
+        }
+
+        private static void BuildIndustry(UIPanelBuilder builder, Industry industry)
+        {
+            builder.AddSection(string.IsNullOrWhiteSpace(industry.name) ? industry.identifier : industry.name);
+            builder.AddField("Id", industry.identifier ?? "(none)");
+            builder.AddField("State", industry.ProgressionDisabled ? "Progression disabled" : "Enabled");
+            builder.AddField("Contract", industry.usesContract ? "Uses company contract" : "Not contracted");
+            builder.AddField("Components", (industry.Components?.Count() ?? 0).ToString());
+
+            try
+            {
+                foreach (var pair in industry.EnumerateComponentContexts(0f))
+                {
+                    var component = pair.Item1;
+                    var context = pair.Item2;
+                    if (component == null)
+                    {
+                        continue;
+                    }
+
+                    var title = string.IsNullOrWhiteSpace(component.DisplayName)
+                        ? component.subIdentifier
+                        : component.DisplayName;
+                    var type = component.GetType().Name;
+                    AddWrappedField(builder, title ?? "Component", type + " — " + ComponentState(component), 36f);
+                    foreach (var field in component.PanelFields(context))
+                    {
+                        AddWrappedField(builder, field.Label, field.Text, 34f);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                AddWrappedField(
+                    builder,
+                    "Component details",
+                    "Unavailable: " + ex.GetBaseException().Message,
+                    42f);
+                FuseLog.Warning(
+                    "FUSE Industry Dashboard could not inspect '" + industry.identifier + "': " +
+                    ex.GetBaseException().Message);
+            }
+
+            builder.Spacer(8f);
+        }
+
+        private static string ComponentState(IndustryComponent component)
+        {
+            var state = component.ProgressionDisabled ? "progression disabled" : "active";
+            var spanCount = component.trackSpans?.Length ?? 0;
+            return state + ", " + spanCount + " track span(s), cars " +
+                   (component.carTypeFilter?.queryString ?? "(none)");
+        }
+    }
+}

--- a/FUSE/Interface/MenuWindow/InspectorToolPage.cs
+++ b/FUSE/Interface/MenuWindow/InspectorToolPage.cs
@@ -169,6 +169,7 @@ namespace FUSE.Interface.MenuWindow
             AddInspectorIndexTargets(results, signatures, "Station", FuseStationRuntimeIndex.Instance, FuseClaimKind.Station, term, limit);
             AddInspectorIndexTargets(results, signatures, "Scenery", FuseSceneryRuntimeIndex.Instance, FuseClaimKind.Scenery, term, limit);
             AddInspectorIndexTargets(results, signatures, "Spliney", FuseSplineyRuntimeIndex.Instance, null, term, limit);
+            AddInspectorIndexTargets(results, signatures, "Water Surface", FuseWaterSurfaceRuntimeIndex.Instance, null, term, limit);
             AddInspectorIndexTargets(results, signatures, "Map Label", FuseMapLabelRuntimeIndex.Instance, null, term, limit);
             AddInspectorIndexTargets(results, signatures, "Progression", FuseProgressionRuntimeIndex.Instance, null, term, limit);
             AddInspectorIndexTargets(results, signatures, "Map Feature", FuseMapFeatureRuntimeIndex.Instance, null, term, limit);

--- a/FUSE/Interface/MenuWindow/LiveDiagnosticsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/LiveDiagnosticsToolPage.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using TMPro;
 using UI.Builder;
 using UI.Common;
 using UnityEngine;
@@ -22,18 +23,10 @@ namespace FUSE.Interface.MenuWindow
         private static string _levelFilter = "All";
         private static string _search = string.Empty;
         private static bool _autoRefresh;
-        private static float _nextAutoRefreshAt;
-
-        internal static bool ShouldAutoRefresh(float now)
-        {
-            if (!_autoRefresh || now < _nextAutoRefreshAt)
-            {
-                return false;
-            }
-
-            _nextAutoRefreshAt = now + 1f;
-            return true;
-        }
+        private static bool _hasViewSnapshot;
+        private static float _nextViewSnapshotAt;
+        private static int _visibleCount;
+        private static string _visibleLines = string.Empty;
 
         public static void Build(UIPanelBuilder builder)
         {
@@ -52,7 +45,17 @@ namespace FUSE.Interface.MenuWindow
         {
             builder.AddSection("FUSE Log");
             builder.AddField("File", string.IsNullOrWhiteSpace(FuseLog.LogFilePath) ? "unavailable" : FuseLog.LogFilePath);
-            builder.AddField("Buffered", FuseLiveLogBuffer.Count + " / " + FuseLiveLogBuffer.Capacity + " recent entries");
+            if (_autoRefresh)
+            {
+                builder.AddField(
+                    "Buffered",
+                    () => FuseLiveLogBuffer.Count + " / " + FuseLiveLogBuffer.Capacity + " recent entries",
+                    UIPanelBuilder.Frequency.Periodic);
+            }
+            else
+            {
+                builder.AddField("Buffered", FuseLiveLogBuffer.Count + " / " + FuseLiveLogBuffer.Capacity + " recent entries");
+            }
 
             var selectedLevel = Math.Max(0, Array.IndexOf(LevelFilters, _levelFilter));
             builder.AddField(
@@ -62,6 +65,7 @@ namespace FUSE.Interface.MenuWindow
                     if (index >= 0 && index < LevelFilters.Length)
                     {
                         _levelFilter = LevelFilters[index];
+                        InvalidateViewSnapshot();
                         builder.Rebuild();
                     }
                 })).Height(32f);
@@ -72,17 +76,22 @@ namespace FUSE.Interface.MenuWindow
 
             builder.HStack(row =>
             {
-                row.AddButtonCompact("Refresh", builder.Rebuild);
+                row.AddButtonCompact("Refresh", () =>
+                {
+                    InvalidateViewSnapshot();
+                    builder.Rebuild();
+                });
                 row.AddButtonCompact(_autoRefresh ? "Pause Auto Refresh" : "Start Auto Refresh", () =>
                 {
                     _autoRefresh = !_autoRefresh;
-                    _nextAutoRefreshAt = 0f;
+                    InvalidateViewSnapshot();
                     builder.Rebuild();
                 });
                 row.AddButtonCompact("Clear Filter", () =>
                 {
                     _levelFilter = "All";
                     _search = string.Empty;
+                    InvalidateViewSnapshot();
                     builder.Rebuild();
                 });
             }, 6f).Height(32f);
@@ -120,11 +129,38 @@ namespace FUSE.Interface.MenuWindow
                     ? "Auto refresh is on (once per second)."
                     : "This in-game snapshot refreshes on demand. Open Live Console for a continuously scrolling second-screen view.");
 
-            var entries = VisibleEntries();
-            builder.AddField("Visible", entries.Length.ToString());
-            var lines = FormatEntries(entries);
-            AddWrappedLabel(builder, string.IsNullOrWhiteSpace(lines) ? "No matching FUSE log entries." : lines,
-                Math.Min(1400f, Math.Max(100f, entries.Length * 19f)));
+            RefreshViewSnapshot(force: true);
+            if (_autoRefresh)
+            {
+                builder.AddField(
+                    "Visible",
+                    () =>
+                    {
+                        RefreshViewSnapshot(force: false);
+                        return _visibleCount.ToString();
+                    },
+                    UIPanelBuilder.Frequency.Periodic);
+                var logView = builder.AddLabel(
+                    () =>
+                    {
+                        RefreshViewSnapshot(force: false);
+                        return string.IsNullOrWhiteSpace(_visibleLines)
+                            ? "No matching FUSE log entries."
+                            : _visibleLines;
+                    },
+                    UIPanelBuilder.Frequency.Periodic);
+                ConfigureLogView(logView);
+            }
+            else
+            {
+                builder.AddField("Visible", _visibleCount.ToString());
+                var logView = builder.AddLabel(
+                    string.IsNullOrWhiteSpace(_visibleLines)
+                        ? "No matching FUSE log entries."
+                        : _visibleLines,
+                    text => ConfigureLogText(text));
+                logView.Height(1400f);
+            }
         }
 
         private static void BuildContainedEvents(UIPanelBuilder builder)
@@ -177,10 +213,70 @@ namespace FUSE.Interface.MenuWindow
         private static FuseLiveLogEntry[] VisibleEntries() =>
             FuseLiveLogBuffer.Snapshot(_levelFilter, _search, 120);
 
-        private static string FormatEntries(FuseLiveLogEntry[] entries) =>
-            string.Join(Environment.NewLine, (entries ?? Array.Empty<FuseLiveLogEntry>())
-                .Select(entry => entry.FormatLine())
-                .ToArray());
+        private static string FormatEntries(FuseLiveLogEntry[] entries)
+        {
+            if (entries == null || entries.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var text = new StringBuilder(entries.Length * 96);
+            for (var index = 0; index < entries.Length; index++)
+            {
+                if (index > 0)
+                {
+                    text.AppendLine();
+                }
+
+                text.Append(entries[index].FormatLine());
+            }
+
+            return text.ToString();
+        }
+
+        private static void InvalidateViewSnapshot()
+        {
+            _hasViewSnapshot = false;
+            _nextViewSnapshotAt = 0f;
+        }
+
+        private static void RefreshViewSnapshot(bool force)
+        {
+            var now = Time.unscaledTime;
+            if (!force && _hasViewSnapshot && (!_autoRefresh || now < _nextViewSnapshotAt))
+            {
+                return;
+            }
+
+            var entries = VisibleEntries();
+            _visibleCount = entries.Length;
+            _visibleLines = FormatEntries(entries);
+            _hasViewSnapshot = true;
+            _nextViewSnapshotAt = now + 0.9f;
+        }
+
+        private static void ConfigureLogView(RectTransform view)
+        {
+            if (view == null)
+            {
+                return;
+            }
+
+            ConfigureLogText(view.GetComponent<TMP_Text>());
+            view.Height(1400f);
+        }
+
+        private static void ConfigureLogText(TMP_Text text)
+        {
+            if (text == null)
+            {
+                return;
+            }
+
+            text.enableWordWrapping = true;
+            text.overflowMode = TextOverflowModes.Ellipsis;
+            text.alignment = TextAlignmentOptions.Left;
+        }
 
         private static string BuildDiagnosticsText()
         {

--- a/FUSE/Interface/MenuWindow/LiveDiagnosticsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/LiveDiagnosticsToolPage.cs
@@ -1,0 +1,209 @@
+using FUSE.Infrastructure;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UI.Builder;
+using UI.Common;
+using UnityEngine;
+using static FUSE.Interface.InterfaceUtils;
+
+namespace FUSE.Interface.MenuWindow
+{
+    internal static class LiveDiagnosticsToolPage
+    {
+        private static readonly string[] LevelFilters =
+        {
+            "All",
+            "Warnings + Errors",
+            "Errors"
+        };
+
+        private static string _levelFilter = "All";
+        private static string _search = string.Empty;
+        private static bool _autoRefresh;
+        private static float _nextAutoRefreshAt;
+
+        internal static bool ShouldAutoRefresh(float now)
+        {
+            if (!_autoRefresh || now < _nextAutoRefreshAt)
+            {
+                return false;
+            }
+
+            _nextAutoRefreshAt = now + 1f;
+            return true;
+        }
+
+        public static void Build(UIPanelBuilder builder)
+        {
+            builder.AddTitle("Live Diagnostics", "");
+            builder.AddLabel(
+                "Runtime guards and third-party exceptions are diagnostics, not load-health failures. " +
+                "They live here so the Status page stays focused on actionable package, asset, graph, progression, and conflict problems.");
+            builder.Spacer(8f);
+
+            BuildLogViewer(builder);
+            builder.Spacer(12f);
+            BuildContainedEvents(builder);
+        }
+
+        private static void BuildLogViewer(UIPanelBuilder builder)
+        {
+            builder.AddSection("FUSE Log");
+            builder.AddField("File", string.IsNullOrWhiteSpace(FuseLog.LogFilePath) ? "unavailable" : FuseLog.LogFilePath);
+            builder.AddField("Buffered", FuseLiveLogBuffer.Count + " / " + FuseLiveLogBuffer.Capacity + " recent entries");
+
+            var selectedLevel = Math.Max(0, Array.IndexOf(LevelFilters, _levelFilter));
+            builder.AddField(
+                "Level",
+                builder.AddDropdown(LevelFilters.ToList(), selectedLevel, index =>
+                {
+                    if (index >= 0 && index < LevelFilters.Length)
+                    {
+                        _levelFilter = LevelFilters[index];
+                        builder.Rebuild();
+                    }
+                })).Height(32f);
+
+            builder.AddField(
+                "Contains",
+                builder.AddInputField(_search ?? string.Empty, value => _search = value ?? string.Empty));
+
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Refresh", builder.Rebuild);
+                row.AddButtonCompact(_autoRefresh ? "Pause Auto Refresh" : "Start Auto Refresh", () =>
+                {
+                    _autoRefresh = !_autoRefresh;
+                    _nextAutoRefreshAt = 0f;
+                    builder.Rebuild();
+                });
+                row.AddButtonCompact("Clear Filter", () =>
+                {
+                    _levelFilter = "All";
+                    _search = string.Empty;
+                    builder.Rebuild();
+                });
+            }, 6f).Height(32f);
+
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Copy Visible Log", () =>
+                {
+                    GUIUtility.systemCopyBuffer = FormatEntries(VisibleEntries());
+                    Toast.Present("Copied the visible FUSE log entries.");
+                });
+                row.AddButtonCompact("Open Log Folder", () =>
+                {
+                    var directory = string.IsNullOrWhiteSpace(FuseLog.LogFilePath)
+                        ? Application.persistentDataPath
+                        : Path.GetDirectoryName(FuseLog.LogFilePath);
+                    Application.OpenURL(directory);
+                    Toast.Present("Opened the FUSE log folder.");
+                });
+                row.AddButtonCompact(
+                    FuseLiveConsole.IsEnabled ? "Stop Live Console" : "Open Live Console",
+                    () =>
+                    {
+                        var result = FuseLiveConsole.IsEnabled
+                            ? FuseLiveConsole.Disable()
+                            : FuseLiveConsole.Enable();
+                        Toast.Present(result);
+                        builder.Rebuild();
+                    });
+            }, 6f).Height(32f);
+
+            builder.AddField(
+                "Viewer",
+                _autoRefresh
+                    ? "Auto refresh is on (once per second)."
+                    : "This in-game snapshot refreshes on demand. Open Live Console for a continuously scrolling second-screen view.");
+
+            var entries = VisibleEntries();
+            builder.AddField("Visible", entries.Length.ToString());
+            var lines = FormatEntries(entries);
+            AddWrappedLabel(builder, string.IsNullOrWhiteSpace(lines) ? "No matching FUSE log entries." : lines,
+                Math.Min(1400f, Math.Max(100f, entries.Length * 19f)));
+        }
+
+        private static void BuildContainedEvents(UIPanelBuilder builder)
+        {
+            builder.AddSection("Contained Runtime Events");
+            AddWrappedField(builder, "Compatibility Guards", FuseRuntimeGuardCounters.FormatSummary(), 76f);
+            builder.AddField(
+                "Native Leak Stacks",
+                $"{FuseNativeLeakDiagnostic.ModeLabel} (setting: {(FuseSettings.EnableNativeLeakStackTraces ? "enabled" : "disabled")})");
+
+            var exceptionState = FuseModExceptionRegistry.CaptureReportState();
+            builder.AddField("Observed Exceptions", exceptionState.Total.ToString());
+            AddWrappedLabel(
+                builder,
+                exceptionState.Total == 0
+                    ? "No third-party exceptions have been observed this session."
+                    : "These observations do not change FUSE readiness. Use them to identify repeating mod behavior; attach the health report when reporting a real symptom.",
+                48f);
+
+            foreach (var record in exceptionState.Mods.OrderByDescending(item => item.Count))
+            {
+                var display = string.IsNullOrWhiteSpace(record.DisplayName) ? record.ModId : record.DisplayName;
+                var top = record.Signatures == null
+                    ? null
+                    : record.Signatures.OrderByDescending(item => item.Count).FirstOrDefault();
+                var text = record.Count + " occurrence(s) over " + record.Episodes + " episode(s)";
+                if (top != null)
+                {
+                    text += " — " + top.ExceptionType + " @ " + top.TopOwnedFrame;
+                }
+
+                AddWrappedField(builder, display, text, 52f);
+            }
+
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Copy Diagnostics", () =>
+                {
+                    GUIUtility.systemCopyBuffer = BuildDiagnosticsText();
+                    Toast.Present("Copied FUSE runtime diagnostics.");
+                });
+                row.AddButtonCompact("Copy Full Health Report", () =>
+                {
+                    GUIUtility.systemCopyBuffer = FUSE.Loading.FuseLoadReport.GetLastDetailReport();
+                    Toast.Present("Copied the full FUSE health report.");
+                });
+            }, 6f).Height(32f);
+        }
+
+        private static FuseLiveLogEntry[] VisibleEntries() =>
+            FuseLiveLogBuffer.Snapshot(_levelFilter, _search, 120);
+
+        private static string FormatEntries(FuseLiveLogEntry[] entries) =>
+            string.Join(Environment.NewLine, (entries ?? Array.Empty<FuseLiveLogEntry>())
+                .Select(entry => entry.FormatLine())
+                .ToArray());
+
+        private static string BuildDiagnosticsText()
+        {
+            var state = FuseModExceptionRegistry.CaptureReportState();
+            var text = new StringBuilder();
+            text.AppendLine("FUSE Runtime Diagnostics");
+            text.AppendLine("Generated: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+            text.AppendLine("Guards: " + FuseRuntimeGuardCounters.FormatSummary());
+            text.AppendLine(state.SummaryLine);
+            foreach (var record in state.Mods.OrderByDescending(item => item.Count))
+            {
+                var display = string.IsNullOrWhiteSpace(record.DisplayName) ? record.ModId : record.DisplayName;
+                text.AppendLine($"{display} ({record.ModId}): {record.Count} occurrence(s), {record.Episodes} episode(s)");
+                foreach (var signature in (record.Signatures ?? Array.Empty<FuseModExceptionSignatureSnapshot>())
+                             .OrderByDescending(item => item.Count))
+                {
+                    text.AppendLine(
+                        $"  {signature.ExceptionType} @ {signature.TopOwnedFrame}: " +
+                        $"{signature.Count} occurrence(s), {signature.Episodes} episode(s) — {signature.SampleMessage}");
+                }
+            }
+
+            return text.ToString().TrimEnd();
+        }
+    }
+}

--- a/FUSE/Interface/MenuWindow/ModConflictsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/ModConflictsToolPage.cs
@@ -1,0 +1,411 @@
+using FUSE.Runtime.Registry;
+using FUSE.Loading;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UI.Builder;
+using UI.Common;
+using UnityEngine;
+using static FUSE.Interface.InterfaceUtils;
+
+namespace FUSE.Interface.MenuWindow
+{
+    /// <summary>
+    /// Human-readable package-pair view over the registry's object-level
+    /// conflict history. The raw history remains available through
+    /// /fuse.conflicts and the health report.
+    /// </summary>
+    internal static class ModConflictsToolPage
+    {
+        internal sealed class ConflictGroup
+        {
+            public string FirstPackageId { get; set; }
+            public string SecondPackageId { get; set; }
+            public FuseRegistryConflict[] Conflicts { get; set; }
+        }
+
+        internal sealed class DeclaredConflictMatch
+        {
+            public FusePackageManifestSnapshot DeclaringPackage { get; set; }
+            public FusePackageManifestSnapshot ConflictingPackage { get; set; }
+            public FUSE.Authoring.Data.FuseModRequirement Reference { get; set; }
+        }
+
+        public static void Build(UIPanelBuilder builder)
+        {
+            builder.AddTitle("Mod Conflicts", "");
+            AddWrappedLabel(
+                builder,
+                "Packages are grouped in pairs so you can see which mods are changing the same runtime objects. " +
+                "Declared requires/loadAfter/loadBefore and conditional mixinto layering is expected and is not listed here. " +
+                "FUSE keeps unrelated mods unless the resolution below says that one definition won. Spatial track overlap is advisory because nearby track can be intentional.",
+                62f);
+
+            var registryRecords = FuseRegistry.Conflicts.ToArray();
+            var cooperativeRecords = registryRecords.Where(conflict => conflict.IsCooperativeMerge).ToArray();
+            var registryConflicts = registryRecords.Where(conflict => !conflict.IsCooperativeMerge).ToArray();
+            var spatialConflicts = FuseSpatialTrackConflictDetector.Conflicts.ToArray();
+            var packageSnapshots = (FuseDataPackageDiscovery.GetPackageManifestSnapshots() ?? Array.Empty<FusePackageManifestSnapshot>())
+                .ToArray();
+            var knownPackageIds = packageSnapshots
+                .Select(package => package.Id)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .ToArray();
+            var groups = BuildGroups(registryConflicts.Concat(spatialConflicts), knownPackageIds);
+            var cooperativeGroups = BuildGroups(cooperativeRecords, knownPackageIds);
+            var declaredConflicts = BuildDeclaredConflictMatches(packageSnapshots);
+            builder.AddSection("Overview");
+            AddValueField(builder, "Pairs Needing Attention", groups.Count.ToString());
+            AddValueField(builder, "Declared Incompatibilities", declaredConflicts.Count.ToString());
+            AddValueField(builder, "Ownership Conflicts", registryConflicts.Length.ToString());
+            AddValueField(builder, "Shared Extension Targets", cooperativeRecords.Length.ToString());
+            AddValueField(builder, "Spatial Warnings", spatialConflicts.Length.ToString());
+
+            builder.Spacer(8f);
+            builder.HStack(row =>
+            {
+                row.AddButtonCompact("Refresh", builder.Rebuild);
+                row.AddButtonCompact("Copy Full Report", () =>
+                {
+                    GUIUtility.systemCopyBuffer = BuildReport(groups, declaredConflicts, cooperativeGroups);
+                    Toast.Present("Copied FUSE mod conflict report to clipboard.");
+                });
+            }, 6f).Height(32f);
+            builder.Spacer(8f);
+
+            if (groups.Count == 0 && declaredConflicts.Count == 0 && cooperativeGroups.Count == 0)
+            {
+                builder.AddField("Status", builder.AddLabelMarkup("<color=\"green\">No mod ownership conflicts have been recorded in this session."));
+                return;
+            }
+
+            if (declaredConflicts.Count > 0)
+            {
+                builder.AddSection("Author-Declared Incompatibilities");
+                AddWrappedLabel(
+                    builder,
+                    "These pairs come from a package's conflictsWith declaration, not from FUSE guessing at nearby track. " +
+                    "The declaring package is skipped while the matching incompatible package/version is enabled.",
+                    48f);
+                foreach (var match in declaredConflicts.Take(30))
+                {
+                    AddWrappedField(builder, "Skipped Package", InsertBreakHints(match.DeclaringPackage.Id), 34f);
+                    AddWrappedField(builder, "Conflicts With", InsertBreakHints(match.ConflictingPackage.Id), 34f);
+                    AddWrappedField(builder, "Versions", FormatDeclaredConflict(match), 42f);
+                    builder.Spacer(6f);
+                }
+
+                if (groups.Count == 0 && cooperativeGroups.Count == 0)
+                {
+                    return;
+                }
+            }
+
+            if (groups.Count > 0)
+            {
+                builder.AddSection("Runtime Ownership Needing Attention");
+                foreach (var group in groups.Take(30))
+                {
+                    AddWrappedField(builder, "Mod A", InsertBreakHints(group.FirstPackageId), 34f);
+                    AddWrappedField(builder, "Mod B", InsertBreakHints(group.SecondPackageId), 34f);
+                    builder.AddField("Records", group.Conflicts.Length.ToString());
+                    builder.AddField("Object Types", FormatKinds(group.Conflicts));
+                    builder.AddField("Result", DescribeGroupResult(group.Conflicts));
+
+                    foreach (var conflict in group.Conflicts.Take(12))
+                    {
+                        AddWrappedField(builder, conflict.Kind.ToString(), FormatConflict(conflict), 54f);
+                    }
+
+                    if (group.Conflicts.Length > 12)
+                    {
+                        AddWrappedField(
+                            builder,
+                            "More",
+                            (group.Conflicts.Length - 12) + " additional records are available in Copy Full Report or /fuse.conflicts.",
+                            34f);
+                    }
+
+                    builder.Spacer(8f);
+                    builder.AddHRule();
+                    builder.Spacer(8f);
+                }
+
+                if (groups.Count > 30)
+                {
+                    AddWrappedField(
+                        builder,
+                        "More Pairs",
+                        (groups.Count - 30) + " additional package pairs are available in Copy Full Report or /fuse.conflicts.",
+                        34f);
+                }
+            }
+
+            if (cooperativeGroups.Count > 0)
+            {
+                builder.AddSection("Shared Extension Targets (Informational)");
+                AddWrappedLabel(
+                    builder,
+                    "These mods touched the same cumulative industry target and FUSE merged their contributions. " +
+                    "Nothing was skipped or replaced, so these records do not count as conflicts or load-health problems.",
+                    50f);
+                foreach (var group in cooperativeGroups.Take(30))
+                {
+                    AddWrappedField(builder, "Mod A", InsertBreakHints(group.FirstPackageId), 34f);
+                    AddWrappedField(builder, "Mod B", InsertBreakHints(group.SecondPackageId), 34f);
+                    builder.AddField("Shared Records", group.Conflicts.Length.ToString());
+                    builder.AddField("Object Types", FormatKinds(group.Conflicts));
+                    builder.AddField("Result", "Definitions merged successfully; no mod lost content.");
+                    foreach (var conflict in group.Conflicts.Take(12))
+                    {
+                        AddWrappedField(builder, conflict.Kind.ToString(), FormatConflict(conflict), 54f);
+                    }
+                    builder.Spacer(8f);
+                    builder.AddHRule();
+                    builder.Spacer(8f);
+                }
+            }
+        }
+
+        internal static List<ConflictGroup> BuildGroups(
+            IEnumerable<FuseRegistryConflict> conflicts,
+            IEnumerable<string> knownPackageIds = null)
+        {
+            var packageRoots = (knownPackageIds ?? Enumerable.Empty<string>())
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(id => id.Length)
+                .ToArray();
+            return (conflicts ?? Enumerable.Empty<FuseRegistryConflict>())
+                .Where(conflict => conflict != null)
+                .Select(conflict => new
+                {
+                    Conflict = conflict,
+                    First = FindPackageRoot(conflict.OwnerPackageId, packageRoots),
+                    Second = FindPackageRoot(conflict.AttemptedPackageId, packageRoots)
+                })
+                .GroupBy(item => BuildPairKey(item.First, item.Second), StringComparer.OrdinalIgnoreCase)
+                .Select(group =>
+                {
+                    var first = group.First();
+                    OrderPackagePair(first.First, first.Second, out var firstId, out var secondId);
+                    return new ConflictGroup
+                    {
+                        FirstPackageId = firstId,
+                        SecondPackageId = secondId,
+                        Conflicts = group
+                            .Select(item => item.Conflict)
+                            .OrderBy(conflict => conflict.Kind)
+                            .ThenBy(conflict => conflict.Id, StringComparer.OrdinalIgnoreCase)
+                            .ToArray()
+                    };
+                })
+                .OrderByDescending(group => group.Conflicts.Length)
+                .ThenBy(group => group.FirstPackageId, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(group => group.SecondPackageId, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        internal static string BuildReport(IEnumerable<ConflictGroup> groups)
+        {
+            return BuildReport(groups, Enumerable.Empty<DeclaredConflictMatch>());
+        }
+
+        internal static string BuildReport(
+            IEnumerable<ConflictGroup> groups,
+            IEnumerable<DeclaredConflictMatch> declaredConflicts)
+        {
+            return BuildReport(groups, declaredConflicts, Enumerable.Empty<ConflictGroup>());
+        }
+
+        internal static string BuildReport(
+            IEnumerable<ConflictGroup> groups,
+            IEnumerable<DeclaredConflictMatch> declaredConflicts,
+            IEnumerable<ConflictGroup> cooperativeGroups)
+        {
+            var materialized = (groups ?? Enumerable.Empty<ConflictGroup>()).ToArray();
+            var declared = (declaredConflicts ?? Enumerable.Empty<DeclaredConflictMatch>()).ToArray();
+            var cooperative = (cooperativeGroups ?? Enumerable.Empty<ConflictGroup>()).ToArray();
+            var sb = new StringBuilder();
+            sb.AppendLine("FUSE Mod Conflict Breakdown");
+            sb.AppendLine("Package pairs needing attention: " + materialized.Length);
+            sb.AppendLine("Actionable conflict/warning records: " + materialized.Sum(group => group.Conflicts?.Length ?? 0));
+            sb.AppendLine("Author-declared incompatibilities: " + declared.Length);
+            sb.AppendLine("Informational shared-extension records: " + cooperative.Sum(group => group.Conflicts?.Length ?? 0));
+            foreach (var match in declared)
+            {
+                sb.AppendLine();
+                sb.AppendLine("DECLARED: " + match.DeclaringPackage.Id + "  X  " + match.ConflictingPackage.Id);
+                sb.AppendLine("  " + FormatDeclaredConflict(match));
+            }
+
+            foreach (var group in materialized)
+            {
+                sb.AppendLine();
+                sb.AppendLine(group.FirstPackageId + "  <->  " + group.SecondPackageId);
+                sb.AppendLine("  object types: " + FormatKinds(group.Conflicts));
+                sb.AppendLine("  result: " + DescribeGroupResult(group.Conflicts));
+                foreach (var conflict in group.Conflicts ?? Array.Empty<FuseRegistryConflict>())
+                {
+                    var id = string.IsNullOrWhiteSpace(conflict?.Id) ? "(unknown target)" : conflict.Id;
+                    var resolution = string.IsNullOrWhiteSpace(conflict?.Resolution) ? "No resolution recorded." : conflict.Resolution;
+                    sb.AppendLine(
+                        "  - " + conflict.Kind + " " + id + " — " + resolution +
+                        " [" + conflict.OwnerPackageId + " -> " + conflict.AttemptedPackageId + "]");
+                }
+            }
+
+            foreach (var group in cooperative)
+            {
+                sb.AppendLine();
+                sb.AppendLine("SHARED: " + group.FirstPackageId + "  +  " + group.SecondPackageId);
+                sb.AppendLine("  result: definitions merged successfully; no mod lost content");
+                foreach (var conflict in group.Conflicts ?? Array.Empty<FuseRegistryConflict>())
+                {
+                    sb.AppendLine("  - " + conflict.Kind + " " + conflict.Id + " — " + conflict.Resolution);
+                }
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        internal static List<DeclaredConflictMatch> BuildDeclaredConflictMatches(
+            IEnumerable<FusePackageManifestSnapshot> packages)
+        {
+            var materialized = (packages ?? Enumerable.Empty<FusePackageManifestSnapshot>())
+                .Where(package => package != null && !string.IsNullOrWhiteSpace(package.Id))
+                .ToArray();
+            var result = new List<DeclaredConflictMatch>();
+            foreach (var declaring in materialized)
+            {
+                foreach (var reference in declaring.ConflictsWith ?? Array.Empty<FUSE.Authoring.Data.FuseModRequirement>())
+                {
+                    var target = materialized.FirstOrDefault(candidate =>
+                        !ReferenceEquals(candidate, declaring) &&
+                        FuseDataPackageDiscovery.IsDeclaredConflictMatch(
+                            reference,
+                            candidate.Id,
+                            candidate.Version,
+                            candidate.Disabled));
+                    if (target == null)
+                    {
+                        continue;
+                    }
+
+                    result.Add(new DeclaredConflictMatch
+                    {
+                        DeclaringPackage = declaring,
+                        ConflictingPackage = target,
+                        Reference = reference
+                    });
+                }
+            }
+
+            return result
+                .GroupBy(match =>
+                    match.DeclaringPackage.Id + "\0" + match.ConflictingPackage.Id,
+                    StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .OrderBy(match => match.DeclaringPackage.Id, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(match => match.ConflictingPackage.Id, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static string FormatDeclaredConflict(DeclaredConflictMatch match)
+        {
+            var reference = match?.Reference;
+            var installedVersion = match?.ConflictingPackage?.Version ?? string.Empty;
+            var bounds = string.IsNullOrWhiteSpace(reference?.NotBefore) && string.IsNullOrWhiteSpace(reference?.NotAfter)
+                ? "all versions"
+                : "notBefore=" + (reference?.NotBefore ?? "(none)") + ", notAfter=" + (reference?.NotAfter ?? "(none)");
+            return "Installed version " + (string.IsNullOrWhiteSpace(installedVersion) ? "(unknown)" : installedVersion) +
+                   " matches " + bounds + ".";
+        }
+
+        internal static bool IsSpatialConflict(FuseRegistryConflict conflict)
+        {
+            return conflict != null &&
+                ((conflict.Id ?? string.Empty).StartsWith("spatial-overlap:", StringComparison.OrdinalIgnoreCase) ||
+                 (conflict.Resolution ?? string.Empty).IndexOf("spatial", StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        private static string DescribeGroupResult(IEnumerable<FuseRegistryConflict> conflicts)
+        {
+            var materialized = (conflicts ?? Enumerable.Empty<FuseRegistryConflict>()).ToArray();
+            if (materialized.Any(IsSpatialConflict))
+            {
+                return "Potential track-layout overlap; both mods retained for the author/user to resolve.";
+            }
+
+            if (materialized.Any(conflict => ContainsAny(conflict.Resolution, "won", "suppressed", "skipped", "retained")))
+            {
+                return "At least one conflicting operation was skipped or replaced; see each record below.";
+            }
+
+            return "Both mods contributed to the same target; FUSE retained the shared merge.";
+        }
+
+        private static string FormatKinds(IEnumerable<FuseRegistryConflict> conflicts)
+        {
+            return string.Join(", ", (conflicts ?? Enumerable.Empty<FuseRegistryConflict>())
+                .Select(conflict => conflict.Kind.ToString())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(kind => kind, StringComparer.OrdinalIgnoreCase));
+        }
+
+        private static string FormatConflict(FuseRegistryConflict conflict)
+        {
+            var id = string.IsNullOrWhiteSpace(conflict?.Id) ? "(unknown target)" : conflict.Id;
+            var resolution = string.IsNullOrWhiteSpace(conflict?.Resolution) ? "No resolution recorded." : conflict.Resolution;
+            var definitions = string.IsNullOrWhiteSpace(conflict?.OwnerPackageId) && string.IsNullOrWhiteSpace(conflict?.AttemptedPackageId)
+                ? string.Empty
+                : " [" + conflict.OwnerPackageId + " -> " + conflict.AttemptedPackageId + "]";
+            return InsertBreakHints(id) + " — " + resolution + InsertBreakHints(definitions);
+        }
+
+        private static string FindPackageRoot(string definitionId, IEnumerable<string> packageRoots)
+        {
+            definitionId = string.IsNullOrWhiteSpace(definitionId) ? "(unknown package)" : definitionId.Trim();
+            foreach (var root in packageRoots ?? Enumerable.Empty<string>())
+            {
+                if (string.Equals(definitionId, root, StringComparison.OrdinalIgnoreCase) ||
+                    definitionId.StartsWith(root + ".", StringComparison.OrdinalIgnoreCase))
+                {
+                    return root;
+                }
+            }
+
+            return definitionId;
+        }
+
+        private static string BuildPairKey(string first, string second)
+        {
+            OrderPackagePair(first, second, out var orderedFirst, out var orderedSecond);
+            return orderedFirst + "\0" + orderedSecond;
+        }
+
+        private static void OrderPackagePair(string first, string second, out string orderedFirst, out string orderedSecond)
+        {
+            first = string.IsNullOrWhiteSpace(first) ? "(unknown package)" : first.Trim();
+            second = string.IsNullOrWhiteSpace(second) ? "(unknown package)" : second.Trim();
+            if (StringComparer.OrdinalIgnoreCase.Compare(first, second) <= 0)
+            {
+                orderedFirst = first;
+                orderedSecond = second;
+            }
+            else
+            {
+                orderedFirst = second;
+                orderedSecond = first;
+            }
+        }
+
+        private static bool ContainsAny(string value, params string[] terms)
+        {
+            return !string.IsNullOrWhiteSpace(value) &&
+                terms.Any(term => value.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+    }
+}

--- a/FUSE/Interface/MenuWindow/ModsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/ModsPanelBuilder.cs
@@ -15,17 +15,42 @@ using UnityEngine;
 
 namespace FUSE.Interface.MenuWindow
 {
+    internal sealed class FusePackageDisplayStatus
+    {
+        public FusePackageDisplayStatus(string label, string detail, string listGroup, int sortOrder, string markup)
+        {
+            Label = label ?? string.Empty;
+            Detail = detail ?? string.Empty;
+            ListGroup = listGroup ?? string.Empty;
+            SortOrder = sortOrder;
+            Markup = markup ?? string.Empty;
+        }
+
+        public string Label { get; }
+        public string Detail { get; }
+        public string ListGroup { get; }
+        public int SortOrder { get; }
+        public string Markup { get; }
+    }
+
     internal struct ModsPanelBuilder
     {
         public static void Build(UIPanelBuilder builder, UIState<string> selectedItem)
         {
             var manifests = MergeHostedLegacyPackageSnapshots(
                 FuseDataPackageDiscovery.GetPackageManifestSnapshots(),
-                FuseLegacyAssemblyHost.EnumerateAllHostedPlugins().Select(info => info.Manifest));
+                FuseLegacyAssemblyHost.EnumerateAllHostedPlugins().Select(info => info.Manifest))
+                .ToArray();
+            HydratePackageRuntimeState(manifests);
 
             List<UIPanelBuilder.ListItem<FusePackageManifestSnapshot>> list = manifests
-                .OrderBy(m => m.DisplayName)
-                .Select(m => new UIPanelBuilder.ListItem<FusePackageManifestSnapshot>(m.Id, m, "Active Mods", m.DisplayName))
+                .OrderBy(m => ClassifyPackageStatus(m).SortOrder)
+                .ThenBy(m => m.DisplayName)
+                .Select(m => new UIPanelBuilder.ListItem<FusePackageManifestSnapshot>(
+                    m.Id,
+                    m,
+                    ClassifyPackageStatus(m).ListGroup,
+                    m.DisplayName))
                 .ToList();
 
             builder.AddListDetail(list, selectedItem, delegate (UIPanelBuilder builder, FusePackageManifestSnapshot manifest)
@@ -36,7 +61,7 @@ namespace FUSE.Interface.MenuWindow
                     // previously selected mod's handler must not stay open.
                     CloseAllLegacyModTabs("mods selection cleared");
                     builder.AddExpandingVerticalSpacer();
-                    builder.AddLabelEmptyState(manifests.Count == 0 ? "No mods found through UMM." : "Select a mod");
+                    builder.AddLabelEmptyState(manifests.Length == 0 ? "No mods found through UMM." : "Select a mod");
                     builder.AddExpandingVerticalSpacer();
                 }
                 else
@@ -87,7 +112,26 @@ namespace FUSE.Interface.MenuWindow
                     Version = hosted.Version ?? string.Empty,
                     FolderName = folderName,
                     FolderPath = folderPath,
-                    IsLegacyHosted = true
+                    RequiredPackageIds = (hosted.RequiredReferences ?? Array.Empty<Railloader.ModReference>())
+                        .Select(reference => reference.Id)
+                        .Where(referenceId => !string.IsNullOrWhiteSpace(referenceId))
+                        .ToArray(),
+                    LoadAfter = (hosted.LoadAfter ?? Array.Empty<Railloader.ModReference>())
+                        .Select(reference => reference.Id)
+                        .Where(referenceId => !string.IsNullOrWhiteSpace(referenceId))
+                        .ToArray(),
+                    LoadBefore = hosted.LoadBefore ?? Array.Empty<string>(),
+                    ConflictsWith = (hosted.ConflictsWith ?? Array.Empty<Railloader.ModReference>())
+                        .Select(reference => new FUSE.Authoring.Data.FuseModRequirement
+                        {
+                            Id = reference.Id,
+                            NotBefore = reference.NotBefore?.ToString(),
+                            NotAfter = reference.NotAfter?.ToString()
+                        })
+                        .ToArray(),
+                    IsLegacyHosted = true,
+                    LoadedFromDisk = true,
+                    AppliedToRuntime = true
                 });
                 AddPackageIdentity(knownFolders, knownIds, folderPath, id);
             }
@@ -118,7 +162,12 @@ namespace FUSE.Interface.MenuWindow
         {
             builder.AddSection(manifest.DisplayName);
 
-            builder.AddField("Status", PackageStatusTextMarkup(manifest));
+            var status = ClassifyPackageStatus(manifest);
+            builder.AddField("Status", status.Markup);
+            if (!string.IsNullOrWhiteSpace(status.Detail))
+            {
+                builder.AddField("State details", status.Detail);
+            }
             builder.AddField("Version", manifest.Version ?? "Unknown");
             builder.AddField("Id", manifest.Id);
             builder.AddField("Folder", manifest.FolderName);
@@ -128,14 +177,24 @@ namespace FUSE.Interface.MenuWindow
 
             builder.AddField("Settings", CountPackageSettings(definitions).ToString());
 
-            if (manifest.Faults.Length > 0)
+            var faults = GetAllFaults(manifest);
+            if (faults.Length > 0)
             {
-                builder.AddField("Faults", string.Join("; ", manifest.Faults));
+                builder.AddField("Faults", string.Join("; ", faults));
             }
 
             if (manifest.Disabled && !string.IsNullOrEmpty(manifest.DisabledReason))
             {
                 builder.AddField("Disabled", manifest.DisabledReason);
+            }
+
+            var skipReasons = GetSkipReasons(manifest);
+            if (skipReasons.Length > 0)
+            {
+                var label = skipReasons.All(FusePackageFaultRegistry.IsOptionalSkipReason)
+                    ? "Optional content"
+                    : "Skipped";
+                builder.AddField(label, string.Join("; ", skipReasons));
             }
 
             var depSummary = BuildDependencySummary(manifest);
@@ -150,7 +209,7 @@ namespace FUSE.Interface.MenuWindow
             {
                 row.AddButton("Copy Mod Info", () =>
                 {
-                    GUIUtility.systemCopyBuffer = BuildSelectedPackageReport(manifest, definitions);
+                    GUIUtility.systemCopyBuffer = BuildSelectedPackageReport(manifest, definitions, status);
                     Toast.Present("Copied mod info to clipboard");
                     builder.Rebuild();
                 });
@@ -180,6 +239,17 @@ namespace FUSE.Interface.MenuWindow
                 if (definitions.Length > 1)
                 {
                     builder.AddLabel(loaded.Definition.Id);
+                }
+
+                if (loaded.FeatureEvaluation.RuleCount > 0)
+                {
+                    builder.AddField("Active feature set", loaded.FeatureEvaluation.Summary);
+                    if (loaded.FeatureEvaluation.DisabledRuleIds.Length > 0)
+                    {
+                        builder.AddField(
+                            "Disabled options",
+                            string.Join(", ", loaded.FeatureEvaluation.DisabledRuleIds));
+                    }
                 }
 
                 foreach (var pair in loaded.Definition.Settings
@@ -325,6 +395,100 @@ namespace FUSE.Interface.MenuWindow
                 .ToArray();
         }
 
+        private static void HydratePackageRuntimeState(IReadOnlyList<FusePackageManifestSnapshot> manifests)
+        {
+            if (manifests == null || manifests.Count == 0)
+            {
+                return;
+            }
+
+            var loadedIds = new HashSet<string>(
+                FusePackageFaultRegistry.GetLoadedPackageIds(),
+                StringComparer.OrdinalIgnoreCase);
+            var appliedIds = new HashSet<string>(
+                FusePackageFaultRegistry.GetAppliedPackageIds(),
+                StringComparer.OrdinalIgnoreCase);
+            var skipped = FusePackageFaultRegistry.GetSkippedPackages();
+            var disabled = FusePackageFaultRegistry.GetDisabledPackages();
+            var faultsByPackage = FusePackageFaultRegistry.GetFaults()
+                .GroupBy(fault => fault.PackageId, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Select(FormatRuntimeFault).ToArray(),
+                    StringComparer.OrdinalIgnoreCase);
+            var loadedDefinitions = FuseModLoader.GetLoadedModsInOrder()
+                .Where(loaded => loaded?.Definition != null)
+                .ToArray();
+
+            foreach (var manifest in manifests.Where(manifest => manifest != null))
+            {
+                var definitionIds = loadedDefinitions
+                    .Where(loaded => DefinitionBelongsToPackage(loaded, manifest))
+                    .Select(loaded => loaded.Definition.Id)
+                    .Where(id => !string.IsNullOrWhiteSpace(id))
+                    .ToArray();
+                var registryIds = new[] { manifest.Id }
+                    .Concat(definitionIds)
+                    .Where(id => !string.IsNullOrWhiteSpace(id))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                manifest.LoadedFromDisk = manifest.LoadedFromDisk || registryIds.Any(loadedIds.Contains);
+                manifest.AppliedToRuntime = manifest.AppliedToRuntime || registryIds.Any(appliedIds.Contains);
+
+                var skipReasons = registryIds
+                    .Select(id => skipped.TryGetValue(id, out var reason) ? reason : string.Empty)
+                    .Concat(manifest.SkipReasons ?? Array.Empty<string>())
+                    .Concat(string.IsNullOrWhiteSpace(manifest.SkipReason)
+                        ? Array.Empty<string>()
+                        : new[] { manifest.SkipReason })
+                    .Where(reason => !string.IsNullOrWhiteSpace(reason))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                manifest.SkipReasons = skipReasons;
+                manifest.SkipReason = skipReasons.FirstOrDefault() ?? string.Empty;
+
+                if (!manifest.Disabled)
+                {
+                    var disabledReason = registryIds
+                        .Select(id => disabled.TryGetValue(id, out var reason) ? reason : string.Empty)
+                        .FirstOrDefault(reason => !string.IsNullOrWhiteSpace(reason));
+                    if (!string.IsNullOrWhiteSpace(disabledReason))
+                    {
+                        manifest.Disabled = true;
+                        manifest.DisabledReason = disabledReason;
+                    }
+                }
+
+                manifest.RuntimeFaults = registryIds
+                    .SelectMany(id => faultsByPackage.TryGetValue(id, out var packageFaults)
+                        ? packageFaults
+                        : Array.Empty<string>())
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+            }
+        }
+
+        private static bool DefinitionBelongsToPackage(FuseLoadedMod loaded, FusePackageManifestSnapshot manifest)
+        {
+            return loaded?.Definition != null && manifest != null &&
+                   (string.Equals(NormalizePath(loaded.FolderPath), NormalizePath(manifest.FolderPath), StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(loaded.Definition.Id, manifest.Id, StringComparison.OrdinalIgnoreCase) ||
+                    loaded.Definition.Id.StartsWith((manifest.Id ?? string.Empty) + ".", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string FormatRuntimeFault(FusePackageFault fault)
+        {
+            if (fault == null)
+            {
+                return string.Empty;
+            }
+
+            return string.IsNullOrWhiteSpace(fault.Stage)
+                ? fault.Message
+                : fault.Stage + ": " + fault.Message;
+        }
+
         private static int CountPackageSettings(IEnumerable<FuseLoadedMod> definitions)
         {
             return (definitions ?? [])
@@ -341,6 +505,7 @@ namespace FUSE.Interface.MenuWindow
 
             var parts = new[]
             {
+                manifest.RequiredPackageIds.Length == 0 ? string.Empty : "requires: " + string.Join(", ", manifest.RequiredPackageIds),
                 manifest.LoadAfter.Length == 0 ? string.Empty : "after: " + string.Join(", ", manifest.LoadAfter),
                 manifest.LoadBefore.Length == 0 ? string.Empty : "before: " + string.Join(", ", manifest.LoadBefore)
             }.Where(value => !string.IsNullOrWhiteSpace(value)).ToArray();
@@ -366,25 +531,88 @@ namespace FUSE.Interface.MenuWindow
             }
         }
 
-        private static string BuildSelectedPackageReport(FusePackageManifestSnapshot manifest, IReadOnlyList<FuseLoadedMod> definitions)
+        private static string BuildSelectedPackageReport(
+            FusePackageManifestSnapshot manifest,
+            IReadOnlyList<FuseLoadedMod> definitions,
+            FusePackageDisplayStatus status)
         {
             var builder = new StringBuilder();
             builder.AppendLine("FUSE selected mod");
             builder.AppendLine("Name: " + PackageDisplayName(manifest));
             builder.AppendLine("Id: " + manifest.Id);
             builder.AppendLine("Version: " + BlankAs(manifest.Version, "?"));
-            builder.AppendLine("Status: " + PackageStatusText(manifest));
+            builder.AppendLine("Status: " + status.Label);
+            if (!string.IsNullOrWhiteSpace(status.Detail))
+            {
+                builder.AppendLine("State details: " + status.Detail);
+            }
             builder.AppendLine("Folder: " + manifest.FolderPath);
             builder.AppendLine("Definitions: " + (definitions?.Count ?? 0));
             builder.AppendLine("Settings: " + CountPackageSettings(definitions));
-            if (manifest.Faults.Length > 0)
+            var skipReasons = GetSkipReasons(manifest);
+            if (skipReasons.Length > 0)
             {
-                builder.AppendLine("Faults: " + string.Join("; ", manifest.Faults));
+                builder.AppendLine("Skip reasons: " + string.Join("; ", skipReasons));
+            }
+
+            var faults = GetAllFaults(manifest);
+            if (faults.Length > 0)
+            {
+                builder.AppendLine("Faults: " + string.Join("; ", faults));
+            }
+
+            var definitionIds = (definitions ?? Array.Empty<FuseLoadedMod>())
+                .Where(loaded => loaded?.Definition != null)
+                .Select(loaded => loaded.Definition.Id)
+                .ToArray();
+            var detailedFaults = FusePackageFaultRegistry.GetFaults()
+                .Where(fault => string.Equals(fault.PackageId, manifest.Id, StringComparison.OrdinalIgnoreCase)
+                                || definitionIds.Contains(fault.PackageId, StringComparer.OrdinalIgnoreCase)
+                                || (!string.IsNullOrWhiteSpace(fault.FolderPath)
+                                    && string.Equals(NormalizePath(fault.FolderPath), NormalizePath(manifest.FolderPath), StringComparison.OrdinalIgnoreCase)))
+                .ToArray();
+            if (detailedFaults.Length > 0)
+            {
+                builder.AppendLine("Actionable package diagnostics:");
+                foreach (var fault in detailedFaults)
+                {
+                    builder.AppendLine("- Stage: " + BlankAs(fault.Stage, "unknown"));
+                    builder.AppendLine("  Message: " + BlankAs(fault.Message, "unknown"));
+                    builder.AppendLine("  Package: " + BlankAs(fault.PackageName, fault.PackageId)
+                                       + " [" + fault.PackageId + "]");
+                    builder.AppendLine("  Source root: " + BlankAs(fault.FolderPath, "unknown"));
+                    builder.AppendLine("  Relative file: " + BlankAs(fault.RelativeSourceFile, "unknown"));
+                    builder.AppendLine("  Absolute file: " + BlankAs(fault.SourceFile, "unknown"));
+                    if (!string.IsNullOrWhiteSpace(fault.JsonPath) || fault.LineNumber > 0)
+                    {
+                        builder.AppendLine("  JSON location: " + BlankAs(fault.JsonPath, "<root>")
+                                           + (fault.LineNumber > 0
+                                               ? $" line {fault.LineNumber}, position {fault.LinePosition}"
+                                               : string.Empty));
+                    }
+                    if (!string.IsNullOrWhiteSpace(fault.ValidationCode))
+                        builder.AppendLine("  Validation code: " + fault.ValidationCode);
+                    if (!string.IsNullOrWhiteSpace(fault.ExpectedShape))
+                        builder.AppendLine("  Expected: " + fault.ExpectedShape);
+                    if (!string.IsNullOrWhiteSpace(fault.ReceivedValue))
+                        builder.AppendLine("  Received: " + fault.ReceivedValue);
+                    builder.AppendLine("  Fix: " + BlankAs(fault.SuggestedAction, "Correct the named package source and reload the map."));
+                }
             }
 
             foreach (var loaded in definitions ?? Array.Empty<FuseLoadedMod>())
             {
                 builder.AppendLine("Definition: " + loaded.Definition.Id);
+                if (loaded.FeatureEvaluation.RuleCount > 0)
+                {
+                    builder.AppendLine("Feature rules: " + loaded.FeatureEvaluation.Summary);
+                    if (loaded.FeatureEvaluation.DisabledRuleIds.Length > 0)
+                    {
+                        builder.AppendLine(
+                            "Disabled feature rules: " +
+                            string.Join(", ", loaded.FeatureEvaluation.DisabledRuleIds));
+                    }
+                }
             }
 
             return builder.ToString();
@@ -405,46 +633,180 @@ namespace FUSE.Interface.MenuWindow
             return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
         }
 
-        private static string PackageStatusText(FusePackageManifestSnapshot manifest)
+        internal static FusePackageDisplayStatus ClassifyPackageStatus(FusePackageManifestSnapshot manifest)
         {
             if (manifest == null)
             {
-                return "unknown";
+                return new FusePackageDisplayStatus(
+                    "Unknown",
+                    "Package state is unavailable.",
+                    "Unknown",
+                    80,
+                    "<color=\"orange\">Unknown</color>");
             }
 
             if (manifest.Disabled)
             {
-                return "disabled";
+                return new FusePackageDisplayStatus(
+                    "Disabled",
+                    BlankAs(manifest.DisabledReason, "Disabled by the active mod configuration."),
+                    "Disabled Mods",
+                    60,
+                    "<color=\"yellow\">Disabled</color>");
             }
 
-            if (manifest.Faults.Length > 0)
+            var faults = GetAllFaults(manifest);
+            var skipReasons = GetSkipReasons(manifest);
+            var evidence = string.Join(
+                " | ",
+                faults
+                    .Concat(skipReasons.Where(reason => !FusePackageFaultRegistry.IsOptionalSkipReason(reason)))
+                    .Where(value => !string.IsNullOrWhiteSpace(value)));
+            var problem = ClassifyProblem(evidence);
+            var hasSkips = skipReasons.Length > 0;
+            var optionalSkip = hasSkips && skipReasons.All(FusePackageFaultRegistry.IsOptionalSkipReason);
+
+            if (manifest.AppliedToRuntime &&
+                (faults.Length > 0 || (hasSkips && !optionalSkip)))
             {
-                return manifest.Faults.Length + " fault(s)";
+                var actionableSkipDetail = string.Join(
+                    "; ",
+                    skipReasons.Where(reason => !FusePackageFaultRegistry.IsOptionalSkipReason(reason)));
+                var detail = problem.Length == 0
+                    ? (hasSkips ? string.Join("; ", skipReasons) : "One or more definitions failed while other content applied.")
+                    : problem + ". Other content from this package applied successfully.";
+                if (!string.IsNullOrWhiteSpace(actionableSkipDetail))
+                {
+                    detail += " Actionable skip: " + actionableSkipDetail;
+                }
+                return new FusePackageDisplayStatus(
+                    "Partially applied",
+                    detail,
+                    "Mods Needing Attention",
+                    20,
+                    "<color=\"orange\">Partially applied</color>");
             }
 
-            return manifest.IsLegacyConverted || manifest.IsLegacyHosted ? "ready | legacy" : "ready";
+            if (faults.Length > 0)
+            {
+                var label = problem.Length == 0 ? "Failed" : problem;
+                return new FusePackageDisplayStatus(
+                    label,
+                    faults[0],
+                    "Mods Needing Attention",
+                    10,
+                    "<color=\"red\">" + label + "</color>");
+            }
+
+            if (hasSkips && !optionalSkip)
+            {
+                var label = problem.Length == 0 ? "Skipped" : problem;
+                return new FusePackageDisplayStatus(
+                    label,
+                    string.Join("; ", skipReasons),
+                    "Mods Needing Attention",
+                    30,
+                    "<color=\"orange\">" + label + "</color>");
+            }
+
+            if (manifest.AppliedToRuntime)
+            {
+                var detail = optionalSkip
+                    ? "Applied successfully. Optional content is inactive: " + string.Join("; ", skipReasons)
+                    : string.Empty;
+                var legacy = manifest.IsLegacyConverted || manifest.IsLegacyHosted
+                    ? " - Legacy compatibility"
+                    : string.Empty;
+                return new FusePackageDisplayStatus(
+                    "Applied",
+                    detail,
+                    "Applied Mods",
+                    40,
+                    "<color=\"green\">Applied</color>" + legacy);
+            }
+
+            if (manifest.LoadedFromDisk)
+            {
+                return new FusePackageDisplayStatus(
+                    "Loaded; awaiting map apply",
+                    optionalSkip ? "Optional content is inactive: " + string.Join("; ", skipReasons) : string.Empty,
+                    "Ready Mods",
+                    50,
+                    "<color=\"green\">Loaded</color> - awaiting map apply");
+            }
+
+            if (manifest.IsLegacyHosted)
+            {
+                return new FusePackageDisplayStatus(
+                    "Active legacy code",
+                    string.Empty,
+                    "Applied Mods",
+                    40,
+                    "<color=\"green\">Active</color> - Legacy compatibility");
+            }
+
+            return new FusePackageDisplayStatus(
+                "Discovered; ready to load",
+                optionalSkip ? "Optional content is inactive: " + string.Join("; ", skipReasons) : string.Empty,
+                "Ready Mods",
+                50,
+                "<color=\"green\">Ready</color>");
         }
 
-        private static string PackageStatusTextMarkup(FusePackageManifestSnapshot manifest)
+        private static string[] GetAllFaults(FusePackageManifestSnapshot manifest)
         {
-            if (manifest == null)
+            return (manifest?.Faults ?? Array.Empty<string>())
+                .Concat(manifest?.RuntimeFaults ?? Array.Empty<string>())
+                .Where(fault => !string.IsNullOrWhiteSpace(fault))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static string[] GetSkipReasons(FusePackageManifestSnapshot manifest)
+        {
+            return (manifest?.SkipReasons ?? Array.Empty<string>())
+                .Concat(string.IsNullOrWhiteSpace(manifest?.SkipReason)
+                    ? Array.Empty<string>()
+                    : new[] { manifest.SkipReason })
+                .Where(reason => !string.IsNullOrWhiteSpace(reason))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static string ClassifyProblem(string evidence)
+        {
+            if (string.IsNullOrWhiteSpace(evidence))
             {
-                return "<color=\"orange\">Unknown";
+                return string.Empty;
             }
 
-            if (manifest.Disabled)
+            if (ContainsAny(evidence, "conflictswith", "conflicts with", "incompatible"))
             {
-                return "<color=\"yellow\">Disabled";
+                return "Incompatible mod installed";
             }
 
-            if (manifest.Faults.Length > 0)
+            if (ContainsAny(
+                evidence,
+                "dependency missing",
+                "no matching package",
+                " requires '",
+                "required package",
+                "required dependency"))
             {
-                return "<color=\"red\">Error: " + manifest.Faults.Length + " fault(s)";
+                return "Missing dependency";
             }
 
-            return manifest.IsLegacyConverted || manifest.IsLegacyHosted
-                ? "<color=\"green\">Ready</color> - Legacy"
-                : "<color=\"green\"Ready";
+            if (ContainsAny(evidence, "manifest json", "json:", "json ", "deserial", "schema", "could not be parsed"))
+            {
+                return "Invalid package data";
+            }
+
+            return string.Empty;
+        }
+
+        private static bool ContainsAny(string value, params string[] candidates)
+        {
+            return candidates.Any(candidate => value.IndexOf(candidate, StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         private static string GetSettingLabel(string key, FuseModSettingDefinition setting)
@@ -464,7 +826,7 @@ namespace FUSE.Interface.MenuWindow
                     BuildEnumSettingControl(builder, definition, key, setting);
                     break;
                 case "number":
-                    BuildTextSettingControl(builder, definition, key, setting, isNumber: true);
+                    BuildNumberSettingControl(builder, definition, key, setting);
                     break;
                 case "path":
                 case "color":
@@ -474,13 +836,25 @@ namespace FUSE.Interface.MenuWindow
                     break;
             }
 
+            var featureRules = definition?.FeatureRules == null
+                ? Enumerable.Empty<FuseFeatureRule>()
+                : definition.FeatureRules.Values;
+            var controlsFeature = featureRules
+                .Any(rule => rule != null && string.Equals(rule.Setting, key, StringComparison.Ordinal));
             if (FuseSettings.ShowAdvancedHealthDetails)
             {
                 builder.AddField(" ", DescribePackageSetting(key, setting));
             }
-            else if (!string.IsNullOrWhiteSpace(setting?.Description))
+            else if (controlsFeature || !string.IsNullOrWhiteSpace(setting?.Description))
             {
-                builder.AddField(" ", setting.Description);
+                var note = string.IsNullOrWhiteSpace(setting?.Description)
+                    ? string.Empty
+                    : setting.Description.Trim() + " ";
+                if (controlsFeature)
+                {
+                    note += "This option changes authored map content and takes effect after saving/reloading the map.";
+                }
+                builder.AddField(" ", note.Trim());
             }
         }
 
@@ -542,6 +916,46 @@ namespace FUSE.Interface.MenuWindow
                 {
                     SaveTextSetting(definition, key, setting, value, isNumber);
                 });
+                AddResetSettingButton(row, definition, key, setting);
+            }, 8f).Height(32f);
+        }
+
+        private static void BuildNumberSettingControl(
+            UIPanelBuilder builder,
+            FuseModDefinition definition,
+            string key,
+            FuseModSettingDefinition setting)
+        {
+            if (!setting.Min.HasValue || !setting.Max.HasValue
+                || setting.Min.Value >= setting.Max.Value)
+            {
+                BuildTextSettingControl(builder, definition, key, setting, isNumber: true);
+                return;
+            }
+
+            var minimum = (float)setting.Min.Value;
+            var maximum = (float)setting.Max.Value;
+            var step = setting.Step.GetValueOrDefault(0d);
+            builder.HStack(row =>
+            {
+                AddSettingRowLabel(row, GetSettingLabel(key, setting));
+                row.AddSlider(
+                    () => (float)FuseModSettingsStore.GetNumberValue(definition, key, setting),
+                    () => FuseModSettingsStore.GetNumberValue(definition, key, setting)
+                        .ToString("0.###", System.Globalization.CultureInfo.InvariantCulture),
+                    value =>
+                    {
+                        var selected = Math.Max(minimum, Math.Min(maximum, value));
+                        if (step > 0d)
+                        {
+                            selected = minimum
+                                + (float)(Math.Round((selected - minimum) / step) * step);
+                            selected = Math.Max(minimum, Math.Min(maximum, selected));
+                        }
+                        FuseModSettingsStore.SetValue(definition, key, setting, new JValue(selected));
+                    },
+                    minimum,
+                    maximum);
                 AddResetSettingButton(row, definition, key, setting);
             }, 8f).Height(32f);
         }

--- a/FUSE/Interface/MenuWindow/ProfilesPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/ProfilesPanelBuilder.cs
@@ -85,7 +85,7 @@ namespace FUSE.Interface.MenuWindow
 
             builder.AddSection("How profiles work");
             builder.Spacer(4f);
-            builder.AddLabel("Use profiles to manage multiple mod lists. UMM decides which mods exist; FUSE profiles only choose from UMM-active mods. If no profile is selected, everything UMM-active is enabled.");
+            builder.AddLabel("Use profiles to manage FUSE-controlled package content. UMM-disabled mods stay unavailable; native FUSE and auto-converted legacy data packages can be enabled or disabled here even when they are not UMM plugins. If no profile is selected, every available package is enabled.");
             builder.Spacer(8f);
             builder.AddLabel("You must restart the game in order for changes to take effect on the active mod profile.");
             builder.Spacer(8f);
@@ -94,10 +94,10 @@ namespace FUSE.Interface.MenuWindow
             builder.Spacer(8f);
 
             builder.Spacer(8f);
-            var activeMods = FuseModSetService.GetVisibleUmmMods();
+            var activeMods = FuseModSetService.GetVisibleProfileMods();
             if (activeMods.Count == 0)
             {
-                builder.AddField("Mods", "None found through UMM");
+                builder.AddField("Packages", "None found through UMM or FUSE package discovery");
             }
             else
             {
@@ -110,7 +110,7 @@ namespace FUSE.Interface.MenuWindow
 
         private static void BuildModListEntry(UIPanelBuilder builder, FuseUmmModInfo mod, FuseModSet modSet)
         {
-            var enabled = modSet.EnabledModIds.Contains(mod.Id);
+            var enabled = FuseModSetService.IsModEnabledInSet(modSet, mod);
             builder.HStack(row =>
             {
                 row.AddToggle(() => enabled, (_) =>
@@ -133,6 +133,7 @@ namespace FUSE.Interface.MenuWindow
             builder.FieldLabelWidth = 192f;
             builder.AddField("Id", mod.Id);
             builder.AddField("Version", mod.Version);
+            builder.AddField("Source", mod.ProfileSource);
 
             builder.Spacer(8f);
             builder.AddHRule();

--- a/FUSE/Interface/MenuWindow/RuntimeActionsToolPage.cs
+++ b/FUSE/Interface/MenuWindow/RuntimeActionsToolPage.cs
@@ -172,11 +172,13 @@ namespace FUSE.Interface.MenuWindow
             builder.AppendLine("Stations: " + SafeCount(() => StationAPI.GetAllStationAgents().Count()));
             builder.AppendLine("Passenger Stops: " + SafeCount(() => StationAPI.GetAllPassengerStops().Count()));
             builder.AppendLine("Scenery: " + SafeCount(() => SceneryAPI.GetAllScenery().Count()));
+            builder.AppendLine("Water Surfaces: " + SafeCount(() => WaterSurfaceAPI.GetAllWaterSurfaces().Count()));
             builder.AppendLine();
             builder.AppendLine("FUSE Registry");
             builder.AppendLine("Exclusive Claims: " + FUSE.Runtime.Registry.FuseRegistry.ExclusiveClaimCount);
             builder.AppendLine("Shared Claims: " + FUSE.Runtime.Registry.FuseRegistry.SharedClaimCount);
-            builder.AppendLine("Conflicts: " + FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count);
+            builder.AppendLine("Conflicts: " + FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => !conflict.IsCooperativeMerge));
+            builder.AppendLine("Shared Extension Targets: " + FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => conflict.IsCooperativeMerge));
             return builder.ToString().TrimEnd();
         }
 
@@ -236,6 +238,7 @@ namespace FUSE.Interface.MenuWindow
                     ["scenery"] = SafeCount(() => SceneryAPI.GetAllScenery().Count()),
                     ["sceneClones"] = SafeCount(() => SceneCloneAPI.GetAllSceneClones().Count()),
                     ["splineys"] = SafeCount(() => SplineyAPI.GetAllSplineys().Count()),
+                    ["waterSurfaces"] = SafeCount(() => WaterSurfaceAPI.GetAllWaterSurfaces().Count()),
                     ["mapLabels"] = SafeCount(() => MapAPI.GetAllMapLabels().Count()),
                     ["mapMasks"] = SafeCount(() => MapAPI.GetAllMapMasks().Count()),
                     ["progressions"] = SafeCount(() => ProgressionAPI.GetAllProgressions().Count()),
@@ -245,7 +248,9 @@ namespace FUSE.Interface.MenuWindow
                 {
                     ["exclusiveClaims"] = FUSE.Runtime.Registry.FuseRegistry.ExclusiveClaimCount,
                     ["sharedClaims"] = FUSE.Runtime.Registry.FuseRegistry.SharedClaimCount,
-                    ["conflicts"] = FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count
+                    ["conflicts"] = FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => !conflict.IsCooperativeMerge),
+                    ["sharedExtensionTargets"] = FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => conflict.IsCooperativeMerge),
+                    ["overlapRecords"] = FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count
                 },
                 ["assets"] = new JObject
                 {

--- a/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/StatusPanelBuilder.cs
@@ -5,7 +5,6 @@ using FUSE.Authoring.Migrations;
 using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
-using System.Linq;
 using System.Text;
 using UI.Builder;
 using UI.Common;
@@ -51,11 +50,7 @@ namespace FUSE.Interface.MenuWindow
                 return;
             }
             var data = checklistData.Value;
-            var modExceptionState = FuseModExceptionRegistry.CaptureReportState();
-            var hasAdvisories =
-                data.NoticesCount > data.BlockingNoticesCount ||
-                !FuseRuntimeGuardCounters.AllIdle ||
-                modExceptionState.Total > 0;
+            var hasAdvisories = data.NoticesCount > data.BlockingNoticesCount;
 
             builder.AddSection("Overview");
 
@@ -77,83 +72,7 @@ namespace FUSE.Interface.MenuWindow
             AddReadinessRow(builder, "Progression", data.ProgressionTransferSkipCount == 0, "0 transfer skips", data.ProgressionTransferSkipCount + " skip(s)");
             AddReadinessRow(builder, "Registry", data.ConflictCount == 0, "0 conflicts", data.ConflictCount + " conflict(s)");
             AddNoticeRow(builder, data.NoticesCount, data.BlockingNoticesCount);
-            // Live session counters, not snapshot state.
-            AddAdvisoryRow(
-                builder,
-                "Guards",
-                FuseRuntimeGuardCounters.AllIdle,
-                "idle",
-                FuseRuntimeGuardCounters.GuardTotal + " compatibility event(s) contained");
-            // Session-cumulative third-party exception observations — same
-            // live-counter semantics as Guards, sourced from the exception
-            // registry rather than the load snapshot. One atomic capture here
-            // (rows + totals + summary line under the registry's lock), reused
-            // by the readiness row and the breakdown section below so a
-            // concurrent log event can never render contradictory rows.
-            var modExceptions = modExceptionState.Mods;
-            // Same threshold as the health report (FuseLoadReport
-            // HasModExceptionProblem): a one-off third-party exception is
-            // informational, not a "Review" — only a recurring thrower flips
-            // this row (issue #208).
-            var problemModCount = modExceptions.Count(record => record.IsProblem);
-            AddReadinessRow(
-                builder,
-                "Mod Health",
-                problemModCount == 0,
-                modExceptionState.Total == 0
-                    ? "0 exceptions observed"
-                    : $"{modExceptionState.Total} below-threshold exception(s) observed across {modExceptions.Length} mod(s) (informational)",
-                $"{modExceptionState.Total} exception(s) across {modExceptions.Length} mod(s); {problemModCount} recurring");
-            builder.Spacer(6f);
-
-            // Full per-guard breakdown (this window is the only UI surface, so
-            // the counters must be readable here, not just in copied reports).
-            builder.AddSection("Runtime Guards");
-            InterfaceUtils.AddWrappedLabel(builder, FuseRuntimeGuardCounters.FormatSummary(), 76f);
-            builder.AddField(
-                "Native leak stacks",
-                $"{FuseNativeLeakDiagnostic.ModeLabel} (FUSE setting: {(FuseSettings.EnableNativeLeakStackTraces ? "enabled" : "disabled")})");
-            InterfaceUtils.AddWrappedLabel(
-                builder,
-                FuseRuntimeGuardCounters.AllIdle
-                    ? "All idle — no broken content needed containing this session."
-                    : "Non-zero counters show compatibility events FUSE handled successfully. They remain visible for troubleshooting but do not make the session unhealthy by themselves.",
-                48f);
-            builder.Spacer(6f);
-
-            // Per-mod breakdown for the third-party exception registry,
-            // mirroring the Runtime Guards treatment above (this window is
-            // the only UI surface, so the observations must be readable
-            // here, not just in copied reports).
-            builder.AddSection("Mod Health");
-            builder.AddLabel(modExceptionState.SummaryLine);
-            if (modExceptions.Length > 0)
-            {
-                foreach (var record in modExceptions.OrderByDescending(item => item.Count).Take(5))
-                {
-                    var display = string.IsNullOrWhiteSpace(record.DisplayName) ? record.ModId : record.DisplayName;
-                    InterfaceUtils.AddWrappedField(builder, display, DescribeModExceptionRecord(record), 52f);
-                }
-
-                if (modExceptions.Length > 5)
-                {
-                    InterfaceUtils.AddWrappedLabel(
-                        builder,
-                        $"...and {modExceptions.Length - 5} more mod(s) — full list in the health report.",
-                        28f);
-                }
-            }
-
-            InterfaceUtils.AddWrappedLabel(
-                builder,
-                modExceptionState.Total == 0
-                    ? "All idle — no third-party mod exceptions were observed this session."
-                    : problemModCount == 0
-                        ? "Below-threshold third-party exceptions were observed and logged for reference; a mod counts as a problem at (" +
-                          FuseModExceptionRegistry.ProblemEpisodeThreshold + "+ episodes or " +
-                          FuseModExceptionRegistry.ProblemCountThreshold + "+ occurrences). Details are in FUSE.log and the health report."
-                        : "Recurring counts are third-party mod faults FUSE observed or contained; offenders are named in FUSE.log and the health report.",
-                48f);
+            builder.AddField("Runtime Diagnostics", "Tools > Live Diagnostics (guards, observed exceptions, and the live FUSE log)");
             builder.Spacer(6f);
 
             builder.AddSection("Actions");
@@ -253,24 +172,6 @@ namespace FUSE.Interface.MenuWindow
             return token != null && bool.TryParse(token.ToString(), out var value) ? value : fallback;
         }
 
-        /// <summary>
-        /// One-line per-mod value for the Mod Health breakdown: counts plus
-        /// the mod's top signature (by count), matching the per-mod row the
-        /// health report renders so the two surfaces read the same.
-        /// </summary>
-        private static string DescribeModExceptionRecord(FuseModExceptionSnapshot record)
-        {
-            var text = $"{record.Count} exception(s) over {record.Episodes} episode(s)";
-            var signatures = record.Signatures;
-            if (signatures != null && signatures.Length > 0)
-            {
-                var top = signatures.OrderByDescending(item => item.Count).First();
-                text += $" — top: {top.ExceptionType} @ {top.TopOwnedFrame}";
-            }
-
-            return text;
-        }
-
         private static void AddReadinessRow(UIPanelBuilder builder, string label, bool ok, string okText, string problemText)
         {
             var value = ok
@@ -318,7 +219,7 @@ namespace FUSE.Interface.MenuWindow
                 {
                     HasProblems = reportSnapshot.HasProblems,
                     AppliedPackagesCount = reportSnapshot.AppliedPackageIds.Length,
-                    ConflictCount = reportSnapshot.Conflicts.Length,
+                    ConflictCount = reportSnapshot.ActionableConflictCount,
                     FaultCount = reportSnapshot.Faults.Length,
                     GraphIssueCount = reportSnapshot.GraphPostBindIssues.Length,
                     LoadedPackagesCount = reportSnapshot.LoadedPackageIds.Length,
@@ -358,17 +259,13 @@ namespace FUSE.Interface.MenuWindow
             builder.AppendLine("Profile: " + FuseModSetService.ActiveSetName);
             builder.AppendLine("Profile Hash: " + FuseModSetService.GetActiveSetFingerprint());
             builder.AppendLine("Loaded Packages: " + ReadInt(counts["loadedPackages"]));
-            builder.AppendLine("Applied Packages: " + ReadInt(counts["appliedPackages"]));
+            builder.AppendLine("Applied Definitions: " + ReadInt(counts["appliedDefinitions"] ?? counts["appliedPackages"]));
             builder.AppendLine("Faults: " + ReadInt(counts["faultedPackages"]));
             builder.AppendLine("Conflicts: " + ReadInt(counts["conflicts"]));
             builder.AppendLine("Unknown Assets: " + ReadInt(counts["unknownSceneryAssets"]));
             builder.AppendLine("Graph Issues: " + ReadInt(counts["graphIssues"]));
             builder.AppendLine("Transfer Skips: " + ReadInt(counts["progressionTransferSkips"]));
             builder.AppendLine("Suppressions: " + ReadInt(counts["suppressions"]));
-            builder.AppendLine("Runtime Guards: " + FuseRuntimeGuardCounters.FormatSummary());
-            builder.AppendLine(
-                "Native Leak Detection: " + FuseNativeLeakDiagnostic.ModeLabel +
-                " (FUSE stack setting " + (FuseSettings.EnableNativeLeakStackTraces ? "enabled" : "disabled") + ")");
             builder.AppendLine("Map Load: " + FusePerformanceMetrics.FormatTiming("map load total"));
             builder.AppendLine("Runtime Apply: " + FusePerformanceMetrics.FormatTiming("apply resident definitions"));
             return builder.ToString().TrimEnd();

--- a/FUSE/Interface/MenuWindow/ToolsPanelBuilder.cs
+++ b/FUSE/Interface/MenuWindow/ToolsPanelBuilder.cs
@@ -14,7 +14,10 @@ namespace FUSE.Interface.MenuWindow
             Inspector,
             DependencyGraph,
             Assets,
+            Conflicts,
             Audits,
+            LiveDiagnostics,
+            IndustryDashboard,
             Stats,
             Actions,
             Benchmark
@@ -41,7 +44,10 @@ namespace FUSE.Interface.MenuWindow
             list.Add(new UIPanelBuilder.ListItem<Page>("inspector", new Page(PageId.Inspector), "Tools", "Object Inspector"));
             list.Add(new UIPanelBuilder.ListItem<Page>("dependencyGraph", new Page(PageId.DependencyGraph), "Tools", "Dependency Graph"));
             list.Add(new UIPanelBuilder.ListItem<Page>("assets", new Page(PageId.Assets), "Tools", "Assets Report"));
+            list.Add(new UIPanelBuilder.ListItem<Page>("conflicts", new Page(PageId.Conflicts), "Tools", "Mod Conflicts"));
             list.Add(new UIPanelBuilder.ListItem<Page>("audits", new Page(PageId.Audits), "Tools", "Diagnostics Report"));
+            list.Add(new UIPanelBuilder.ListItem<Page>("liveDiagnostics", new Page(PageId.LiveDiagnostics), "Tools", "Live Diagnostics"));
+            list.Add(new UIPanelBuilder.ListItem<Page>("industryDashboard", new Page(PageId.IndustryDashboard), "Tools", "Industry Dashboard"));
             list.Add(new UIPanelBuilder.ListItem<Page>("stats", new Page(PageId.Stats), "Tools", "World Stats"));
             list.Add(new UIPanelBuilder.ListItem<Page>("actions", new Page(PageId.Actions), "Tools", "Runtime Actions"));
             list.Add(new UIPanelBuilder.ListItem<Page>("benchmark", new Page(PageId.Benchmark), "Tools", "Scenery Benchmark"));
@@ -69,8 +75,17 @@ namespace FUSE.Interface.MenuWindow
                             case PageId.Assets:
                                 AssetsToolPage.Build(builder);
                                 break;
+                            case PageId.Conflicts:
+                                ModConflictsToolPage.Build(builder);
+                                break;
                             case PageId.Audits:
                                 AuditsToolPage.Build(builder);
+                                break;
+                            case PageId.LiveDiagnostics:
+                                LiveDiagnosticsToolPage.Build(builder);
+                                break;
+                            case PageId.IndustryDashboard:
+                                IndustryDashboardToolPage.Build(builder);
                                 break;
                             case PageId.Stats:
                                 BuildStatsPage(builder);
@@ -108,6 +123,7 @@ namespace FUSE.Interface.MenuWindow
             builder.AddField("Scenery", SafeCount(() => SceneryAPI.GetAllScenery().Count()).ToString());
             builder.AddField("Scene Clones", SafeCount(() => SceneCloneAPI.GetAllSceneClones().Count()).ToString());
             builder.AddField("Splineys", SafeCount(() => SplineyAPI.GetAllSplineys().Count()).ToString());
+            builder.AddField("Water Surfaces", SafeCount(() => WaterSurfaceAPI.GetAllWaterSurfaces().Count()).ToString());
             builder.AddField("Map Labels", SafeCount(() => MapAPI.GetAllMapLabels().Count()).ToString());
             builder.AddField("Map Masks", SafeCount(() => MapAPI.GetAllMapMasks().Count()).ToString());
             builder.AddField("Progressions", SafeCount(() => ProgressionAPI.GetAllProgressions().Count()).ToString());
@@ -117,7 +133,12 @@ namespace FUSE.Interface.MenuWindow
             builder.AddSection("Registry");
             builder.AddField("Exclusive Claims", FUSE.Runtime.Registry.FuseRegistry.ExclusiveClaimCount.ToString());
             builder.AddField("Shared Claims", FUSE.Runtime.Registry.FuseRegistry.SharedClaimCount.ToString());
-            builder.AddField("Conflicts", FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count.ToString());
+            builder.AddField(
+                "Conflicts",
+                FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => !conflict.IsCooperativeMerge).ToString());
+            builder.AddField(
+                "Shared Extension Targets",
+                FUSE.Runtime.Registry.FuseRegistry.Conflicts.Count(conflict => conflict.IsCooperativeMerge).ToString());
             builder.AddField("Asset Stores", FUSE.Infrastructure.FusePerformanceMetrics.FormatCount("direct asset pack store count"));
         }
     }

--- a/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.DirectStore.cs
@@ -21,6 +21,8 @@ namespace FUSE.Loading
         private static readonly FieldInfo PrefabStoreStoresField =
             AccessTools.Field(typeof(PrefabStore), "_stores");
 
+        private static PrefabStore _activePrefabStore;
+
         /// <summary>
         /// Mounts a FUSE-generated definitions folder (e.g. the whistle
         /// picker store) as a fuseasset:// direct store on the supplied
@@ -97,10 +99,19 @@ namespace FUSE.Loading
                 return;
             }
 
+            _activePrefabStore = prefabStore;
+
+            // AssetLoader supported definitions-only immediate child folders
+            // in addition to ordinary Catalog.json stores. Build that routing
+            // table before any store's Container is opened.
+            RefreshLegacyDefinitionOverrides();
+            InvalidateLegacyDefinitionOverrideTargetContainers(prefabStore);
+
             var sourcePaths = EnumerateAvailableAssetPackFolders().ToArray();
             if (sourcePaths.Length == 0)
             {
                 ReplaceStoreIdentifierMappings(null);
+                ValidateLegacyDefinitionOverrideTargets(prefabStore);
                 FusePerformanceMetrics.RecordTiming("direct asset pack stores", stopwatch.ElapsedMilliseconds);
                 FusePerformanceMetrics.RecordCount("direct asset pack store count", 0);
                 return;
@@ -258,6 +269,8 @@ namespace FUSE.Loading
             {
                 FuseLog.Exception("FUSE could not warm-mount the generated whistle store", ex);
             }
+
+            ValidateLegacyDefinitionOverrideTargets(prefabStore);
 
             FusePerformanceMetrics.RecordTiming("direct asset pack stores", stopwatch.ElapsedMilliseconds);
             FusePerformanceMetrics.RecordCount("direct asset pack store count", DirectAssetPackStoreIdentifiers.Count);
@@ -734,6 +747,8 @@ namespace FUSE.Loading
                 SanitizeDeserializedDirectContainer(container);
                 RuntimeStoreContainerField?.SetValue(store, container);
 
+                RecordMissingComponentKinds(store.Identifier, removedByKind.Keys);
+
                 if (removedByKind.Count > 0 && SanitizedDirectContainerWarnings.Add(store.Identifier))
                 {
                     var packId = Path.GetFileName(basePath);
@@ -762,6 +777,17 @@ namespace FUSE.Loading
 
         private static Container LoadResilientDirectContainer(string sourceText, string storeIdentifier, IDictionary<string, int> droppedByKind)
         {
+            if (ConsumeLateComponentReload(storeIdentifier) && ContainerSerializerSettingsMethod != null)
+            {
+                // The first cold load already passed its filtered text through the
+                // public ContainerSerialization entry point. Re-entering that method
+                // would make old-loader postfixes (notably Lego's definition edits)
+                // mutate the same pack twice. The newly registered subtype is visible
+                // to the identical serializer settings here, so reload the untouched
+                // source without firing those postfixes again.
+                return BypassDeserialize(sourceText);
+            }
+
             // No reflection-based strict bypass available (rare): defer to the legacy
             // deserialize path, which itself falls back to ContainerSerialization.Deserialize.
             if (ContainerSerializerSettingsMethod == null)
@@ -862,6 +888,98 @@ namespace FUSE.Loading
 
                 return BypassDeserialize(filtered);
             }
+        }
+
+        private static void RecordMissingComponentKinds(string storeIdentifier, IEnumerable<string> kinds)
+        {
+            if (string.IsNullOrWhiteSpace(storeIdentifier) || kinds == null)
+            {
+                return;
+            }
+
+            lock (LateComponentRegistrationLock)
+            {
+                foreach (var kind in kinds)
+                {
+                    if (string.IsNullOrWhiteSpace(kind))
+                    {
+                        continue;
+                    }
+
+                    if (!StoresMissingComponentKind.TryGetValue(kind, out var stores))
+                    {
+                        stores = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        StoresMissingComponentKind[kind] = stores;
+                    }
+
+                    stores.Add(storeIdentifier);
+                }
+            }
+        }
+
+        private static bool ConsumeLateComponentReload(string storeIdentifier)
+        {
+            if (string.IsNullOrWhiteSpace(storeIdentifier))
+            {
+                return false;
+            }
+
+            lock (LateComponentRegistrationLock)
+            {
+                return StoresRequiringLateComponentReload.Remove(storeIdentifier);
+            }
+        }
+
+        internal static void OnLegacyComponentKindRegistered(string kind)
+        {
+            if (string.IsNullOrWhiteSpace(kind))
+            {
+                return;
+            }
+
+            string[] affectedStoreIdentifiers;
+            lock (LateComponentRegistrationLock)
+            {
+                if (!StoresMissingComponentKind.TryGetValue(kind, out var stores) || stores.Count == 0)
+                {
+                    return;
+                }
+
+                affectedStoreIdentifiers = stores.ToArray();
+                StoresMissingComponentKind.Remove(kind);
+                foreach (var identifier in affectedStoreIdentifiers)
+                {
+                    StoresRequiringLateComponentReload.Add(identifier);
+                }
+            }
+
+            var invalidated = 0;
+            try
+            {
+                if (_activePrefabStore != null &&
+                    PrefabStoreStoresField?.GetValue(_activePrefabStore) is System.Collections.IEnumerable stores)
+                {
+                    var affected = new HashSet<string>(affectedStoreIdentifiers, StringComparer.OrdinalIgnoreCase);
+                    foreach (var item in stores)
+                    {
+                        if (item is AssetPackRuntimeStore store && affected.Contains(store.Identifier))
+                        {
+                            RuntimeStoreContainerField?.SetValue(store, null);
+                            invalidated++;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not invalidate asset packs after component kind '{kind}' registered: {ex.Message}");
+            }
+
+            FusePrefabStoreAllCarDefinitionInfosFilterPatch.InvalidateCache(_activePrefabStore);
+            FuseLog.Info(
+                $"FUSE component kind '{kind}' became available after asset-pack discovery; " +
+                $"invalidated {invalidated} affected store(s) so their full definitions load before use.");
         }
 
         private static void NoteNativeDeserializeFallback(string storeIdentifier, Exception ex)

--- a/FUSE/Loading/FuseAssetPackRegistry.LegacyAlias.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.LegacyAlias.cs
@@ -158,6 +158,14 @@ namespace FUSE.Loading
             AddLegacyAssetPackAlias(aliases, resolved, resolved);
             AddLegacyAssetPackAlias(aliases, Path.GetFileName(assetPackFolder), resolved);
 
+            if (string.Equals(
+                    NormalizeAssetPackPhysicalPath(packagePath),
+                    NormalizeAssetPackPhysicalPath(assetPackFolder),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                AddLegacyAssetPackAlias(aliases, packageId, resolved);
+            }
+
             var relative = GetRelativePath(packagePath, assetPackFolder).Replace(Path.DirectorySeparatorChar, '/');
             if (!string.IsNullOrWhiteSpace(packageId) && !string.IsNullOrWhiteSpace(relative))
             {
@@ -213,7 +221,7 @@ namespace FUSE.Loading
                     : Path.GetFileName(packagePath);
                 RecordCatalogInspectionFailure(
                     $"Asset pack Catalog.json could not be read: package='{package}' " +
-                    $"pack='{Path.GetFileName(assetPackFolder)}' reason='{ex.Message}' — " +
+                    $"pack='{Path.GetFileName(assetPackFolder)}' file='{catalogPath}' reason='{ex.Message}' — " +
                     "catalog-declared aliases were skipped; content referencing them may not resolve.");
             }
         }

--- a/FUSE/Loading/FuseAssetPackRegistry.LegacyDefinitionOverrides.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.LegacyDefinitionOverrides.cs
@@ -1,0 +1,551 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using AssetPack.Runtime;
+using Model.Definition;
+using Model.Database;
+using Newtonsoft.Json.Linq;
+using FUSE.Infrastructure;
+
+namespace FUSE.Loading
+{
+    internal static partial class FuseAssetPackRegistry
+    {
+        private const string FuseDefinitionOverridesProperty = "FuseDefinitionOverrides";
+
+        private static readonly object LegacyDefinitionOverrideLock = new object();
+        private static Dictionary<string, FuseLegacyDefinitionOverrideRegistration>
+            LegacyDefinitionOverridesByStore =
+                new Dictionary<string, FuseLegacyDefinitionOverrideRegistration>(StringComparer.Ordinal);
+        private static string[] LegacyDefinitionOverrideIssues = Array.Empty<string>();
+        private static readonly HashSet<string> LoggedLegacyDefinitionOverrideLoads =
+            new HashSet<string>(StringComparer.Ordinal);
+        private static readonly HashSet<string> LoggedLegacyDefinitionOverrideFailures =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Rebuilds the FUSE-owned equivalent of AssetLoader's definitions-only
+        /// child-folder routing. A folder containing Catalog.json remains a normal
+        /// store. An immediate child containing only Definitions.json targets the
+        /// existing store whose identifier equals the child folder name.
+        /// Native packages can opt into nested or differently named files through
+        /// Info.json/FuseDefinitionOverrides.
+        /// </summary>
+        private static void RefreshLegacyDefinitionOverrides()
+        {
+            var candidates = new List<FuseLegacyDefinitionOverrideRegistration>();
+            var issues = new List<string>();
+            var modsRoot = FuseDataPackageDiscovery.GetModsRoot();
+
+            if (!string.IsNullOrWhiteSpace(modsRoot) && Directory.Exists(modsRoot))
+            {
+                string[] packagePaths;
+                try
+                {
+                    packagePaths = Directory.GetDirectories(modsRoot)
+                        .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+                }
+                catch (Exception ex)
+                {
+                    packagePaths = Array.Empty<string>();
+                    issues.Add(
+                        $"Asset definition override discovery could not enumerate '{modsRoot}': " +
+                        ex.GetBaseException().Message);
+                }
+
+                foreach (var packagePath in packagePaths)
+                {
+                    if (!ShouldInspectPackage(packagePath))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        candidates.AddRange(
+                            DiscoverDefinitionOverrideCandidatesForPackage(packagePath, out var packageIssues));
+                        issues.AddRange(packageIssues);
+                    }
+                    catch (Exception ex)
+                    {
+                        issues.Add(
+                            $"Asset definition override discovery failed for package '{packagePath}': " +
+                            ex.GetBaseException().Message);
+                    }
+                }
+            }
+
+            var winners = SelectLegacyDefinitionOverrides(candidates, out var selectionIssues);
+            issues.AddRange(selectionIssues);
+
+            lock (LegacyDefinitionOverrideLock)
+            {
+                LegacyDefinitionOverridesByStore = winners;
+                LegacyDefinitionOverrideIssues = issues
+                    .Where(issue => !string.IsNullOrWhiteSpace(issue))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                LoggedLegacyDefinitionOverrideLoads.Clear();
+                LoggedLegacyDefinitionOverrideFailures.Clear();
+            }
+
+            if (winners.Count > 0)
+            {
+                FuseLog.Info(
+                    $"FUSE discovered {winners.Count} AssetLoader-compatible definition override(s); " +
+                    $"issues={issues.Count}.");
+            }
+        }
+
+        internal static FuseLegacyDefinitionOverrideRegistration[]
+            DiscoverDefinitionOverrideCandidatesForPackage(
+                string packagePath,
+                out string[] issues)
+        {
+            var result = new List<FuseLegacyDefinitionOverrideRegistration>();
+            var issueList = new List<string>();
+            if (string.IsNullOrWhiteSpace(packagePath) || !Directory.Exists(packagePath))
+            {
+                issues = Array.Empty<string>();
+                return Array.Empty<FuseLegacyDefinitionOverrideRegistration>();
+            }
+
+            var packageRoot = Path.GetFullPath(packagePath);
+            var packageId = TryReadPackageId(packageRoot) ?? Path.GetFileName(packageRoot);
+            var infoPath = Path.Combine(packageRoot, "Info.json");
+            if (!File.Exists(infoPath))
+            {
+                var lowerInfoPath = Path.Combine(packageRoot, "info.json");
+                if (File.Exists(lowerInfoPath))
+                {
+                    infoPath = lowerInfoPath;
+                }
+            }
+
+            if (File.Exists(infoPath))
+            {
+                try
+                {
+                    var info = FuseLegacyDataConverter.ReadLegacyObject(infoPath);
+                    AppendExplicitDefinitionOverrideCandidates(
+                        packageRoot,
+                        packageId,
+                        info[FuseDefinitionOverridesProperty],
+                        result,
+                        issueList);
+                }
+                catch (Exception ex)
+                {
+                    issueList.Add(
+                        $"Package '{packageId}' could not parse '{infoPath}' while reading " +
+                        $"{FuseDefinitionOverridesProperty}: {ex.GetBaseException().Message}");
+                }
+            }
+
+            // Preserve AssetLoader 1.0.1's implicit convention exactly: only
+            // immediate child folders, only when Catalog.json is absent.
+            foreach (var child in Directory.GetDirectories(packageRoot)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+            {
+                var definitionsPath = Path.Combine(child, "Definitions.json");
+                if (File.Exists(Path.Combine(child, "Catalog.json")) ||
+                    !File.Exists(definitionsPath))
+                {
+                    continue;
+                }
+
+                result.Add(new FuseLegacyDefinitionOverrideRegistration
+                {
+                    StoreIdentifier = Path.GetFileName(child),
+                    DefinitionsPath = Path.GetFullPath(definitionsPath),
+                    PackageId = packageId,
+                    PackagePath = packageRoot,
+                    Explicit = false
+                });
+            }
+
+            issues = issueList.ToArray();
+            return result
+                .GroupBy(
+                    item => item.StoreIdentifier + "\0" + item.DefinitionsPath,
+                    StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.OrderByDescending(item => item.Explicit).First())
+                .ToArray();
+        }
+
+        private static void AppendExplicitDefinitionOverrideCandidates(
+            string packageRoot,
+            string packageId,
+            JToken token,
+            ICollection<FuseLegacyDefinitionOverrideRegistration> result,
+            ICollection<string> issues)
+        {
+            if (token == null || token.Type == JTokenType.Null)
+            {
+                return;
+            }
+
+            if (token.Type == JTokenType.Array)
+            {
+                foreach (var item in token.Children())
+                {
+                    AppendExplicitDefinitionOverrideCandidates(
+                        packageRoot,
+                        packageId,
+                        item,
+                        result,
+                        issues);
+                }
+                return;
+            }
+
+            string storeIdentifier = null;
+            string relativePath = null;
+            if (token.Type == JTokenType.String)
+            {
+                relativePath = (string)token;
+            }
+            else if (token is JObject obj)
+            {
+                storeIdentifier =
+                    (string)obj["StoreIdentifier"] ??
+                    (string)obj["storeIdentifier"] ??
+                    (string)obj["Identifier"] ??
+                    (string)obj["identifier"];
+                relativePath =
+                    (string)obj["Path"] ??
+                    (string)obj["path"] ??
+                    (string)obj["DefinitionsPath"] ??
+                    (string)obj["definitionsPath"];
+            }
+
+            if (string.IsNullOrWhiteSpace(relativePath))
+            {
+                issues.Add(
+                    $"Package '{packageId}' has a {FuseDefinitionOverridesProperty} entry " +
+                    "without a non-empty Path.");
+                return;
+            }
+
+            string fullPath;
+            try
+            {
+                fullPath = Path.GetFullPath(Path.Combine(packageRoot, relativePath.Trim()));
+                if (Directory.Exists(fullPath))
+                {
+                    fullPath = Path.Combine(fullPath, "Definitions.json");
+                }
+            }
+            catch (Exception ex)
+            {
+                issues.Add(
+                    $"Package '{packageId}' has invalid definition override path " +
+                    $"'{relativePath}': {ex.GetBaseException().Message}");
+                return;
+            }
+
+            if (!IsPathWithinPackage(packageRoot, fullPath))
+            {
+                issues.Add(
+                    $"Package '{packageId}' definition override path '{relativePath}' " +
+                    "escapes the package folder and was ignored.");
+                return;
+            }
+
+            if (!File.Exists(fullPath))
+            {
+                issues.Add(
+                    $"Package '{packageId}' definition override file was not found: '{fullPath}'.");
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(storeIdentifier))
+            {
+                storeIdentifier = Path.GetFileName(Path.GetDirectoryName(fullPath));
+            }
+
+            if (string.IsNullOrWhiteSpace(storeIdentifier))
+            {
+                issues.Add(
+                    $"Package '{packageId}' could not infer a target store for '{relativePath}'.");
+                return;
+            }
+
+            result.Add(new FuseLegacyDefinitionOverrideRegistration
+            {
+                StoreIdentifier = storeIdentifier.Trim(),
+                DefinitionsPath = fullPath,
+                PackageId = packageId,
+                PackagePath = packageRoot,
+                Explicit = true
+            });
+        }
+
+        private static bool IsPathWithinPackage(string packageRoot, string candidatePath)
+        {
+            var normalizedRoot = Path.GetFullPath(packageRoot)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
+                Path.DirectorySeparatorChar;
+            var normalizedCandidate = Path.GetFullPath(candidatePath);
+            return normalizedCandidate.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static Dictionary<string, FuseLegacyDefinitionOverrideRegistration>
+            SelectLegacyDefinitionOverrides(
+                IEnumerable<FuseLegacyDefinitionOverrideRegistration> candidates,
+                out string[] issues)
+        {
+            var winners = new Dictionary<string, FuseLegacyDefinitionOverrideRegistration>(
+                StringComparer.Ordinal);
+            var issueList = new List<string>();
+
+            foreach (var candidate in (candidates ??
+                    Enumerable.Empty<FuseLegacyDefinitionOverrideRegistration>())
+                .Where(item => item != null &&
+                               !string.IsNullOrWhiteSpace(item.StoreIdentifier) &&
+                               !string.IsNullOrWhiteSpace(item.DefinitionsPath))
+                .OrderByDescending(item => item.Explicit)
+                .ThenBy(item => item.PackagePath, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(item => item.DefinitionsPath, StringComparer.OrdinalIgnoreCase))
+            {
+                if (!winners.TryGetValue(candidate.StoreIdentifier, out var existing))
+                {
+                    winners[candidate.StoreIdentifier] = candidate;
+                    continue;
+                }
+
+                if (string.Equals(
+                        existing.DefinitionsPath,
+                        candidate.DefinitionsPath,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                issueList.Add(
+                    $"Multiple packages target asset store '{candidate.StoreIdentifier}'. " +
+                    $"FUSE selected '{existing.DefinitionsPath}' from '{existing.PackageId}' and " +
+                    $"ignored '{candidate.DefinitionsPath}' from '{candidate.PackageId}'.");
+            }
+
+            issues = issueList.ToArray();
+            return winners;
+        }
+
+        private static void ValidateLegacyDefinitionOverrideTargets(PrefabStore prefabStore)
+        {
+            HashSet<string> storeIdentifiers;
+            try
+            {
+                storeIdentifiers = new HashSet<string>(StringComparer.Ordinal);
+                if (PrefabStoreStoresField?.GetValue(prefabStore) is System.Collections.IEnumerable stores)
+                {
+                    foreach (var item in stores)
+                    {
+                        if (item is AssetPackRuntimeStore store &&
+                            !string.IsNullOrWhiteSpace(store.Identifier))
+                        {
+                            storeIdentifiers.Add(store.Identifier);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                AddLegacyDefinitionOverrideIssue(
+                    "FUSE could not validate asset definition override targets: " +
+                    ex.GetBaseException().Message);
+                return;
+            }
+
+            foreach (var registration in GetLegacyDefinitionOverrides())
+            {
+                if (!storeIdentifiers.Contains(registration.StoreIdentifier))
+                {
+                    AddLegacyDefinitionOverrideIssue(
+                        $"Package '{registration.PackageId}' supplies definitions for asset store " +
+                        $"'{registration.StoreIdentifier}', but no store with that exact identifier is installed.");
+                }
+            }
+        }
+
+        private static int InvalidateLegacyDefinitionOverrideTargetContainers(PrefabStore prefabStore)
+        {
+            var targets = new HashSet<string>(
+                GetLegacyDefinitionOverrides().Select(item => item.StoreIdentifier),
+                StringComparer.Ordinal);
+            if (targets.Count == 0 || prefabStore == null || PrefabStoreStoresField == null)
+            {
+                return 0;
+            }
+
+            var invalidated = 0;
+            try
+            {
+                if (PrefabStoreStoresField.GetValue(prefabStore) is System.Collections.IEnumerable stores)
+                {
+                    foreach (var item in stores)
+                    {
+                        if (item is AssetPackRuntimeStore store && targets.Contains(store.Identifier))
+                        {
+                            RuntimeStoreContainerField?.SetValue(store, null);
+                            invalidated++;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                AddLegacyDefinitionOverrideIssue(
+                    "FUSE could not invalidate original containers before applying asset definition overrides: " +
+                    ex.GetBaseException().Message);
+            }
+
+            return invalidated;
+        }
+
+        internal static bool TryLoadLegacyDefinitionOverrideContainer(
+            AssetPackRuntimeStore store,
+            out Container container)
+        {
+            container = null;
+            if (store == null || string.IsNullOrWhiteSpace(store.Identifier))
+            {
+                return false;
+            }
+
+            FuseLegacyDefinitionOverrideRegistration registration;
+            lock (LegacyDefinitionOverrideLock)
+            {
+                if (!LegacyDefinitionOverridesByStore.TryGetValue(
+                        store.Identifier,
+                        out registration))
+                {
+                    return false;
+                }
+            }
+
+            try
+            {
+                var cached = RuntimeStoreContainerField?.GetValue(store) as Container;
+                if (cached != null)
+                {
+                    container = cached;
+                    return true;
+                }
+
+                var sourceText = File.ReadAllText(registration.DefinitionsPath);
+                var droppedByKind = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                container = LoadResilientDirectContainer(
+                    sourceText,
+                    store.Identifier,
+                    droppedByKind);
+                if (container == null)
+                {
+                    throw new InvalidDataException("Definitions deserialized to null.");
+                }
+
+                SanitizeDeserializedDirectContainer(container);
+                RuntimeStoreContainerField?.SetValue(store, container);
+                RecordMissingComponentKinds(store.Identifier, droppedByKind.Keys);
+
+                lock (LegacyDefinitionOverrideLock)
+                {
+                    if (LoggedLegacyDefinitionOverrideLoads.Add(store.Identifier))
+                    {
+                        var dropped = droppedByKind.Count == 0
+                            ? string.Empty
+                            : " Unbindable components dropped: " + string.Join(
+                                ", ",
+                                droppedByKind.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)
+                                    .Select(item => item.Key + "=" + item.Value)) + ".";
+                        FuseLog.Info(
+                            $"FUSE applied AssetLoader-compatible definitions for store " +
+                            $"'{store.Identifier}' from '{registration.DefinitionsPath}'.{dropped}");
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                var message =
+                    $"Package '{registration.PackageId}' could not apply asset definitions " +
+                    $"for store '{store.Identifier}' from '{registration.DefinitionsPath}': " +
+                    $"{ex.GetBaseException().GetType().Name}: {ex.GetBaseException().Message}. " +
+                    "FUSE kept the store's original definitions so other equipment and menus remain usable.";
+                AddLegacyDefinitionOverrideIssue(message);
+
+                lock (LegacyDefinitionOverrideLock)
+                {
+                    if (LoggedLegacyDefinitionOverrideFailures.Add(store.Identifier))
+                    {
+                        FuseLog.Warning(message);
+                    }
+                }
+
+                container = null;
+                return false;
+            }
+        }
+
+        private static void AddLegacyDefinitionOverrideIssue(string issue)
+        {
+            if (string.IsNullOrWhiteSpace(issue))
+            {
+                return;
+            }
+
+            lock (LegacyDefinitionOverrideLock)
+            {
+                if (!LegacyDefinitionOverrideIssues.Contains(issue, StringComparer.Ordinal))
+                {
+                    LegacyDefinitionOverrideIssues = LegacyDefinitionOverrideIssues
+                        .Concat(new[] { issue })
+                        .ToArray();
+                }
+            }
+        }
+
+        internal static FuseLegacyDefinitionOverrideRegistration[] GetLegacyDefinitionOverrides()
+        {
+            lock (LegacyDefinitionOverrideLock)
+            {
+                return LegacyDefinitionOverridesByStore.Values
+                    .OrderBy(item => item.StoreIdentifier, StringComparer.Ordinal)
+                    .ToArray();
+            }
+        }
+
+        internal static string[] GetLegacyDefinitionOverrideIssues()
+        {
+            lock (LegacyDefinitionOverrideLock)
+            {
+                return LegacyDefinitionOverrideIssues.ToArray();
+            }
+        }
+
+        private static void ResetLegacyDefinitionOverrides()
+        {
+            lock (LegacyDefinitionOverrideLock)
+            {
+                LegacyDefinitionOverridesByStore =
+                    new Dictionary<string, FuseLegacyDefinitionOverrideRegistration>(StringComparer.Ordinal);
+                LegacyDefinitionOverrideIssues = Array.Empty<string>();
+                LoggedLegacyDefinitionOverrideLoads.Clear();
+                LoggedLegacyDefinitionOverrideFailures.Clear();
+            }
+        }
+    }
+
+    internal sealed class FuseLegacyDefinitionOverrideRegistration
+    {
+        public string StoreIdentifier { get; set; }
+        public string DefinitionsPath { get; set; }
+        public string PackageId { get; set; }
+        public string PackagePath { get; set; }
+        public bool Explicit { get; set; }
+    }
+}

--- a/FUSE/Loading/FuseAssetPackRegistry.Mounting.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.Mounting.cs
@@ -312,6 +312,14 @@ namespace FUSE.Loading
             // modern saves on the modern bundle.
             var scAssetPacks = Path.Combine(packagePath, "SCAssetPacks");
 
+            // AssetLoader also accepts Catalog.json directly in the UMM
+            // package root and registers it under the package id. This shape
+            // is uncommon but is part of its observable contract.
+            if (IsAssetPackFolder(packagePath))
+            {
+                yield return packagePath;
+            }
+
             foreach (var folder in EnumerateRootAssetPackFolders(packagePath, scAssetPacks))
             {
                 yield return folder;
@@ -385,8 +393,14 @@ namespace FUSE.Loading
 
         private static bool IsAssetPackFolder(string folderPath)
         {
-            return File.Exists(Path.Combine(folderPath, "Bundle")) &&
-                   File.Exists(Path.Combine(folderPath, "Catalog.json"));
+            // AssetLoader's public wire contract is Catalog.json, not Bundle.
+            // Several real rolling-stock packages publish definitions-only or
+            // catalog-plus-definitions stores whose assets live in another pack.
+            // Requiring Bundle here made FUSE silently skip those stores while
+            // still appearing to replace AssetLoader. If a catalog actually
+            // references a missing local bundle, the normal per-asset load and
+            // bundle audit paths report that problem when the asset is requested.
+            return File.Exists(Path.Combine(folderPath, "Catalog.json"));
         }
 
         private static int MountAssetPackFolder(string sourcePath)

--- a/FUSE/Loading/FuseAssetPackRegistry.cs
+++ b/FUSE/Loading/FuseAssetPackRegistry.cs
@@ -64,6 +64,11 @@ namespace FUSE.Loading
             new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private static readonly HashSet<string> SanitizedDirectContainerWarnings =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private static readonly object LateComponentRegistrationLock = new object();
+        private static readonly Dictionary<string, HashSet<string>> StoresMissingComponentKind =
+            new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly HashSet<string> StoresRequiringLateComponentReload =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private static readonly object LegacyAssetPackAliasLock = new object();
         private static Dictionary<string, string> LegacyAssetPackAliases;
         // Physical pack folder -> identifier of the store PrefabStore will
@@ -174,6 +179,11 @@ namespace FUSE.Loading
             _mountComplete = false;
             MountedAssetPackSourcesById.Clear();
             DirectAssetPackStoreIdentifiers.Clear();
+            lock (LateComponentRegistrationLock)
+            {
+                StoresMissingComponentKind.Clear();
+                StoresRequiringLateComponentReload.Clear();
+            }
             lock (LegacyAssetPackAliasLock)
             {
                 hadState |= StoreIdentifiersByPhysicalPath.Count > 0 || LegacyAssetPackAliases != null;
@@ -186,6 +196,7 @@ namespace FUSE.Loading
                 CatalogInspectionFailures.Clear();
             }
             FuseLegacyContainerMixintoRegistry.Reset();
+            ResetLegacyDefinitionOverrides();
             FuseAssetCollisionRegistry.Reset();
             FUSE.Runtime.API.SceneryAPI.InvalidateKnownSceneryIdentifierIndex();
             if (hadState)
@@ -214,7 +225,9 @@ namespace FUSE.Loading
         {
             var folders = EnumerateAvailableAssetPackFolders().ToArray();
             var firstSourceByKey = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var firstDefinitionByKey = new Dictionary<string, JObject>(StringComparer.OrdinalIgnoreCase);
             var duplicateKeys = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            var duplicateDefinitionsDiffer = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
             var failedLookups = new List<string>();
 
             foreach (var folder in folders)
@@ -245,6 +258,7 @@ namespace FUSE.Loading
                         if (!firstSourceByKey.TryGetValue(key, out var existing))
                         {
                             firstSourceByKey[key] = folder;
+                            firstDefinitionByKey[key] = obj;
                             continue;
                         }
 
@@ -257,6 +271,13 @@ namespace FUSE.Loading
                         if (!sources.Contains(folder, StringComparer.OrdinalIgnoreCase))
                         {
                             sources.Add(folder);
+                        }
+
+                        if (!duplicateDefinitionsDiffer.TryGetValue(key, out var definitionsDiffer) || !definitionsDiffer)
+                        {
+                            duplicateDefinitionsDiffer[key] =
+                                !firstDefinitionByKey.TryGetValue(key, out var firstDefinition) ||
+                                !JToken.DeepEquals(firstDefinition, obj);
                         }
                     }
                 }
@@ -275,11 +296,48 @@ namespace FUSE.Loading
                     .Select(item => new FuseDuplicateAssetKey
                     {
                         Key = item.Key,
-                        Sources = item.Value.Select(Path.GetFileName).ToArray()
+                        Sources = item.Value.Select(DescribeAssetPackSource).ToArray(),
+                        DefinitionsDiffer = duplicateDefinitionsDiffer.TryGetValue(item.Key, out var differ) && differ
                     })
                     .ToArray(),
-                FailedDefinitionLoads = failedLookups.ToArray()
+                FailedDefinitionLoads = failedLookups.ToArray(),
+                LegacyDefinitionOverrides = GetLegacyDefinitionOverrides(),
+                LegacyDefinitionOverrideIssues = GetLegacyDefinitionOverrideIssues()
             };
+        }
+
+        private static string DescribeAssetPackSource(string folder)
+        {
+            if (string.IsNullOrWhiteSpace(folder))
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                var packageFolder = ReadHostingPackageFolder(folder);
+                if (!string.IsNullOrWhiteSpace(packageFolder))
+                {
+                    var packageName = Path.GetFileName(packageFolder);
+                    var relative = folder.Substring(packageFolder.Length)
+                        .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                        .Replace(Path.DirectorySeparatorChar, '/');
+                    return string.IsNullOrWhiteSpace(relative)
+                        ? packageName
+                        : packageName + "/" + relative;
+                }
+            }
+            catch (Exception ex)
+            {
+                // Diagnostics must never make an otherwise usable asset pack
+                // fail to load, but retaining the reason avoids hiding a path
+                // or permissions problem from the live log.
+                FuseLog.Warning(
+                    $"FUSE could not build a package-relative asset source label for '{folder}': " +
+                    ex.GetBaseException().Message);
+            }
+
+            return Path.GetFileName(folder);
         }
     }
 
@@ -289,11 +347,15 @@ namespace FUSE.Loading
         public int UniqueAssetKeys { get; set; }
         public FuseDuplicateAssetKey[] DuplicateKeys { get; set; } = Array.Empty<FuseDuplicateAssetKey>();
         public string[] FailedDefinitionLoads { get; set; } = Array.Empty<string>();
+        public FuseLegacyDefinitionOverrideRegistration[] LegacyDefinitionOverrides { get; set; } =
+            Array.Empty<FuseLegacyDefinitionOverrideRegistration>();
+        public string[] LegacyDefinitionOverrideIssues { get; set; } = Array.Empty<string>();
     }
 
     internal sealed class FuseDuplicateAssetKey
     {
         public string Key { get; set; } = string.Empty;
         public string[] Sources { get; set; } = Array.Empty<string>();
+        public bool DefinitionsDiffer { get; set; }
     }
 }

--- a/FUSE/Loading/FuseDataPackageDiscovery.cs
+++ b/FUSE/Loading/FuseDataPackageDiscovery.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using FUSE.Authoring.Data;
 using FUSE.Infrastructure;
 using FUSE.Runtime.Lifecycle;
 using Newtonsoft.Json;
@@ -95,6 +96,8 @@ namespace FUSE.Loading
                     Priority = manifest.Priority,
                     LoadAfter = manifest.LoadAfter ?? Array.Empty<string>(),
                     LoadBefore = manifest.LoadBefore ?? Array.Empty<string>(),
+                    RequiredPackageIds = manifest.RequiredPackageIds ?? Array.Empty<string>(),
+                    ConflictsWith = manifest.ConflictsWith ?? Array.Empty<FuseModRequirement>(),
                     Disabled = manifest.Disabled,
                     DisabledReason = manifest.DisabledReason ?? string.Empty,
                     IsLegacyConverted = manifest.IsLegacyDataPackage,
@@ -168,9 +171,36 @@ namespace FUSE.Loading
 
                 if (manifest.HasBlockingFaults)
                 {
-                    foreach (var fault in manifest.Faults)
+                    if (manifest.ManifestReadException != null)
                     {
-                        FusePackageFaultRegistry.RecordFault(manifest.Id, "dependency/load-order", fault);
+                        FusePackageFaultRegistry.RecordFault(
+                            manifest.Id,
+                            "manifest JSON",
+                            manifest.Faults.FirstOrDefault() ?? manifest.ManifestReadException.GetBaseException().Message,
+                            manifest.ManifestReadException,
+                            manifest.FolderPath,
+                            manifest.ManifestPath,
+                            packageName: manifest.DisplayName,
+                            expectedShape: "A valid Info.json or Definition.json package manifest.",
+                            receivedValue: manifest.ManifestReadException.GetBaseException().Message);
+                    }
+                    else
+                    {
+                        foreach (var fault in manifest.Faults)
+                        {
+                            FusePackageFaultRegistry.RecordFault(
+                                manifest.Id,
+                                "dependency/load-order",
+                                fault,
+                                null,
+                                manifest.FolderPath,
+                                manifest.ManifestPath,
+                                InferManifestFaultJsonPath(manifest, fault),
+                                suggestedAction: SuggestedActionForManifestFault(fault),
+                                packageName: manifest.DisplayName,
+                                expectedShape: "Package dependency and load-order declarations accepted by FUSE.",
+                                receivedValue: fault);
+                        }
                     }
 
                     FusePackageFaultRegistry.MarkSkipped(manifest.Id, "dependency/load-order fault");
@@ -178,6 +208,7 @@ namespace FUSE.Loading
                     continue;
                 }
 
+                var faultCountBeforeLoad = FusePackageFaultRegistry.FaultCount;
                 try
                 {
                     var packageStopwatch = Stopwatch.StartNew();
@@ -187,7 +218,7 @@ namespace FUSE.Loading
                     }
                     else
                     {
-                        FuseModLoader.LoadMod(packagePath);
+                        FuseModLoader.LoadMod(packagePath, manifest.Id);
                     }
                     FusePackageFaultRegistry.MarkLoadedFromDisk(manifest.Id);
                     FuseLog.Info($"FUSE loaded package '{Path.GetFileName(packagePath)}' id='{manifest.Id}' from disk into resident definitions in {packageStopwatch.ElapsedMilliseconds} ms. Runtime apply has not run in this step.");
@@ -195,7 +226,15 @@ namespace FUSE.Loading
                 }
                 catch (Exception ex)
                 {
-                    FusePackageFaultRegistry.RecordFault(manifest.Id, "deserialization", ex.Message, ex);
+                    if (FusePackageFaultRegistry.FaultCount == faultCountBeforeLoad)
+                    {
+                        FusePackageFaultRegistry.RecordFault(
+                            manifest.Id,
+                            "package load",
+                            ex.GetBaseException().Message,
+                            ex,
+                            packagePath);
+                    }
                     FusePackageFaultRegistry.MarkSkipped(manifest.Id, "deserialization failed");
                     FuseLog.Exception($"Failed to deserialize FUSE data package '{packagePath}' from disk", ex);
                 }
@@ -268,6 +307,7 @@ namespace FUSE.Loading
 
         public static void ResetDiscovery()
         {
+            FuseLegacyCapabilityActivation.Reset();
             if (!_discoveryComplete && !_definitionsLoadedFromDisk && _discoveredPackageFolders.Length == 0)
             {
                 return;
@@ -338,14 +378,29 @@ namespace FUSE.Loading
             JObject info;
             try
             {
-                info = FuseLegacyDataConverter.ReadLegacyObject(infoPath);
+                info = FuseLegacyDataConverter.ReadManifestObject(infoPath);
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
             {
                 // A malformed Info.json is an authoring error in a FUSE/UMM package, not a signal to
                 // reinterpret the folder as a legacy data package. Surface the parse failure and stop.
                 FuseLog.Exception($"FUSE ignored package '{folderPath}' because Info.json could not be parsed", ex);
-                return false;
+                if (!LooksLikeFusePackageWithBrokenInfo(folderPath))
+                {
+                    return false;
+                }
+
+                var fallbackId = Path.GetFileName(folderPath);
+                manifest = new FusePackageManifest
+                {
+                    Id = fallbackId,
+                    DisplayName = fallbackId,
+                    FolderPath = folderPath,
+                    ManifestPath = infoPath,
+                    ManifestReadException = ex
+                };
+                manifest.Faults.Add(ex.GetBaseException().Message);
+                return true;
             }
 
             var id = ((string)info["Id"] ?? Path.GetFileName(folderPath)).Trim();
@@ -354,10 +409,11 @@ namespace FUSE.Loading
                 return false;
             }
 
-            var hasExplicitDataFiles = HasFuseDataFile(info["FuseDataFile"]) ||
-                HasFuseDataFile(info["FuseDataFiles"]);
-            var isAssetPackOnly = HasFuseAssetPacks(info) && !hasExplicitDataFiles;
-            var isDataPackage = hasExplicitDataFiles ||
+            var dataFileToken = info["FuseDataFile"] ?? info["FuseDataFiles"];
+            var declaresDataFiles = dataFileToken != null;
+            var hasExplicitDataFiles = HasFuseDataFile(dataFileToken);
+            var isAssetPackOnly = HasFuseAssetPacks(info) && !declaresDataFiles;
+            var isDataPackage = declaresDataFiles ||
                 (!isAssetPackOnly && HasRootDefinitionFile(folderPath) && (ContainsFuseReference(info["Requirements"]) || ContainsFuseReference(info["LoadAfter"])));
             if (!isDataPackage)
             {
@@ -384,13 +440,20 @@ namespace FUSE.Loading
                 DisplayName = ((string)info["DisplayName"] ?? (string)info["Name"] ?? (string)info["name"] ?? id ?? string.Empty).Trim(),
                 Version = ((string)info["Version"] ?? (string)info["version"] ?? string.Empty).Trim(),
                 FolderPath = folderPath,
+                ManifestPath = infoPath,
                 Priority = ReadPriority(info["FuseLoadPriority"]),
                 RequiredPackageIds = ReadDependencyIds(info["FuseRequires"]),
                 LoadAfter = ReadDependencyIds(info["FuseLoadAfter"]),
                 LoadBefore = ReadDependencyIds(info["FuseLoadBefore"]),
+                ConflictsWith = ReadPackageReferences(info["FuseConflictsWith"]),
                 Disabled = disabled,
                 DisabledReason = disabledReason
             };
+            if (declaresDataFiles && !hasExplicitDataFiles)
+            {
+                manifest.Faults.Add(
+                    "Info.json field 'FuseDataFile'/'FuseDataFiles' must be a non-empty file name or an array of non-empty file names.");
+            }
             return true;
         }
 
@@ -423,15 +486,88 @@ namespace FUSE.Loading
                 DisplayName = legacy.DisplayName ?? id,
                 Version = legacy.Version ?? string.Empty,
                 FolderPath = folderPath,
+                ManifestPath = Path.Combine(folderPath, "Definition.json"),
                 Priority = ReadPriority(info?["FuseLoadPriority"]),
                 RequiredPackageIds = legacy.RequiredPackageIds ?? Array.Empty<string>(),
                 LoadAfter = legacy.LoadAfter ?? Array.Empty<string>(),
                 LoadBefore = ReadDependencyIds(info?["FuseLoadBefore"]),
+                ConflictsWith = legacy.ConflictsWith ?? Array.Empty<FuseModRequirement>(),
                 Disabled = disabled,
                 DisabledReason = disabledReason,
                 IsLegacyDataPackage = true
             };
             return true;
+        }
+
+        private static bool LooksLikeFusePackageWithBrokenInfo(string folderPath)
+        {
+            try
+            {
+                return File.Exists(Path.Combine(folderPath, "Definition.json")) ||
+                       Directory.GetFiles(folderPath, "*.fuse.json", SearchOption.TopDirectoryOnly).Length > 0 ||
+                       Directory.GetFiles(folderPath, "*.bson", SearchOption.TopDirectoryOnly).Length > 0;
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                FuseLog.Exception($"FUSE could not inspect malformed package folder '{folderPath}'", ex);
+                return false;
+            }
+        }
+
+        private static string InferManifestFaultJsonPath(FusePackageManifest manifest, string message)
+        {
+            if (message?.IndexOf("requires", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return manifest != null && manifest.IsLegacyDataPackage ? "requires" : "FuseRequires";
+            }
+
+            if (message?.IndexOf("LoadAfter", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return manifest != null && manifest.IsLegacyDataPackage ? "loadAfter" : "FuseLoadAfter";
+            }
+
+            if (message?.IndexOf("LoadBefore", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return manifest != null && manifest.IsLegacyDataPackage ? "loadBefore" : "FuseLoadBefore";
+            }
+
+            if (message?.IndexOf("conflictsWith", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return manifest != null && manifest.IsLegacyDataPackage ? "conflictsWith" : "FuseConflictsWith";
+            }
+
+            if (message?.IndexOf("FuseDataFile", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return "FuseDataFiles";
+            }
+
+            return string.Empty;
+        }
+
+        private static string SuggestedActionForManifestFault(string message)
+        {
+            if (message?.IndexOf("FuseDataFile", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return "Correct the FuseDataFile/FuseDataFiles value in Info.json, then reload package discovery.";
+            }
+
+            if (message?.IndexOf("requires", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return "Install and enable the named dependency, or correct this package's required dependency id.";
+            }
+
+            if (message?.IndexOf("LoadAfter", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                message?.IndexOf("LoadBefore", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return "Correct the load-order id or install and enable the referenced package.";
+            }
+
+            if (message?.IndexOf("conflictsWith", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return "Disable one of the author-declared incompatible packages, or correct the conflictsWith declaration if the packages are compatible.";
+            }
+
+            return "Correct the reported package manifest problem, then reload package discovery.";
         }
 
         private static IReadOnlyList<FusePackageManifest> SortPackages(IReadOnlyList<FusePackageManifest> packages)
@@ -441,7 +577,7 @@ namespace FUSE.Loading
                 .ThenBy(package => package.Id, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(package => package.FolderPath, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
-            if (fallbackOrder.Length <= 1)
+            if (fallbackOrder.Length == 0)
             {
                 return fallbackOrder;
             }
@@ -460,6 +596,52 @@ namespace FUSE.Loading
                 FuseLog.Warning($"FUSE {message}");
             }
 
+            var installedMods = FuseModRequirementResolver.CollectInstalledMods();
+            foreach (var package in fallbackOrder)
+            {
+                foreach (var conflict in package.ConflictsWith ?? Array.Empty<FuseModRequirement>())
+                {
+                    string conflictingId;
+                    string conflictingVersion;
+                    string conflictingSource;
+                    if (TryResolvePackage(byId, conflict?.Id, out var conflictingPackage) &&
+                        !ReferenceEquals(package, conflictingPackage) &&
+                        IsDeclaredConflictMatch(
+                            conflict,
+                            conflictingPackage.Id,
+                            conflictingPackage.Version,
+                            conflictingPackage.Disabled))
+                    {
+                        conflictingId = conflictingPackage.Id;
+                        conflictingVersion = conflictingPackage.Version;
+                        conflictingSource = "discovered data package";
+                    }
+                    else if (TryMatchInstalledConflict(
+                                 package.Id,
+                                 package.FolderPath,
+                                 conflict,
+                                 installedMods,
+                                 out var installed))
+                    {
+                        conflictingId = installed.Id;
+                        conflictingVersion = installed.Version;
+                        conflictingSource = installed.Source;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+
+                    var bounds = FormatVersionBounds(conflict);
+                    var message =
+                        $"Package '{package.Id}' conflictsWith '{conflict.Id}'{bounds}; " +
+                        $"matching package '{conflictingId}' version '{conflictingVersion}' is enabled " +
+                        $"(source: {conflictingSource}).";
+                    package.Faults.Add(message);
+                    FuseLog.Warning($"FUSE {message}");
+                }
+            }
+
             var outgoing = fallbackOrder.ToDictionary(package => package, _ => new HashSet<FusePackageManifest>());
             var incomingCount = fallbackOrder.ToDictionary(package => package, _ => 0);
 
@@ -467,7 +649,7 @@ namespace FUSE.Loading
             {
                 foreach (var dependencyId in package.RequiredPackageIds)
                 {
-                    if (byId.TryGetValue(dependencyId, out var dependency))
+                    if (TryResolvePackage(byId, dependencyId, out var dependency))
                     {
                         if (dependency.Disabled)
                         {
@@ -478,6 +660,14 @@ namespace FUSE.Loading
                         }
 
                         AddPackageOrderEdge(dependency, package, outgoing, incomingCount);
+                        continue;
+                    }
+
+                    if (FuseReplacementCapabilityCatalog.IsProvided(dependencyId))
+                    {
+                        FuseLog.Info(
+                            $"FUSE dependency '{dependencyId}' required by '{package.Id}' is supplied by the FUSE runtime; " +
+                            "the runtime initializes before data packages, so no package load-order edge was needed.");
                         continue;
                     }
 
@@ -496,7 +686,7 @@ namespace FUSE.Loading
 
                 foreach (var dependencyId in package.LoadAfter)
                 {
-                    if (byId.TryGetValue(dependencyId, out var dependency))
+                    if (TryResolvePackage(byId, dependencyId, out var dependency))
                     {
                         if (dependency.Disabled)
                         {
@@ -515,6 +705,12 @@ namespace FUSE.Loading
 
                         AddPackageOrderEdge(dependency, package, outgoing, incomingCount);
                     }
+                    else if (FuseReplacementCapabilityCatalog.IsProvided(dependencyId))
+                    {
+                        FuseLog.Info(
+                            $"FUSE loadAfter '{dependencyId}' declared by '{package.Id}' resolves to a FUSE runtime replacement; " +
+                            "the runtime is already initialized before this package.");
+                    }
                     else
                     {
                         var message = $"Package '{package.Id}' declares FuseLoadAfter '{dependencyId}', but no matching FUSE data package was discovered.";
@@ -532,7 +728,7 @@ namespace FUSE.Loading
 
                 foreach (var dependencyId in package.LoadBefore)
                 {
-                    if (byId.TryGetValue(dependencyId, out var dependency))
+                    if (TryResolvePackage(byId, dependencyId, out var dependency))
                     {
                         if (dependency.Disabled)
                         {
@@ -550,6 +746,14 @@ namespace FUSE.Loading
                         }
 
                         AddPackageOrderEdge(package, dependency, outgoing, incomingCount);
+                    }
+                    else if (FuseReplacementCapabilityCatalog.IsProvided(dependencyId))
+                    {
+                        var message =
+                            $"Package '{package.Id}' declares loadBefore '{dependencyId}', but '{dependencyId}' is a FUSE runtime replacement " +
+                            "that necessarily initializes before data packages.";
+                        package.Faults.Add(message);
+                        FuseLog.Warning($"FUSE {message}");
                     }
                     else
                     {
@@ -605,6 +809,117 @@ namespace FUSE.Loading
             return result;
         }
 
+        private static bool TryResolvePackage(
+            IReadOnlyDictionary<string, FusePackageManifest> packagesById,
+            string dependencyId,
+            out FusePackageManifest package)
+        {
+            package = null;
+            if (packagesById == null || string.IsNullOrWhiteSpace(dependencyId))
+            {
+                return false;
+            }
+
+            if (packagesById.TryGetValue(dependencyId.Trim(), out package))
+            {
+                return true;
+            }
+
+            package = packagesById.Values.FirstOrDefault(candidate =>
+                FuseDeclaredPackageRelationship.SamePackageId(candidate?.Id, dependencyId));
+            return package != null;
+        }
+
+        internal static bool IsDeclaredConflictMatch(
+            FuseModRequirement conflict,
+            string targetId,
+            string targetVersion,
+            bool targetDisabled)
+        {
+            if (conflict == null || string.IsNullOrWhiteSpace(conflict.Id) ||
+                string.IsNullOrWhiteSpace(targetId) || targetDisabled ||
+                !FuseDeclaredPackageRelationship.SamePackageId(conflict.Id, targetId))
+            {
+                return false;
+            }
+
+            var installed = new FuseModRequirementResolver.InstalledMod
+            {
+                Id = targetId,
+                Version = targetVersion ?? string.Empty,
+                Source = "discovered data package"
+            };
+            return FuseModRequirementResolver.VersionSatisfies(
+                "declared-conflict",
+                conflict,
+                installed,
+                out _);
+        }
+
+        internal static bool TryMatchInstalledConflict(
+            string declaringPackageId,
+            string declaringFolderPath,
+            FuseModRequirement conflict,
+            Dictionary<string, FuseModRequirementResolver.InstalledMod> installedMods,
+            out FuseModRequirementResolver.InstalledMod installed)
+        {
+            installed = null;
+            if (string.IsNullOrWhiteSpace(declaringPackageId) || conflict == null || string.IsNullOrWhiteSpace(conflict.Id) ||
+                !FuseModRequirementResolver.TryFindInstalled(conflict.Id, installedMods, out var candidate))
+            {
+                return false;
+            }
+
+            if (FuseDeclaredPackageRelationship.SamePackageId(declaringPackageId, candidate.Id) ||
+                (!string.IsNullOrWhiteSpace(declaringFolderPath) &&
+                 !string.IsNullOrWhiteSpace(candidate.FolderPath) &&
+                 string.Equals(
+                     NormalizePackagePath(declaringFolderPath),
+                     NormalizePackagePath(candidate.FolderPath),
+                     StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+
+            if (!candidate.IsReplacementCapability &&
+                !IsDeclaredConflictMatch(conflict, candidate.Id, candidate.Version, targetDisabled: false))
+            {
+                return false;
+            }
+
+            installed = candidate;
+            return true;
+        }
+
+        private static string NormalizePackagePath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                return Path.GetFullPath(path)
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+            catch
+            {
+                return path.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+        }
+
+        private static string FormatVersionBounds(FuseModRequirement reference)
+        {
+            if (reference == null ||
+                (string.IsNullOrWhiteSpace(reference.NotBefore) && string.IsNullOrWhiteSpace(reference.NotAfter)))
+            {
+                return string.Empty;
+            }
+
+            return $" (notBefore='{reference.NotBefore ?? string.Empty}', notAfter='{reference.NotAfter ?? string.Empty}')";
+        }
+
         private static void AddPackageOrderEdge(
             FusePackageManifest before,
             FusePackageManifest after,
@@ -655,6 +970,10 @@ namespace FUSE.Loading
                 .Select(id => id.Trim())
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
+            foreach (var dependencyId in wanted.Where(FuseReplacementCapabilityCatalog.IsProvided))
+            {
+                present.Add(dependencyId);
+            }
             if (wanted.Length == 0)
             {
                 return present;
@@ -712,6 +1031,11 @@ namespace FUSE.Loading
             if (string.IsNullOrWhiteSpace(dependencyId))
             {
                 return false;
+            }
+
+            if (FuseReplacementCapabilityCatalog.IsProvided(dependencyId))
+            {
+                return true;
             }
 
             var modsRoot = GetModsRoot();
@@ -881,6 +1205,35 @@ namespace FUSE.Loading
             return result
                 .Where(id => !string.IsNullOrWhiteSpace(id))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        private static FuseModRequirement[] ReadPackageReferences(JToken token)
+        {
+            if (token == null)
+            {
+                return Array.Empty<FuseModRequirement>();
+            }
+
+            IEnumerable<JToken> items = token.Type == JTokenType.Array
+                ? token.Children()
+                : new[] { token };
+            return items
+                .Select(item => item.Type == JTokenType.String
+                    ? new FuseModRequirement { Id = ((string)item)?.Trim() }
+                    : new FuseModRequirement
+                    {
+                        Id = ((string)item["Id"] ?? (string)item["id"])?.Trim(),
+                        NotBefore = ((string)item["NotBefore"] ?? (string)item["notBefore"])?.Trim(),
+                        NotAfter = ((string)item["NotAfter"] ?? (string)item["notAfter"])?.Trim()
+                    })
+                .Where(reference => !string.IsNullOrWhiteSpace(reference.Id))
+                .GroupBy(reference =>
+                    (reference.Id ?? string.Empty) + "\0" +
+                    (reference.NotBefore ?? string.Empty) + "\0" +
+                    (reference.NotAfter ?? string.Empty),
+                    StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
                 .ToArray();
         }
 
@@ -1083,10 +1436,13 @@ namespace FUSE.Loading
             public string DisplayName { get; set; }
             public string Version { get; set; }
             public string FolderPath { get; set; }
+            public string ManifestPath { get; set; } = string.Empty;
+            public Exception ManifestReadException { get; set; }
             public int Priority { get; set; }
             public string[] RequiredPackageIds { get; set; } = Array.Empty<string>();
             public string[] LoadAfter { get; set; } = Array.Empty<string>();
             public string[] LoadBefore { get; set; } = Array.Empty<string>();
+            public FuseModRequirement[] ConflictsWith { get; set; } = Array.Empty<FuseModRequirement>();
             public bool Disabled { get; set; }
             public string DisabledReason { get; set; } = string.Empty;
             public bool IsLegacyDataPackage { get; set; }
@@ -1106,10 +1462,17 @@ namespace FUSE.Loading
         public int Priority { get; set; }
         public string[] LoadAfter { get; set; } = Array.Empty<string>();
         public string[] LoadBefore { get; set; } = Array.Empty<string>();
+        public string[] RequiredPackageIds { get; set; } = Array.Empty<string>();
+        public FuseModRequirement[] ConflictsWith { get; set; } = Array.Empty<FuseModRequirement>();
         public bool Disabled { get; set; }
         public string DisabledReason { get; set; } = string.Empty;
         public bool IsLegacyConverted { get; set; }
         public bool IsLegacyHosted { get; set; }
         public string[] Faults { get; set; } = Array.Empty<string>();
+        public bool LoadedFromDisk { get; set; }
+        public bool AppliedToRuntime { get; set; }
+        public string SkipReason { get; set; } = string.Empty;
+        public string[] SkipReasons { get; set; } = Array.Empty<string>();
+        public string[] RuntimeFaults { get; set; } = Array.Empty<string>();
     }
 }

--- a/FUSE/Loading/FuseDataPackageDiscovery.cs
+++ b/FUSE/Loading/FuseDataPackageDiscovery.cs
@@ -164,7 +164,6 @@ namespace FUSE.Loading
                 if (manifest.Disabled)
                 {
                     FusePackageFaultRegistry.MarkDisabled(manifest.Id, manifest.DisabledReason);
-                    FusePackageFaultRegistry.MarkSkipped(manifest.Id, manifest.DisabledReason);
                     FuseLog.Warning($"FUSE skipped disabled data package '{manifest.Id}' path='{packagePath}' reason='{manifest.DisabledReason}'.");
                     continue;
                 }
@@ -599,6 +598,11 @@ namespace FUSE.Loading
             var installedMods = FuseModRequirementResolver.CollectInstalledMods();
             foreach (var package in fallbackOrder)
             {
+                if (package.Disabled)
+                {
+                    continue;
+                }
+
                 foreach (var conflict in package.ConflictsWith ?? Array.Empty<FuseModRequirement>())
                 {
                     string conflictingId;
@@ -647,6 +651,15 @@ namespace FUSE.Loading
 
             foreach (var package in fallbackOrder)
             {
+                // Disabled packages stay in the lookup table so an enabled package
+                // that requires one can report that dependency accurately. Their
+                // own requirements and order declarations are intentionally inert:
+                // a profile-disabled package must not fault the active mod set.
+                if (package.Disabled)
+                {
+                    continue;
+                }
+
                 foreach (var dependencyId in package.RequiredPackageIds)
                 {
                     if (TryResolvePackage(byId, dependencyId, out var dependency))

--- a/FUSE/Loading/FuseDeclaredPackageRelationship.cs
+++ b/FUSE/Loading/FuseDeclaredPackageRelationship.cs
@@ -1,0 +1,68 @@
+using FUSE.Authoring.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// Classifies an override as expected only when the resolved package graph
+    /// placed the overriding package after a package it explicitly requires or
+    /// names in loadAfter (or the base names it in loadBefore).
+    /// </summary>
+    internal static class FuseDeclaredPackageRelationship
+    {
+        internal static bool IsExpectedLaterOverride(
+            FusePackageManifestSnapshot existingPackage,
+            FusePackageManifestSnapshot laterPackage,
+            FuseModDefinition existingDefinition = null,
+            FuseModDefinition laterDefinition = null)
+        {
+            if (existingPackage == null || laterPackage == null ||
+                SamePackageId(existingPackage.Id, laterPackage.Id))
+            {
+                return false;
+            }
+
+            // Snapshot order is the final topological order. If both values are
+            // populated, do not call a contradicted declaration "expected".
+            if (existingPackage.Order > 0 && laterPackage.Order > 0 &&
+                laterPackage.Order <= existingPackage.Order)
+            {
+                return false;
+            }
+
+            return ContainsPackageId(laterPackage.RequiredPackageIds, existingPackage.Id) ||
+                   ContainsPackageId(laterPackage.LoadAfter, existingPackage.Id) ||
+                   ContainsPackageId(existingPackage.LoadBefore, laterPackage.Id) ||
+                   ContainsPackageId(
+                       laterDefinition?.Mixinto?.Requires?.Select(requirement => requirement?.Id),
+                       existingPackage.Id);
+        }
+
+        internal static bool ContainsPackageId(IEnumerable<string> values, string expected)
+        {
+            return !string.IsNullOrWhiteSpace(expected) &&
+                   (values ?? Enumerable.Empty<string>()).Any(value => SamePackageId(value, expected));
+        }
+
+        internal static bool SamePackageId(string left, string right)
+        {
+            return !string.IsNullOrWhiteSpace(left) &&
+                   !string.IsNullOrWhiteSpace(right) &&
+                   string.Equals(NormalizePackageId(left), NormalizePackageId(right), StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string NormalizePackageId(string value)
+        {
+            value = (value ?? string.Empty).Trim();
+            if (value.EndsWith(".FUSE", StringComparison.OrdinalIgnoreCase) ||
+                value.EndsWith(".RAIL", StringComparison.OrdinalIgnoreCase))
+            {
+                return value.Substring(0, value.Length - 5);
+            }
+
+            return value;
+        }
+    }
+}

--- a/FUSE/Loading/FuseDefinitionFileDiscovery.cs
+++ b/FUSE/Loading/FuseDefinitionFileDiscovery.cs
@@ -20,6 +20,7 @@ namespace FUSE.Loading
             "Catalog.json",
             "Definitions.json",
             "Definition.json",
+            "registry.json",
             "bridge_state.json",
             "bridge_command.json",
             "test_state.json"

--- a/FUSE/Loading/FuseFeatureRuleEvaluator.cs
+++ b/FUSE/Loading/FuseFeatureRuleEvaluator.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using FUSE.Authoring.Data;
+using FUSE.Infrastructure;
+using Newtonsoft.Json.Linq;
+
+namespace FUSE.Loading
+{
+    public sealed class FuseFeatureEvaluation
+    {
+        public int RuleCount { get; internal set; }
+        public int EnabledRuleCount { get; internal set; }
+        public int DisabledRuleCount { get; internal set; }
+        public int RemovedObjectCount { get; internal set; }
+        public string[] DisabledRuleIds { get; internal set; } = Array.Empty<string>();
+
+        public string Summary => RuleCount == 0
+            ? "No feature rules declared."
+            : $"{EnabledRuleCount} enabled, {DisabledRuleCount} disabled; {RemovedObjectCount} authored object(s) omitted until reload.";
+    }
+
+    internal static class FuseFeatureRuleEvaluator
+    {
+        internal static FuseFeatureEvaluation Apply(FuseModDefinition definition)
+        {
+            return Apply(
+                definition,
+                (key, setting) => FuseModSettingsStore.GetValue(definition, key, setting));
+        }
+
+        internal static FuseFeatureEvaluation Apply(
+            FuseModDefinition definition,
+            Func<string, FuseModSettingDefinition, JToken> valueResolver)
+        {
+            if (definition == null)
+                throw new ArgumentNullException(nameof(definition));
+            if (valueResolver == null)
+                throw new ArgumentNullException(nameof(valueResolver));
+
+            var evaluation = new FuseFeatureEvaluation();
+            var disabled = new List<string>();
+            foreach (var pair in (definition.FeatureRules ?? new Dictionary<string, FuseFeatureRule>())
+                .OrderBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                var rule = pair.Value;
+                evaluation.RuleCount++;
+                definition.Settings.TryGetValue(rule.Setting, out var setting);
+                var current = valueResolver(rule.Setting, setting);
+                if (Matches(current, rule.Operator, rule.Value))
+                {
+                    evaluation.EnabledRuleCount++;
+                    continue;
+                }
+
+                evaluation.DisabledRuleCount++;
+                disabled.Add(pair.Key);
+                evaluation.RemovedObjectCount += RemoveTargets(definition, rule.Targets);
+            }
+
+            evaluation.DisabledRuleIds = disabled.ToArray();
+            return evaluation;
+        }
+
+        internal static bool Matches(JToken current, string rawOperator, JToken expected)
+        {
+            var operation = string.IsNullOrWhiteSpace(rawOperator)
+                ? "equals"
+                : rawOperator.Trim();
+            if (operation.Equals("equals", StringComparison.OrdinalIgnoreCase))
+                return ValuesEqual(current, expected);
+            if (operation.Equals("notEquals", StringComparison.OrdinalIgnoreCase))
+                return !ValuesEqual(current, expected);
+
+            if (!TryNumber(current, out var actual) || !TryNumber(expected, out var target))
+                return false;
+            if (operation.Equals("greaterThan", StringComparison.OrdinalIgnoreCase))
+                return actual > target;
+            if (operation.Equals("greaterThanOrEqual", StringComparison.OrdinalIgnoreCase))
+                return actual >= target;
+            if (operation.Equals("lessThan", StringComparison.OrdinalIgnoreCase))
+                return actual < target;
+            if (operation.Equals("lessThanOrEqual", StringComparison.OrdinalIgnoreCase))
+                return actual <= target;
+            return false;
+        }
+
+        private static bool ValuesEqual(JToken left, JToken right)
+        {
+            if (TryNumber(left, out var leftNumber) && TryNumber(right, out var rightNumber))
+                return Math.Abs(leftNumber - rightNumber) <= 0.0000001d;
+            return JToken.DeepEquals(left, right);
+        }
+
+        private static bool TryNumber(JToken value, out double number)
+        {
+            number = 0d;
+            if (value == null)
+                return false;
+            if (value.Type == JTokenType.Integer || value.Type == JTokenType.Float)
+            {
+                number = value.Value<double>();
+                return !double.IsNaN(number) && !double.IsInfinity(number);
+            }
+            return double.TryParse(
+                value.Type == JTokenType.String ? value.Value<string>() : value.ToString(),
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out number) && !double.IsNaN(number) && !double.IsInfinity(number);
+        }
+
+        private static int RemoveTargets(FuseModDefinition definition, FuseFeatureTargets targets)
+        {
+            if (targets == null)
+                return 0;
+            var removed = 0;
+            removed += Remove(definition.Tracks.Nodes, targets.TrackNodes);
+            removed += Remove(definition.Tracks.Segments, targets.TrackSegments);
+            removed += Remove(definition.Tracks.Spans, targets.TrackSpans);
+            removed += Remove(definition.Tracks.Areas, targets.TrackAreas);
+            removed += Remove(definition.Operations.Loads, targets.Loads);
+            removed += Remove(definition.Operations.Industries, targets.Industries);
+            removed += RemoveIndustryComponents(definition, targets.IndustryComponents);
+            removed += Remove(definition.Operations.Loaders, targets.Loaders);
+            removed += Remove(definition.Operations.Turntables, targets.Turntables);
+            removed += Remove(definition.Operations.Stations, targets.Stations);
+            removed += Remove(definition.World.Scenery, targets.Scenery);
+            removed += Remove(definition.World.Splineys, targets.Splineys);
+            removed += Remove(definition.World.WaterSurfaces, targets.WaterSurfaces);
+            removed += Remove(definition.World.TelegraphPoles, targets.TelegraphPoles);
+            removed += Remove(definition.World.MapLabels, targets.MapLabels);
+            removed += Remove(definition.World.MapMasks, targets.MapMasks);
+            removed += Remove(definition.World.MapTiles, targets.MapTiles);
+            removed += Remove(definition.World.SceneClones, targets.SceneClones);
+            removed += Remove(definition.Progression.Progressions, targets.Progressions);
+            removed += Remove(definition.Progression.MapFeatures, targets.MapFeatures);
+            removed += Remove(definition.Audio.Whistles, targets.Whistles);
+            removed += Remove(definition.Audio.Horns, targets.Horns);
+            removed += Remove(definition.Audio.Bells, targets.Bells);
+            return removed;
+        }
+
+        private static int RemoveIndustryComponents(FuseModDefinition definition, IEnumerable<string> ids)
+        {
+            var removed = 0;
+            foreach (var id in ids ?? Array.Empty<string>())
+            {
+                var separator = id.IndexOf('/');
+                if (separator <= 0 || separator == id.Length - 1)
+                    continue;
+                var industryId = id.Substring(0, separator);
+                var componentId = id.Substring(separator + 1);
+                if (definition.Operations.Industries.TryGetValue(industryId, out var industry) &&
+                    industry?.Components?.Remove(componentId) == true)
+                    removed++;
+            }
+            return removed;
+        }
+
+        private static int Remove<T>(IDictionary<string, T> values, IEnumerable<string> ids)
+        {
+            if (values == null)
+                return 0;
+            var removed = 0;
+            foreach (var id in ids ?? Array.Empty<string>())
+                if (!string.IsNullOrWhiteSpace(id) && values.Remove(id))
+                    removed++;
+            return removed;
+        }
+    }
+}

--- a/FUSE/Loading/FuseInstalledDependencyCatalog.cs
+++ b/FUSE/Loading/FuseInstalledDependencyCatalog.cs
@@ -1,0 +1,714 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using FUSE.Infrastructure;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// Builds the dependency view for every installed package, including
+    /// equipment and asset-only packages that are not FUSE data packages.
+    /// Network access deliberately lives in the installer; the in-game UI
+    /// consumes only manifests on disk and the installer's offline cache.
+    /// </summary>
+    internal static class FuseInstalledDependencyCatalog
+    {
+        internal const string MetadataDirectoryName = ".fuse-metadata";
+        internal const string MetadataFileName = "dependencies.json";
+
+        private static readonly Regex UmmVersionedRequirement = new Regex(
+            @"^(?<id>.+)-(?<version>\d+\.\d+\.\d+(?:\.\d+)?)(?:[^\d].*)?$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex NexusPageIdentity = new Regex(
+            @"https?://(?:www\.)?nexusmods\.com/(?:games/)?(?<game>[^/]+)/mods/(?<mod>\d+)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+        internal static IReadOnlyList<FuseInstalledPackageDependencySnapshot> DiscoverInstalledPackages()
+        {
+            var packages = DiscoverInstalledPackages(
+                FuseDataPackageDiscovery.GetModsRoot(),
+                FuseDataPackageDiscovery.GetPackageManifestSnapshots());
+            foreach (var package in packages)
+            {
+                if (package == null || string.IsNullOrWhiteSpace(package.FolderPath))
+                {
+                    continue;
+                }
+
+                package.Disabled = package.Disabled ||
+                    FuseUmmState.TryGetDisabledReason(package.FolderPath, package.Id, out _) ||
+                    !FuseModSetService.IsPackageEnabledByActiveSet(package.Id, package.FolderPath);
+            }
+
+            return packages;
+        }
+
+        internal static IReadOnlyList<FuseInstalledPackageDependencySnapshot> DiscoverInstalledPackages(
+            string modsRoot,
+            IReadOnlyList<FusePackageManifestSnapshot> fusePackages)
+        {
+            var packages = new List<FuseInstalledPackageDependencySnapshot>();
+            if (!string.IsNullOrWhiteSpace(modsRoot) && Directory.Exists(modsRoot))
+            {
+                string[] folders;
+                try
+                {
+                    folders = Directory.GetDirectories(modsRoot);
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    FuseLog.Exception($"FUSE could not inspect installed packages for the dependency graph in '{modsRoot}'", ex);
+                    folders = Array.Empty<string>();
+                }
+
+                foreach (var folder in folders)
+                {
+                    if (string.Equals(Path.GetFileName(folder), MetadataDirectoryName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    var package = ReadInstalledFolder(folder);
+                    if (package != null)
+                    {
+                        packages.Add(package);
+                    }
+                }
+
+                MergeOfflineMetadata(Path.Combine(modsRoot, MetadataDirectoryName, MetadataFileName), packages);
+            }
+
+            MergeFuseSnapshots(fusePackages, packages);
+            return packages
+                .Where(package => package != null && !string.IsNullOrWhiteSpace(package.Id))
+                .OrderBy(package => package.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(package => package.Id, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        private static FuseInstalledPackageDependencySnapshot ReadInstalledFolder(string folder)
+        {
+            var folderName = Path.GetFileName(folder) ?? string.Empty;
+            var package = new FuseInstalledPackageDependencySnapshot
+            {
+                Id = folderName,
+                DisplayName = folderName,
+                FolderName = folderName,
+                FolderPath = folder,
+                Category = "Mod",
+                ManifestSource = "folder"
+            };
+            var foundManifest = false;
+
+            var infoPath = Path.Combine(folder, "Info.json");
+            if (File.Exists(infoPath))
+            {
+                foundManifest = true;
+                TryMergeManifest(infoPath, package, isUmmInfo: true);
+            }
+
+            var definitionPath = Path.Combine(folder, "Definition.json");
+            if (File.Exists(definitionPath))
+            {
+                foundManifest = true;
+                TryMergeManifest(definitionPath, package, isUmmInfo: false);
+            }
+
+            if (!foundManifest)
+            {
+                return null;
+            }
+
+            ClassifyPackage(package);
+            return package;
+        }
+
+        private static void TryMergeManifest(
+            string path,
+            FuseInstalledPackageDependencySnapshot package,
+            bool isUmmInfo)
+        {
+            JObject manifest;
+            try
+            {
+                manifest = FuseLegacyDataConverter.ReadLegacyObject(path);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
+            {
+                package.AddFault($"{Path.GetFileName(path)} could not be read: {ex.GetBaseException().Message}");
+                return;
+            }
+
+            var id = ReadString(manifest, "Id", "id");
+            var name = ReadString(manifest, "DisplayName", "displayName", "Name", "name");
+            var version = ReadString(manifest, "Version", "version");
+            var homepage = ReadString(manifest, "Homepage", "homepage", "Website", "website", "url");
+            if (!string.IsNullOrWhiteSpace(id) &&
+                (isUmmInfo || string.Equals(package.Id, package.FolderName, StringComparison.OrdinalIgnoreCase)))
+            {
+                package.Id = id;
+            }
+
+            if (!string.IsNullOrWhiteSpace(name) &&
+                (isUmmInfo || string.Equals(package.DisplayName, package.FolderName, StringComparison.OrdinalIgnoreCase)))
+            {
+                package.DisplayName = name;
+            }
+
+            if (!string.IsNullOrWhiteSpace(version) &&
+                (isUmmInfo || string.IsNullOrWhiteSpace(package.Version)))
+            {
+                package.Version = version;
+            }
+
+            package.Disabled = package.Disabled ||
+                ReadBoolean(manifest, "FuseDisabled", false) ||
+                ReadBoolean(manifest, "Disabled", false) ||
+                ReadBoolean(manifest, "disabled", false) ||
+                !ReadBoolean(manifest, "Enabled", true) ||
+                !ReadBoolean(manifest, "enabled", true);
+            ApplyNexusIdentity(package, homepage);
+
+            var source = isUmmInfo ? "UMM Info.json" : "legacy Definition.json";
+            if (isUmmInfo)
+            {
+                package.ManifestSource = "UMM Info.json";
+                package.IsCodePlugin = !string.IsNullOrWhiteSpace(ReadString(manifest, "EntryMethod", "entryMethod")) ||
+                                       !string.IsNullOrWhiteSpace(ReadString(manifest, "AssemblyName", "assemblyName"));
+                AddEdges(package.Requirements, manifest["Requirements"] ?? manifest["requirements"], source, parseUmmVersion: true);
+                AddEdges(package.Requirements, manifest["FuseRequires"], "FUSE Info.json", parseUmmVersion: false);
+                AddEdges(package.LoadAfter, manifest["LoadAfter"], source, parseUmmVersion: false);
+                AddEdges(package.LoadAfter, manifest["FuseLoadAfter"], "FUSE Info.json", parseUmmVersion: false);
+                AddEdges(package.LoadBefore, manifest["FuseLoadBefore"], "FUSE Info.json", parseUmmVersion: false);
+            }
+            else
+            {
+                if (string.Equals(package.ManifestSource, "folder", StringComparison.OrdinalIgnoreCase))
+                {
+                    package.ManifestSource = source;
+                }
+
+                package.IsLegacy = true;
+                AddEdges(package.Requirements, manifest["requires"] ?? manifest["Requires"], source, parseUmmVersion: false);
+                AddEdges(package.LoadAfter, manifest["loadAfter"] ?? manifest["LoadAfter"], source, parseUmmVersion: false);
+                AddEdges(package.LoadBefore, manifest["loadBefore"] ?? manifest["LoadBefore"], source, parseUmmVersion: false);
+            }
+        }
+
+        private static void ClassifyPackage(FuseInstalledPackageDependencySnapshot package)
+        {
+            if (package.IsLegacy)
+            {
+                package.Category = "Legacy package";
+            }
+            else if (package.IsCodePlugin)
+            {
+                package.Category = "Code plugin";
+            }
+
+            if (!package.HasEdges)
+            {
+                return;
+            }
+
+            string[] definitionFiles;
+            try
+            {
+                definitionFiles = Directory.GetFiles(package.FolderPath, "Definitions.json", SearchOption.AllDirectories);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                package.AddFault($"AssetLoader metadata could not be inspected: {ex.GetBaseException().Message}");
+                return;
+            }
+
+            if (definitionFiles.Length == 0)
+            {
+                return;
+            }
+
+            package.Category = "Asset package";
+            package.HasAssetLoaderMetadata = true;
+            foreach (var path in definitionFiles)
+            {
+                try
+                {
+                    var text = File.ReadAllText(path);
+                    if (ContainsEquipmentKind(text))
+                    {
+                        package.Category = "Equipment";
+                        return;
+                    }
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    package.AddFault($"AssetLoader metadata '{path}' could not be read: {ex.GetBaseException().Message}");
+                }
+            }
+        }
+
+        private static bool ContainsEquipmentKind(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            return Regex.IsMatch(
+                text,
+                "\\\"kind\\\"\\s*:\\s*\\\"(?:Car|DieselLocomotive|SteamLocomotive|Locomotive|Tender)\\\"",
+                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        }
+
+        private static void AddEdges(
+            ICollection<FuseInstalledDependencyEdge> destination,
+            JToken token,
+            string source,
+            bool parseUmmVersion)
+        {
+            if (token == null || token.Type == JTokenType.Null)
+            {
+                return;
+            }
+
+            IEnumerable<JToken> entries = token.Type == JTokenType.Array
+                ? token.Children()
+                : new[] { token };
+            foreach (var entry in entries)
+            {
+                var edge = ReadEdge(entry, source, parseUmmVersion);
+                AddOrReplaceEdge(destination, edge);
+            }
+        }
+
+        private static FuseInstalledDependencyEdge ReadEdge(JToken token, string source, bool parseUmmVersion)
+        {
+            if (token == null)
+            {
+                return null;
+            }
+
+            string id;
+            string notBefore = string.Empty;
+            string notAfter = string.Empty;
+            var displayName = string.Empty;
+            var nexusModId = string.Empty;
+            if (token.Type == JTokenType.Object)
+            {
+                id = ReadString((JObject)token, "Id", "id", "packageId");
+                notBefore = ReadString((JObject)token, "NotBefore", "notBefore", "MinimumVersion", "minimumVersion");
+                notAfter = ReadString((JObject)token, "NotAfter", "notAfter", "MaximumVersion", "maximumVersion");
+                displayName = ReadString((JObject)token, "DisplayName", "displayName", "name");
+                nexusModId = ReadString((JObject)token, "NexusModId", "nexusModId", "modId");
+            }
+            else
+            {
+                id = token.Type == JTokenType.String ? ((string)token)?.Trim() : token.ToString().Trim();
+                if (parseUmmVersion && !string.IsNullOrWhiteSpace(id))
+                {
+                    var match = UmmVersionedRequirement.Match(id);
+                    if (match.Success)
+                    {
+                        id = match.Groups["id"].Value.Trim();
+                        notBefore = match.Groups["version"].Value.Trim();
+                    }
+                }
+            }
+
+            return string.IsNullOrWhiteSpace(id)
+                ? null
+                : new FuseInstalledDependencyEdge
+                {
+                    Id = id.Trim(),
+                    DisplayName = displayName,
+                    NotBefore = notBefore,
+                    NotAfter = notAfter,
+                    Source = source ?? string.Empty,
+                    NexusModId = nexusModId
+                };
+        }
+
+        private static void AddOrReplaceEdge(
+            ICollection<FuseInstalledDependencyEdge> destination,
+            FuseInstalledDependencyEdge edge)
+        {
+            if (destination == null || edge == null || string.IsNullOrWhiteSpace(edge.Id))
+            {
+                return;
+            }
+
+            var existing = destination.FirstOrDefault(candidate =>
+                FuseDeclaredPackageRelationship.SamePackageId(candidate?.Id, edge.Id));
+            if (existing == null)
+            {
+                destination.Add(edge);
+                return;
+            }
+
+            if (SourcePriority(edge.Source) <= SourcePriority(existing.Source))
+            {
+                return;
+            }
+
+            destination.Remove(existing);
+            destination.Add(edge);
+        }
+
+        private static int SourcePriority(string source)
+        {
+            if (source?.IndexOf("FUSE Info", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return 40;
+            }
+
+            if (source?.IndexOf("UMM Info", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return 30;
+            }
+
+            if (source?.IndexOf("Definition", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return 20;
+            }
+
+            return source?.IndexOf("Nexus", StringComparison.OrdinalIgnoreCase) >= 0 ? 10 : 0;
+        }
+
+        private static void MergeOfflineMetadata(
+            string path,
+            ICollection<FuseInstalledPackageDependencySnapshot> packages)
+        {
+            if (!File.Exists(path))
+            {
+                return;
+            }
+
+            JObject root;
+            try
+            {
+                root = FuseLegacyDataConverter.ReadLegacyObject(path);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
+            {
+                FuseLog.Exception($"FUSE could not read the offline dependency metadata cache '{path}'", ex);
+                return;
+            }
+
+            foreach (var token in (root["packages"] as JArray)?.OfType<JObject>() ?? Enumerable.Empty<JObject>())
+            {
+                var id = ReadString(token, "id", "Id");
+                var folderName = ReadString(token, "folder", "folderName");
+                var package = packages.FirstOrDefault(candidate =>
+                    (!string.IsNullOrWhiteSpace(folderName) && string.Equals(candidate.FolderName, folderName, StringComparison.OrdinalIgnoreCase)) ||
+                    (!string.IsNullOrWhiteSpace(id) && FuseDeclaredPackageRelationship.SamePackageId(candidate.Id, id)));
+                if (package == null)
+                {
+                    // A stale cache entry for an uninstalled mod must never
+                    // masquerade as an installed dependency provider.
+                    continue;
+                }
+
+                package.HasOfflineMetadata = true;
+                var source = token["source"] as JObject;
+                package.NexusUrl = ReadString(token, "nexusUrl", "url");
+                if (string.IsNullOrWhiteSpace(package.NexusUrl))
+                {
+                    package.NexusUrl = ReadString(source, "url");
+                }
+                package.NexusGameDomain = ReadString(source, "gameDomain", "game");
+                package.NexusModId = ReadString(source, "gameScopedModId", "nexusModId", "modId");
+                ApplyNexusIdentity(package, package.NexusUrl);
+                var packageSourceIsNexus = string.Equals(ReadString(source, "kind"), "nexus", StringComparison.OrdinalIgnoreCase);
+                // Nexus is only a fallback for manifests that provide no hard
+                // dependency list. If an author adds local requirements after
+                // an older install, stale cached edges must not remain active.
+                if (package.Requirements.Count == 0)
+                {
+                    AddEdges(package.Requirements, NexusOnly(token["requirements"], packageSourceIsNexus), "Nexus API cache", parseUmmVersion: false);
+                }
+                AddEdges(package.LoadAfter, NexusOnly(token["loadAfter"], packageSourceIsNexus), "Nexus API cache", parseUmmVersion: false);
+                AddEdges(package.LoadBefore, NexusOnly(token["loadBefore"], packageSourceIsNexus), "Nexus API cache", parseUmmVersion: false);
+                ClassifyPackage(package);
+            }
+        }
+
+        private static JToken NexusOnly(JToken token, bool packageSourceIsNexus)
+        {
+            if (token == null || packageSourceIsNexus)
+            {
+                return token;
+            }
+
+            IEnumerable<JToken> items = token.Type == JTokenType.Array
+                ? token.Children()
+                : new[] { token };
+            return new JArray(items.Where(item =>
+            {
+                if (!(item is JObject obj))
+                {
+                    return false;
+                }
+
+                var source = ReadString(obj, "source");
+                var id = ReadString(obj, "id", "Id");
+                return string.Equals(source, "nexus", StringComparison.OrdinalIgnoreCase) ||
+                       id.StartsWith("nexus:", StringComparison.OrdinalIgnoreCase);
+            }));
+        }
+
+        private static void MergeFuseSnapshots(
+            IReadOnlyList<FusePackageManifestSnapshot> fusePackages,
+            List<FuseInstalledPackageDependencySnapshot> packages)
+        {
+            foreach (var snapshot in fusePackages ?? Array.Empty<FusePackageManifestSnapshot>())
+            {
+                var package = packages.FirstOrDefault(candidate =>
+                    FuseDeclaredPackageRelationship.SamePackageId(candidate.Id, snapshot.Id) ||
+                    (!string.IsNullOrWhiteSpace(snapshot.FolderPath) &&
+                     string.Equals(candidate.FolderPath, snapshot.FolderPath, StringComparison.OrdinalIgnoreCase)));
+                if (package == null)
+                {
+                    package = new FuseInstalledPackageDependencySnapshot
+                    {
+                        Id = snapshot.Id,
+                        DisplayName = snapshot.DisplayName,
+                        Version = snapshot.Version,
+                        FolderName = snapshot.FolderName,
+                        FolderPath = snapshot.FolderPath
+                    };
+                    packages.Add(package);
+                }
+
+                package.Id = snapshot.Id;
+                package.DisplayName = string.IsNullOrWhiteSpace(snapshot.DisplayName) ? snapshot.Id : snapshot.DisplayName;
+                package.Version = snapshot.Version ?? package.Version;
+                package.Disabled = snapshot.Disabled;
+                package.IsFuseDataPackage = true;
+                package.IsLegacy = snapshot.IsLegacyConverted;
+                package.Category = snapshot.IsLegacyConverted ? "Legacy data package" : "FUSE data package";
+                package.ManifestSource = snapshot.IsLegacyConverted ? "legacy Definition.json" : "FUSE Info.json";
+                foreach (var dependency in snapshot.RequiredPackageIds ?? Array.Empty<string>())
+                {
+                    AddOrReplaceEdge(package.Requirements, new FuseInstalledDependencyEdge
+                    {
+                        Id = dependency,
+                        Source = package.ManifestSource
+                    });
+                }
+
+                foreach (var dependency in snapshot.LoadAfter ?? Array.Empty<string>())
+                {
+                    AddOrReplaceEdge(package.LoadAfter, new FuseInstalledDependencyEdge
+                    {
+                        Id = dependency,
+                        Source = package.ManifestSource
+                    });
+                }
+
+                foreach (var dependency in snapshot.LoadBefore ?? Array.Empty<string>())
+                {
+                    AddOrReplaceEdge(package.LoadBefore, new FuseInstalledDependencyEdge
+                    {
+                        Id = dependency,
+                        Source = package.ManifestSource
+                    });
+                }
+
+                foreach (var fault in snapshot.Faults ?? Array.Empty<string>())
+                {
+                    package.AddFault(fault);
+                }
+            }
+        }
+
+        internal static FuseInstalledPackageDependencySnapshot FindInstalled(
+            IEnumerable<FuseInstalledPackageDependencySnapshot> packages,
+            string dependencyId)
+        {
+            ParseNexusDependencyId(dependencyId, out var nexusGame, out var nexusModId);
+            return (packages ?? Enumerable.Empty<FuseInstalledPackageDependencySnapshot>())
+                .FirstOrDefault(candidate =>
+                    FuseDeclaredPackageRelationship.SamePackageId(candidate?.Id, dependencyId) ||
+                    string.Equals(candidate?.FolderName, dependencyId, StringComparison.OrdinalIgnoreCase) ||
+                    (!string.IsNullOrWhiteSpace(nexusModId) &&
+                     string.Equals(candidate?.NexusModId, nexusModId, StringComparison.OrdinalIgnoreCase) &&
+                     (string.IsNullOrWhiteSpace(nexusGame) ||
+                      string.Equals(candidate?.NexusGameDomain, nexusGame, StringComparison.OrdinalIgnoreCase))));
+        }
+
+        private static void ApplyNexusIdentity(FuseInstalledPackageDependencySnapshot package, string url)
+        {
+            if (package == null || string.IsNullOrWhiteSpace(url))
+            {
+                return;
+            }
+
+            var match = NexusPageIdentity.Match(url);
+            if (!match.Success)
+            {
+                return;
+            }
+
+            package.NexusUrl = url;
+            if (string.IsNullOrWhiteSpace(package.NexusGameDomain))
+            {
+                package.NexusGameDomain = match.Groups["game"].Value;
+            }
+
+            if (string.IsNullOrWhiteSpace(package.NexusModId))
+            {
+                package.NexusModId = match.Groups["mod"].Value;
+            }
+        }
+
+        private static void ParseNexusDependencyId(string dependencyId, out string game, out string modId)
+        {
+            game = string.Empty;
+            modId = string.Empty;
+            var parts = (dependencyId ?? string.Empty).Split(':');
+            if (parts.Length != 3 || !string.Equals(parts[0], "nexus", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            game = parts[1].Trim();
+            modId = parts[2].Trim();
+        }
+
+        internal static bool VersionSatisfies(
+            string installedVersion,
+            string notBefore,
+            string notAfter,
+            out bool versionReadable)
+        {
+            versionReadable = TryReadVersion(installedVersion, out var installed);
+            if (!versionReadable)
+            {
+                return string.IsNullOrWhiteSpace(notBefore) && string.IsNullOrWhiteSpace(notAfter);
+            }
+
+            if (!string.IsNullOrWhiteSpace(notBefore) &&
+                TryReadVersion(notBefore, out var minimum) &&
+                installed < minimum)
+            {
+                return false;
+            }
+
+            return string.IsNullOrWhiteSpace(notAfter) ||
+                   !TryReadVersion(notAfter, out var maximum) ||
+                   installed <= maximum;
+        }
+
+        private static bool TryReadVersion(string value, out Version version)
+        {
+            version = null;
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var match = Regex.Match(value, @"\d+(?:\.\d+){0,3}", RegexOptions.CultureInvariant);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            var parts = match.Value.Split('.').Take(4).ToList();
+            while (parts.Count < 2)
+            {
+                parts.Add("0");
+            }
+
+            return Version.TryParse(string.Join(".", parts), out version);
+        }
+
+        private static string ReadString(JObject obj, params string[] names)
+        {
+            if (obj == null)
+            {
+                return string.Empty;
+            }
+
+            foreach (var name in names ?? Array.Empty<string>())
+            {
+                var token = obj[name];
+                if (token == null || token.Type == JTokenType.Null)
+                {
+                    continue;
+                }
+
+                var value = token.Type == JTokenType.String ? (string)token : token.ToString();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    return value.Trim();
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private static bool ReadBoolean(JObject obj, string name, bool defaultValue)
+        {
+            var token = obj?[name];
+            if (token == null || token.Type == JTokenType.Null)
+            {
+                return defaultValue;
+            }
+
+            if (token.Type == JTokenType.Boolean)
+            {
+                return (bool)token;
+            }
+
+            return bool.TryParse(token.ToString(), out var value) ? value : defaultValue;
+        }
+    }
+
+    internal sealed class FuseInstalledPackageDependencySnapshot
+    {
+        public string Id { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public string Version { get; set; } = string.Empty;
+        public string FolderName { get; set; } = string.Empty;
+        public string FolderPath { get; set; } = string.Empty;
+        public string Category { get; set; } = "Mod";
+        public string ManifestSource { get; set; } = string.Empty;
+        public string NexusUrl { get; set; } = string.Empty;
+        public string NexusGameDomain { get; set; } = string.Empty;
+        public string NexusModId { get; set; } = string.Empty;
+        public bool Disabled { get; set; }
+        public bool IsLegacy { get; set; }
+        public bool IsCodePlugin { get; set; }
+        public bool IsFuseDataPackage { get; set; }
+        public bool HasAssetLoaderMetadata { get; set; }
+        public bool HasOfflineMetadata { get; set; }
+        public List<FuseInstalledDependencyEdge> Requirements { get; } = new List<FuseInstalledDependencyEdge>();
+        public List<FuseInstalledDependencyEdge> LoadAfter { get; } = new List<FuseInstalledDependencyEdge>();
+        public List<FuseInstalledDependencyEdge> LoadBefore { get; } = new List<FuseInstalledDependencyEdge>();
+        public List<string> Faults { get; } = new List<string>();
+        public bool HasEdges => Requirements.Count > 0 || LoadAfter.Count > 0 || LoadBefore.Count > 0;
+
+        internal void AddFault(string fault)
+        {
+            if (!string.IsNullOrWhiteSpace(fault) && !Faults.Contains(fault, StringComparer.OrdinalIgnoreCase))
+            {
+                Faults.Add(fault);
+            }
+        }
+    }
+
+    internal sealed class FuseInstalledDependencyEdge
+    {
+        public string Id { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public string NotBefore { get; set; } = string.Empty;
+        public string NotAfter { get; set; } = string.Empty;
+        public string Source { get; set; } = string.Empty;
+        public string NexusModId { get; set; } = string.Empty;
+    }
+}

--- a/FUSE/Loading/FuseLegacyAssemblyHost.cs
+++ b/FUSE/Loading/FuseLegacyAssemblyHost.cs
@@ -24,41 +24,16 @@ namespace FUSE.Loading
     {
         private static readonly Dictionary<string, HostedLegacyPlugin> HostedPlugins =
             new Dictionary<string, HostedLegacyPlugin>(StringComparer.OrdinalIgnoreCase);
+        // RailLoader captures its IUpdateHandler instances once after startup.
+        // Keep the same shape here: UpdateHostedPlugins runs every Unity frame,
+        // so enumerating Dictionary.Values.ToArray() and re-reflecting each type
+        // there produces permanent GC pressure in large mod sets.
+        private static HostedLegacyPlugin[] _hostedUpdatePlugins =
+            Array.Empty<HostedLegacyPlugin>();
 
         private static readonly List<IConsoleCommand> PendingConsoleCommands = new List<IConsoleCommand>();
-        // Package IDs that FUSE supersedes natively. When a legacy package
-        // declares itself (e.g. an old loader plugin we no longer host) or
-        // declares one of these as a dependency, the legacy-assembly host
-        // either skips the package itself or — for the dependency case at
-        // line ~399 — considers the dependency satisfied because FUSE
-        // provides the equivalent surface. Per the project's compat
-        // contract, FUSE shims the full public API of Railloader,
-        // StrangeCustoms, ConfusingSupplements, For Your Convenience, and
-        // Alina's Map Mod, so any of those package IDs appearing in a
-        // mod's "requires" must be treated as satisfied without needing
-        // the host binary on disk. Earlier revisions of this set omitted
-        // Zamu.ConfusingSupplements and Zamu.ForYourConvenience, which
-        // caused FUSE to skip every Foxy coal-patch package and any pack
-        // that built on the old For Your Convenience helpers — all of
-        // them must work day-1 of FUSE.
-        private static readonly HashSet<string> FuseReplacedLegacyPackages =
-            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            {
-                "AlinaNova21.AlinasMapMod",
-                "AlinaNova21.MapEditor",
-                "railroader",
-                "Railloader",
-                "RailLoader",
-                "Zamu.StrangeCustoms",
-                "Zamu.ConfusingSupplements",
-                "Zamu.ForYourConvenience",
-                // Defensive coverage for short-form / capitalization
-                // variants we have seen referenced in mod manifests.
-                "StrangeCustoms",
-                "ConfusingSupplements",
-                "ForYourConvenience"
-            };
-
+        private static readonly HashSet<string> ReportedLoadOrderCycles =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private static GameObject _startupHost;
         private static bool _consoleSurfaceUnavailableLogged;
 
@@ -249,16 +224,108 @@ namespace FUSE.Loading
                         continue;
                     }
 
-                    foreach (var fileReference in EnumerateMixintoReferences(property.Value))
+                    foreach (var entry in EnumerateMixintoEntries(property.Value))
                     {
-                        var mixintoPath = ResolvePackageFile(manifest.FolderPath, fileReference);
+                        if (!IsLegacyMixintoActive(manifest, entry))
+                        {
+                            continue;
+                        }
+
+                        var mixintoPath = ResolvePackageFile(manifest.FolderPath, entry.Reference);
                         if (!string.IsNullOrWhiteSpace(mixintoPath))
                         {
-                            yield return new ModMixinto(new FuseLegacyModDefinition(manifest), mixintoPath);
+                            yield return new ModMixinto(
+                                new FuseLegacyModDefinition(manifest),
+                                mixintoPath,
+                                MixintoType.File,
+                                entry.Requires,
+                                entry.ConflictsWith);
                         }
                     }
                 }
             }
+        }
+
+        internal static IReadOnlyCollection<IMod> EnumerateInstalledMods(
+            string modsRoot,
+            Func<string, string, bool> enabledByActiveSet = null)
+        {
+            var mods = new Dictionary<string, IMod>(StringComparer.OrdinalIgnoreCase);
+            var isEnabled = enabledByActiveSet ?? FuseModSetService.IsPackageEnabledByActiveSet;
+            if (!string.IsNullOrWhiteSpace(modsRoot) && Directory.Exists(modsRoot))
+            {
+                foreach (var manifest in DiscoverLegacyManifests(modsRoot))
+                {
+                    if (manifest == null || string.IsNullOrWhiteSpace(manifest.Id) ||
+                        FuseUmmState.TryGetDisabledReason(manifest.FolderPath, manifest.Id, out _) ||
+                        !isEnabled(manifest.Id, manifest.FolderPath))
+                    {
+                        continue;
+                    }
+
+                    mods[manifest.Id] = new FuseLegacyModDefinition(manifest);
+                }
+            }
+
+            // Old plugins commonly use context.Mods as a capability check. A
+            // FUSE-owned replacement must therefore be visible under the legacy
+            // package id even though its superseded DLL is intentionally absent.
+            var fuseVersion = typeof(FuseLegacyAssemblyHost).Assembly.GetName().Version?.ToString() ?? "1.0.0";
+            foreach (var replacedId in FuseReplacementCapabilityCatalog.AdvertisedPackageIds)
+            {
+                if (string.IsNullOrWhiteSpace(replacedId) || mods.ContainsKey(replacedId))
+                {
+                    continue;
+                }
+
+                mods[replacedId] = new FuseLegacyModDefinition(new FuseLegacyAssemblyManifest
+                {
+                    Id = replacedId,
+                    Name = replacedId,
+                    Version = fuseVersion,
+                    FolderPath = modsRoot ?? string.Empty
+                });
+            }
+
+            return mods.Values.ToArray();
+        }
+
+        internal static void UpdateHostedPlugins()
+        {
+            var updatePlugins = _hostedUpdatePlugins;
+            for (var index = 0; index < updatePlugins.Length; index++)
+            {
+                var hosted = updatePlugins[index];
+                if (hosted == null || hosted.Plugin == null || hosted.UpdateFaulted)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    hosted.InvokeUpdate();
+                }
+                catch (Exception ex)
+                {
+                    hosted.UpdateFaulted = true;
+                    FuseModExceptionRegistry.RecordContained(ex, hosted.Manifest.Id, "legacy host update");
+                    FuseLog.Exception(
+                        $"FUSE legacy support disabled the per-frame update callback for '{hosted.Type.FullName}' from '{hosted.Manifest.Id}' after it threw",
+                        ex);
+                }
+            }
+        }
+
+        private static bool ImplementsLegacyUpdateHandler(Type pluginType)
+        {
+            if (pluginType == null)
+            {
+                return false;
+            }
+
+            return typeof(IUpdateHandler).IsAssignableFrom(pluginType) ||
+                   pluginType.GetInterfaces().Any(candidate =>
+                       string.Equals(candidate.FullName, "Railloader.IUpdateHandler", StringComparison.Ordinal));
         }
 
         internal static void RegisterConsoleCommand(IConsoleCommand command)
@@ -317,6 +384,7 @@ namespace FUSE.Loading
             }
 
             HostedPlugins.Clear();
+            _hostedUpdatePlugins = Array.Empty<HostedLegacyPlugin>();
             PendingConsoleCommands.Clear();
             if (_startupHost != null)
             {
@@ -361,7 +429,16 @@ namespace FUSE.Loading
             try
             {
                 InvokePluginLifecycleMethod(plugin, nameof(LegacyPluginBase.OnEnable));
-                HostedPlugins[key] = new HostedLegacyPlugin(manifest, pluginType, plugin);
+                var hosted = new HostedLegacyPlugin(manifest, pluginType, plugin);
+                HostedPlugins[key] = hosted;
+                if (hosted.HasUpdateHandler)
+                {
+                    var existing = _hostedUpdatePlugins;
+                    var replacement = new HostedLegacyPlugin[existing.Length + 1];
+                    Array.Copy(existing, replacement, existing.Length);
+                    replacement[replacement.Length - 1] = hosted;
+                    _hostedUpdatePlugins = replacement;
+                }
                 FuseLog.Info(
                     $"FUSE legacy support enabled hosted old-loader plugin '{pluginType.FullName}' " +
                     $"from package '{manifest.Id}'. This is temporary legacy compatibility, not a native FUSE package.");
@@ -419,11 +496,32 @@ namespace FUSE.Loading
 
         private static bool IsLegacyPluginType(Type type)
         {
-            return type != null &&
-                   type.IsClass &&
-                   !type.IsAbstract &&
-                   (typeof(LegacyPluginBase).IsAssignableFrom(type) ||
-                    InheritsFromFullName(type, "Railloader.PluginBase"));
+            if (type == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                return type.IsClass &&
+                       !type.IsAbstract &&
+                       (typeof(LegacyPluginBase).IsAssignableFrom(type) ||
+                        InheritsFromFullName(type, "Railloader.PluginBase"));
+            }
+            catch (Exception ex) when (
+                ex is TypeLoadException ||
+                ex is FileLoadException ||
+                ex is FileNotFoundException ||
+                ex is BadImageFormatException)
+            {
+                // A UMM package can already have a stale, partially bound copy
+                // of its DLL in the AppDomain before recovery runs. Reflection
+                // over compiler-generated nested types may throw here even
+                // though FuseLegacyUmmRecovery subsequently activates the real
+                // entry. Treat that type as unhostable; the package-level host
+                // must not turn a recoverable probe into a mod error.
+                return false;
+            }
         }
 
         private static bool TryBuildLegacyConstructorArguments(
@@ -455,6 +553,12 @@ namespace FUSE.Loading
                     continue;
                 }
 
+                if (parameterType.IsInstanceOfType(FuseLegacyUIHelper.Shared))
+                {
+                    arguments[i] = FuseLegacyUIHelper.Shared;
+                    continue;
+                }
+
                 if (string.Equals(parameterType.FullName, "Railloader.IModdingContext", StringComparison.Ordinal))
                 {
                     arguments[i] = CreateRealModdingContextProxy(parameterType, context);
@@ -465,6 +569,12 @@ namespace FUSE.Loading
                     string.Equals(parameterType.FullName, "Railloader.IMod", StringComparison.Ordinal))
                 {
                     arguments[i] = CreateRealModDefinitionProxy(parameterType, definition);
+                    continue;
+                }
+
+                if (string.Equals(parameterType.FullName, "Railloader.IUIHelper", StringComparison.Ordinal))
+                {
+                    arguments[i] = CreateRealUIHelperProxy(parameterType);
                     continue;
                 }
 
@@ -536,6 +646,60 @@ namespace FUSE.Loading
                 InvokeRealModdingContext(context, method, args)).GetTransparentProxy();
         }
 
+        private static object CreateRealUIHelperProxy(Type interfaceType)
+        {
+            return new LegacyInterfaceProxy(interfaceType, InvokeRealUIHelper).GetTransparentProxy();
+        }
+
+        private static object InvokeRealUIHelper(MethodInfo method, object[] args)
+        {
+            if (method == null)
+            {
+                return null;
+            }
+
+            if (string.Equals(method.Name, "PopulateWindow", StringComparison.Ordinal))
+            {
+                return FuseLegacyUIHelper.Shared.PopulateWindow(
+                    args != null && args.Length > 0 ? args[0] as UI.Common.Window : null,
+                    args != null && args.Length > 1 ? args[1] as Action<UI.Builder.UIPanelBuilder> : null);
+            }
+
+            if (!string.Equals(method.Name, "CreateWindow", StringComparison.Ordinal))
+            {
+                return DefaultValue(method.ReturnType);
+            }
+
+            if (!method.IsGenericMethod)
+            {
+                if (args != null && args.Length == 3)
+                {
+                    return FuseLegacyUIHelper.Shared.CreateWindow(
+                        (int)args[0],
+                        (int)args[1],
+                        (UI.Common.Window.Position)args[2]);
+                }
+
+                if (args != null && args.Length == 4)
+                {
+                    return FuseLegacyUIHelper.Shared.CreateWindow(
+                        args[0] as string,
+                        (int)args[1],
+                        (int)args[2],
+                        (UI.Common.Window.Position)args[3]);
+                }
+            }
+
+            var genericArguments = method.GetGenericArguments();
+            var target = typeof(FuseLegacyUIHelper)
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                .Where(candidate => candidate.Name == "CreateWindow" && candidate.IsGenericMethodDefinition)
+                .FirstOrDefault(candidate => candidate.GetParameters().Length == (args?.Length ?? 0));
+            return target?.MakeGenericMethod(genericArguments).Invoke(
+                FuseLegacyUIHelper.Shared,
+                args ?? Array.Empty<object>());
+        }
+
         private static object InvokeRealModDefinition(FuseLegacyModDefinition definition, MethodInfo method)
         {
             switch (method?.Name)
@@ -549,10 +713,13 @@ namespace FUSE.Loading
                 case "get_Directory":
                     return definition.Directory;
                 case "get_LoadBefore":
-                    return Array.Empty<string>();
+                    return definition.LoadBefore;
                 case "get_LoadAfter":
+                    return ConvertModReferences(definition.LoadAfter, method.ReturnType);
                 case "get_Requires":
+                    return ConvertModReferences(definition.Requires, method.ReturnType);
                 case "get_ConflictsWith":
+                    return ConvertModReferences(definition.ConflictsWith, method.ReturnType);
                 case "get_Plugins":
                     return CreateEmptyArrayForReturnType(method.ReturnType);
                 case "get_IsEnabled":
@@ -576,7 +743,7 @@ namespace FUSE.Loading
                 case "get_ModsBaseDirectory":
                     return context.ModsBaseDirectory;
                 case "get_Mods":
-                    return CreateEmptyArrayForReturnType(method.ReturnType);
+                    return CreateRealModCollectionForReturnType(context.Mods, method.ReturnType);
                 case "RegisterConsoleCommand":
                     if (args != null && args.Length > 0 && args[0] is IConsoleCommand command)
                     {
@@ -593,16 +760,172 @@ namespace FUSE.Loading
                         args != null && args.Length > 1 ? args[1] : null);
                     return null;
                 case "GetMixintos":
-                    return CreateEmptyArrayForReturnType(method.ReturnType);
+                    return CreateRealMixintoCollectionForReturnType(context, method, args);
                 case "TryResolveFilePath":
                     return TryResolveFilePathFromProxy(context, method, args);
                 case "RegisterSubTypeOverload":
+                    RegisterLegacySubtypeFromProxy(method, args);
+                    return null;
                 case "RegisterComponent":
+                    RegisterLegacyComponentFromProxy(method, args);
                     return null;
                 case "ToString":
                     return "FUSE legacy Railloader context bridge";
                 default:
                     return DefaultValue(method?.ReturnType);
+            }
+        }
+
+        private static void RegisterLegacySubtypeFromProxy(MethodInfo method, object[] args)
+        {
+            var genericArguments = method?.GetGenericArguments() ?? Type.EmptyTypes;
+            if (genericArguments.Length == 2)
+            {
+                FuseLegacyTypeRegistry.RegisterSubType(
+                    genericArguments[0],
+                    args != null && args.Length > 0 ? args[0] as string : null,
+                    genericArguments[1]);
+                return;
+            }
+
+            if (args != null && args.Length >= 3)
+            {
+                FuseLegacyTypeRegistry.RegisterSubType(
+                    args[0] as Type,
+                    args[1] as string,
+                    args[2] as Type);
+                return;
+            }
+
+            throw new MissingMethodException("Unsupported legacy RegisterSubTypeOverload signature.");
+        }
+
+        private static void RegisterLegacyComponentFromProxy(MethodInfo method, object[] args)
+        {
+            var genericArguments = method?.GetGenericArguments() ?? Type.EmptyTypes;
+            if (genericArguments.Length != 2)
+            {
+                throw new MissingMethodException("Unsupported legacy RegisterComponent signature.");
+            }
+
+            FuseLegacyTypeRegistry.RegisterComponent(
+                genericArguments[0],
+                genericArguments[1],
+                args != null && args.Length > 0 ? args[0] as string : null);
+        }
+
+        private static object CreateRealModCollectionForReturnType(IReadOnlyCollection<IMod> mods, Type returnType)
+        {
+            var elementType = returnType?.IsArray == true
+                ? returnType.GetElementType()
+                : returnType?.GetGenericArguments().FirstOrDefault();
+            if (elementType == null)
+            {
+                return CreateEmptyArrayForReturnType(returnType);
+            }
+
+            var definitions = (mods ?? Array.Empty<IMod>()).OfType<FuseLegacyModDefinition>().ToArray();
+            var result = Array.CreateInstance(elementType, definitions.Length);
+            for (var index = 0; index < definitions.Length; index++)
+            {
+                result.SetValue(CreateRealModDefinitionProxy(elementType, definitions[index]), index);
+            }
+
+            return result;
+        }
+
+        private static object CreateRealMixintoCollectionForReturnType(
+            FuseLegacyModdingContext context,
+            MethodInfo method,
+            object[] args)
+        {
+            var targets = args != null && args.Length > 0 && args[0] is string[] many
+                ? many
+                : new[] { args != null && args.Length > 0 ? args[0] as string : null };
+            var mixintos = context.GetMixintos(targets).ToArray();
+            var elementType = method.ReturnType?.IsArray == true
+                ? method.ReturnType.GetElementType()
+                : method.ReturnType?.GetGenericArguments().FirstOrDefault();
+            if (elementType == null)
+            {
+                return CreateEmptyArrayForReturnType(method.ReturnType);
+            }
+
+            var result = Array.CreateInstance(elementType, mixintos.Length);
+            for (var index = 0; index < mixintos.Length; index++)
+            {
+                result.SetValue(ConvertMixintoForForeignContract(mixintos[index], elementType), index);
+            }
+
+            return result;
+        }
+
+        private static object ConvertMixintoForForeignContract(ModMixinto mixinto, Type targetType)
+        {
+            var converted = Activator.CreateInstance(targetType);
+            SetMemberValue(converted, targetType, "Mixinto", mixinto.Mixinto);
+            SetMemberValue(converted, targetType, "Type", ConvertEnumValue(mixinto.Type, GetMemberType(targetType, "Type")));
+
+            var sourceType = GetMemberType(targetType, "Source");
+            if (sourceType != null && mixinto.Source is FuseLegacyModDefinition source)
+            {
+                SetMemberValue(converted, targetType, "Source", CreateRealModDefinitionProxy(sourceType, source));
+            }
+
+            SetMemberValue(converted, targetType, "Requires", ConvertModReferences(mixinto.Requires, GetMemberType(targetType, "Requires")));
+            SetMemberValue(converted, targetType, "ConflictsWith", ConvertModReferences(mixinto.ConflictsWith, GetMemberType(targetType, "ConflictsWith")));
+            SetMemberValue(converted, targetType, "ManagedObject", mixinto.ManagedObject);
+            return converted;
+        }
+
+        private static object ConvertModReferences(ModReference[] references, Type targetType)
+        {
+            if (targetType?.IsArray != true)
+            {
+                return null;
+            }
+
+            var values = references ?? Array.Empty<ModReference>();
+            var elementType = targetType.GetElementType();
+            var result = Array.CreateInstance(elementType, values.Length);
+            for (var index = 0; index < values.Length; index++)
+            {
+                var converted = Activator.CreateInstance(elementType);
+                SetMemberValue(converted, elementType, "Id", values[index].Id);
+                SetMemberValue(converted, elementType, "NotBefore", values[index].NotBefore);
+                SetMemberValue(converted, elementType, "NotAfter", values[index].NotAfter);
+                result.SetValue(converted, index);
+            }
+
+            return result;
+        }
+
+        private static object ConvertEnumValue(object value, Type targetType)
+        {
+            return targetType?.IsEnum == true
+                ? Enum.ToObject(targetType, Convert.ToInt32(value))
+                : value;
+        }
+
+        private static Type GetMemberType(Type declaringType, string name)
+        {
+            return declaringType?.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.PropertyType ??
+                   declaringType?.GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.FieldType;
+        }
+
+        private static void SetMemberValue(object target, Type declaringType, string name, object value)
+        {
+            var property = declaringType?.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (property?.CanWrite == true && (value == null || property.PropertyType.IsInstanceOfType(value)))
+            {
+                property.SetValue(target, value, null);
+                return;
+            }
+
+            var field = declaringType?.GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (field != null && (value == null || field.FieldType.IsInstanceOfType(value)))
+            {
+                field.SetValue(target, value);
             }
         }
 
@@ -668,12 +991,128 @@ namespace FUSE.Loading
 
         private static IEnumerable<FuseLegacyAssemblyManifest> DiscoverLegacyManifests(string modsRoot)
         {
+            var manifests = new List<FuseLegacyAssemblyManifest>();
             foreach (var packagePath in Directory.GetDirectories(modsRoot).OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
             {
                 if (TryReadLegacyManifest(packagePath, out var manifest))
                 {
-                    yield return manifest;
+                    manifests.Add(manifest);
                 }
+            }
+
+            return OrderLegacyManifestsForHosting(manifests);
+        }
+
+        internal static IReadOnlyList<FuseLegacyAssemblyManifest> OrderLegacyManifestsForHosting(
+            IEnumerable<FuseLegacyAssemblyManifest> manifests)
+        {
+            var baseline = (manifests ?? Enumerable.Empty<FuseLegacyAssemblyManifest>())
+                .Where(manifest => manifest != null)
+                .OrderBy(manifest => manifest.FolderPath ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(manifest => manifest.Id ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (baseline.Length <= 1)
+            {
+                return baseline;
+            }
+
+            var baselineIndex = baseline
+                .Select((manifest, index) => new { manifest, index })
+                .ToDictionary(item => item.manifest, item => item.index);
+            var outgoing = baseline.ToDictionary(
+                manifest => manifest,
+                _ => new HashSet<FuseLegacyAssemblyManifest>());
+            var incoming = baseline.ToDictionary(manifest => manifest, _ => 0);
+
+            foreach (var manifest in baseline)
+            {
+                foreach (var reference in (manifest.RequiredReferences ?? Array.Empty<ModReference>())
+                             .Concat(manifest.LoadAfter ?? Array.Empty<ModReference>()))
+                {
+                    if (TryResolveLegacyManifest(baseline, reference.Id, out var dependency))
+                    {
+                        AddLegacyLoadOrderEdge(dependency, manifest, outgoing, incoming);
+                    }
+                }
+
+                foreach (var targetId in manifest.LoadBefore ?? Array.Empty<string>())
+                {
+                    if (TryResolveLegacyManifest(baseline, targetId, out var target))
+                    {
+                        AddLegacyLoadOrderEdge(manifest, target, outgoing, incoming);
+                    }
+                }
+            }
+
+            var ready = baseline
+                .Where(manifest => incoming[manifest] == 0)
+                .OrderBy(manifest => baselineIndex[manifest])
+                .ToList();
+            var ordered = new List<FuseLegacyAssemblyManifest>(baseline.Length);
+            while (ready.Count > 0)
+            {
+                var next = ready[0];
+                ready.RemoveAt(0);
+                ordered.Add(next);
+                foreach (var after in outgoing[next].OrderBy(manifest => baselineIndex[manifest]))
+                {
+                    incoming[after]--;
+                    if (incoming[after] == 0)
+                    {
+                        ready.Add(after);
+                        ready.Sort((left, right) => baselineIndex[left].CompareTo(baselineIndex[right]));
+                    }
+                }
+            }
+
+            if (ordered.Count == baseline.Length)
+            {
+                return ordered;
+            }
+
+            var cycleMembers = baseline.Where(manifest => !ordered.Contains(manifest)).ToArray();
+            var signature = string.Join(",", cycleMembers.Select(manifest => manifest.Id).OrderBy(id => id, StringComparer.OrdinalIgnoreCase));
+            if (ReportedLoadOrderCycles.Add(signature))
+            {
+                FuseLog.Warning(
+                    $"FUSE legacy support found a loadAfter/loadBefore cycle among '{signature}'. " +
+                    "A deterministic folder order will be used for the cycle; correct the declarations to guarantee plugin initialization order.");
+            }
+
+            ordered.AddRange(cycleMembers);
+            return ordered;
+        }
+
+        private static bool TryResolveLegacyManifest(
+            IEnumerable<FuseLegacyAssemblyManifest> manifests,
+            string id,
+            out FuseLegacyAssemblyManifest match)
+        {
+            match = null;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return false;
+            }
+
+            match = manifests.FirstOrDefault(candidate =>
+                candidate != null && FuseDeclaredPackageRelationship.SamePackageId(candidate.Id, id));
+            return match != null;
+        }
+
+        private static void AddLegacyLoadOrderEdge(
+            FuseLegacyAssemblyManifest before,
+            FuseLegacyAssemblyManifest after,
+            IDictionary<FuseLegacyAssemblyManifest, HashSet<FuseLegacyAssemblyManifest>> outgoing,
+            IDictionary<FuseLegacyAssemblyManifest, int> incoming)
+        {
+            if (before == null || after == null || ReferenceEquals(before, after))
+            {
+                return;
+            }
+
+            if (outgoing[before].Add(after))
+            {
+                incoming[after]++;
             }
         }
 
@@ -706,6 +1145,10 @@ namespace FUSE.Loading
                 FolderPath = folderPath,
                 Assemblies = ReadStringArray(definition["assemblies"] ?? definition["Assemblies"]).ToArray(),
                 Requires = ReadLegacyRequirementIds(definition["requires"] ?? definition["Requires"]).ToArray(),
+                RequiredReferences = ReadLegacyModReferences(definition["requires"] ?? definition["Requires"]).ToArray(),
+                LoadAfter = ReadLegacyModReferences(definition["loadAfter"] ?? definition["LoadAfter"]).ToArray(),
+                LoadBefore = ReadLegacyRequirementIds(definition["loadBefore"] ?? definition["LoadBefore"]).ToArray(),
+                ConflictsWith = ReadLegacyModReferences(definition["conflictsWith"] ?? definition["ConflictsWith"]).ToArray(),
                 RawDefinition = definition
             };
             return true;
@@ -723,7 +1166,7 @@ namespace FUSE.Loading
                 return false;
             }
 
-            if (FuseReplacedLegacyPackages.Contains(manifest.Id ?? string.Empty))
+            if (FuseReplacementCapabilityCatalog.IsProvided(manifest.Id))
             {
                 FuseLog.Info(
                     $"FUSE legacy support skipped old-loader package '{manifest.Id}' " +
@@ -753,25 +1196,78 @@ namespace FUSE.Loading
                 return false;
             }
 
-            foreach (var requirementId in manifest.Requires ?? Array.Empty<string>())
+            foreach (var requirement in manifest.RequiredReferences ?? Array.Empty<ModReference>())
             {
-                if (FuseReplacedLegacyPackages.Contains(requirementId ?? string.Empty))
+                if (FuseReplacementCapabilityCatalog.IsProvided(requirement.Id))
                 {
                     continue;
                 }
 
-                if (IsLegacyRequirementPresent(manifest, requirementId))
+                if (IsLegacyReferencePresent(manifest, requirement))
                 {
                     continue;
                 }
 
                 FuseLog.Warning(
                     $"FUSE legacy support skipped old-loader package '{manifest.Id}' " +
-                    $"because required legacy package '{requirementId}' is not installed or enabled.");
+                    $"because required legacy package '{requirement}' is not installed, enabled, or version-compatible.");
+                return false;
+            }
+
+            foreach (var conflict in manifest.ConflictsWith ?? Array.Empty<ModReference>())
+            {
+                if (!IsLegacyReferencePresent(manifest, conflict))
+                {
+                    continue;
+                }
+
+                FuseLog.Warning(
+                    $"FUSE legacy support skipped old-loader package '{manifest.Id}' because its conflictsWith " +
+                    $"reference '{conflict}' matches an enabled package. Disable one of the declared incompatible packages.");
                 return false;
             }
 
             return true;
+        }
+
+        private static bool IsLegacyReferencePresent(FuseLegacyAssemblyManifest manifest, ModReference reference)
+        {
+            if (manifest == null || string.IsNullOrWhiteSpace(reference.Id))
+            {
+                return false;
+            }
+
+            if (FuseReplacementCapabilityCatalog.IsProvided(reference.Id))
+            {
+                return true;
+            }
+
+            var modsRoot = Directory.GetParent(manifest.FolderPath)?.FullName;
+            if (string.IsNullOrWhiteSpace(modsRoot) || !Directory.Exists(modsRoot))
+            {
+                return false;
+            }
+
+            foreach (var packagePath in Directory.GetDirectories(modsRoot))
+            {
+                if (!TryReadLegacyManifest(packagePath, out var candidate) ||
+                    !FuseDeclaredPackageRelationship.SamePackageId(candidate.Id, reference.Id) ||
+                    FuseUmmState.TryGetDisabledReason(candidate.FolderPath, candidate.Id, out _) ||
+                    !FuseModSetService.IsPackageEnabledByActiveSet(candidate.Id, candidate.FolderPath))
+                {
+                    continue;
+                }
+
+                if (!FuseModRequirementResolver.TryParseVersion(candidate.Version, out var installedVersion))
+                {
+                    return true;
+                }
+
+                return (reference.NotBefore == null || installedVersion.CompareTo(reference.NotBefore) >= 0) &&
+                       (reference.NotAfter == null || installedVersion.CompareTo(reference.NotAfter) <= 0);
+            }
+
+            return false;
         }
 
         private static bool IsLegacyRequirementPresent(FuseLegacyAssemblyManifest manifest, string requirementId)
@@ -861,7 +1357,7 @@ namespace FUSE.Loading
             FuseLog.Warning($"FUSE legacy support console command registration is unavailable: {detail}");
         }
 
-        private static IEnumerable<string> EnumerateMixintoReferences(JToken token)
+        private static IEnumerable<FuseLegacyMixintoEntry> EnumerateMixintoEntries(JToken token)
         {
             if (token == null || token.Type == JTokenType.Null)
             {
@@ -873,7 +1369,7 @@ namespace FUSE.Loading
                 var reference = ExtractFileReference(token.Value<string>());
                 if (!string.IsNullOrWhiteSpace(reference))
                 {
-                    yield return reference;
+                    yield return new FuseLegacyMixintoEntry { Reference = reference };
                 }
 
                 yield break;
@@ -883,7 +1379,7 @@ namespace FUSE.Loading
             {
                 foreach (var item in array)
                 {
-                    foreach (var reference in EnumerateMixintoReferences(item))
+                    foreach (var reference in EnumerateMixintoEntries(item))
                     {
                         yield return reference;
                     }
@@ -900,13 +1396,20 @@ namespace FUSE.Loading
                     var reference = ExtractFileReference(direct);
                     if (!string.IsNullOrWhiteSpace(reference))
                     {
-                        yield return reference;
+                        yield return new FuseLegacyMixintoEntry
+                        {
+                            Reference = reference,
+                            Requires = ReadLegacyModReferences(obj["requires"] ?? obj["Requires"]).ToArray(),
+                            ConflictsWith = ReadLegacyModReferences(obj["conflictsWith"] ?? obj["ConflictsWith"]).ToArray()
+                        };
                     }
+
+                    yield break;
                 }
 
                 foreach (var property in obj.Properties())
                 {
-                    foreach (var reference in EnumerateMixintoReferences(property.Value))
+                    foreach (var reference in EnumerateMixintoEntries(property.Value))
                     {
                         yield return reference;
                     }
@@ -1121,16 +1624,120 @@ namespace FUSE.Loading
 
         private sealed class HostedLegacyPlugin
         {
+            private readonly IUpdateHandler _typedUpdateHandler;
+            private readonly MethodInfo _reflectedUpdateMethod;
+
             public HostedLegacyPlugin(FuseLegacyAssemblyManifest manifest, Type type, object plugin)
             {
                 Manifest = manifest;
                 Type = type;
                 Plugin = plugin;
+                _typedUpdateHandler = plugin as IUpdateHandler;
+                if (_typedUpdateHandler == null && ImplementsLegacyUpdateHandler(type))
+                {
+                    _reflectedUpdateMethod = type.GetMethod(
+                        nameof(IUpdateHandler.Update),
+                        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                        null,
+                        Type.EmptyTypes,
+                        null);
+                }
             }
 
             public FuseLegacyAssemblyManifest Manifest { get; }
             public Type Type { get; }
             public object Plugin { get; }
+            public bool UpdateFaulted { get; set; }
+            public bool HasUpdateHandler => _typedUpdateHandler != null || _reflectedUpdateMethod != null;
+
+            public void InvokeUpdate()
+            {
+                if (_typedUpdateHandler != null)
+                {
+                    _typedUpdateHandler.Update();
+                    return;
+                }
+
+                _reflectedUpdateMethod?.Invoke(Plugin, Array.Empty<object>());
+            }
+        }
+
+        private static bool IsLegacyMixintoActive(
+            FuseLegacyAssemblyManifest manifest,
+            FuseLegacyMixintoEntry entry)
+        {
+            if (entry == null)
+            {
+                return false;
+            }
+
+            foreach (var requirement in entry.Requires ?? Array.Empty<ModReference>())
+            {
+                if (!IsLegacyReferencePresent(manifest, requirement))
+                {
+                    return false;
+                }
+            }
+
+            foreach (var conflict in entry.ConflictsWith ?? Array.Empty<ModReference>())
+            {
+                if (IsLegacyReferencePresent(manifest, conflict))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private sealed class FuseLegacyMixintoEntry
+        {
+            public string Reference { get; set; }
+            public ModReference[] Requires { get; set; } = Array.Empty<ModReference>();
+            public ModReference[] ConflictsWith { get; set; } = Array.Empty<ModReference>();
+        }
+
+        private static IEnumerable<ModReference> ReadLegacyModReferences(JToken token)
+        {
+            if (token == null || token.Type == JTokenType.Null)
+            {
+                yield break;
+            }
+
+            if (token is JArray array)
+            {
+                foreach (var item in array)
+                {
+                    foreach (var reference in ReadLegacyModReferences(item))
+                    {
+                        yield return reference;
+                    }
+                }
+
+                yield break;
+            }
+
+            var id = ReadLegacyRequirementId(token);
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                yield break;
+            }
+
+            var obj = token as JObject;
+            var notBeforeText = ReadString(obj, "notBefore", "NotBefore");
+            var notAfterText = ReadString(obj, "notAfter", "NotAfter");
+            var notBefore = FuseModRequirementResolver.TryParseVersion(notBeforeText, out var parsedNotBefore)
+                ? parsedNotBefore
+                : null;
+            var notAfter = FuseModRequirementResolver.TryParseVersion(notAfterText, out var parsedNotAfter)
+                ? parsedNotAfter
+                : null;
+            yield return new ModReference
+            {
+                Id = id,
+                NotBefore = notBefore,
+                NotAfter = notAfter
+            };
         }
 
         private sealed class LegacyInterfaceProxy : RealProxy
@@ -1192,6 +1799,10 @@ namespace FUSE.Loading
             // UnityModManager._Start's foreach has released its enumerator.
             FUSE.Infrastructure.FuseUmmInjector.FlushPendingInjection();
             FuseLegacyAssemblyHost.LoadAllAvailableAssemblies("legacy support startup");
+            // Dual-format packages need their RailLoader plugin instance first:
+            // its singleton/context is part of the UMM patch side's runtime
+            // contract. Recover the failed UMM entry only after hosting succeeds.
+            FUSE.Compatibility.FuseLegacyUmmRecovery.RecoverFailedEntries();
         }
 #pragma warning restore CA1822
     }
@@ -1204,6 +1815,10 @@ namespace FUSE.Loading
         public string FolderPath { get; set; }
         public string[] Assemblies { get; set; } = Array.Empty<string>();
         public string[] Requires { get; set; } = Array.Empty<string>();
+        public ModReference[] RequiredReferences { get; set; } = Array.Empty<ModReference>();
+        public ModReference[] LoadAfter { get; set; } = Array.Empty<ModReference>();
+        public string[] LoadBefore { get; set; } = Array.Empty<string>();
+        public ModReference[] ConflictsWith { get; set; } = Array.Empty<ModReference>();
         public JObject RawDefinition { get; set; }
     }
 
@@ -1215,9 +1830,10 @@ namespace FUSE.Loading
             Name = manifest?.Name ?? Id;
             Version = manifest?.Version ?? string.Empty;
             Directory = manifest?.FolderPath ?? string.Empty;
-            Requires = (manifest?.Requires ?? Array.Empty<string>())
-                .Select(static r => (ModReference)r)
-                .ToArray();
+            Requires = manifest?.RequiredReferences ?? Array.Empty<ModReference>();
+            LoadAfter = manifest?.LoadAfter ?? Array.Empty<ModReference>();
+            LoadBefore = manifest?.LoadBefore ?? Array.Empty<string>();
+            ConflictsWith = manifest?.ConflictsWith ?? Array.Empty<ModReference>();
         }
 
         public string Id { get; }
@@ -1225,10 +1841,10 @@ namespace FUSE.Loading
         public string Version { get; }
         public string Directory { get; }
 
-        public string[] LoadBefore => Array.Empty<string>();
-        public ModReference[] LoadAfter => Array.Empty<ModReference>();
+        public string[] LoadBefore { get; }
+        public ModReference[] LoadAfter { get; }
         public ModReference[] Requires { get; }
-        public ModReference[] ConflictsWith => Array.Empty<ModReference>();
+        public ModReference[] ConflictsWith { get; }
 
         // We host the assembly so by definition it loaded and enabled. We do not
         // track per-plugin fault state from the IMod shim; callers that need it
@@ -1266,7 +1882,7 @@ namespace FUSE.Loading
 
         public System.Version RailloaderVersion => LegacyRailloaderVersion;
         public string ModsBaseDirectory { get; }
-        public IReadOnlyCollection<IMod> Mods => Array.Empty<IMod>();
+        public IReadOnlyCollection<IMod> Mods => FuseLegacyAssemblyHost.EnumerateInstalledMods(ModsBaseDirectory);
 
         public void RegisterConsoleCommand(IConsoleCommand command)
         {
@@ -1511,19 +2127,19 @@ namespace FUSE.Loading
 
         public void RegisterSubTypeOverload<TBaseClass, TImplementation>(string identifier)
         {
-            FuseLog.Warning($"FUSE legacy IModdingContext.RegisterSubTypeOverload<{typeof(TBaseClass).Name}, {typeof(TImplementation).Name}>('{identifier}') is not wired; no-op. Migrate to FUSE registration API.");
+            FuseLegacyTypeRegistry.RegisterSubType(typeof(TBaseClass), identifier, typeof(TImplementation));
         }
 
         public void RegisterSubTypeOverload(System.Type baseClass, string identifier, System.Type implementation)
         {
-            FuseLog.Warning($"FUSE legacy IModdingContext.RegisterSubTypeOverload('{baseClass?.Name}', '{identifier}', '{implementation?.Name}') is not wired; no-op. Migrate to FUSE registration API.");
+            FuseLegacyTypeRegistry.RegisterSubType(baseClass, identifier, implementation);
         }
 
         public void RegisterComponent<TComponent, TComponentBuilder>(string kind)
-            where TComponent : Component
-            where TComponentBuilder : IComponentBuilder
+            where TComponent : Model.Definition.Component
+            where TComponentBuilder : Model.IComponentBuilder
         {
-            FuseLog.Warning($"FUSE legacy IModdingContext.RegisterComponent<{typeof(TComponent).Name}, {typeof(TComponentBuilder).Name}>('{kind}') is not wired; no-op. Migrate to FUSE component registration API.");
+            FuseLegacyTypeRegistry.RegisterComponent(typeof(TComponent), typeof(TComponentBuilder), kind);
         }
     }
 }

--- a/FUSE/Loading/FuseLegacyAssemblyHost.cs
+++ b/FUSE/Loading/FuseLegacyAssemblyHost.cs
@@ -1182,6 +1182,14 @@ namespace FUSE.Loading
                 return false;
             }
 
+            if (FuseUmmState.HasActiveRuntimeEntry(manifest.FolderPath, manifest.Id))
+            {
+                FuseLog.Info(
+                    $"FUSE legacy support skipped old-loader plugin hosting for '{manifest.Id}' " +
+                    "because its active Unity Mod Manager entry already owns the plugin lifecycle.");
+                return false;
+            }
+
             if (FuseUmmState.TryGetDisabledReason(manifest.FolderPath, manifest.Id, out var disabledReason))
             {
                 FuseLog.Info($"FUSE legacy support skipped UMM-disabled old-loader package '{manifest.Id}' reason='{disabledReason}'.");

--- a/FUSE/Loading/FuseLegacyCapabilityActivation.cs
+++ b/FUSE/Loading/FuseLegacyCapabilityActivation.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// Determines whether a non-identity gameplay replacement was actually
+    /// requested by an enabled package. This lets FUSE advertise a retired
+    /// dependency without globally turning that mod's gameplay choices on for
+    /// every player.
+    /// </summary>
+    internal static class FuseLegacyCapabilityActivation
+    {
+        private static readonly object Gate = new object();
+        private static HashSet<string> _requested;
+
+        internal static bool IsRequested(params string[] packageIds)
+        {
+            var requested = GetRequestedIds();
+            return (packageIds ?? Array.Empty<string>())
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(FuseReplacementCapabilityCatalog.Normalize)
+                .Any(requested.Contains);
+        }
+
+        internal static void Reset()
+        {
+            lock (Gate)
+            {
+                _requested = null;
+            }
+        }
+
+        private static HashSet<string> GetRequestedIds()
+        {
+            lock (Gate)
+            {
+                if (_requested != null)
+                {
+                    return _requested;
+                }
+
+                _requested = BuildRequestedIds(FuseDataPackageDiscovery.GetPackageManifestSnapshots());
+                return _requested;
+            }
+        }
+
+        internal static HashSet<string> BuildRequestedIds(
+            IEnumerable<FusePackageManifestSnapshot> manifests)
+        {
+            var requested = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var manifest in manifests ?? Enumerable.Empty<FusePackageManifestSnapshot>())
+            {
+                if (manifest == null || manifest.Disabled)
+                {
+                    continue;
+                }
+
+                Add(requested, manifest.Id);
+                foreach (var requirement in manifest.RequiredPackageIds ?? Array.Empty<string>())
+                {
+                    Add(requested, requirement);
+                }
+            }
+
+            return requested;
+        }
+
+        private static void Add(HashSet<string> requested, string packageId)
+        {
+            var normalized = FuseReplacementCapabilityCatalog.Normalize(packageId);
+            if (!string.IsNullOrWhiteSpace(normalized))
+            {
+                requested.Add(normalized);
+            }
+        }
+    }
+}

--- a/FUSE/Loading/FuseLegacyDataConverter.Helpers.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.Helpers.cs
@@ -233,7 +233,10 @@ namespace FUSE.Loading
             foreach (var property in obj.Properties())
             {
                 var cleaned = Clean(property.Value);
-                if (cleaned == null || cleaned.Type == JTokenType.Null || IsEmpty(cleaned))
+                if (cleaned == null ||
+                    cleaned.Type == JTokenType.Null ||
+                    cleaned is JValue scalar && scalar.Value == null ||
+                    IsEmpty(cleaned))
                 {
                     continue;
                 }

--- a/FUSE/Loading/FuseLegacyDataConverter.Json.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.Json.cs
@@ -14,10 +14,27 @@ namespace FUSE.Loading
 {
     internal static partial class FuseLegacyDataConverter
     {
+        private static readonly object JsonRepairWarningGate = new object();
+        private static readonly HashSet<string> ReportedControlCharacterFiles =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         internal static JObject ReadLegacyObject(string path)
         {
             return JObject.Parse(ReadLegacyJsonText(path));
+        }
+
+        internal static JObject ReadManifestObject(string path)
+        {
+            // Manifest files decide whether a package is discovered at all. Keep
+            // the harmless RailLoader-era allowances (comments, trailing commas,
+            // and stray control bytes), but never invent missing braces here. A
+            // structurally incomplete Info.json must remain attributable to the
+            // package and surface in /fuse.report with its real line/column.
+            var text = File.ReadAllText(path);
+            text = StripJsonControlCharacters(text, path);
+            text = StripJsonComments(text);
+            text = RemoveTrailingCommas(text);
+            return JObject.Parse(text);
         }
 
         // Counterpart for legacy sources whose top-level token is a JSON
@@ -118,12 +135,23 @@ namespace FUSE.Loading
                     }
                 }
 
-                FuseLog.Warning(
-                    $"FUSE stripped {stripped} stray control byte(s) from legacy file '{path}' " +
-                    $"before parsing (first occurrence: 0x{(int)firstByte:X2} at line {line}, column {column}). " +
-                    "This is almost always an editor accident (e.g. a Ctrl+V verbatim insert) and the " +
-                    "mod author should fix the source file. FUSE only tolerates this on the legacy " +
-                    "pipeline; native FUSE addons (*.fuse.json) must be valid JSON.");
+                var warningKey = path ?? string.Empty;
+                var report = false;
+                lock (JsonRepairWarningGate)
+                {
+                    report = ReportedControlCharacterFiles.Add(warningKey);
+                }
+
+                if (report)
+                {
+                    FuseLog.Warning(
+                        $"FUSE stripped {stripped} stray control byte(s) from legacy file '{path}' " +
+                        $"before parsing (first occurrence: 0x{(int)firstByte:X2} at line {line}, column {column}). " +
+                        "This is almost always an editor accident (e.g. a Ctrl+V verbatim insert) and the " +
+                        "mod author should fix the source file. This warning is shown once per file per session. " +
+                        "FUSE only tolerates this on the legacy pipeline; native FUSE addons (*.fuse.json) " +
+                        "must be valid JSON.");
+                }
             }
 
             return builder == null ? text : builder.ToString();

--- a/FUSE/Loading/FuseLegacyDataConverter.World.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.World.cs
@@ -273,7 +273,8 @@ namespace FUSE.Loading
             {
                 ["position"] = Vector(item["position"] ?? item["localPosition"], false),
                 ["rotation"] = Vector(item["rotation"] ?? item["localRotation"], false),
-                ["flipSwitchStand"] = ReadBool(item, "flipSwitchStand", false)
+                ["flipSwitchStand"] = ReadBool(item, "flipSwitchStand", false),
+                ["isDiamond"] = ReadBool(item, "isDiamond", ReadBool(item, "IsDiamond", false))
             };
         }
 
@@ -293,20 +294,25 @@ namespace FUSE.Loading
             }
 
             var hasStyle = HasAnyProperty(item, "Style", "style");
+            var hasFlags = HasAnyProperty(item, "flags", "Flags");
             var hasTrackClass = HasAnyProperty(item, "trackClass", "TrackClass");
             var hasSpeedLimit = HasAnyProperty(item, "speedLimit", "SpeedLimit");
             var hasPriority = HasAnyProperty(item, "priority");
             var hasGroupId = HasAnyProperty(item, "groupId", "GroupId");
             var partial = string.IsNullOrWhiteSpace(startNodeId) || string.IsNullOrWhiteSpace(endNodeId);
+            var flags = ReadInt(item["flags"] ?? item["Flags"], 0);
+            var style = ReadString(item, "Style", "style");
 
             var result = new JObject
             {
-                ["style"] = ReadString(item, "Style", "style") ?? "standard",
+                ["style"] = style ?? StyleFromTrackFlags(flags),
                 ["trackClass"] = ReadString(item, "trackClass", "TrackClass") ?? "main",
                 ["speedLimit"] = ReadInt(item["speedLimit"] ?? item["SpeedLimit"], 45),
                 ["priority"] = ReadInt(item["priority"], 0),
                 ["groupId"] = ReadString(item, "groupId", "GroupId"),
-                ["gauge"] = ReadString(item, "gauge", "Gauge")
+                ["gauge"] = ReadString(item, "gauge", "Gauge"),
+                ["bridgeSupportsSteel"] = hasFlags && (flags & 4) != 0,
+                ["yard"] = hasFlags && (flags & 16) != 0
             };
 
             if (!string.IsNullOrWhiteSpace(startNodeId))
@@ -323,6 +329,8 @@ namespace FUSE.Loading
             {
                 result["partial"] = true;
                 result["preserveStyle"] = !hasStyle;
+                result["preserveBridgeSupportsSteel"] = !hasFlags && !hasStyle;
+                result["preserveYard"] = !hasFlags && !hasStyle;
                 result["preserveTrackClass"] = !hasTrackClass;
                 result["preserveSpeedLimit"] = !hasSpeedLimit;
                 result["preservePriority"] = !hasPriority;
@@ -330,6 +338,21 @@ namespace FUSE.Loading
             }
 
             return result;
+        }
+
+        private static string StyleFromTrackFlags(int flags)
+        {
+            if ((flags & 8) != 0)
+            {
+                return "tunnel";
+            }
+
+            if ((flags & 2) != 0)
+            {
+                return "bridge";
+            }
+
+            return (flags & 16) != 0 ? "yard" : "standard";
         }
 
         private static JToken ConvertSpan(JToken token)
@@ -416,16 +439,42 @@ namespace FUSE.Loading
 
         private static JObject ConvertArea(string id, JObject item)
         {
-            return CleanObject(new JObject
+            var result = new JObject
             {
-                ["name"] = ReadString(item, "name") ?? id,
-                ["position"] = Vector(item["localPosition"] ?? item["position"], false),
+                ["name"] = ReadString(item, "name"),
                 ["radius"] = Clone(item["radius"]),
                 ["tagColor"] = NormalizeAreaTagColor(id, item["tagColor"] ?? item["TagColor"]),
                 ["order"] = Clone(item["order"]),
                 ["spanIds"] = ToStringArray(item["spanIds"] ?? item["spans"]),
                 ["groupId"] = ReadString(item, "groupId", "GroupId")
-            });
+            };
+
+            var position = item["localPosition"] ?? item["position"];
+            if (position != null && position.Type != JTokenType.Null)
+            {
+                result["position"] = Vector(position, false);
+            }
+
+            return CleanObject(result);
+        }
+
+        private static bool HasLegacyAreaDefinition(JObject item)
+        {
+            if (item == null)
+            {
+                return false;
+            }
+
+            return item.Properties().Any(property =>
+                string.Equals(property.Name, "name", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "localPosition", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "position", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "radius", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "tagColor", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "order", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "spanIds", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "spans", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(property.Name, "groupId", StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -634,6 +683,17 @@ namespace FUSE.Loading
             }
 
             var model = ReadString(item, "assetIdentifier", "model", "modelIdentifier", "prefabIdentifier", "prefab") ?? string.Empty;
+            if (IsLegacyEditorOnlySceneryAsset(model))
+            {
+                // Alina's turntable measurement disc is an authoring overlay,
+                // not part of the finished scene. A small number of old map
+                // packages shipped the helper beside the real turntable. The
+                // old editor hid it outside edit mode; materializing it as
+                // ordinary FUSE scenery leaves a bright yellow disc over the
+                // completed bridge (issue #235).
+                return null;
+            }
+
             if (!string.IsNullOrWhiteSpace(model) && !model.Contains("://"))
             {
                 model = "scenery://" + model;
@@ -647,6 +707,26 @@ namespace FUSE.Loading
                 ["scale"] = Vector(item["scale"] ?? item["localScale"], true),
                 ["anchorSpanIds"] = ToStringArray(item["anchorSpanIds"] ?? item["spanIds"] ?? item["spans"] ?? item["trackSpanIds"] ?? item["trackSpans"])
             });
+        }
+
+        internal static bool IsLegacyEditorOnlySceneryAsset(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var normalized = value.Trim();
+            var scheme = normalized.IndexOf("://", StringComparison.Ordinal);
+            if (scheme >= 0)
+            {
+                normalized = normalized.Substring(scheme + 3);
+            }
+
+            return string.Equals(
+                normalized,
+                "TurntableMeasurementTool",
+                StringComparison.OrdinalIgnoreCase);
         }
 
         private static void ConvertSplineys(JObject source, JObject root)
@@ -733,7 +813,8 @@ namespace FUSE.Loading
                 FuseLog.Info(
                     "FUSE legacy spliney plugin host dispatched GraphWillChangeEvent " +
                     $"pendingSplineys={flush.PendingSplineyCount} " +
-                    $"nodesAdded={flush.NodesAdded} segmentsAdded={flush.SegmentsAdded}.");
+                    $"nodesAdded={flush.NodesAdded} nodesUpdated={flush.NodesUpdated} " +
+                    $"segmentsAdded={flush.SegmentsAdded} segmentsUpdated={flush.SegmentsUpdated}.");
             }
         }
 
@@ -789,6 +870,16 @@ namespace FUSE.Loading
                 ["tailStyle"] = ReadString(item, "tailStyle", "tailstyle"),
                 ["points"] = points
             });
+        }
+
+        internal static JObject ConvertSplineyForCompatibility(JObject item)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            return ConvertSpliney(item);
         }
 
         private static string InferSplineyType(JObject item, string handler)

--- a/FUSE/Loading/FuseLegacyDataConverter.cs
+++ b/FUSE/Loading/FuseLegacyDataConverter.cs
@@ -187,6 +187,7 @@ namespace FUSE.Loading
                 Author = ReadString(definition, "author", "Author") ?? string.Empty,
                 RequiredPackageIds = ReadLegacyRequiredDependencyIds(definition),
                 LoadAfter = ReadLegacyDependencyIds(definition),
+                ConflictsWith = ReadLegacyConflictRequirements(definition),
                 SourceFiles = sourceFiles,
                 MapTileSources = mapTileSources
             };
@@ -247,14 +248,32 @@ namespace FUSE.Loading
                 // Route them through the audio-specific converter so the
                 // entries land in the FUSE audio dict instead of being
                 // dropped by the "not an object" branch in ReadLegacyObject.
-                if (TryClassifyLegacyAudioFile(sourceFile, out var audioKind))
+                try
                 {
-                    ConvertLegacyAudioSource(sourceFile, audioKind, root);
+                    if (TryClassifyLegacyAudioFile(sourceFile, out var audioKind))
+                    {
+                        ConvertLegacyAudioSource(sourceFile, audioKind, root);
+                    }
+                    else
+                    {
+                        var source = ReadLegacyObject(sourceFile);
+                        ConvertSource(source, root, manifest);
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    var source = ReadLegacyObject(sourceFile);
-                    ConvertSource(source, root, manifest);
+                    FusePackageFaultRegistry.RecordFault(
+                        manifest.PackageId,
+                        "legacy JSON conversion",
+                        ex.GetBaseException().Message,
+                        ex,
+                        folderPath,
+                        sourceFile,
+                        packageName: manifest.DisplayName,
+                        expectedShape: "RailLoader/Strange Customs JSON data supported by the FUSE legacy compatibility converter.",
+                        receivedValue: ex.GetBaseException().Message,
+                        suggestedAction: "Correct the named legacy JSON file at the reported property/line, or remove that optional source from the package manifest, then reload the map.");
+                    throw;
                 }
                 var definition = FuseSerializer.FromJson(root.ToString(Formatting.None));
                 var definitionPath = "legacy://" + sourceKey;
@@ -488,7 +507,7 @@ namespace FUSE.Loading
 
             if (value.Type == JTokenType.String)
             {
-                RecordMixinto(target, value.Value<string>(), null, result, order++);
+                RecordMixinto(target, value.Value<string>(), null, null, result, order++);
                 return;
             }
 
@@ -508,12 +527,19 @@ namespace FUSE.Loading
                     target,
                     ReadString(obj, "mixinto", "Mixinto"),
                     ConvertRequirements(obj["requires"] ?? obj["Requires"]),
+                    ConvertLegacyReferences(obj["conflictsWith"] ?? obj["ConflictsWith"], false),
                     result,
                     order++);
             }
         }
 
-        private static void RecordMixinto(string target, string reference, JArray requirements, IDictionary<string, JObject> result, int order)
+        private static void RecordMixinto(
+            string target,
+            string reference,
+            JArray requirements,
+            JArray conflictsWith,
+            IDictionary<string, JObject> result,
+            int order)
         {
             var sourceFile = ExtractFileReference(reference);
             if (string.IsNullOrWhiteSpace(sourceFile))
@@ -527,7 +553,8 @@ namespace FUSE.Loading
                 ["target"] = target ?? string.Empty,
                 ["sourceFile"] = key,
                 ["order"] = order,
-                ["requires"] = requirements ?? new JArray()
+                ["requires"] = requirements ?? new JArray(),
+                ["conflictsWith"] = conflictsWith ?? new JArray()
             });
         }
 
@@ -587,6 +614,11 @@ namespace FUSE.Loading
 
         private static JArray ConvertRequirements(JToken value)
         {
+            return ConvertLegacyReferences(value, true);
+        }
+
+        private static JArray ConvertLegacyReferences(JToken value, bool filterReplacementCapabilities)
+        {
             var result = new JArray();
             if (!(value is JArray array))
             {
@@ -598,7 +630,8 @@ namespace FUSE.Loading
                 var id = item.Type == JTokenType.String
                     ? item.Value<string>()
                     : ReadString(item as JObject, "id", "Id");
-                if (string.IsNullOrWhiteSpace(id) || IsCoreLegacyRequirement(id))
+                if (string.IsNullOrWhiteSpace(id) ||
+                    (filterReplacementCapabilities && IsCoreLegacyRequirement(id)))
                 {
                     continue;
                 }
@@ -614,6 +647,22 @@ namespace FUSE.Loading
             return result;
         }
 
+        private static FuseModRequirement[] ReadLegacyConflictRequirements(JObject definition)
+        {
+            return ConvertLegacyReferences(
+                    definition?["conflictsWith"] ?? definition?["ConflictsWith"],
+                    false)
+                .OfType<JObject>()
+                .Select(item => new FuseModRequirement
+                {
+                    Id = ReadString(item, "id", "Id"),
+                    NotBefore = ReadString(item, "notBefore", "NotBefore"),
+                    NotAfter = ReadString(item, "notAfter", "NotAfter")
+                })
+                .Where(item => !string.IsNullOrWhiteSpace(item.Id))
+                .ToArray();
+        }
+
         private static string[] ReadLegacyDependencyIds(JObject definition)
         {
             var result = new List<string>(ReadLegacyRequiredDependencyIds(definition));
@@ -626,7 +675,68 @@ namespace FUSE.Loading
                 }
             }
 
+            // A conditional legacy mixinto is optional when its requirement is
+            // absent, but it must run after that package when the dependency is
+            // present. Carry those ids into advisory ordering rather than hard
+            // requirements so discovery can build the correct topological edge
+            // without disabling the package when an optional layer is missing.
+            foreach (var id in ReadMixintoRequirementIds(definition?["mixintos"] ?? definition?["Mixintos"]))
+            {
+                if (!IsCoreLegacyRequirement(id))
+                {
+                    result.Add(EnsureFusePackageId(id));
+                }
+            }
+
             return result.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        }
+
+        private static IEnumerable<string> ReadMixintoRequirementIds(JToken value)
+        {
+            if (value == null || value.Type == JTokenType.Null)
+            {
+                yield break;
+            }
+
+            if (value is JArray array)
+            {
+                foreach (var item in array)
+                {
+                    foreach (var id in ReadMixintoRequirementIds(item))
+                    {
+                        yield return id;
+                    }
+                }
+
+                yield break;
+            }
+
+            if (!(value is JObject obj))
+            {
+                yield break;
+            }
+
+            foreach (var requirement in ConvertRequirements(obj["requires"] ?? obj["Requires"]).OfType<JObject>())
+            {
+                var id = ReadString(requirement, "id");
+                if (!string.IsNullOrWhiteSpace(id))
+                {
+                    yield return id;
+                }
+            }
+
+            foreach (var property in obj.Properties())
+            {
+                if (string.Equals(property.Name, "requires", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                foreach (var id in ReadMixintoRequirementIds(property.Value))
+                {
+                    yield return id;
+                }
+            }
         }
 
         private static string[] ReadLegacyRequiredDependencyIds(JObject definition)
@@ -654,22 +764,7 @@ namespace FUSE.Loading
 
         private static bool IsCoreLegacyRequirement(string id)
         {
-            var value = (id ?? string.Empty).Trim().ToLowerInvariant();
-            return value == "railroader" ||
-                   value == "railloader" ||
-                   value == "rail-loader" ||
-                   value == "alinanova21.alinasmapmod" ||
-                   value == "alinasmapmod" ||
-                   value == "alinamapmod" ||
-                   value == "alinanova21.mapeditor" ||
-                   value == "mapeditor" ||
-                   value == "mmapeditor" ||
-                   value == "alinanova21.alinasmapexpansion" ||
-                   value == "alinasmapexpansion" ||
-                   value == "zamu.strangecustoms" ||
-                   value == "strangecustoms" ||
-                   value == "zamu.confusingsupplements" ||
-                   value == "confusingsupplements";
+            return FuseReplacementCapabilityCatalog.IsProvided(id);
         }
 
         internal static JObject CreateSkeleton(FuseLegacyPackageManifest manifest, string fragment)
@@ -786,7 +881,16 @@ namespace FUSE.Loading
                         continue;
                     }
 
-                    (root["tracks"]["areas"] as JObject)[area.Name] = ConvertArea(area.Name, areaObject);
+                    // In Strange Customs game-graph files an area object is often
+                    // only a namespace around `industries`. It is not an area
+                    // mutation. Converting that wrapper used to manufacture a
+                    // zero position and update the live base area, moving every
+                    // Whittier industry away from its tracks (issues #210/#239).
+                    if (HasLegacyAreaDefinition(areaObject))
+                    {
+                        (root["tracks"]["areas"] as JObject)[area.Name] =
+                            ConvertArea(area.Name, areaObject);
+                    }
                     var industries = areaObject["industries"] as JObject;
                     if (industries == null)
                     {
@@ -978,6 +1082,7 @@ namespace FUSE.Loading
         public string Author { get; set; }
         public string[] RequiredPackageIds { get; set; } = Array.Empty<string>();
         public string[] LoadAfter { get; set; } = Array.Empty<string>();
+        public FuseModRequirement[] ConflictsWith { get; set; } = Array.Empty<FuseModRequirement>();
         public string[] SourceFiles { get; set; } = Array.Empty<string>();
         public FuseLegacyMapTileSource[] MapTileSources { get; set; } = Array.Empty<FuseLegacyMapTileSource>();
     }

--- a/FUSE/Loading/FuseLegacyGameGraphCompatibility.cs
+++ b/FUSE/Loading/FuseLegacyGameGraphCompatibility.cs
@@ -152,7 +152,7 @@ namespace FUSE.Loading
             }
         }
 
-        private static bool ShouldExpand(FuseLoadedMod loaded)
+        internal static bool ShouldExpand(FuseLoadedMod loaded)
         {
             var definition = loaded?.Definition;
             if (definition == null || !IsLegacyConverted(definition) || IsExpanded(definition))
@@ -161,8 +161,9 @@ namespace FUSE.Loading
             }
 
             var target = definition.Mixinto?.Target;
-            return string.IsNullOrWhiteSpace(target) ||
-                   string.Equals(target, GameGraphTarget, StringComparison.OrdinalIgnoreCase);
+            return (string.IsNullOrWhiteSpace(target) ||
+                    string.Equals(target, GameGraphTarget, StringComparison.OrdinalIgnoreCase)) &&
+                   !string.IsNullOrWhiteSpace(ResolveSourcePath(loaded));
         }
 
         private static bool IsLegacyConverted(FuseModDefinition definition)

--- a/FUSE/Loading/FuseLegacyUIHelper.cs
+++ b/FUSE/Loading/FuseLegacyUIHelper.cs
@@ -1,0 +1,109 @@
+using System;
+using FUSE.Infrastructure;
+using Railloader;
+using UI;
+using UI.Builder;
+using UI.Common;
+using UnityEngine;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// FUSE-owned implementation of the legacy window service. Hosted plugins
+    /// receive this object through constructor injection; no legacy loader code
+    /// is required at runtime.
+    /// </summary>
+    internal sealed class FuseLegacyUIHelper : IUIHelper
+    {
+        internal static FuseLegacyUIHelper Shared { get; } = new FuseLegacyUIHelper();
+
+        private FuseLegacyUIHelper()
+        {
+        }
+
+        public Window CreateWindow(int width, int height, Window.Position position)
+        {
+            return WindowCreatorHelper.CreateWindow(width, height, position);
+        }
+
+        public Window CreateWindow(string identifier, int width, int height, Window.Position position)
+        {
+            return WindowCreatorHelper.CreateWindow(identifier, width, height, position);
+        }
+
+        public Window CreateWindow<TWindow>(
+            string identifier,
+            int width,
+            int height,
+            Window.Position position,
+            Action<TWindow> configure = null)
+            where TWindow : Component, IBuilderWindow
+        {
+            var creator = FindCreator();
+            var window = InstantiateWindow(creator);
+            if (window == null)
+            {
+                return null;
+            }
+
+            window.SetInitialPositionSize(
+                identifier,
+                new Vector2(width, height),
+                position,
+                Window.Sizing.Fixed(new Vector2Int(width, height)));
+            window.name = typeof(TWindow).FullName ?? typeof(TWindow).Name;
+
+            var component = window.gameObject.AddComponent<TWindow>();
+            component.BuilderAssets = creator.builderAssets;
+            configure?.Invoke(component);
+            window.CloseWindow();
+            return window;
+        }
+
+        public Window CreateWindow<TWindow>(Action<TWindow> configure = null)
+            where TWindow : Component, IProgrammaticWindow
+        {
+            var creator = FindCreator();
+            var window = InstantiateWindow(creator);
+            if (window == null)
+            {
+                return null;
+            }
+
+            window.name = typeof(TWindow).FullName ?? typeof(TWindow).Name;
+            var component = window.gameObject.AddComponent<TWindow>();
+            component.BuilderAssets = creator.builderAssets;
+            configure?.Invoke(component);
+            window.SetInitialPositionSize(
+                component.WindowIdentifier,
+                component.DefaultSize,
+                component.DefaultPosition,
+                component.Sizing);
+            window.CloseWindow();
+            return window;
+        }
+
+        public UIPanel PopulateWindow(Window window, Action<UIPanelBuilder> closure)
+        {
+            return WindowCreatorHelper.PopulateWindow(window, closure);
+        }
+
+        private static ProgrammaticWindowCreator FindCreator()
+        {
+            return UnityEngine.Object.FindObjectOfType<ProgrammaticWindowCreator>(true);
+        }
+
+        private static Window InstantiateWindow(ProgrammaticWindowCreator creator)
+        {
+            if (creator == null || creator.windowPrefab == null)
+            {
+                FuseLog.Warning(
+                    "FUSE legacy UI helper could not create a window because the game's " +
+                    "ProgrammaticWindowCreator is not available yet.");
+                return null;
+            }
+
+            return UnityEngine.Object.Instantiate(creator.windowPrefab, creator.transform, false);
+        }
+    }
+}

--- a/FUSE/Loading/FuseLoadReport.cs
+++ b/FUSE/Loading/FuseLoadReport.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using FUSE.Authoring.Data;
 using FUSE.Infrastructure;
+using FUSE.Compatibility;
 using FUSE.Runtime.Registry;
 using Newtonsoft.Json.Linq;
 using UI.Common;
@@ -233,7 +234,8 @@ namespace FUSE.Loading
             var snapshot = CaptureCurrentSnapshot();
             _lastReportSnapshot = snapshot;
             var summary = BuildSummary(snapshot);
-            return BuildDetails(snapshot, summary);
+            return FuseLegacyDebugInformation.AppendToReport(
+                BuildDetails(snapshot, summary));
         }
 
         public static string GetLastJsonReport()
@@ -480,11 +482,11 @@ namespace FUSE.Loading
 
             return
                 $"FUSE: {loadedCount} loaded | faults {snapshot.FaultedPackageCount} | " +
-                $"conflicts {snapshot.Conflicts.Length} | assets {snapshot.UnknownSceneryAssets.Length} | " +
+                $"conflicts {snapshot.ActionableConflictCount} | assets {snapshot.UnknownSceneryAssets.Length} | " +
                 $"brokenAssets {snapshot.SceneryLoadFailureCount} | " +
                 $"graph {snapshot.GraphPostBindIssues.Length} | transfers {snapshot.ProgressionTransferSkips.Length} | " +
                 $"suppressions {suppressionCount} | orphans {snapshot.OrphanedCarCount} | " +
-                $"modErrors {snapshot.ModExceptionTotal} | /fuse.report";
+                "/fuse.report";
         }
 
         private static string BuildDetails(ReportSnapshot snapshot, string summary)
@@ -495,17 +497,21 @@ namespace FUSE.Loading
                 $"Reason: {snapshot.Reason}; disk-loaded this pass={snapshot.LoadedFromDiskThisPass}; " +
                 $"runtime-applied this pass={snapshot.AppliedToRuntimeThisPass}; resident definitions={snapshot.ResidentDefinitionCount}.");
             sb.AppendLine(
-                $"Packages: loaded={snapshot.LoadedPackageIds.Length}; applied={snapshot.AppliedPackageIds.Length}; " +
-                $"skipped={snapshot.SkippedPackages.Count}; disabled={snapshot.DisabledPackages.Count}; " +
+                $"Package folders: loaded={snapshot.LoadedPackageIds.Length}; disabled={snapshot.DisabledPackages.Count}; " +
                 $"faulted={snapshot.FaultedPackageCount}.");
+            sb.AppendLine(
+                $"Runtime definitions: resident={snapshot.ResidentDefinitionCount}; applied={snapshot.AppliedPackageIds.Length}; " +
+                $"actionable skips={snapshot.ActionableSkippedPackages.Count}; " +
+                $"optional fragments inactive={snapshot.OptionalSkippedPackages.Count}.");
             sb.AppendLine(
                 $"Post-bind: graphIssues={snapshot.GraphPostBindIssues.Length}; " +
                 $"progressionTransferSkips={snapshot.ProgressionTransferSkips.Length}.");
 
-            AppendList(sb, "Loaded packages", snapshot.LoadedPackageIds);
-            AppendList(sb, "Applied packages", snapshot.AppliedPackageIds);
+            AppendList(sb, "Loaded package folders", snapshot.LoadedPackageIds);
+            AppendList(sb, "Applied definitions", snapshot.AppliedPackageIds);
             AppendList(sb, "Legacy-converted packages", snapshot.LegacyConvertedPackageIds);
-            AppendMap(sb, "Skipped packages", snapshot.SkippedPackages);
+            AppendMap(sb, "Definitions skipped with actionable problems", snapshot.ActionableSkippedPackages);
+            AppendMap(sb, "Optional conditional fragments inactive", snapshot.OptionalSkippedPackages);
             AppendMap(sb, "Disabled packages", snapshot.DisabledPackages);
 
             if (snapshot.Faults.Length > 0)
@@ -513,11 +519,50 @@ namespace FUSE.Loading
                 sb.AppendLine("Faults:");
                 foreach (var fault in snapshot.Faults)
                 {
-                    sb.AppendLine($"  {fault.PackageId} [{fault.Stage}] {fault.Message}");
+                    var packageName = string.IsNullOrWhiteSpace(fault.PackageName)
+                        || string.Equals(fault.PackageName, fault.PackageId, StringComparison.OrdinalIgnoreCase)
+                        ? string.Empty
+                        : $" ({fault.PackageName})";
+                    sb.AppendLine($"  {fault.PackageId}{packageName} [{fault.Stage}] {fault.Message}");
+                    if (!string.IsNullOrWhiteSpace(fault.FolderPath))
+                    {
+                        sb.AppendLine($"    source root: {fault.FolderPath}");
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(fault.SourceFile))
+                    {
+                        sb.AppendLine($"    file: {fault.SourceFile}");
+                        if (!string.IsNullOrWhiteSpace(fault.RelativeSourceFile))
+                            sb.AppendLine($"    relative file: {fault.RelativeSourceFile}");
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(fault.ValidationCode))
+                        sb.AppendLine($"    validation code: {fault.ValidationCode}");
+                    if (!string.IsNullOrWhiteSpace(fault.ExpectedShape))
+                        sb.AppendLine($"    expected: {fault.ExpectedShape}");
+                    if (!string.IsNullOrWhiteSpace(fault.ReceivedValue))
+                        sb.AppendLine($"    received: {fault.ReceivedValue}");
+
+                    if (!string.IsNullOrWhiteSpace(fault.JsonPath) || fault.LineNumber > 0)
+                    {
+                        var path = string.IsNullOrWhiteSpace(fault.JsonPath) ? "<root>" : fault.JsonPath;
+                        var line = fault.LineNumber > 0
+                            ? $" line {fault.LineNumber}, position {fault.LinePosition}"
+                            : string.Empty;
+                        sb.AppendLine($"    JSON location: {path}{line}");
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(fault.SuggestedAction))
+                    {
+                        sb.AppendLine($"    action: {fault.SuggestedAction}");
+                    }
                 }
             }
 
-            sb.AppendLine($"Conflicts recorded: {snapshot.Conflicts.Length} (details: /fuse.conflicts).");
+            sb.AppendLine(
+                $"Ownership conflicts requiring attention: {snapshot.ActionableConflictCount}; " +
+                $"shared extension targets merged successfully: {snapshot.CooperativeConflictCount} " +
+                "(details: /fuse.conflicts).");
 
             // Live session counters, not part of the load snapshot: every guard FUSE
             // keeps around broken content, so a pasted report answers "did the guards
@@ -642,12 +687,19 @@ namespace FUSE.Loading
                     ["appliedToRuntimeThisPass"] = snapshot.AppliedToRuntimeThisPass,
                     ["residentDefinitions"] = snapshot.ResidentDefinitionCount,
                     ["loadedPackages"] = snapshot.LoadedPackageIds.Length,
+                    ["appliedDefinitions"] = snapshot.AppliedPackageIds.Length,
+                    ["actionableSkippedDefinitions"] = snapshot.ActionableSkippedPackages.Count,
+                    ["optionalInactiveDefinitions"] = snapshot.OptionalSkippedPackages.Count,
+                    ["registryOverlapRecords"] = snapshot.Conflicts.Length,
+                    ["sharedExtensionOverlaps"] = snapshot.CooperativeConflictCount,
+                    // Backward-compatible aliases retained for report consumers
+                    // written before definition/package terminology was fixed.
                     ["appliedPackages"] = snapshot.AppliedPackageIds.Length,
                     ["skippedPackages"] = snapshot.SkippedPackages.Count,
                     ["disabledPackages"] = snapshot.DisabledPackages.Count,
                     ["legacyConvertedPackages"] = snapshot.LegacyConvertedPackageIds.Length,
                     ["faultedPackages"] = snapshot.FaultedPackageCount,
-                    ["conflicts"] = snapshot.Conflicts.Length,
+                    ["conflicts"] = snapshot.ActionableConflictCount,
                     ["unknownSceneryAssets"] = snapshot.UnknownSceneryAssets.Length,
                     ["graphIssues"] = snapshot.GraphPostBindIssues.Length,
                     ["progressionTransferSkips"] = snapshot.ProgressionTransferSkips.Length,
@@ -660,6 +712,9 @@ namespace FUSE.Loading
                 ["packages"] = new JObject
                 {
                     ["loaded"] = ToArray(snapshot.LoadedPackageIds),
+                    ["appliedDefinitions"] = ToArray(snapshot.AppliedPackageIds),
+                    ["actionableSkippedDefinitions"] = ToObject(snapshot.ActionableSkippedPackages),
+                    ["optionalInactiveDefinitions"] = ToObject(snapshot.OptionalSkippedPackages),
                     ["applied"] = ToArray(snapshot.AppliedPackageIds),
                     ["legacyConverted"] = ToArray(snapshot.LegacyConvertedPackageIds),
                     ["skipped"] = ToObject(snapshot.SkippedPackages),
@@ -668,7 +723,19 @@ namespace FUSE.Loading
                     {
                         ["packageId"] = fault.PackageId ?? string.Empty,
                         ["stage"] = fault.Stage ?? string.Empty,
-                        ["message"] = fault.Message ?? string.Empty
+                        ["message"] = fault.Message ?? string.Empty,
+                        ["folderPath"] = fault.FolderPath ?? string.Empty,
+                        ["sourceFile"] = fault.SourceFile ?? string.Empty,
+                        ["jsonPath"] = fault.JsonPath ?? string.Empty,
+                        ["lineNumber"] = fault.LineNumber,
+                        ["linePosition"] = fault.LinePosition,
+                        ["packageName"] = fault.PackageName ?? string.Empty,
+                        ["relativeSourceFile"] = fault.RelativeSourceFile ?? string.Empty,
+                        ["validationCode"] = fault.ValidationCode ?? string.Empty,
+                        ["expectedShape"] = fault.ExpectedShape ?? string.Empty,
+                        ["receivedValue"] = fault.ReceivedValue ?? string.Empty,
+                        ["suggestedAction"] = fault.SuggestedAction ?? string.Empty,
+                        ["details"] = fault.Details ?? string.Empty
                     }))
                 },
                 ["conflicts"] = new JArray(snapshot.Conflicts.Select(conflict => new JObject
@@ -677,8 +744,9 @@ namespace FUSE.Loading
                     ["target"] = conflict.Target ?? string.Empty,
                     ["objectId"] = conflict.Id ?? string.Empty,
                     ["ownerPackageId"] = conflict.OwnerPackageId ?? string.Empty,
-                    ["attemptedPackageId"] = conflict.AttemptedPackageId ?? string.Empty,
-                    ["resolution"] = conflict.Resolution ?? string.Empty
+                        ["attemptedPackageId"] = conflict.AttemptedPackageId ?? string.Empty,
+                        ["resolution"] = conflict.Resolution ?? string.Empty,
+                        ["classification"] = conflict.IsCooperativeMerge ? "shared-extension" : "actionable"
                 })),
                 // Live session counters (see BuildDetails); intentionally outside
                 // "counts" so they do not read as load-snapshot state.
@@ -692,6 +760,7 @@ namespace FUSE.Loading
                     ["curveMeshSuppressed"] = FuseRuntimeGuardCounters.CurveMeshSuppressed,
                     ["sceneryCarDecalsDisabled"] = FuseRuntimeGuardCounters.SceneryDecalComponentsDisabled,
                     ["sceneryLoadFailures"] = FuseRuntimeGuardCounters.SceneryLoadFailures,
+                    ["passengerStopSpansSanitized"] = FuseRuntimeGuardCounters.PassengerStopSpansSanitized,
                     ["flaresSuppressed"] = FuseRuntimeGuardCounters.FlareSuppressed,
                     ["frameSpikes"] = FuseRuntimeGuardCounters.FrameSpikes,
                     ["frameSpikeWorstMs"] = FuseRuntimeGuardCounters.FrameSpikeWorstMs
@@ -898,6 +967,18 @@ namespace FUSE.Loading
             public long ModExceptionTotal { get; set; }
             public long ModExceptionUnattributed { get; set; }
 
+            public IReadOnlyDictionary<string, string> ActionableSkippedPackages =>
+                FilterSkippedPackages(optional: false);
+
+            public IReadOnlyDictionary<string, string> OptionalSkippedPackages =>
+                FilterSkippedPackages(optional: true);
+
+            public int ActionableConflictCount =>
+                Conflicts?.Count(conflict => conflict != null && !conflict.IsCooperativeMerge) ?? 0;
+
+            public int CooperativeConflictCount =>
+                Conflicts?.Count(conflict => conflict?.IsCooperativeMerge == true) ?? 0;
+
             public int FaultedPackageCount =>
                 Faults == null
                     ? 0
@@ -913,15 +994,21 @@ namespace FUSE.Loading
 
             public bool HasProblems =>
                 FaultedPackageCount > 0 ||
-                (Conflicts != null && Conflicts.Length > 0) ||
+                ActionableConflictCount > 0 ||
                 (UnknownSceneryAssets != null && UnknownSceneryAssets.Length > 0) ||
                 (GraphPostBindIssues != null && GraphPostBindIssues.Length > 0) ||
                 (ProgressionTransferSkips != null && ProgressionTransferSkips.Length > 0) ||
                 (SkippedPackages != null && SkippedPackages.Any(item => !FusePackageFaultRegistry.IsOptionalSkipReason(item.Value))) ||
                 BlockingNoticeCount > 0 ||
                 SceneryLoadFailureCount > 0 ||
-                OrphanedCarCount > 0 ||
-                HasModExceptionProblem;
+                OrphanedCarCount > 0;
+
+            private IReadOnlyDictionary<string, string> FilterSkippedPackages(bool optional)
+            {
+                return (SkippedPackages ?? new Dictionary<string, string>())
+                    .Where(item => FusePackageFaultRegistry.IsOptionalSkipReason(item.Value) == optional)
+                    .ToDictionary(item => item.Key, item => item.Value, StringComparer.OrdinalIgnoreCase);
+            }
 
             // Notices preserve useful diagnostics (for example, a malformed
             // optional alias catalog) but do not by themselves mean the
@@ -931,10 +1018,9 @@ namespace FUSE.Loading
             // above.
             public bool HasAdvisories => AdvisoryNoticeCount > 0;
 
-            // A single one-off third-party exception must not flip the report
-            // red, but a per-cycle thrower (world moves, update ticks) crosses
-            // the registry's thresholds within seconds of the fault starting.
-            // The Status page shares this predicate (issue #208).
+            // Exception observations are diagnostics, not package readiness.
+            // This predicate remains available to the diagnostics page and
+            // structured report, but it deliberately does not feed HasProblems.
             public bool HasModExceptionProblem =>
                 ModExceptions != null &&
                 ModExceptions.Any(record => record.IsProblem);

--- a/FUSE/Loading/FuseLoadedMod.cs
+++ b/FUSE/Loading/FuseLoadedMod.cs
@@ -4,15 +4,24 @@ namespace FUSE.Loading
 {
     public sealed class FuseLoadedMod
     {
-        public FuseLoadedMod(string folderPath, string definitionPath, FuseModDefinition definition)
+        public FuseLoadedMod(
+            string folderPath,
+            string definitionPath,
+            FuseModDefinition definition,
+            FuseModDefinition sourceDefinition = null,
+            FuseFeatureEvaluation featureEvaluation = null)
         {
             FolderPath = folderPath ?? string.Empty;
             DefinitionPath = definitionPath ?? string.Empty;
             Definition = definition;
+            SourceDefinition = sourceDefinition ?? definition;
+            FeatureEvaluation = featureEvaluation ?? new FuseFeatureEvaluation();
         }
 
         public string FolderPath { get; }
         public string DefinitionPath { get; }
         public FuseModDefinition Definition { get; }
+        public FuseModDefinition SourceDefinition { get; }
+        public FuseFeatureEvaluation FeatureEvaluation { get; }
     }
 }

--- a/FUSE/Loading/FuseMapTileRegistry.cs
+++ b/FUSE/Loading/FuseMapTileRegistry.cs
@@ -47,6 +47,61 @@ namespace FUSE.Loading
             }
         }
 
+        internal static bool RegisterTileSource(
+            string modId,
+            string modFolder,
+            string sourceId,
+            FuseMapTileSource tileSource)
+        {
+            if (string.IsNullOrWhiteSpace(modId)
+                || string.IsNullOrWhiteSpace(sourceId)
+                || tileSource == null)
+            {
+                return false;
+            }
+
+            string resolvedFolder;
+            try
+            {
+                resolvedFolder = ResolveSourceFolder(
+                    modFolder,
+                    tileSource.SourceFolder);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception(
+                    $"Skipping map tile source '{sourceId}' in '{modId}' "
+                    + "because its sourceFolder threw while resolving",
+                    ex);
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(resolvedFolder))
+            {
+                FuseLog.Warning(
+                    $"Skipping map tile source '{sourceId}' in '{modId}' "
+                    + "because its sourceFolder could not be resolved.");
+                return false;
+            }
+
+            lock (Sync)
+            {
+                var key = BuildSourceKey(modId, sourceId);
+                Sources[key] = new RegisteredTileSource
+                {
+                    SourceKey = key,
+                    ModId = modId,
+                    DirectoryName = NormalizeDirectoryName(
+                        tileSource.Directory),
+                    ResolvedFolder = resolvedFolder,
+                    Priority = tileSource.Priority
+                };
+                _sourceVersion++;
+            }
+
+            return true;
+        }
+
         internal static int MountIntoStore(MapStore store, string directoryName)
         {
             if (store == null)

--- a/FUSE/Loading/FuseModLoader.Apply.cs
+++ b/FUSE/Loading/FuseModLoader.Apply.cs
@@ -449,15 +449,24 @@ namespace FUSE.Loading
                 return true;
             }
 
-            if (CanReplaceSiblingClaim(owner, packageId))
+            var siblingHandoff = CanReplaceSiblingClaim(owner, packageId);
+            var declaredLayeringHandoff = !siblingHandoff && IsExpectedDeclaredLayering(owner, packageId);
+            if (siblingHandoff || declaredLayeringHandoff)
             {
                 var previousOwner = owner;
                 FuseRegistry.Release(kind, id, owner);
                 if (FuseRegistry.TryClaim(kind, id, packageId, out owner))
                 {
-                    FuseLog.Info(
-                        $"FUSE reassigned sibling claim package='{packageId}' operation='claim runtime object' " +
-                        $"kind='{transactionKind}' id='{id}' previousOwner='{previousOwner ?? string.Empty}'.");
+                    if (declaredLayeringHandoff)
+                    {
+                        LogExpectedDeclaredLayering(previousOwner, packageId);
+                    }
+                    else
+                    {
+                        FuseLog.Info(
+                            $"FUSE reassigned sibling claim package='{packageId}' operation='claim runtime object' " +
+                            $"kind='{transactionKind}' id='{id}' previousOwner='{previousOwner ?? string.Empty}'.");
+                    }
                     return true;
                 }
             }
@@ -772,6 +781,10 @@ namespace FUSE.Loading
                     }
 
                     var industryDefinition = industry.Value;
+                    RecordIndustryComponentOwnership(
+                        definition.Id,
+                        industry.Key,
+                        industryDefinition);
                     var exists = IndustryAPI.GetIndustry(industry.Key) != null;
                     // Diagnostic: surface the actual deserialized flag values so we
                     // can match converter intent against what the apply path sees.
@@ -885,6 +898,124 @@ namespace FUSE.Loading
             }
         }
 
+        private static void RecordIndustryComponentOwnership(
+            string packageId,
+            string industryId,
+            FuseIndustry industry)
+        {
+            if (string.IsNullOrWhiteSpace(packageId) || industry?.Components == null)
+            {
+                return;
+            }
+
+            foreach (var component in industry.Components)
+            {
+                var target = BuildIndustryComponentClaimId(industryId, component.Key, component.Value);
+                if (string.IsNullOrWhiteSpace(target))
+                {
+                    continue;
+                }
+
+                var existingOwners = new List<string>();
+                foreach (var owner in FuseRegistry.GetSharedOwners(FuseClaimKind.Industry, target))
+                {
+                    if (string.Equals(owner, packageId, StringComparison.OrdinalIgnoreCase) ||
+                        CanReplaceSiblingClaim(owner, packageId))
+                    {
+                        continue;
+                    }
+
+                    if (IsExpectedDeclaredLayering(owner, packageId))
+                    {
+                        LogExpectedDeclaredLayering(owner, packageId);
+                        continue;
+                    }
+
+                    existingOwners.Add(owner);
+                }
+
+                FuseRegistry.TryClaim(FuseClaimKind.Industry, target, packageId);
+                foreach (var owner in existingOwners)
+                {
+                    var resolution = component.Value?.Remove == true
+                        ? "shared industry component removal overlap; later removal applied"
+                        : "shared industry destination overlap; definitions merged into the same runtime location";
+                    FuseRegistry.RecordPlannedConflict(
+                        FuseClaimKind.Industry,
+                        target,
+                        owner,
+                        packageId,
+                        resolution);
+                }
+            }
+        }
+
+        internal static string BuildIndustryComponentClaimId(
+            string industryId,
+            string componentId,
+            FuseIndustryComponent component)
+        {
+            var directId = $"component:{industryId ?? string.Empty}.{componentId ?? string.Empty}";
+            if (component == null || component.Remove)
+            {
+                return directId;
+            }
+
+            var spanIds = EnumerateComponentClaimSpanIds(component)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var name = component.Name?.Trim();
+            if (spanIds.Length == 0 || string.IsNullOrWhiteSpace(name))
+            {
+                return directId;
+            }
+
+            return
+                $"destination:type={component.Type?.Trim() ?? "component"};" +
+                $"name={name};spans={string.Join(",", spanIds)}";
+        }
+
+        private static IEnumerable<string> EnumerateComponentClaimSpanIds(
+            FuseIndustryComponent component)
+        {
+            if (component?.TrackSpanIds != null)
+            {
+                foreach (var id in component.TrackSpanIds)
+                {
+                    yield return id;
+                }
+            }
+
+            var patch = component?.TrackSpanPatch;
+            if (patch == null)
+            {
+                yield break;
+            }
+
+            foreach (var values in new[]
+            {
+                patch.Replace,
+                patch.Add,
+                patch.Append,
+                patch.Prepend,
+                patch.Insert
+            })
+            {
+                if (values == null)
+                {
+                    continue;
+                }
+
+                foreach (var id in values)
+                {
+                    yield return id;
+                }
+            }
+        }
+
         private static bool LoaderDependenciesAvailable(FuseLoader loader, out string reason)
         {
             reason = string.Empty;
@@ -945,6 +1076,16 @@ namespace FUSE.Loading
             {
                 foreach (var scenery in definition.World.Scenery)
                 {
+                    var allowUnverifiedLegacyAsset = false;
+                    if (SceneryAPI.IsEditorOnlyLegacySceneryReference(scenery.Value))
+                    {
+                        FuseLog.Info(
+                            $"FUSE omitted editor-only turntable measurement helper '{scenery.Key}' " +
+                            $"from runtime package '{definition.Id}'.");
+                        transaction.Skipped("scenery", scenery.Key, "editor-only legacy measurement helper");
+                        continue;
+                    }
+
                     if (!SceneryAPI.TryResolveAssetIdentifier(scenery.Key, scenery.Value, out _))
                     {
                         if (SceneryAPI.IsKnownOptionalLegacyAssetReference(scenery.Value))
@@ -956,17 +1097,25 @@ namespace FUSE.Loading
                             continue;
                         }
 
-                        FuseLog.Warning(
-                            $"FUSE skipping scenery '{scenery.Key}' in package '{definition.Id}': " +
-                            $"AssetIdentifier='{scenery.Value?.AssetIdentifier ?? string.Empty}', " +
-                            $"Model='{scenery.Value?.Model ?? string.Empty}' did not resolve to a known PrefabStore asset.");
-                        FuseLoadReport.RecordUnknownSceneryAsset(
-                            definition.Id,
-                            scenery.Key,
-                            scenery.Value?.AssetIdentifier,
-                            scenery.Value?.Model);
-                        transaction.Skipped("scenery", scenery.Key, "unknown asset identifier");
-                        continue;
+                        if (!string.IsNullOrWhiteSpace(definitionPath) &&
+                            definitionPath.StartsWith("legacy://", StringComparison.OrdinalIgnoreCase))
+                        {
+                            allowUnverifiedLegacyAsset = true;
+                        }
+                        else
+                        {
+                            FuseLog.Warning(
+                                $"FUSE skipping scenery '{scenery.Key}' in package '{definition.Id}': " +
+                                $"AssetIdentifier='{scenery.Value?.AssetIdentifier ?? string.Empty}', " +
+                                $"Model='{scenery.Value?.Model ?? string.Empty}' did not resolve to a known PrefabStore asset.");
+                            FuseLoadReport.RecordUnknownSceneryAsset(
+                                definition.Id,
+                                scenery.Key,
+                                scenery.Value?.AssetIdentifier,
+                                scenery.Value?.Model);
+                            transaction.Skipped("scenery", scenery.Key, "unknown asset identifier");
+                            continue;
+                        }
                     }
 
                     if (!TryClaimOrSkip(FuseClaimKind.Scenery, "scenery", scenery.Key, definition.Id, transaction))
@@ -981,6 +1130,7 @@ namespace FUSE.Loading
                                      new FuseSceneryEntity(scenery.Key, definition.Id);
                         entity.InitializeIdentity(scenery.Key, definition.Id);
                         entity.BindDefinition(definition, definitionPath);
+                        entity.AllowUnverifiedLegacyAsset = allowUnverifiedLegacyAsset;
                         entity.LoadDefinition(scenery.Value);
                         if (!FuseAuthoringPersistenceService.ApplyPackageEntityToRuntime(entity))
                         {
@@ -1043,6 +1193,21 @@ namespace FUSE.Loading
                         {
                             SplineyAPI.AddSpliney(spliney.Key, spliney.Value);
                         }
+                    });
+                }
+            }
+
+            if (definition.World.WaterSurfaces != null)
+            {
+                foreach (var waterSurface in definition.World.WaterSurfaces)
+                {
+                    var exists = WaterSurfaceAPI.GetWaterSurface(waterSurface.Key) != null;
+                    transaction.TryApply("water surface", waterSurface.Key, exists, () =>
+                    {
+                        if (exists)
+                            WaterSurfaceAPI.UpdateWaterSurface(waterSurface.Key, waterSurface.Value);
+                        else
+                            WaterSurfaceAPI.AddWaterSurface(waterSurface.Key, waterSurface.Value);
                     });
                 }
             }
@@ -1158,6 +1323,7 @@ namespace FUSE.Loading
             RemoveWorldItems("scene clone", removals.SceneClones, SceneCloneAPI.TryRemoveSceneClone, transaction);
             RemoveWorldItems("scenery", removals.Scenery, SceneryAPI.TryRemoveScenery, transaction);
             RemoveWorldItems("spliney", removals.Splineys, SplineyAPI.TryRemoveSpliney, transaction);
+            RemoveWorldItems("water surface", removals.WaterSurfaces, WaterSurfaceAPI.TryRemoveWaterSurface, transaction);
             RemoveWorldItems("telegraph pole set", removals.TelegraphPoles, MapAPI.TryRemoveTelegraphPoles, transaction);
             RemoveWorldItems("map label", removals.MapLabels, MapAPI.TryRemoveMapLabel, transaction);
             RemoveWorldItems("map mask", removals.MapMasks, MapAPI.TryRemoveMapMask, transaction);

--- a/FUSE/Loading/FuseModLoader.TrackMerging.cs
+++ b/FUSE/Loading/FuseModLoader.TrackMerging.cs
@@ -19,6 +19,9 @@ namespace FUSE.Loading
 {
     public static partial class FuseModLoader
     {
+        private static readonly object DeclaredLayeringLogSync = new object();
+        private static readonly HashSet<string> DeclaredLayeringLogPairs =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         private sealed class FuseStagedApplyCandidate
         {
@@ -154,6 +157,8 @@ namespace FUSE.Loading
                 new Dictionary<string, FuseMergedTrackRemoval>(StringComparer.OrdinalIgnoreCase);
             public readonly Dictionary<string, FuseMergedTrackRemoval> Splineys =
                 new Dictionary<string, FuseMergedTrackRemoval>(StringComparer.OrdinalIgnoreCase);
+            public readonly Dictionary<string, FuseMergedTrackRemoval> WaterSurfaces =
+                new Dictionary<string, FuseMergedTrackRemoval>(StringComparer.OrdinalIgnoreCase);
             public readonly Dictionary<string, FuseMergedTrackRemoval> MapLabels =
                 new Dictionary<string, FuseMergedTrackRemoval>(StringComparer.OrdinalIgnoreCase);
             public readonly Dictionary<string, FuseMergedTrackRemoval> MapMasks =
@@ -164,7 +169,7 @@ namespace FUSE.Loading
                 new Dictionary<string, FuseMergedTrackRemoval>(StringComparer.OrdinalIgnoreCase);
 
             public bool HasAny =>
-                Scenery.Count > 0 || SceneClones.Count > 0 || Splineys.Count > 0 ||
+                Scenery.Count > 0 || SceneClones.Count > 0 || Splineys.Count > 0 || WaterSurfaces.Count > 0 ||
                 MapLabels.Count > 0 || MapMasks.Count > 0 || TelegraphPoles.Count > 0 ||
                 Industries.Count > 0;
         }
@@ -215,7 +220,14 @@ namespace FUSE.Loading
                     }
                     catch (Exception ex)
                     {
-                        FusePackageFaultRegistry.RecordFault(definition.Id, "runtime apply", ex.Message, ex);
+                        FusePackageFaultRegistry.RecordFault(
+                            definition.Id,
+                            "runtime apply",
+                            ex.Message,
+                            ex,
+                            candidate.Loaded.FolderPath,
+                            candidate.Loaded.DefinitionPath,
+                            suggestedAction: "Review this package file and the exception details, correct the referenced runtime definition, then reload the map.");
                         FusePackageFaultRegistry.MarkSkipped(definition.Id, "runtime apply exception");
                         outcomes.Add(PackageApplyOutcome.ForErrored(definition.Id, ex.Message));
                         FuseLog.Exception($"Failed to prepare FUSE definition '{definition.Id}' for staged runtime apply", ex);
@@ -255,6 +267,7 @@ namespace FUSE.Loading
                         "merged graph pre-apply");
 
                     ApplyMergedTrackGraph(mergedTrackPlan, reason);
+                    FuseSplineyPluginHost.NotifyGraphDidChange();
 
                     foreach (var candidate in active.Where(item => !item.Transaction.Report.IsFatal))
                     {
@@ -435,7 +448,13 @@ namespace FUSE.Loading
 
                     if (transaction.Report.IsFatal)
                     {
-                        FusePackageFaultRegistry.RecordFault(definition.Id, "runtime apply", transaction.Report.FatalReason);
+                        FusePackageFaultRegistry.RecordFault(
+                            definition.Id,
+                            "runtime apply",
+                            transaction.Report.FatalReason,
+                            folderPath: candidate.Loaded.FolderPath,
+                            sourceFile: candidate.Loaded.DefinitionPath,
+                            suggestedAction: "Review the per-object errors for this package in the health report, correct the referenced file, then reload the map.");
                         FusePackageFaultRegistry.MarkSkipped(definition.Id, transaction.Report.FatalReason);
                         if (HasRuntimeMutations(transaction.Report))
                         {
@@ -447,7 +466,13 @@ namespace FUSE.Loading
                     }
                     else if (transaction.Report.HasErrors)
                     {
-                        FusePackageFaultRegistry.RecordFault(definition.Id, "runtime apply", $"Runtime apply completed with {transaction.Report.Errors.Count} error(s).");
+                        FusePackageFaultRegistry.RecordFault(
+                            definition.Id,
+                            "runtime apply",
+                            $"Runtime apply completed with {transaction.Report.Errors.Count} error(s).",
+                            folderPath: candidate.Loaded.FolderPath,
+                            sourceFile: candidate.Loaded.DefinitionPath,
+                            suggestedAction: "Review the per-object errors for this package in the health report, correct the referenced file, then reload the map.");
                         if (HasRuntimeMutations(transaction.Report))
                         {
                             candidate.RegistryTransaction?.Commit();
@@ -518,6 +543,39 @@ namespace FUSE.Loading
                 .SelectMany(group => group.OrderBy(item => item.index))
                 .ToArray();
 
+            var manifestSnapshots = FuseDataPackageDiscovery.GetPackageManifestSnapshots() ??
+                                    Array.Empty<FusePackageManifestSnapshot>();
+            FuseSpatialTrackConflictDetector.Replace(
+                ordered
+                    .GroupBy(item => item.folder, StringComparer.OrdinalIgnoreCase)
+                    .Select(group =>
+                    {
+                        var loaded = group
+                            .Select(item => item.candidate?.Loaded)
+                            .FirstOrDefault(candidate => candidate?.Definition != null);
+                        var manifest = FindPackageManifestSnapshot(loaded, manifestSnapshots);
+                        var conditionalRequirements = group
+                            .SelectMany(item => item.candidate?.Loaded?.Definition?.Mixinto?.Requires ??
+                                                Array.Empty<FuseModRequirement>())
+                            .Select(requirement => requirement?.Id)
+                            .Where(id => !string.IsNullOrWhiteSpace(id));
+                        return new FuseSpatialTrackPackage
+                        {
+                            PackageId = manifest?.Id ?? loaded?.Definition?.Id ?? string.Empty,
+                            FolderPath = loaded?.FolderPath ?? string.Empty,
+                            RequiredPackageIds = (manifest?.RequiredPackageIds ?? Array.Empty<string>())
+                                .Concat(conditionalRequirements)
+                                .Distinct(StringComparer.OrdinalIgnoreCase)
+                                .ToArray(),
+                            LoadAfter = manifest?.LoadAfter ?? Array.Empty<string>(),
+                            LoadBefore = manifest?.LoadBefore ?? Array.Empty<string>(),
+                            TrackDefinitions = group
+                                .Select(item => item.candidate?.Loaded?.Definition?.Tracks)
+                                .Where(tracks => tracks != null)
+                                .ToArray()
+                        };
+                    }));
+
             var sequence = 0;
             var baseGraphSnapshot = TrackAPI.GetBaseGraphSnapshotDefinition();
             foreach (var item in ordered)
@@ -530,7 +588,7 @@ namespace FUSE.Loading
                 }
 
                 plan.OrderedCandidates.Add(candidate);
-                MergeFinalDefinitions(plan.Turntables, definition.Operations?.Turntables, candidate, ref sequence);
+                MergeFinalDefinitions(plan.Turntables, definition.Operations?.Turntables, candidate, FuseClaimKind.Turntable, ref sequence);
 
                 var tracks = definition.Tracks;
                 if (tracks == null)
@@ -538,13 +596,13 @@ namespace FUSE.Loading
                     continue;
                 }
 
-                MergeFinalDeletes(plan.RemovedSpans, plan.Spans, tracks.Removals?.Spans, candidate, ref sequence);
-                MergeFinalDeletes(plan.RemovedSegments, plan.Segments, tracks.Removals?.Segments, candidate, ref sequence);
-                MergeFinalDeletes(plan.RemovedNodes, plan.Nodes, tracks.Removals?.Nodes, candidate, ref sequence);
+                MergeFinalDeletes(plan.RemovedSpans, plan.Spans, tracks.Removals?.Spans, candidate, FuseClaimKind.Span, ref sequence);
+                MergeFinalDeletes(plan.RemovedSegments, plan.Segments, tracks.Removals?.Segments, candidate, FuseClaimKind.Segment, ref sequence);
+                MergeFinalDeletes(plan.RemovedNodes, plan.Nodes, tracks.Removals?.Nodes, candidate, FuseClaimKind.Node, ref sequence);
 
-                MergeFinalDefinitions(plan.Nodes, plan.RemovedNodes, tracks.Nodes, candidate, ref sequence);
+                MergeFinalDefinitions(plan.Nodes, plan.RemovedNodes, tracks.Nodes, candidate, FuseClaimKind.Node, ref sequence);
                 MergeFinalSegmentDefinitions(plan, tracks.Segments, candidate, baseGraphSnapshot, ref sequence);
-                MergeFinalDefinitions(plan.Spans, plan.RemovedSpans, tracks.Spans, candidate, ref sequence);
+                MergeFinalDefinitions(plan.Spans, plan.RemovedSpans, tracks.Spans, candidate, FuseClaimKind.Span, ref sequence);
             }
 
             FuseLog.Info(
@@ -579,11 +637,114 @@ namespace FUSE.Loading
             }
         }
 
+        private static FusePackageManifestSnapshot FindPackageManifestSnapshot(
+            FuseLoadedMod loaded,
+            IEnumerable<FusePackageManifestSnapshot> snapshots = null)
+        {
+            if (loaded == null)
+            {
+                return null;
+            }
+
+            var normalizedFolder = NormalizePackageFolder(loaded.FolderPath);
+            var available = snapshots ?? FuseDataPackageDiscovery.GetPackageManifestSnapshots() ??
+                            Array.Empty<FusePackageManifestSnapshot>();
+            var byFolder = available.FirstOrDefault(snapshot =>
+                !string.IsNullOrWhiteSpace(normalizedFolder) &&
+                string.Equals(
+                    NormalizePackageFolder(snapshot?.FolderPath),
+                    normalizedFolder,
+                    StringComparison.OrdinalIgnoreCase));
+            if (byFolder != null)
+            {
+                return byFolder;
+            }
+
+            return available.FirstOrDefault(snapshot =>
+                FuseDeclaredPackageRelationship.SamePackageId(snapshot?.Id, loaded.Definition?.Id));
+        }
+
+        private static bool IsExpectedDeclaredLayering(
+            FuseStagedApplyCandidate existing,
+            FuseStagedApplyCandidate later)
+        {
+            return IsExpectedDeclaredLayering(existing?.Loaded, later?.Loaded);
+        }
+
+        private static bool IsExpectedDeclaredLayering(string existingOwner, string laterOwner)
+        {
+            if (string.IsNullOrWhiteSpace(existingOwner) ||
+                string.IsNullOrWhiteSpace(laterOwner) ||
+                !LoadedMods.TryGetValue(existingOwner, out var existing) ||
+                !LoadedMods.TryGetValue(laterOwner, out var later))
+            {
+                return false;
+            }
+
+            return IsExpectedDeclaredLayering(existing, later);
+        }
+
+        private static bool IsExpectedDeclaredLayering(FuseLoadedMod existing, FuseLoadedMod later)
+        {
+            if (existing == null || later == null)
+            {
+                return false;
+            }
+
+            var snapshots = FuseDataPackageDiscovery.GetPackageManifestSnapshots() ??
+                            Array.Empty<FusePackageManifestSnapshot>();
+            return FuseDeclaredPackageRelationship.IsExpectedLaterOverride(
+                FindPackageManifestSnapshot(existing, snapshots),
+                FindPackageManifestSnapshot(later, snapshots),
+                existing.Definition,
+                later.Definition);
+        }
+
+        private static void LogExpectedDeclaredLayering(
+            FuseStagedApplyCandidate existing,
+            FuseStagedApplyCandidate later)
+        {
+            LogExpectedDeclaredLayering(existing?.Loaded, later?.Loaded);
+        }
+
+        private static void LogExpectedDeclaredLayering(string existingOwner, string laterOwner)
+        {
+            if (LoadedMods.TryGetValue(existingOwner ?? string.Empty, out var existing) &&
+                LoadedMods.TryGetValue(laterOwner ?? string.Empty, out var later))
+            {
+                LogExpectedDeclaredLayering(existing, later);
+            }
+        }
+
+        private static void LogExpectedDeclaredLayering(FuseLoadedMod existing, FuseLoadedMod later)
+        {
+            var snapshots = FuseDataPackageDiscovery.GetPackageManifestSnapshots() ??
+                            Array.Empty<FusePackageManifestSnapshot>();
+            var existingManifest = FindPackageManifestSnapshot(existing, snapshots);
+            var laterManifest = FindPackageManifestSnapshot(later, snapshots);
+            var existingId = existingManifest?.Id ?? existing?.Definition?.Id ?? string.Empty;
+            var laterId = laterManifest?.Id ?? later?.Definition?.Id ?? string.Empty;
+            var key = existingId + "\0" + laterId;
+            lock (DeclaredLayeringLogSync)
+            {
+                if (!DeclaredLayeringLogPairs.Add(key))
+                {
+                    return;
+                }
+            }
+
+            FuseLog.Info(
+                $"FUSE recognized intentional package layering base='{existingId}' extension='{laterId}' " +
+                "from the resolved requires/loadAfter/loadBefore/mixinto graph; later definitions apply in resolved order " +
+                "and this relationship is excluded from Mod Conflicts.");
+        }
+
         private static void MergeFinalDeletes<T>(
             Dictionary<string, FuseMergedTrackRemoval> removals,
             Dictionary<string, FuseMergedTrackEntry<T>> definitions,
             IEnumerable<string> ids,
             FuseStagedApplyCandidate owner,
+            FuseClaimKind claimKind,
             ref int sequence)
         {
             if (ids == null)
@@ -600,15 +761,53 @@ namespace FUSE.Loading
 
                 var id = rawId.Trim();
                 sequence++;
+                if (definitions.TryGetValue(id, out var displaced) &&
+                    IsCrossPackagePlanCollision(displaced?.Owner, owner))
+                {
+                    if (IsExpectedDeclaredLayering(displaced.Owner, owner))
+                    {
+                        LogExpectedDeclaredLayering(displaced.Owner, owner);
+                    }
+                    else
+                    {
+                        FuseRegistry.RecordPlannedConflict(
+                            claimKind,
+                            id,
+                            displaced.Owner.Loaded.Definition.Id,
+                            owner.Loaded.Definition.Id,
+                            "later package removal won; earlier package definition suppressed");
+                    }
+                }
                 definitions.Remove(id);
                 removals[id] = new FuseMergedTrackRemoval(id, owner, sequence);
             }
+        }
+
+        private static bool IsCrossPackagePlanCollision(
+            FuseStagedApplyCandidate existing,
+            FuseStagedApplyCandidate attempted)
+        {
+            var existingId = existing?.Loaded?.Definition?.Id;
+            var attemptedId = attempted?.Loaded?.Definition?.Id;
+            if (string.IsNullOrWhiteSpace(existingId) ||
+                string.IsNullOrWhiteSpace(attemptedId) ||
+                string.Equals(existingId, attemptedId, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var existingFolder = NormalizePackageFolder(existing.Loaded.FolderPath);
+            var attemptedFolder = NormalizePackageFolder(attempted.Loaded.FolderPath);
+            return string.IsNullOrWhiteSpace(existingFolder) ||
+                   string.IsNullOrWhiteSpace(attemptedFolder) ||
+                   !string.Equals(existingFolder, attemptedFolder, StringComparison.OrdinalIgnoreCase);
         }
 
         private static void MergeFinalDefinitions<T>(
             Dictionary<string, FuseMergedTrackEntry<T>> definitions,
             IDictionary<string, T> values,
             FuseStagedApplyCandidate owner,
+            FuseClaimKind claimKind,
             ref int sequence)
             where T : class
         {
@@ -626,6 +825,7 @@ namespace FUSE.Loading
 
                 var id = pair.Key.Trim();
                 sequence++;
+                RecordDefinitionReplacementConflict(definitions, id, owner, claimKind);
                 definitions[id] = new FuseMergedTrackEntry<T>(id, pair.Value, owner, sequence);
             }
         }
@@ -635,6 +835,7 @@ namespace FUSE.Loading
             Dictionary<string, FuseMergedTrackRemoval> removals,
             IDictionary<string, T> values,
             FuseStagedApplyCandidate owner,
+            FuseClaimKind claimKind,
             ref int sequence)
             where T : class
         {
@@ -653,6 +854,7 @@ namespace FUSE.Loading
                 var id = pair.Key.Trim();
                 sequence++;
                 removals.Remove(id);
+                RecordDefinitionReplacementConflict(definitions, id, owner, claimKind);
                 definitions[id] = new FuseMergedTrackEntry<T>(id, pair.Value, owner, sequence);
             }
         }
@@ -692,7 +894,33 @@ namespace FUSE.Loading
                 }
 
                 plan.RemovedSegments.Remove(id);
+                RecordDefinitionReplacementConflict(plan.Segments, id, owner, FuseClaimKind.Segment);
                 plan.Segments[id] = new FuseMergedTrackEntry<FuseSegment>(id, pair.Value, owner, sequence);
+            }
+        }
+
+        private static void RecordDefinitionReplacementConflict<T>(
+            IDictionary<string, FuseMergedTrackEntry<T>> definitions,
+            string id,
+            FuseStagedApplyCandidate owner,
+            FuseClaimKind claimKind)
+        {
+            if (definitions != null &&
+                definitions.TryGetValue(id, out var existing) &&
+                IsCrossPackagePlanCollision(existing?.Owner, owner))
+            {
+                if (IsExpectedDeclaredLayering(existing.Owner, owner))
+                {
+                    LogExpectedDeclaredLayering(existing.Owner, owner);
+                    return;
+                }
+
+                FuseRegistry.RecordPlannedConflict(
+                    claimKind,
+                    id,
+                    existing.Owner.Loaded.Definition.Id,
+                    owner.Loaded.Definition.Id,
+                    "later package definition won; earlier package definition suppressed");
             }
         }
 
@@ -814,6 +1042,7 @@ namespace FUSE.Loading
                     MergeRemovalIds(plan.Scenery, worldRemovals.Scenery, candidate, ref sequence);
                     MergeRemovalIds(plan.SceneClones, worldRemovals.SceneClones, candidate, ref sequence);
                     MergeRemovalIds(plan.Splineys, worldRemovals.Splineys, candidate, ref sequence);
+                    MergeRemovalIds(plan.WaterSurfaces, worldRemovals.WaterSurfaces, candidate, ref sequence);
                     MergeRemovalIds(plan.MapLabels, worldRemovals.MapLabels, candidate, ref sequence);
                     MergeRemovalIds(plan.MapMasks, worldRemovals.MapMasks, candidate, ref sequence);
                     MergeRemovalIds(plan.TelegraphPoles, worldRemovals.TelegraphPoles, candidate, ref sequence);
@@ -834,6 +1063,7 @@ namespace FUSE.Loading
                     CancelRemovalsByAdds(plan.Scenery, world.Scenery?.Keys, ref sequence);
                     CancelRemovalsByAdds(plan.SceneClones, world.SceneClones?.Keys, ref sequence);
                     CancelRemovalsByAdds(plan.Splineys, world.Splineys?.Keys, ref sequence);
+                    CancelRemovalsByAdds(plan.WaterSurfaces, world.WaterSurfaces?.Keys, ref sequence);
                     CancelRemovalsByAdds(plan.MapLabels, world.MapLabels?.Keys, ref sequence);
                     CancelRemovalsByAdds(plan.MapMasks, world.MapMasks?.Keys, ref sequence);
                     CancelRemovalsByAdds(plan.TelegraphPoles, world.TelegraphPoles?.Keys, ref sequence);
@@ -850,7 +1080,7 @@ namespace FUSE.Loading
                 $"FUSE merged removal plan operation='build merged removal plan' " +
                 $"packages={ordered.Select(item => item.folder).Distinct(StringComparer.OrdinalIgnoreCase).Count()} " +
                 $"definitions={ordered.Length} " +
-                $"scenery={plan.Scenery.Count} sceneClones={plan.SceneClones.Count} splineys={plan.Splineys.Count} " +
+                $"scenery={plan.Scenery.Count} sceneClones={plan.SceneClones.Count} splineys={plan.Splineys.Count} waterSurfaces={plan.WaterSurfaces.Count} " +
                 $"mapLabels={plan.MapLabels.Count} mapMasks={plan.MapMasks.Count} telegraphPoles={plan.TelegraphPoles.Count} " +
                 $"industries={plan.Industries.Count}.");
             return plan;
@@ -920,6 +1150,7 @@ namespace FUSE.Loading
             ApplyMergedRemovalsForKind(plan.Scenery, "scenery", SceneryAPI.TryRemoveScenery);
             ApplyMergedRemovalsForKind(plan.SceneClones, "scene clone", SceneCloneAPI.TryRemoveSceneClone);
             ApplyMergedRemovalsForKind(plan.Splineys, "spliney", SplineyAPI.TryRemoveSpliney);
+            ApplyMergedRemovalsForKind(plan.WaterSurfaces, "water surface", WaterSurfaceAPI.TryRemoveWaterSurface);
             ApplyMergedRemovalsForKind(plan.MapLabels, "map label", MapAPI.TryRemoveMapLabel);
             ApplyMergedRemovalsForKind(plan.MapMasks, "map mask", MapAPI.TryRemoveMapMask);
             ApplyMergedRemovalsForKind(plan.TelegraphPoles, "telegraph pole set", MapAPI.TryRemoveTelegraphPoles);
@@ -1416,6 +1647,8 @@ namespace FUSE.Loading
                 StartNodeId = hasStartNode ? definition.StartNodeId : current.StartNodeId,
                 EndNodeId = hasEndNode ? definition.EndNodeId : current.EndNodeId,
                 Style = definition.PreserveStyle ? current.Style : definition.Style,
+                BridgeSupportsSteel = definition.PreserveBridgeSupportsSteel ? current.BridgeSupportsSteel : definition.BridgeSupportsSteel,
+                Yard = definition.PreserveYard ? current.Yard : definition.Yard,
                 TrackClass = definition.PreserveTrackClass ? current.TrackClass : definition.TrackClass,
                 SpeedLimit = definition.PreserveSpeedLimit ? current.SpeedLimit : definition.SpeedLimit,
                 Priority = definition.PreservePriority ? current.Priority : definition.Priority,
@@ -1483,8 +1716,7 @@ namespace FUSE.Loading
                     // to succeed, then disappear when Unity finishes the pending
                     // destroy. A fresh graph child is required when the endpoint
                     // segment set changes (ARC Whittier's Pyc3/Pap9 case).
-                    TrackAPI.RemoveSpan(entry.Id);
-                    TrackAPI.AddSpan(entry.Id, entry.Value);
+                    TrackAPI.ReplaceSpan(entry.Id, entry.Value);
                     FuseLog.Info(
                         $"FUSE recreated track span package='{definition.Id}' operation='apply-merged-spans' " +
                         $"kind='track span' id='{entry.Id}' message='endpoint topology changed; avoided reusing retiring runtime span instance'.");

--- a/FUSE/Loading/FuseModLoader.Validation.cs
+++ b/FUSE/Loading/FuseModLoader.Validation.cs
@@ -537,6 +537,12 @@ namespace FUSE.Loading
                 }
             }
 
+            foreach (var waterSurfaceId in definition.World?.WaterSurfaces?.Keys ?? Enumerable.Empty<string>())
+            {
+                if (WaterSurfaceAPI.GetWaterSurface(waterSurfaceId) == null)
+                    transaction.Warning("water surface", waterSurfaceId, "missing after apply");
+            }
+
             foreach (var sceneCloneId in definition.World?.SceneClones?.Keys ?? Enumerable.Empty<string>())
             {
                 if (SceneCloneAPI.GetSceneClone(sceneCloneId) == null)

--- a/FUSE/Loading/FuseModLoader.cs
+++ b/FUSE/Loading/FuseModLoader.cs
@@ -35,7 +35,7 @@ namespace FUSE.Loading
                 .ToArray();
         }
 
-        public static FuseLoadedMod LoadMod(string modFolder)
+        public static FuseLoadedMod LoadMod(string modFolder, string packageId = null)
         {
             if (string.IsNullOrWhiteSpace(modFolder))
             {
@@ -48,11 +48,43 @@ namespace FUSE.Loading
             for (var index = 0; index < definitionPaths.Length; index++)
             {
                 var definitionPath = definitionPaths[index];
-                var definition = FuseSerializer.Load(definitionPath);
+                FuseModDefinition definition;
+                try
+                {
+                    definition = FuseSerializer.Load(definitionPath);
+                }
+                catch (Exception ex)
+                {
+                    var reportedId = string.IsNullOrWhiteSpace(packageId)
+                        ? Path.GetFileName(modFolder)
+                        : packageId;
+                    FusePackageFaultRegistry.RecordFault(
+                        reportedId,
+                        "JSON deserialization",
+                        ex.GetBaseException().Message,
+                        ex,
+                        modFolder,
+                        definitionPath,
+                        expectedShape: "A valid native FUSE definition object matching fuse-mod.schema.json.",
+                        receivedValue: ex.GetBaseException().Message);
+                    throw;
+                }
                 var definitionId = definition?.Id;
                 if (string.IsNullOrWhiteSpace(definitionId))
                 {
-                    FusePackageFaultRegistry.RecordFault(Path.GetFileName(modFolder), "validation", $"Definition file '{definitionPath}' is missing an id.");
+                    FusePackageFaultRegistry.RecordFault(
+                        string.IsNullOrWhiteSpace(packageId) ? Path.GetFileName(modFolder) : packageId,
+                        "schema validation",
+                        "Definition is missing the required 'id' field.",
+                        null,
+                        modFolder,
+                        definitionPath,
+                        "id",
+                        suggestedAction: "Add a unique, non-empty 'id' to this definition.",
+                        packageName: definition?.Name,
+                        validationCode: "fuse.required",
+                        expectedShape: "A unique, non-empty native FUSE definition id.",
+                        receivedValue: definitionId);
                     throw new InvalidOperationException($"FUSE definition file '{definitionPath}' is missing an id.");
                 }
 
@@ -61,7 +93,19 @@ namespace FUSE.Loading
                     var message =
                         $"Duplicate FUSE definition id '{definitionId}' in package folder '{modFolder}'. " +
                         $"First file='{firstPath}', duplicate file='{definitionPath}'.";
-                    FusePackageFaultRegistry.RecordFault(definitionId, "validation", message);
+                    FusePackageFaultRegistry.RecordFault(
+                        definitionId,
+                        "schema validation",
+                        message,
+                        null,
+                        modFolder,
+                        definitionPath,
+                        "id",
+                        suggestedAction: "Give every definition file in this package a unique id.",
+                        packageName: definition?.Name,
+                        validationCode: "fuse.id.duplicate",
+                        expectedShape: "A definition id used only once in this package.",
+                        receivedValue: definitionId);
                     throw new InvalidOperationException(message);
                 }
 
@@ -92,6 +136,21 @@ namespace FUSE.Loading
                     FuseLog.Error(
                         $"FUSE validation error package='{packageId}' operation='load definition' " +
                         $"kind='{error.Field ?? string.Empty}' message='{error.Message ?? string.Empty}'{code}{value}.");
+                    FusePackageFaultRegistry.RecordFault(
+                        packageId,
+                        "schema validation",
+                        error.Message,
+                        null,
+                        folderPath,
+                        definitionPath,
+                        error.Field,
+                        suggestedAction:
+                            $"Correct '{error.Field ?? "<root>"}' in this definition" +
+                            (string.IsNullOrWhiteSpace(error.Code) ? "." : $" (validation code {error.Code})."),
+                        packageName: definition?.Name,
+                        validationCode: error.Code,
+                        expectedShape: error.Message,
+                        receivedValue: error.Value?.ToString());
                 }
 
                 foreach (var warning in validation.Warnings)
@@ -103,11 +162,23 @@ namespace FUSE.Loading
                         $"kind='{warning.Field ?? string.Empty}' message='{warning.Message ?? string.Empty}'{code}{value}.");
                 }
 
-                FusePackageFaultRegistry.RecordFault(packageId, "validation", $"Definition failed validation with {validation.Errors.Count} error(s).");
                 throw new InvalidOperationException($"FUSE definition '{definition?.Id ?? "<null>"}' failed validation with {validation.Errors.Count} error(s).");
             }
 
-            RegisterLoadedDefinition(definition, folderPath, definitionPath);
+            var sourceDefinition = definition;
+            var runtimeDefinition = definition;
+            var featureEvaluation = new FuseFeatureEvaluation();
+            if (definition.FeatureRules != null && definition.FeatureRules.Count > 0)
+            {
+                runtimeDefinition = FuseSerializer.FromJson(FuseSerializer.ToJson(definition));
+                featureEvaluation = FuseFeatureRuleEvaluator.Apply(runtimeDefinition);
+                FuseLog.Info(
+                    $"FUSE evaluated package feature rules package='{definition.Id}' " +
+                    $"rules={featureEvaluation.RuleCount} enabled={featureEvaluation.EnabledRuleCount} " +
+                    $"disabled={featureEvaluation.DisabledRuleCount} omittedObjects={featureEvaluation.RemovedObjectCount}.");
+            }
+
+            RegisterLoadedDefinition(runtimeDefinition, folderPath, definitionPath, sourceDefinition, featureEvaluation);
         }
 
         public static int ApplyLoadedDefinitions(string reason)
@@ -163,7 +234,14 @@ namespace FUSE.Loading
                 }
                 catch (Exception ex)
                 {
-                    FusePackageFaultRegistry.RecordFault(id, "runtime apply", ex.Message, ex);
+                    FusePackageFaultRegistry.RecordFault(
+                        id,
+                        "runtime apply",
+                        ex.Message,
+                        ex,
+                        loaded.FolderPath,
+                        loaded.DefinitionPath,
+                        suggestedAction: "Review this package file and the exception details, correct the referenced runtime definition, then reload the map.");
                     FusePackageFaultRegistry.MarkSkipped(id, "runtime apply exception");
                     outcomes.Add(PackageApplyOutcome.ForErrored(id, ex.Message));
                     FuseLog.Exception($"Failed to prepare loaded FUSE definition '{id}' for runtime apply '{reason ?? "unspecified"}'", ex);
@@ -210,7 +288,12 @@ namespace FUSE.Loading
             }
         }
 
-        private static void RegisterLoadedDefinition(FuseModDefinition definition, string folderPath, string definitionPath)
+        private static void RegisterLoadedDefinition(
+            FuseModDefinition definition,
+            string folderPath,
+            string definitionPath,
+            FuseModDefinition sourceDefinition,
+            FuseFeatureEvaluation featureEvaluation)
         {
             if (definition == null || string.IsNullOrWhiteSpace(definition.Id))
             {
@@ -231,7 +314,12 @@ namespace FUSE.Loading
                     $"FUSE definition replacement package='{definition.Id}' operation='replace loaded definition' id='{definition.Id}' releasedClaims={released}.");
             }
 
-            LoadedMods[definition.Id] = new FuseLoadedMod(folderPath, definitionPath, definition);
+            LoadedMods[definition.Id] = new FuseLoadedMod(
+                folderPath,
+                definitionPath,
+                definition,
+                sourceDefinition,
+                featureEvaluation);
             if (firstLoad && !LoadedOrder.Contains(definition.Id, StringComparer.OrdinalIgnoreCase))
             {
                 LoadedOrder.Add(definition.Id);
@@ -575,6 +663,11 @@ namespace FUSE.Loading
             // Per-mod claims were released in UnloadMod; reset registry to drop
             // any orphaned shared claims and the conflict history.
             FuseRegistry.Reset();
+            FuseSpatialTrackConflictDetector.Clear();
+            lock (DeclaredLayeringLogSync)
+            {
+                DeclaredLayeringLogPairs.Clear();
+            }
             if (resetDiscovery)
             {
                 FuseDataPackageDiscovery.ResetDiscovery();
@@ -658,6 +751,13 @@ namespace FUSE.Loading
                 : null;
         }
 
+        public static FuseModDefinition GetLoadedSourceDefinition(string modId)
+        {
+            return !string.IsNullOrWhiteSpace(modId) && LoadedMods.TryGetValue(modId, out var loaded)
+                ? loaded.SourceDefinition
+                : null;
+        }
+
         public static bool TryGetLoadedMod(string modId, out FuseLoadedMod loaded)
         {
             if (string.IsNullOrWhiteSpace(modId))
@@ -682,7 +782,7 @@ namespace FUSE.Loading
 
         public static void ExportToJson(string modId, string outputPath)
         {
-            var definition = GetLoadedDefinition(modId);
+            var definition = GetLoadedSourceDefinition(modId);
             if (definition == null)
             {
                 throw new InvalidOperationException($"FUSE mod '{modId}' is not loaded.");

--- a/FUSE/Loading/FuseModRequirementResolver.cs
+++ b/FUSE/Loading/FuseModRequirementResolver.cs
@@ -24,40 +24,80 @@ namespace FUSE.Loading
                 .Where(requirement => !string.IsNullOrWhiteSpace(requirement?.Id))
                 .ToArray() ?? Array.Empty<FuseModRequirement>();
 
-            if (requirements.Length == 0)
+            var conflictsWith = mixinto?.ConflictsWith?
+                .Where(requirement => !string.IsNullOrWhiteSpace(requirement?.Id))
+                .ToArray() ?? Array.Empty<FuseModRequirement>();
+
+            if (requirements.Length == 0 && conflictsWith.Length == 0)
             {
                 return true;
             }
 
             var installedMods = CollectInstalledMods();
+            var sourceFile = string.IsNullOrWhiteSpace(loaded.DefinitionPath)
+                ? mixinto?.SourceFile ?? string.Empty
+                : loaded.DefinitionPath;
             foreach (var requirement in requirements)
             {
                 if (!TryFindInstalled(requirement.Id, installedMods, out var installed))
                 {
                     reason =
-                        $"mixinto dependency missing id='{requirement.Id}' " +
-                        $"target='{mixinto?.Target ?? string.Empty}' sourceFile='{mixinto?.SourceFile ?? string.Empty}'";
+                        $"package='{definition?.Id ?? string.Empty}' mixinto dependency missing id='{requirement.Id}' " +
+                        $"target='{mixinto?.Target ?? string.Empty}' folder='{loaded.FolderPath}' sourceFile='{sourceFile}' " +
+                        "action='Install and enable the named dependency, or correct mixinto.requires in this file.'";
                     return false;
                 }
 
-                if (!VersionSatisfies(definition?.Id, requirement, installed, out reason))
+                // Replacement capabilities use FUSE's version line, not the
+                // retired package's version line. Once the capability is
+                // declared provided, legacy notBefore/notAfter values do not
+                // compare meaningfully and must not reject the mixinto.
+                if (!installed.IsReplacementCapability &&
+                    !VersionSatisfies(definition?.Id, requirement, installed, out reason))
                 {
                     reason =
-                        $"mixinto dependency version mismatch id='{requirement.Id}' installedVersion='{installed.Version}' " +
+                        $"package='{definition?.Id ?? string.Empty}' mixinto dependency version mismatch id='{requirement.Id}' installedVersion='{installed.Version}' " +
                         $"notBefore='{requirement.NotBefore ?? string.Empty}' notAfter='{requirement.NotAfter ?? string.Empty}' " +
-                        $"target='{mixinto?.Target ?? string.Empty}' sourceFile='{mixinto?.SourceFile ?? string.Empty}'";
+                        $"target='{mixinto?.Target ?? string.Empty}' folder='{loaded.FolderPath}' sourceFile='{sourceFile}' " +
+                        "action='Install a compatible dependency version, or correct the version bounds in mixinto.requires.'";
                     return false;
                 }
             }
 
-            reason = $"mixinto requirements satisfied target='{mixinto?.Target ?? string.Empty}' sourceFile='{mixinto?.SourceFile ?? string.Empty}'";
+            foreach (var conflict in conflictsWith)
+            {
+                if (!TryFindInstalled(conflict.Id, installedMods, out var installed))
+                {
+                    continue;
+                }
+
+                var matchesVersion = installed.IsReplacementCapability ||
+                    VersionSatisfies(definition?.Id, conflict, installed, out _);
+                if (!matchesVersion)
+                {
+                    continue;
+                }
+
+                reason =
+                    $"package='{definition?.Id ?? string.Empty}' mixinto conflict matched id='{conflict.Id}' " +
+                    $"installedVersion='{installed.Version}' target='{mixinto?.Target ?? string.Empty}' " +
+                    $"folder='{loaded.FolderPath}' sourceFile='{sourceFile}' " +
+                    "action='This conditional fragment is intentionally inactive while the conflicting package is enabled.'";
+                return false;
+            }
+
+            reason = $"mixinto requirements satisfied; conflicts clear target='{mixinto?.Target ?? string.Empty}' sourceFile='{sourceFile}'";
             return true;
         }
 
-        private static Dictionary<string, InstalledMod> CollectInstalledMods()
+        internal static Dictionary<string, InstalledMod> CollectInstalledMods()
         {
             var result = new Dictionary<string, InstalledMod>(StringComparer.OrdinalIgnoreCase);
-            AddInstalled(result, "FUSE", "1.0.0", "runtime");
+            var fuseVersion = typeof(FuseModRequirementResolver).Assembly.GetName().Version?.ToString() ?? "1.0.0";
+            foreach (var capabilityId in FuseReplacementCapabilityCatalog.AdvertisedPackageIds)
+            {
+                AddInstalled(result, capabilityId, fuseVersion, "FUSE replacement capability", true);
+            }
 
             foreach (var loaded in FuseModLoader.GetLoadedModsInOrder())
             {
@@ -67,7 +107,12 @@ namespace FUSE.Loading
                     continue;
                 }
 
-                AddInstalled(result, definition.Id, definition.ModVersion, "loaded definition");
+                AddInstalled(
+                    result,
+                    definition.Id,
+                    definition.ModVersion,
+                    "loaded definition",
+                    folderPath: loaded.FolderPath);
                 TryReadFolderManifests(loaded.FolderPath, result);
             }
 
@@ -90,6 +135,14 @@ namespace FUSE.Loading
 
             foreach (var folder in folders)
             {
+                var packageId = TryReadPrimaryPackageId(folder);
+                if (IsManifestDisabled(folder) ||
+                    FuseUmmState.TryGetDisabledReason(folder, packageId, out _) ||
+                    !FuseModSetService.IsPackageEnabledByActiveSet(packageId, folder))
+                {
+                    continue;
+                }
+
                 TryReadFolderManifests(folder, result);
             }
 
@@ -111,9 +164,83 @@ namespace FUSE.Loading
                 return;
             }
 
-            AddInstalled(result, Path.GetFileName(folder), string.Empty, "mod folder");
+            AddInstalled(result, Path.GetFileName(folder), string.Empty, "mod folder", folderPath: folder);
             TryReadManifest(infoPath, "Id", "Version", "Info.json", result);
             TryReadManifest(definitionPath, "id", "version", "Definition.json", result);
+        }
+
+        private static string TryReadPrimaryPackageId(string folder)
+        {
+            foreach (var candidate in new[]
+                     {
+                         new { Path = Path.Combine(folder, "Info.json"), Id = "Id" },
+                         new { Path = Path.Combine(folder, "Definition.json"), Id = "id" }
+                     })
+            {
+                if (!File.Exists(candidate.Path))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var manifest = FuseLegacyDataConverter.ReadLegacyObject(candidate.Path);
+                    var id = ReadString(manifest, candidate.Id, "Id", "id");
+                    if (!string.IsNullOrWhiteSpace(id))
+                    {
+                        return id;
+                    }
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
+                {
+                    // The normal manifest reader reports the parse problem. The
+                    // folder name remains sufficient for enabled-state checks.
+                    FuseLog.Info(
+                        $"FUSE dependency scan could not read primary package id from '{candidate.Path}'; " +
+                        $"using folder identity instead. reason='{ex.Message}'");
+                }
+            }
+
+            return Path.GetFileName(folder) ?? string.Empty;
+        }
+
+        private static bool IsManifestDisabled(string folder)
+        {
+            var infoPath = Path.Combine(folder, "Info.json");
+            if (!File.Exists(infoPath))
+            {
+                return false;
+            }
+
+            try
+            {
+                var info = FuseLegacyDataConverter.ReadLegacyObject(infoPath);
+                return ReadBoolean(info, "FuseDisabled", false) ||
+                       ReadBoolean(info, "Disabled", false) ||
+                       ReadBoolean(info, "disabled", false) ||
+                       !ReadBoolean(info, "Enabled", true) ||
+                       !ReadBoolean(info, "enabled", true);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
+            {
+                return false;
+            }
+        }
+
+        private static bool ReadBoolean(JObject manifest, string propertyName, bool defaultValue)
+        {
+            var token = manifest?[propertyName];
+            if (token == null)
+            {
+                return defaultValue;
+            }
+
+            if (token.Type == JTokenType.Boolean)
+            {
+                return (bool)token;
+            }
+
+            return bool.TryParse(token.ToString(), out var value) ? value : defaultValue;
         }
 
         private static void TryReadManifest(
@@ -138,7 +265,7 @@ namespace FUSE.Loading
                 }
 
                 var version = ReadString(manifest, versionProperty, versionProperty.ToLowerInvariant(), "Version", "version");
-                AddInstalled(result, id, version, sourceName);
+                AddInstalled(result, id, version, sourceName, folderPath: Path.GetDirectoryName(path));
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException)
             {
@@ -178,7 +305,13 @@ namespace FUSE.Loading
             return string.Empty;
         }
 
-        private static void AddInstalled(IDictionary<string, InstalledMod> result, string id, string version, string source)
+        private static void AddInstalled(
+            IDictionary<string, InstalledMod> result,
+            string id,
+            string version,
+            string source,
+            bool isReplacementCapability = false,
+            string folderPath = null)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
@@ -186,15 +319,27 @@ namespace FUSE.Loading
             }
 
             var normalizedId = id.Trim();
-            AddAlias(result, normalizedId, version, source);
+            AddAlias(result, normalizedId, version, source, isReplacementCapability, folderPath);
             if (normalizedId.EndsWith(".FUSE", StringComparison.OrdinalIgnoreCase) ||
                 normalizedId.EndsWith(".RAIL", StringComparison.OrdinalIgnoreCase))
             {
-                AddAlias(result, normalizedId.Substring(0, normalizedId.Length - 5), version, source);
+                AddAlias(
+                    result,
+                    normalizedId.Substring(0, normalizedId.Length - 5),
+                    version,
+                    source,
+                    isReplacementCapability,
+                    folderPath);
             }
         }
 
-        private static void AddAlias(IDictionary<string, InstalledMod> result, string id, string version, string source)
+        private static void AddAlias(
+            IDictionary<string, InstalledMod> result,
+            string id,
+            string version,
+            string source,
+            bool isReplacementCapability,
+            string folderPath)
         {
             if (string.IsNullOrWhiteSpace(id) || result.ContainsKey(id))
             {
@@ -205,16 +350,40 @@ namespace FUSE.Loading
             {
                 Id = id,
                 Version = version ?? string.Empty,
-                Source = source ?? string.Empty
+                Source = source ?? string.Empty,
+                IsReplacementCapability = isReplacementCapability,
+                FolderPath = folderPath ?? string.Empty
             };
         }
 
-        private static bool TryFindInstalled(string id, Dictionary<string, InstalledMod> installedMods, out InstalledMod installed)
+        internal static bool TryFindInstalled(string id, Dictionary<string, InstalledMod> installedMods, out InstalledMod installed)
         {
             installed = null;
-            return !string.IsNullOrWhiteSpace(id) &&
-                   installedMods != null &&
-                   installedMods.TryGetValue(id.Trim(), out installed);
+            if (string.IsNullOrWhiteSpace(id) || installedMods == null)
+            {
+                return false;
+            }
+
+            if (installedMods.TryGetValue(id.Trim(), out installed))
+            {
+                return true;
+            }
+
+            if (!FuseReplacementCapabilityCatalog.IsProvided(id))
+            {
+                return false;
+            }
+
+            var fuseVersion = typeof(FuseModRequirementResolver).Assembly.GetName().Version?.ToString() ?? "1.0.0";
+            installed = new InstalledMod
+            {
+                Id = id.Trim(),
+                Version = fuseVersion,
+                Source = "FUSE replacement capability",
+                IsReplacementCapability = true,
+                FolderPath = string.Empty
+            };
+            return true;
         }
 
         internal static bool VersionSatisfies(
@@ -337,6 +506,8 @@ namespace FUSE.Loading
             public string Id { get; set; }
             public string Version { get; set; }
             public string Source { get; set; }
+            public bool IsReplacementCapability { get; set; }
+            public string FolderPath { get; set; }
         }
     }
 }

--- a/FUSE/Loading/FusePackageFaultRegistry.cs
+++ b/FUSE/Loading/FusePackageFaultRegistry.cs
@@ -1,30 +1,126 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using FUSE.Infrastructure;
+using Newtonsoft.Json;
 
 namespace FUSE.Loading
 {
     internal sealed class FusePackageFault
     {
         public FusePackageFault(string packageId, string stage, string message, string details)
+            : this(packageId, stage, message, details, string.Empty, string.Empty, string.Empty, 0, 0, string.Empty)
+        {
+        }
+
+        public FusePackageFault(
+            string packageId,
+            string stage,
+            string message,
+            string details,
+            string folderPath,
+            string sourceFile,
+            string jsonPath,
+            int lineNumber,
+            int linePosition,
+            string suggestedAction,
+            string packageName = null,
+            string validationCode = null,
+            string expectedShape = null,
+            string receivedValue = null)
         {
             PackageId = packageId ?? string.Empty;
+            PackageName = string.IsNullOrWhiteSpace(packageName)
+                ? InferPackageName(PackageId, folderPath)
+                : packageName.Trim();
             Stage = stage ?? string.Empty;
             Message = message ?? string.Empty;
             Details = details ?? string.Empty;
+            FolderPath = folderPath ?? string.Empty;
+            SourceFile = sourceFile ?? string.Empty;
+            RelativeSourceFile = MakeRelativeSourceFile(FolderPath, SourceFile);
+            JsonPath = jsonPath ?? string.Empty;
+            LineNumber = Math.Max(0, lineNumber);
+            LinePosition = Math.Max(0, linePosition);
+            SuggestedAction = suggestedAction ?? string.Empty;
+            ValidationCode = validationCode ?? string.Empty;
+            ExpectedShape = expectedShape ?? string.Empty;
+            ReceivedValue = receivedValue ?? string.Empty;
             TimestampUtc = DateTime.UtcNow;
         }
 
         public string PackageId { get; }
+        public string PackageName { get; }
         public string Stage { get; }
         public string Message { get; }
         public string Details { get; }
+        public string FolderPath { get; }
+        public string SourceFile { get; }
+        public string RelativeSourceFile { get; }
+        public string JsonPath { get; }
+        public int LineNumber { get; }
+        public int LinePosition { get; }
+        public string SuggestedAction { get; }
+        public string ValidationCode { get; }
+        public string ExpectedShape { get; }
+        public string ReceivedValue { get; }
         public DateTime TimestampUtc { get; }
 
         public override string ToString()
         {
-            return $"package='{PackageId}' stage='{Stage}' message='{Message}' details='{Details}'";
+            return
+                $"package='{PackageId}' packageName='{PackageName}' stage='{Stage}' message='{Message}' " +
+                $"folder='{FolderPath}' file='{SourceFile}' relativeFile='{RelativeSourceFile}' jsonPath='{JsonPath}' " +
+                $"line={LineNumber} position={LinePosition} code='{ValidationCode}' expected='{ExpectedShape}' " +
+                $"received='{ReceivedValue}' action='{SuggestedAction}' details='{Details}'";
+        }
+
+        private static string InferPackageName(string packageId, string folderPath)
+        {
+            if (!string.IsNullOrWhiteSpace(folderPath))
+            {
+                try
+                {
+                    var folderName = Path.GetFileName(folderPath.TrimEnd(
+                        Path.DirectorySeparatorChar,
+                        Path.AltDirectorySeparatorChar));
+                    if (!string.IsNullOrWhiteSpace(folderName))
+                        return folderName;
+                }
+                catch (Exception ex) when (
+                    ex is ArgumentException ||
+                    ex is NotSupportedException ||
+                    ex is PathTooLongException)
+                {
+                    // Keep the package id fallback; diagnostics must not fail
+                    // while formatting an already-broken path.
+                    return packageId ?? string.Empty;
+                }
+            }
+            return packageId ?? string.Empty;
+        }
+
+        private static string MakeRelativeSourceFile(string folderPath, string sourceFile)
+        {
+            if (string.IsNullOrWhiteSpace(sourceFile))
+                return string.Empty;
+            if (string.IsNullOrWhiteSpace(folderPath))
+                return Path.GetFileName(sourceFile) ?? sourceFile;
+            try
+            {
+                var root = Path.GetFullPath(folderPath).TrimEnd(
+                    Path.DirectorySeparatorChar,
+                    Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+                var file = Path.GetFullPath(sourceFile);
+                return file.StartsWith(root, StringComparison.OrdinalIgnoreCase)
+                    ? file.Substring(root.Length)
+                    : Path.GetFileName(file);
+            }
+            catch
+            {
+                return Path.GetFileName(sourceFile) ?? sourceFile;
+            }
         }
     }
 
@@ -68,11 +164,65 @@ namespace FUSE.Loading
             AppliedPackages.Remove(packageId);
         }
 
-        public static void RecordFault(string packageId, string stage, string message, Exception exception = null)
+        public static void RecordFault(
+            string packageId,
+            string stage,
+            string message,
+            Exception exception = null,
+            string folderPath = null,
+            string sourceFile = null,
+            string jsonPath = null,
+            int lineNumber = 0,
+            int linePosition = 0,
+            string suggestedAction = null,
+            string packageName = null,
+            string validationCode = null,
+            string expectedShape = null,
+            string receivedValue = null)
         {
             packageId = NormalizePackageId(packageId);
+            ExtractJsonLocation(exception, ref jsonPath, ref lineNumber, ref linePosition);
+            if (string.IsNullOrWhiteSpace(folderPath) && !string.IsNullOrWhiteSpace(sourceFile))
+            {
+                try
+                {
+                    folderPath = Path.GetDirectoryName(sourceFile);
+                }
+                catch
+                {
+                    folderPath = string.Empty;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(suggestedAction) && IsJsonException(exception))
+            {
+                suggestedAction =
+                    "Correct the JSON at the reported location, validate the file against the bundled FUSE schema, then reload the package.";
+            }
+            if (IsJsonException(exception))
+            {
+                if (string.IsNullOrWhiteSpace(expectedShape))
+                    expectedShape = "Valid JSON matching the declared FUSE or package manifest schema.";
+                if (string.IsNullOrWhiteSpace(receivedValue))
+                    receivedValue = exception.GetBaseException().Message;
+            }
+
             var details = exception == null ? string.Empty : exception.ToString();
-            var fault = new FusePackageFault(packageId, stage, message, details);
+            var fault = new FusePackageFault(
+                packageId,
+                stage,
+                message,
+                details,
+                folderPath,
+                sourceFile,
+                jsonPath,
+                lineNumber,
+                linePosition,
+                suggestedAction,
+                packageName,
+                validationCode,
+                expectedShape,
+                receivedValue);
 
             if (!Faults.TryGetValue(packageId, out var packageFaults))
             {
@@ -82,13 +232,54 @@ namespace FUSE.Loading
 
             if (packageFaults.Any(existing =>
                 string.Equals(existing.Stage, fault.Stage, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(existing.Message, fault.Message, StringComparison.Ordinal)))
+                string.Equals(existing.Message, fault.Message, StringComparison.Ordinal) &&
+                string.Equals(existing.SourceFile, fault.SourceFile, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(existing.JsonPath, fault.JsonPath, StringComparison.Ordinal)))
             {
                 return;
             }
 
             packageFaults.Add(fault);
             FuseLog.Error($"FUSE package fault recorded: {fault}");
+        }
+
+        private static void ExtractJsonLocation(
+            Exception exception,
+            ref string jsonPath,
+            ref int lineNumber,
+            ref int linePosition)
+        {
+            for (var current = exception; current != null; current = current.InnerException)
+            {
+                if (current is JsonReaderException reader)
+                {
+                    jsonPath = string.IsNullOrWhiteSpace(jsonPath) ? reader.Path : jsonPath;
+                    lineNumber = lineNumber > 0 ? lineNumber : reader.LineNumber;
+                    linePosition = linePosition > 0 ? linePosition : reader.LinePosition;
+                    return;
+                }
+
+                if (current is JsonSerializationException serialization)
+                {
+                    jsonPath = string.IsNullOrWhiteSpace(jsonPath) ? serialization.Path : jsonPath;
+                    lineNumber = lineNumber > 0 ? lineNumber : serialization.LineNumber;
+                    linePosition = linePosition > 0 ? linePosition : serialization.LinePosition;
+                    return;
+                }
+            }
+        }
+
+        private static bool IsJsonException(Exception exception)
+        {
+            for (var current = exception; current != null; current = current.InnerException)
+            {
+                if (current is JsonException)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public static void MarkDisabled(string packageId, string reason)

--- a/FUSE/Loading/FusePackageFaultRegistry.cs
+++ b/FUSE/Loading/FusePackageFaultRegistry.cs
@@ -359,7 +359,7 @@ namespace FUSE.Loading
         public static bool IsOptionalSkipReason(string reason)
         {
             return !string.IsNullOrWhiteSpace(reason) &&
-                   (reason.StartsWith("mixinto dependency missing", StringComparison.OrdinalIgnoreCase) ||
+                   (reason.IndexOf("mixinto dependency missing", StringComparison.OrdinalIgnoreCase) >= 0 ||
                     reason.StartsWith(FuseMapSession.InactiveSkipReasonPrefix, StringComparison.OrdinalIgnoreCase));
         }
 

--- a/FUSE/Loading/FuseReplacementCapabilityCatalog.cs
+++ b/FUSE/Loading/FuseReplacementCapabilityCatalog.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FUSE.Loading
+{
+    /// <summary>
+    /// Legacy package identifiers whose runtime contract is supplied by FUSE.
+    /// These are virtual capabilities, not ordinary data packages: they satisfy
+    /// dependency checks, but do not create a data-package ordering node because
+    /// the FUSE runtime is initialized before discovered packages are applied.
+    /// </summary>
+    internal static class FuseReplacementCapabilityCatalog
+    {
+        private static readonly string[] ExplicitPackageIds =
+        {
+            "FUSE",
+            "railroader",
+            "Railloader",
+            "RailLoader.Injector",
+            "RailLoader.Interchange",
+            "AssetLoader",
+            "AlinaNova21.AlinasMapMod",
+            "AlinasMapMod",
+            "AlinaMapMod",
+            "AlinaNova21.MapEditor",
+            "MapEditor",
+            "MMapEditor",
+            "Zamu.ConfusingSupplements",
+            "Zamu.C1CD",
+            "Zamu.FallFromGrace",
+            "Zamu.AbsoluteMadness",
+            "Zamu.SomeKindOfMadness",
+            "Zamu.Interchange2Interchange",
+            "Zamu.ForYourConvenience",
+            "Zamu.StrangeCustoms",
+            "StrangeCustoms",
+            "ConfusingSupplements",
+            "C1CD",
+            "FallFromGrace",
+            "AbsoluteMadness",
+            "SomeKindOfMadness",
+            "Interchange2Interchange",
+            "ForYourConvenience"
+        };
+
+        private static readonly HashSet<string> ExplicitPackageIdSet =
+            new HashSet<string>(ExplicitPackageIds.Select(Normalize), StringComparer.OrdinalIgnoreCase);
+
+        internal static IEnumerable<string> AdvertisedPackageIds => ExplicitPackageIds;
+
+        internal static bool IsProvided(string packageId)
+        {
+            var normalized = Normalize(packageId);
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                return false;
+            }
+
+            // Do not use a broad Zamu.* match here. Several ZAMU gameplay mods
+            // are still hosted and do not yet have native parity; advertising
+            // those ids would silently waive a real dependency and regress the
+            // dependent package.
+            return ExplicitPackageIdSet.Contains(normalized);
+        }
+
+        internal static string Normalize(string packageId)
+        {
+            var value = (packageId ?? string.Empty).Trim();
+            while (value.EndsWith(".FUSE", StringComparison.OrdinalIgnoreCase) ||
+                   value.EndsWith(".RAIL", StringComparison.OrdinalIgnoreCase))
+            {
+                value = value.Substring(0, value.Length - 5);
+            }
+
+            if (string.Equals(value, "rail-loader", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Railloader";
+            }
+
+            return value;
+        }
+    }
+}

--- a/FUSE/Loading/FuseSpatialTrackConflictDetector.cs
+++ b/FUSE/Loading/FuseSpatialTrackConflictDetector.cs
@@ -1,0 +1,296 @@
+using FUSE.Authoring.Data;
+using FUSE.Runtime.Registry;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+
+namespace FUSE.Loading
+{
+    internal sealed class FuseSpatialTrackPackage
+    {
+        public string PackageId { get; set; }
+        public string FolderPath { get; set; }
+        public string[] RequiredPackageIds { get; set; } = Array.Empty<string>();
+        public string[] LoadAfter { get; set; } = Array.Empty<string>();
+        public string[] LoadBefore { get; set; } = Array.Empty<string>();
+        public FuseTrackDefinition[] TrackDefinitions { get; set; } = Array.Empty<FuseTrackDefinition>();
+    }
+
+    /// <summary>
+    /// Finds conservative, advisory overlap between independent track
+    /// packages. This is deliberately separate from FuseRegistry: nearby
+    /// custom track may be a legitimate extension, so these findings must not
+    /// affect ownership, apply order, or the main Status conflict count.
+    /// </summary>
+    internal static class FuseSpatialTrackConflictDetector
+    {
+        private const float NearbyHorizontalDistance = 20f;
+        private const float NearbyVerticalDistance = 10f;
+        private static readonly object Sync = new object();
+        private static FuseRegistryConflict[] _conflicts = Array.Empty<FuseRegistryConflict>();
+
+        public static IReadOnlyList<FuseRegistryConflict> Conflicts
+        {
+            get
+            {
+                lock (Sync)
+                {
+                    return _conflicts.ToArray();
+                }
+            }
+        }
+
+        public static void Replace(IEnumerable<FuseSpatialTrackPackage> packages)
+        {
+            var detected = Detect(packages);
+            lock (Sync)
+            {
+                _conflicts = detected;
+            }
+        }
+
+        public static void Clear()
+        {
+            lock (Sync)
+            {
+                _conflicts = Array.Empty<FuseRegistryConflict>();
+            }
+        }
+
+        internal static FuseRegistryConflict[] Detect(IEnumerable<FuseSpatialTrackPackage> packages)
+        {
+            var footprints = (packages ?? Enumerable.Empty<FuseSpatialTrackPackage>())
+                .Select(BuildFootprint)
+                .Where(footprint => footprint != null && footprint.Nodes.Length >= 2 && footprint.SegmentCount >= 2)
+                .ToArray();
+            var conflicts = new List<FuseRegistryConflict>();
+
+            for (var leftIndex = 0; leftIndex < footprints.Length; leftIndex++)
+            {
+                var left = footprints[leftIndex];
+                for (var rightIndex = leftIndex + 1; rightIndex < footprints.Length; rightIndex++)
+                {
+                    var right = footprints[rightIndex];
+                    if (SamePackageFolder(left.FolderPath, right.FolderPath) ||
+                        IsExpectedLayering(left, right) ||
+                        !BoundsMayOverlap(left, right, NearbyHorizontalDistance))
+                    {
+                        continue;
+                    }
+
+                    var nearby = FindNearbyNodePairs(left.Nodes, right.Nodes);
+                    if (nearby.Count < 2)
+                    {
+                        continue;
+                    }
+
+                    var centerX = nearby.Average(pair => (pair.Left.Position.x + pair.Right.Position.x) * 0.5f);
+                    var centerZ = nearby.Average(pair => (pair.Left.Position.z + pair.Right.Position.z) * 0.5f);
+                    conflicts.Add(new FuseRegistryConflict
+                    {
+                        Kind = FuseClaimKind.Segment,
+                        Target = "SpatialTrackOverlap",
+                        Id = $"spatial-overlap:{Math.Round(centerX)},{Math.Round(centerZ)}",
+                        OwnerPackageId = left.PackageId,
+                        AttemptedPackageId = right.PackageId,
+                        Resolution =
+                            $"spatial track overlap detected from {nearby.Count} nearby node pair(s) within {NearbyHorizontalDistance:0}m; " +
+                            "both packages retained because proximity may be intentional",
+                        AtUtc = DateTime.UtcNow
+                    });
+                }
+            }
+
+            return conflicts.ToArray();
+        }
+
+        private static TrackFootprint BuildFootprint(FuseSpatialTrackPackage package)
+        {
+            if (package == null || string.IsNullOrWhiteSpace(package.PackageId))
+            {
+                return null;
+            }
+
+            var nodes = new Dictionary<string, PositionedNode>(StringComparer.OrdinalIgnoreCase);
+            var segmentCount = 0;
+            foreach (var tracks in package.TrackDefinitions ?? Array.Empty<FuseTrackDefinition>())
+            {
+                segmentCount += tracks?.Segments?.Count ?? 0;
+                if (tracks?.Nodes == null)
+                {
+                    continue;
+                }
+
+                foreach (var pair in tracks.Nodes)
+                {
+                    if (string.IsNullOrWhiteSpace(pair.Key) || pair.Value == null || !IsUsablePosition(pair.Value.Position))
+                    {
+                        continue;
+                    }
+
+                    nodes[pair.Key] = new PositionedNode(pair.Key, pair.Value.Position);
+                }
+            }
+
+            if (nodes.Count == 0)
+            {
+                return null;
+            }
+
+            var values = nodes.Values.ToArray();
+            return new TrackFootprint
+            {
+                PackageId = package.PackageId.Trim(),
+                FolderPath = package.FolderPath ?? string.Empty,
+                RequiredPackageIds = package.RequiredPackageIds ?? Array.Empty<string>(),
+                LoadAfter = package.LoadAfter ?? Array.Empty<string>(),
+                LoadBefore = package.LoadBefore ?? Array.Empty<string>(),
+                Nodes = values,
+                SegmentCount = segmentCount,
+                MinX = values.Min(node => node.Position.x),
+                MaxX = values.Max(node => node.Position.x),
+                MinZ = values.Min(node => node.Position.z),
+                MaxZ = values.Max(node => node.Position.z)
+            };
+        }
+
+        private static List<NearbyNodePair> FindNearbyNodePairs(
+            IReadOnlyList<PositionedNode> left,
+            IReadOnlyList<PositionedNode> right)
+        {
+            var maxDistanceSquared = NearbyHorizontalDistance * NearbyHorizontalDistance;
+            var candidates = new List<NearbyNodePair>();
+            foreach (var leftNode in left)
+            {
+                foreach (var rightNode in right)
+                {
+                    var vertical = Math.Abs(leftNode.Position.y - rightNode.Position.y);
+                    if (vertical > NearbyVerticalDistance)
+                    {
+                        continue;
+                    }
+
+                    var x = leftNode.Position.x - rightNode.Position.x;
+                    var z = leftNode.Position.z - rightNode.Position.z;
+                    var distanceSquared = (x * x) + (z * z);
+                    if (distanceSquared <= maxDistanceSquared)
+                    {
+                        candidates.Add(new NearbyNodePair(leftNode, rightNode, distanceSquared));
+                    }
+                }
+            }
+
+            // Greedy nearest matching prevents one dense package node from
+            // satisfying the two-node threshold more than once.
+            var usedLeft = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var usedRight = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var selected = new List<NearbyNodePair>();
+            foreach (var pair in candidates.OrderBy(candidate => candidate.DistanceSquared))
+            {
+                if (usedLeft.Contains(pair.Left.Id) || usedRight.Contains(pair.Right.Id))
+                {
+                    continue;
+                }
+
+                usedLeft.Add(pair.Left.Id);
+                usedRight.Add(pair.Right.Id);
+                selected.Add(pair);
+            }
+
+            return selected;
+        }
+
+        private static bool BoundsMayOverlap(TrackFootprint left, TrackFootprint right, float padding)
+        {
+            return left.MinX - padding <= right.MaxX && left.MaxX + padding >= right.MinX &&
+                   left.MinZ - padding <= right.MaxZ && left.MaxZ + padding >= right.MinZ;
+        }
+
+        private static bool IsExpectedLayering(TrackFootprint existing, TrackFootprint later)
+        {
+            return FuseDeclaredPackageRelationship.ContainsPackageId(later.RequiredPackageIds, existing.PackageId) ||
+                   FuseDeclaredPackageRelationship.ContainsPackageId(later.LoadAfter, existing.PackageId) ||
+                   FuseDeclaredPackageRelationship.ContainsPackageId(existing.LoadBefore, later.PackageId);
+        }
+
+        private static bool SamePackageFolder(string left, string right)
+        {
+            if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+            {
+                return false;
+            }
+
+            try
+            {
+                left = Path.GetFullPath(left).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                right = Path.GetFullPath(right).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+            catch (Exception ex)
+            {
+                // Compare the original values when a synthetic/test path is
+                // not valid for the current platform.
+                FUSE.Infrastructure.FuseLog.Warning(
+                    "FUSE spatial track overlap check could not normalize package folders " +
+                    $"left='{left}' right='{right}' message='{ex.GetBaseException().Message}'.");
+            }
+
+            return string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsUsablePosition(Vector3 position)
+        {
+            // A zero vector is the deserializer default for legacy partial
+            // node declarations, not reliable spatial evidence.
+            return position != Vector3.zero &&
+                   IsFinite(position.x) && IsFinite(position.y) && IsFinite(position.z);
+        }
+
+        private static bool IsFinite(float value)
+        {
+            return !float.IsNaN(value) && !float.IsInfinity(value);
+        }
+
+        private sealed class TrackFootprint
+        {
+            public string PackageId { get; set; }
+            public string FolderPath { get; set; }
+            public string[] RequiredPackageIds { get; set; }
+            public string[] LoadAfter { get; set; }
+            public string[] LoadBefore { get; set; }
+            public PositionedNode[] Nodes { get; set; }
+            public int SegmentCount { get; set; }
+            public float MinX { get; set; }
+            public float MaxX { get; set; }
+            public float MinZ { get; set; }
+            public float MaxZ { get; set; }
+        }
+
+        private sealed class PositionedNode
+        {
+            public PositionedNode(string id, Vector3 position)
+            {
+                Id = id;
+                Position = position;
+            }
+
+            public string Id { get; }
+            public Vector3 Position { get; }
+        }
+
+        private sealed class NearbyNodePair
+        {
+            public NearbyNodePair(PositionedNode left, PositionedNode right, float distanceSquared)
+            {
+                Left = left;
+                Right = right;
+                DistanceSquared = distanceSquared;
+            }
+
+            public PositionedNode Left { get; }
+            public PositionedNode Right { get; }
+            public float DistanceSquared { get; }
+        }
+    }
+}

--- a/FUSE/Loading/FuseSplineyPluginHost.cs
+++ b/FUSE/Loading/FuseSplineyPluginHost.cs
@@ -35,6 +35,12 @@ namespace FUSE.Loading
         private static readonly List<LegacyBuilderTask> BuilderTasks =
             new List<LegacyBuilderTask>();
 
+        // GraphDidChange must be raised after the merged graph has been committed
+        // to the live game graph, not while the legacy JSON is still being
+        // converted. Keep the state from the most recent conversion until the
+        // staged apply reaches that commit point.
+        private static StrangeCustoms.Tracks.TrackState _pendingDidChangeState;
+
         /// <summary>
         /// Defers a legacy spliney whose handler FUSE doesn't recognize natively
         /// to the GraphWillChangeEvent path so loaded old-loader plugins can
@@ -107,10 +113,14 @@ namespace FUSE.Loading
             var existingSegmentIds = new HashSet<string>(
                 state.Tracks.Segments.Keys,
                 StringComparer.OrdinalIgnoreCase);
+            var changedNodeIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var changedSegmentIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             try
             {
-                var evt = new StrangeCustoms.GraphWillChangeEvent(state, _ => { });
+                var evt = new StrangeCustoms.GraphWillChangeEvent(
+                    state,
+                    path => RecordChangedGraphPath(path, changedNodeIds, changedSegmentIds));
                 Messenger.Default.Send(evt);
             }
             catch (Exception ex)
@@ -122,15 +132,64 @@ namespace FUSE.Loading
                     ex);
             }
 
-            result.NodesAdded = MergeNewNodes(state, existingNodeIds, root);
-            result.SegmentsAdded = MergeNewSegments(state, existingSegmentIds, root);
+            result.NodesAdded = MergeNodes(state, existingNodeIds, changedNodeIds, root, out var nodesUpdated);
+            result.NodesUpdated = nodesUpdated;
+            result.SegmentsAdded = MergeSegments(state, existingSegmentIds, changedSegmentIds, root, out var segmentsUpdated);
+            result.SegmentsUpdated = segmentsUpdated;
+            _pendingDidChangeState = state;
             return result;
+        }
+
+        /// <summary>
+        /// Completes the legacy graph-event transaction after FUSE has committed
+        /// the merged track plan to the live graph. Signals Everywhere and other
+        /// hosted plugins use this notification to rebuild runtime objects.
+        /// </summary>
+        public static void NotifyGraphDidChange()
+        {
+            var state = _pendingDidChangeState ?? new StrangeCustoms.Tracks.TrackState();
+            _pendingDidChangeState = null;
+
+            try
+            {
+                Messenger.Default.Send(new StrangeCustoms.GraphDidChangeEvent(state));
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception(
+                    "FUSE spliney plugin host caught an exception while dispatching " +
+                    "GraphDidChangeEvent to legacy plugin handlers",
+                    ex);
+            }
         }
 
         public static void Reset()
         {
             Pending.Clear();
             BuilderTasks.Clear();
+            _pendingDidChangeState = null;
+        }
+
+        private static void RecordChangedGraphPath(
+            string[] path,
+            HashSet<string> changedNodeIds,
+            HashSet<string> changedSegmentIds)
+        {
+            if (path == null || path.Length < 3 ||
+                !string.Equals(path[0], "tracks", StringComparison.OrdinalIgnoreCase) ||
+                string.IsNullOrWhiteSpace(path[2]))
+            {
+                return;
+            }
+
+            if (string.Equals(path[1], "nodes", StringComparison.OrdinalIgnoreCase))
+            {
+                changedNodeIds.Add(path[2]);
+            }
+            else if (string.Equals(path[1], "segments", StringComparison.OrdinalIgnoreCase))
+            {
+                changedSegmentIds.Add(path[2]);
+            }
         }
 
         private static StrangeCustoms.Tracks.TrackState BuildState(
@@ -189,10 +248,29 @@ namespace FUSE.Loading
             {
                 StartId = segment["startNodeId"]?.Value<string>() ?? segment["startId"]?.Value<string>(),
                 EndId = segment["endNodeId"]?.Value<string>() ?? segment["endId"]?.Value<string>(),
+                Style = ParseEnum(segment["style"]?.Value<string>(), Track.TrackSegment.Style.Standard),
+                TrackClass = ParseTrackClass(segment["trackClass"]?.Value<string>()),
                 Priority = segment["priority"]?.Value<int>() ?? 0,
                 SpeedLimit = segment["speedLimit"]?.Value<int>() ?? 45,
                 GroupId = segment["groupId"]?.Value<string>(),
             };
+        }
+
+        private static TEnum ParseEnum<TEnum>(string value, TEnum fallback) where TEnum : struct
+        {
+            return !string.IsNullOrWhiteSpace(value) && Enum.TryParse(value, true, out TEnum parsed)
+                ? parsed
+                : fallback;
+        }
+
+        private static Track.TrackClass ParseTrackClass(string value)
+        {
+            if (string.Equals(value, "main", StringComparison.OrdinalIgnoreCase))
+            {
+                return Track.TrackClass.Mainline;
+            }
+
+            return ParseEnum(value, Track.TrackClass.Mainline);
         }
 
         private static Vector3 ReadVector3(JToken token)
@@ -208,11 +286,14 @@ namespace FUSE.Loading
                 obj["z"]?.Value<float>() ?? 0f);
         }
 
-        private static int MergeNewNodes(
+        private static int MergeNodes(
             StrangeCustoms.Tracks.TrackState state,
             HashSet<string> existingIds,
-            JObject root)
+            HashSet<string> changedIds,
+            JObject root,
+            out int updated)
         {
+            updated = 0;
             var rootNodes = root?["tracks"]?["nodes"] as JObject;
             if (rootNodes == null)
             {
@@ -222,23 +303,34 @@ namespace FUSE.Loading
             var added = 0;
             foreach (var entry in state.Tracks.Nodes)
             {
-                if (existingIds.Contains(entry.Key))
+                var exists = existingIds.Contains(entry.Key);
+                if (exists && !changedIds.Contains(entry.Key))
                 {
                     continue;
                 }
 
                 rootNodes[entry.Key] = SerializeNode(entry.Value);
-                added++;
+                if (exists)
+                {
+                    updated++;
+                }
+                else
+                {
+                    added++;
+                }
             }
 
             return added;
         }
 
-        private static int MergeNewSegments(
+        private static int MergeSegments(
             StrangeCustoms.Tracks.TrackState state,
             HashSet<string> existingIds,
-            JObject root)
+            HashSet<string> changedIds,
+            JObject root,
+            out int updated)
         {
+            updated = 0;
             var rootSegments = root?["tracks"]?["segments"] as JObject;
             if (rootSegments == null)
             {
@@ -248,13 +340,21 @@ namespace FUSE.Loading
             var added = 0;
             foreach (var entry in state.Tracks.Segments)
             {
-                if (existingIds.Contains(entry.Key))
+                var exists = existingIds.Contains(entry.Key);
+                if (exists && !changedIds.Contains(entry.Key))
                 {
                     continue;
                 }
 
                 rootSegments[entry.Key] = SerializeSegment(entry.Value);
-                added++;
+                if (exists)
+                {
+                    updated++;
+                }
+                else
+                {
+                    added++;
+                }
             }
 
             return added;
@@ -286,8 +386,10 @@ namespace FUSE.Loading
             {
                 ["startNodeId"] = segment.StartId,
                 ["endNodeId"] = segment.EndId,
-                ["style"] = "standard",
-                ["trackClass"] = "main",
+                ["style"] = segment.Style.ToString(),
+                ["trackClass"] = segment.TrackClass == Track.TrackClass.Mainline
+                    ? "main"
+                    : segment.TrackClass.ToString(),
                 ["speedLimit"] = segment.SpeedLimit,
                 ["priority"] = segment.Priority,
             };
@@ -524,7 +626,9 @@ namespace FUSE.Loading
         {
             public int PendingSplineyCount { get; set; }
             public int NodesAdded { get; set; }
+            public int NodesUpdated { get; set; }
             public int SegmentsAdded { get; set; }
+            public int SegmentsUpdated { get; set; }
         }
 
         public sealed class BuilderInvocationResult

--- a/FUSE/Loading/FuseTrackRemovalSnapshotStore.cs
+++ b/FUSE/Loading/FuseTrackRemovalSnapshotStore.cs
@@ -6,6 +6,7 @@ using FUSE.Authoring.Data;
 using FUSE.Authoring.Data.Common;
 using FUSE.Infrastructure;
 using FUSE.Runtime.Registry;
+using FUSE.Compatibility;
 using Track;
 using UnityEngine;
 
@@ -463,6 +464,7 @@ namespace FUSE.Loading
                 Position = node.transform.localPosition,
                 Rotation = node.transform.localEulerAngles,
                 FlipSwitchStand = node.flipSwitchStand,
+                IsDiamond = RailroaderTrackContract.GetNodeIsDiamond(node),
                 IsThrown = node.isThrown,
                 IsCtcSwitch = node.IsCTCSwitch,
                 IsCtcSwitchUnlocked = node.IsCTCSwitchUnlocked
@@ -490,7 +492,8 @@ namespace FUSE.Loading
                 Id = segment.id,
                 StartNodeId = segment.a.id,
                 EndNodeId = segment.b.id,
-                Style = segment.style.ToString(),
+                Style = RailroaderTrackContract.GetStyleName(segment),
+                StructureFlags = RailroaderTrackContract.GetStructureFlags(segment),
                 TrackClass = segment.trackClass == TrackClass.Mainline ? "main" : segment.trackClass.ToString(),
                 GroupId = segment.groupId,
                 Priority = segment.priority,
@@ -581,6 +584,7 @@ namespace FUSE.Loading
                 var restored = TrackAPI.GetNode(snapshot.Id);
                 if (restored != null)
                 {
+                    RailroaderTrackContract.SetNodeIsDiamond(restored, snapshot.IsDiamond);
                     restored.IsCTCSwitch = snapshot.IsCtcSwitch;
                     restored.IsCTCSwitchUnlocked = snapshot.IsCtcSwitchUnlocked;
                     restored.isThrown = snapshot.IsThrown;
@@ -615,6 +619,8 @@ namespace FUSE.Loading
                 StartNodeId = snapshot.StartNodeId,
                 EndNodeId = snapshot.EndNodeId,
                 Style = snapshot.Style,
+                BridgeSupportsSteel = (snapshot.StructureFlags & 4) != 0,
+                Yard = (snapshot.StructureFlags & 16) != 0,
                 TrackClass = snapshot.TrackClass,
                 SpeedLimit = snapshot.SpeedLimit,
                 Priority = snapshot.Priority,

--- a/FUSE/Patches/FuseAlinasUtilitiesCompatibility.cs
+++ b/FUSE/Patches/FuseAlinasUtilitiesCompatibility.cs
@@ -67,14 +67,19 @@ namespace FUSE.Patches
                     var settingsField = pluginType.GetField(
                         SettingsFieldName,
                         BindingFlags.Instance | BindingFlags.NonPublic);
-                    if (settingsField == null || settingsField.GetValue(shared) != null)
+                    if (settingsField == null)
                     {
                         continue;
                     }
 
-                    var settings = ReadUmmSettings(assembly, settingsField.FieldType) ??
-                                   CreateDefaultSettings(settingsField.FieldType);
-                    if (settings == null)
+                    var currentSettings = settingsField.GetValue(shared);
+                    var settings = ResolveSettings(
+                        currentSettings,
+                        currentSettings == null
+                            ? ReadUmmSettings(assembly, settingsField.FieldType)
+                            : null,
+                        () => CreateDefaultSettings(settingsField.FieldType));
+                    if (settings == null || ReferenceEquals(settings, currentSettings))
                     {
                         continue;
                     }
@@ -95,7 +100,7 @@ namespace FUSE.Patches
                     // with an AlinasUtils identity. One stale or incompatible copy
                     // must not prevent the compatible copy from being repaired.
                     FuseLog.Warning(
-                        $"FUSE could not inspect one Alina Utilities assembly " +
+                        $"FUSE could not inspect one Alina Utilities " +
                         $"assembly='{assembly.GetName().Name}': {ex.Message}");
                 }
             }
@@ -119,7 +124,7 @@ namespace FUSE.Patches
                    assemblyName.StartsWith("AlinasUtils", StringComparison.OrdinalIgnoreCase);
         }
 
-        internal static object ResolveSettingsForTests(
+        internal static object ResolveSettings(
             object currentSettings,
             object ummSettings,
             Func<object> createDefault)

--- a/FUSE/Patches/FuseAlinasUtilitiesCompatibility.cs
+++ b/FUSE/Patches/FuseAlinasUtilitiesCompatibility.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using FUSE.Infrastructure;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Keeps the supported, separately-installed Alina Utilities mod usable
+    /// when its RailLoader and UMM entry points are both discovered during the
+    /// same startup. Older builds can leave the RailLoader singleton alive
+    /// without an <c>IModdingContext</c>; its Settings getter then throws from
+    /// camera-distance, damage, and main-menu patches before it can fall back
+    /// to the UMM settings object.
+    ///
+    /// FUSE does not replace Alina Utilities. It only supplies the missing
+    /// settings reference on that partially-bound instance. The original mod
+    /// continues to own its settings UI and feature patches.
+    /// </summary>
+    internal static class FuseAlinasUtilitiesCompatibility
+    {
+        private const string PluginTypeName = "AlinasUtils.AlinasUtilsPlugin";
+        private const string UmmModTypeName = "AlinasUtils.UMM.Mod";
+        private const string SettingsFieldName = "_settings";
+
+        private static readonly HashSet<object> RepairedInstances =
+            new HashSet<object>(ReferenceEqualityComparer.Instance);
+
+        internal static string EnsureInstalled()
+        {
+            var foundAssembly = false;
+            var foundShared = false;
+            var repaired = 0;
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (assembly == null || assembly.IsDynamic)
+                {
+                    continue;
+                }
+
+                Type pluginType;
+                try
+                {
+                    pluginType = assembly.GetType(PluginTypeName, false);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (pluginType == null)
+                {
+                    continue;
+                }
+
+                foundAssembly = true;
+                try
+                {
+                    var shared = ReadSharedInstance(pluginType);
+                    if (shared == null)
+                    {
+                        continue;
+                    }
+
+                    foundShared = true;
+                    var settingsField = pluginType.GetField(
+                        SettingsFieldName,
+                        BindingFlags.Instance | BindingFlags.NonPublic);
+                    if (settingsField == null || settingsField.GetValue(shared) != null)
+                    {
+                        continue;
+                    }
+
+                    var settings = ReadUmmSettings(assembly, settingsField.FieldType) ??
+                                   CreateDefaultSettings(settingsField.FieldType);
+                    if (settings == null)
+                    {
+                        continue;
+                    }
+
+                    settingsField.SetValue(shared, settings);
+                    if (RepairedInstances.Add(shared))
+                    {
+                        repaired++;
+                        FuseLog.Info(
+                            "FUSE repaired a partially-bound Alina Utilities legacy instance by " +
+                            "connecting it to the mod's working settings object. Alina Utilities " +
+                            "remains installed and owns its original features.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Recovered distributions can contain more than one assembly
+                    // with an AlinasUtils identity. One stale or incompatible copy
+                    // must not prevent the compatible copy from being repaired.
+                    FuseLog.Warning(
+                        $"FUSE could not inspect one Alina Utilities assembly " +
+                        $"assembly='{assembly.GetName().Name}': {ex.Message}");
+                }
+            }
+
+            if (repaired > 0)
+            {
+                return $"repaired ({repaired})";
+            }
+
+            if (!foundAssembly)
+            {
+                return "idle (not present)";
+            }
+
+            return foundShared ? "ready" : "idle (no legacy instance)";
+        }
+
+        internal static bool IsTargetAssemblyName(string assemblyName)
+        {
+            return !string.IsNullOrWhiteSpace(assemblyName) &&
+                   assemblyName.StartsWith("AlinasUtils", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static object ResolveSettingsForTests(
+            object currentSettings,
+            object ummSettings,
+            Func<object> createDefault)
+        {
+            if (currentSettings != null)
+            {
+                return currentSettings;
+            }
+
+            return ummSettings ?? createDefault?.Invoke();
+        }
+
+        private static object ReadSharedInstance(Type pluginType)
+        {
+            try
+            {
+                var baseType = pluginType.BaseType;
+                var property = baseType?.GetProperty(
+                    "Shared",
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                return property?.GetValue(null, null);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static object ReadUmmSettings(Assembly assembly, Type settingsType)
+        {
+            try
+            {
+                var modType = assembly.GetType(UmmModTypeName, false);
+                var property = modType?.GetProperty(
+                    "Settings",
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                var value = property?.GetValue(null, null);
+                return value != null && settingsType.IsInstanceOfType(value) ? value : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static object CreateDefaultSettings(Type settingsType)
+        {
+            try
+            {
+                return settingsType == null ? null : Activator.CreateInstance(settingsType);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private sealed class ReferenceEqualityComparer : IEqualityComparer<object>
+        {
+            internal static readonly ReferenceEqualityComparer Instance =
+                new ReferenceEqualityComparer();
+
+            bool IEqualityComparer<object>.Equals(object left, object right)
+            {
+                return ReferenceEquals(left, right);
+            }
+
+            int IEqualityComparer<object>.GetHashCode(object value)
+            {
+                return value == null
+                    ? 0
+                    : System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(value);
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseAssetLoaderReplacementCompatibility.cs
+++ b/FUSE/Patches/FuseAssetLoaderReplacementCompatibility.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using HarmonyLib;
+using FUSE.Infrastructure;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// FUSE replaces AssetLoader's asset-pack discovery. Leaving the old mod's
+    /// CheckDefinitions prefix active creates a second set of stores outside
+    /// FUSE's quarantine path; one malformed Definitions.json can then abort
+    /// the Equipment or Customize window while it enumerates those stores.
+    /// Remove only patches owned by AssetLoader. The assembly stays loaded so
+    /// packages with a historical UMM dependency continue to see it installed.
+    /// </summary>
+    internal static class FuseAssetLoaderReplacementCompatibility
+    {
+        internal const string LegacyHarmonyOwner = "AssetLoader";
+
+        internal static string EnsureInstalled(Harmony harmony)
+        {
+            if (harmony == null)
+            {
+                return "unavailable";
+            }
+
+            var assetLoaderType = AccessTools.TypeByName("AssetLoader.Patches.AssetLoaderPatch");
+            if (assetLoaderType == null ||
+                !IsTargetAssemblyName(assetLoaderType.Assembly.GetName().Name))
+            {
+                return "absent";
+            }
+
+            var ownedBefore = CountOwnedPatches();
+            if (ownedBefore == 0)
+            {
+                return "replaced (no active legacy patches)";
+            }
+
+            harmony.UnpatchAll(LegacyHarmonyOwner);
+            var ownedAfter = CountOwnedPatches();
+            if (ownedAfter > 0)
+            {
+                return $"failed ({ownedAfter} patch(es) remain)";
+            }
+
+            FuseLog.Info(
+                $"FUSE disabled {ownedBefore} legacy AssetLoader Harmony patch(es). " +
+                "FUSE asset discovery remains active; the AssetLoader assembly was not removed.");
+            return $"replaced ({ownedBefore} patch(es) disabled)";
+        }
+
+        internal static bool IsTargetAssemblyName(string assemblyName) =>
+            string.Equals(assemblyName, "AssetLoader", StringComparison.OrdinalIgnoreCase);
+
+        private static int CountOwnedPatches()
+        {
+            try
+            {
+                return Harmony.GetAllPatchedMethods()
+                    .Select(Harmony.GetPatchInfo)
+                    .Where(info => info != null)
+                    .Sum(info =>
+                        info.Prefixes.Count(patch => IsLegacyOwner(patch.owner)) +
+                        info.Postfixes.Count(patch => IsLegacyOwner(patch.owner)) +
+                        info.Transpilers.Count(patch => IsLegacyOwner(patch.owner)) +
+                        info.Finalizers.Count(patch => IsLegacyOwner(patch.owner)));
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        private static bool IsLegacyOwner(string owner) =>
+            string.Equals(owner, LegacyHarmonyOwner, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/FUSE/Patches/FuseAssetPackRuntimeStoreContainerPatch.cs
+++ b/FUSE/Patches/FuseAssetPackRuntimeStoreContainerPatch.cs
@@ -25,6 +25,12 @@ namespace FUSE.Patches
                     __result = container;
                     return false;
                 }
+
+                if (FuseAssetPackRegistry.TryLoadLegacyDefinitionOverrideContainer(__instance, out container))
+                {
+                    __result = container;
+                    return false;
+                }
             }
             catch (System.Exception ex)
             {

--- a/FUSE/Patches/FuseAudioPatches.cs
+++ b/FUSE/Patches/FuseAudioPatches.cs
@@ -182,4 +182,42 @@ namespace FUSE.Patches
         }
 
     }
+
+    /// <summary>
+    /// Contains a bad whistle/horn/bell provider at the individual picker
+    /// boundary. Asset packs are third-party inputs; one provider throwing
+    /// while its definitions are enumerated must not abort construction of the
+    /// entire customize window and leave the player locked out of its controls.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FuseCarCustomizeSoundPickerGuardPatch
+    {
+        private static IEnumerable<MethodBase> TargetMethods()
+        {
+            var windowType = typeof(UI.CarCustomizeWindow.CarCustomizeWindow);
+            foreach (var name in new[] { "BuildSoundTabWhistle", "BuildSoundTabHorn", "BuildSoundTabBell" })
+            {
+                var method = AccessTools.DeclaredMethod(windowType, name);
+                if (method != null)
+                {
+                    yield return method;
+                }
+            }
+        }
+
+        private static Exception Finalizer(Exception __exception, MethodBase __originalMethod)
+        {
+            if (__exception == null)
+            {
+                return null;
+            }
+
+            var picker = (__originalMethod?.Name ?? "sound picker").Replace("BuildSoundTab", string.Empty);
+            FuseLog.Warning(
+                $"FUSE contained a broken {picker} definition provider while building the car customize window: " +
+                $"{__exception.GetBaseException().GetType().Name}: {__exception.GetBaseException().Message}. " +
+                "Only that sound picker was omitted; the rest of the window remains available.");
+            return null;
+        }
+    }
 }

--- a/FUSE/Patches/FuseAudioPatches.cs
+++ b/FUSE/Patches/FuseAudioPatches.cs
@@ -198,10 +198,15 @@ namespace FUSE.Patches
             foreach (var name in new[] { "BuildSoundTabWhistle", "BuildSoundTabHorn", "BuildSoundTabBell" })
             {
                 var method = AccessTools.DeclaredMethod(windowType, name);
-                if (method != null)
+                if (method == null)
                 {
-                    yield return method;
+                    FuseLog.Warning(
+                        $"FUSE could not guard the car customize sound picker because " +
+                        $"'{windowType.FullName}.{name}' could not be resolved.");
+                    continue;
                 }
+
+                yield return method;
             }
         }
 

--- a/FUSE/Patches/FuseC1CdCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseC1CdCompatibilityPatch.cs
@@ -5,7 +5,10 @@ using Model.Ops;
 
 namespace FUSE.Patches
 {
-    [HarmonyPatch(typeof(Interchange), nameof(Interchange.NextAvailableServiceTime))]
+    [HarmonyPatch(
+        typeof(Interchange),
+        nameof(Interchange.NextAvailableServiceTime),
+        new[] { typeof(GameDateTime) })]
     internal static class FuseC1CdNextServiceTimePatch
     {
         private static bool Prefix(GameDateTime now, ref GameDateTime __result)

--- a/FUSE/Patches/FuseC1CdCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseC1CdCompatibilityPatch.cs
@@ -1,0 +1,65 @@
+using FUSE.Infrastructure;
+using Game;
+using HarmonyLib;
+using Model.Ops;
+
+namespace FUSE.Patches
+{
+    [HarmonyPatch(typeof(Interchange), nameof(Interchange.NextAvailableServiceTime))]
+    internal static class FuseC1CdNextServiceTimePatch
+    {
+        private static bool Prefix(GameDateTime now, ref GameDateTime __result)
+        {
+            __result = FuseC1CdSchedulePolicy.CalculateNextServiceTime(
+                now,
+                FuseSettings.InterchangeServiceIntervalMinutes,
+                FuseSettings.InterchangeNotBeforeHour,
+                FuseSettings.InterchangeNotAfterHour);
+            return false;
+        }
+    }
+
+    internal static class FuseC1CdSchedulePolicy
+    {
+        internal static GameDateTime CalculateNextServiceTime(
+            GameDateTime now,
+            int intervalMinutes,
+            float notBeforeHour,
+            float notAfterHour)
+        {
+            var interval = FuseSettings.NormalizeInterchangeServiceIntervalMinutes(intervalMinutes);
+            var start = FuseSettings.ClampInterchangeServiceHour(notBeforeHour);
+            var end = FuseSettings.ClampInterchangeServiceHour(notAfterHour);
+            var candidate = now.AddingMinutes(interval).RoundingMinutes(5);
+
+            if (start <= 0f && end >= 24f)
+            {
+                return candidate;
+            }
+
+            if (start <= end)
+            {
+                if (candidate.Hours < start)
+                {
+                    return candidate.WithHours(start).RoundingMinutes(5);
+                }
+
+                if (candidate.Hours > end)
+                {
+                    return candidate.AddingDays(1f).WithHours(start).RoundingMinutes(5);
+                }
+
+                return candidate;
+            }
+
+            // A window whose start is later than its end crosses midnight
+            // (for example 22:00–06:00). Only the daytime gap is excluded.
+            if (candidate.Hours > end && candidate.Hours < start)
+            {
+                return candidate.WithHours(start).RoundingMinutes(5);
+            }
+
+            return candidate;
+        }
+    }
+}

--- a/FUSE/Patches/FuseCompanyStarterPlacementPatch.cs
+++ b/FUSE/Patches/FuseCompanyStarterPlacementPatch.cs
@@ -151,10 +151,23 @@ namespace FUSE.Patches
             }
 
             var placement = PendingPlacements.Peek();
-            var descriptors = BuildDescriptors(placement);
-            if (descriptors.Count == 0)
+            var preparationSucceeded = TryBuildDescriptors(
+                placement,
+                out var descriptors);
+            var consumedEmpty = TryConsumeConfirmedEmpty(
+                PendingPlacements,
+                preparationSucceeded,
+                descriptors.Count);
+            if (!preparationSucceeded)
             {
-                PendingPlacements.Dequeue();
+                Toast.Present(
+                    "Starter equipment retained. Run /fuse.starters when "
+                    + "placement is available.",
+                    ToastPosition.Middle);
+                return;
+            }
+            if (consumedEmpty)
+            {
                 PresentNextPlacement();
                 return;
             }
@@ -241,6 +254,23 @@ namespace FUSE.Patches
                    && placedCarCount == expectedCarCount;
         }
 
+        internal static bool TryConsumeConfirmedEmpty<T>(
+            Queue<T> queue,
+            bool preparationSucceeded,
+            int descriptorCount)
+        {
+            if (!preparationSucceeded
+                || descriptorCount != 0
+                || queue == null
+                || queue.Count == 0)
+            {
+                return false;
+            }
+
+            queue.Dequeue();
+            return true;
+        }
+
         private static IEnumerator PresentAfterFrame()
         {
             yield return null;
@@ -271,13 +301,15 @@ namespace FUSE.Patches
                    + " cut(s) remaining).";
         }
 
-        private static List<CarDescriptor> BuildDescriptors(
-            SetupDescriptor.CarPlacement placement)
+        private static bool TryBuildDescriptors(
+            SetupDescriptor.CarPlacement placement,
+            out List<CarDescriptor> descriptors)
         {
+            descriptors = new List<CarDescriptor>();
             try
             {
                 var identifiers = placement?.carIdentifier ?? Array.Empty<string>();
-                var descriptors = StateManager.DescriptorsForIdentifiers(identifiers)
+                descriptors = StateManager.DescriptorsForIdentifiers(identifiers)
                     .Select(descriptor =>
                     {
                         descriptor.Properties["oiled"] = placement.oiled;
@@ -301,14 +333,16 @@ namespace FUSE.Patches
                     descriptors,
                     1f);
 
-                return descriptors;
+                return true;
             }
             catch (Exception ex)
             {
                 FuseLog.Exception(
-                    "FUSE failed to prepare a queued Company starter cut.",
+                    "FUSE failed to prepare a queued Company starter cut; "
+                    + "the cut remains queued.",
                     ex);
-                return new List<CarDescriptor>();
+                descriptors = new List<CarDescriptor>();
+                return false;
             }
         }
 

--- a/FUSE/Patches/FuseCompanyStarterPlacementPatch.cs
+++ b/FUSE/Patches/FuseCompanyStarterPlacementPatch.cs
@@ -112,7 +112,6 @@ namespace FUSE.Patches
             }
 
             var queued = 0;
-            var retained = new List<SetupDescriptor.CarPlacement>(source.Length);
             foreach (var placement in source)
             {
                 placementQueue?.Enqueue(placement);
@@ -123,7 +122,8 @@ namespace FUSE.Patches
                     "The local player will choose its track location.");
             }
 
-            setupDescriptor.placements = retained.ToArray();
+            // Every placement moves to the interactive queue, so the setup keeps none.
+            setupDescriptor.placements = Array.Empty<SetupDescriptor.CarPlacement>();
             return queued;
         }
 

--- a/FUSE/Patches/FuseCompanyStarterPlacementPatch.cs
+++ b/FUSE/Patches/FuseCompanyStarterPlacementPatch.cs
@@ -42,16 +42,32 @@ namespace FUSE.Patches
             SetupDescriptor setupDescriptor,
             ref IEnumerator __result)
         {
-            PendingPlacements.Clear();
-            _presenting = false;
-            if (__result != null
-                && setupDescriptor != null
-                && ShouldQueueStarterSetup(
-                    setupDescriptor.identifier,
-                    FuseModLoader.GetLoadedMods()))
+            var shouldQueue = __result != null
+                              && setupDescriptor != null
+                              && ShouldQueueStarterSetup(
+                                  setupDescriptor.identifier,
+                                  FuseModLoader.GetLoadedMods());
+            if (TryPrepareStarterQueue(
+                    PendingPlacements,
+                    shouldQueue,
+                    _presenting))
             {
                 __result = RepairAfterInitialDelay(__result, setupDescriptor);
             }
+        }
+
+        internal static bool TryPrepareStarterQueue<T>(
+            Queue<T> placementQueue,
+            bool shouldQueue,
+            bool presentationActive)
+        {
+            if (!shouldQueue || presentationActive)
+            {
+                return false;
+            }
+
+            placementQueue?.Clear();
+            return true;
         }
 
         private static IEnumerator RepairAfterInitialDelay(

--- a/FUSE/Patches/FuseCompanyStarterPlacementPatch.cs
+++ b/FUSE/Patches/FuseCompanyStarterPlacementPatch.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using FUSE.Loading;
 using FUSE.Infrastructure;
 using Game.Messages;
 using Game.Progression;
+using Game.Scripting.Interactive;
 using Game.State;
 using HarmonyLib;
 using KeyValue.Runtime;
@@ -13,25 +15,40 @@ using Model.Definition;
 using Model.Ops;
 using Model.Ops.Definition;
 using Track;
+using UI.Common;
 using UnityEngine;
 
 namespace FUSE.Patches
 {
     /// <summary>
     /// Moves the stock East Whittier Company starter equipment into an
-    /// interactive placement queue, and does the same for invalid placements
-    /// from any other setup. This lets the player choose live track after the
-    /// progression has settled instead of depending on one fixed scene marker.
+    /// interactive placement queue when Appalachian Railway's Whittier start
+    /// package is active. This lets the player choose live track after the
+    /// progression and tutorial have settled instead of depending on one fixed
+    /// scene marker.
     /// </summary>
     [HarmonyPatch(typeof(CompanyModeSetup), nameof(CompanyModeSetup.Setup))]
     internal static class FuseCompanyStarterPlacementPatch
     {
+        private const string AppalachianWhittierStartId =
+            "KingG.Appalachian-Railway.start-whit";
+        private static readonly Queue<SetupDescriptor.CarPlacement>
+            PendingPlacements =
+                new Queue<SetupDescriptor.CarPlacement>();
+        private static bool _presenting;
+
         [HarmonyPostfix]
         private static void SetupPostfix(
             SetupDescriptor setupDescriptor,
             ref IEnumerator __result)
         {
-            if (__result != null && setupDescriptor != null)
+            PendingPlacements.Clear();
+            _presenting = false;
+            if (__result != null
+                && setupDescriptor != null
+                && ShouldQueueStarterSetup(
+                    setupDescriptor.identifier,
+                    FuseModLoader.GetLoadedMods()))
             {
                 __result = RepairAfterInitialDelay(__result, setupDescriptor);
             }
@@ -42,7 +59,6 @@ namespace FUSE.Patches
             SetupDescriptor setupDescriptor)
         {
             var repairPending = true;
-            var placementQueue = new Queue<SetupDescriptor.CarPlacement>();
             while (original.MoveNext())
             {
                 yield return original.Current;
@@ -52,14 +68,36 @@ namespace FUSE.Patches
                 }
 
                 repairPending = false;
-                QueueStarterPlacements(setupDescriptor, placementQueue);
+                QueueStarterPlacements(
+                    setupDescriptor,
+                    PendingPlacements);
             }
 
-            if (placementQueue.Count > 0)
+            if (PendingPlacements.Count > 0)
             {
                 yield return null;
-                PresentNextPlacement(placementQueue);
+                while (InteractiveBookWindow.Shared != null
+                       && InteractiveBookWindow.Shared.IsShown)
+                {
+                    yield return null;
+                }
+                PresentNextPlacement();
             }
+        }
+
+        internal static bool ShouldQueueStarterSetup(
+            string setupIdentifier,
+            IEnumerable<string> loadedDefinitionIds)
+        {
+            return !string.IsNullOrWhiteSpace(setupIdentifier)
+                   && setupIdentifier.StartsWith(
+                       "ewh-",
+                       StringComparison.OrdinalIgnoreCase)
+                   && (loadedDefinitionIds ?? Array.Empty<string>()).Any(id =>
+                       string.Equals(
+                           id,
+                           AppalachianWhittierStartId,
+                           StringComparison.OrdinalIgnoreCase));
         }
 
         internal static int QueueStarterPlacements(
@@ -74,16 +112,9 @@ namespace FUSE.Patches
             }
 
             var queued = 0;
-            var queueEntireSetup = IsStockEastWhittierSetup(setupDescriptor);
             var retained = new List<SetupDescriptor.CarPlacement>(source.Length);
             foreach (var placement in source)
             {
-                if (!queueEntireSetup && PlacementIsUsable(placement))
-                {
-                    retained.Add(placement);
-                    continue;
-                }
-
                 placementQueue?.Enqueue(placement);
                 queued++;
                 FuseLog.Info(
@@ -96,45 +127,19 @@ namespace FUSE.Patches
             return queued;
         }
 
-        private static bool IsStockEastWhittierSetup(
-            SetupDescriptor setupDescriptor)
+        private static void PresentNextPlacement()
         {
-            return setupDescriptor != null &&
-                   !string.IsNullOrWhiteSpace(setupDescriptor.identifier) &&
-                   setupDescriptor.identifier.StartsWith(
-                       "ewh-",
-                       StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static bool PlacementIsUsable(
-            SetupDescriptor.CarPlacement placement)
-        {
-            if (placement?.marker == null)
-            {
-                return false;
-            }
-
-            var location = placement.marker.Location;
-            return location.HasValue &&
-                   location.Value.IsValid &&
-                   location.Value.segment != null &&
-                   location.Value.segment.GroupEnabled &&
-                   location.Value.segment.Available;
-        }
-
-        private static void PresentNextPlacement(
-            Queue<SetupDescriptor.CarPlacement> placementQueue)
-        {
-            if (placementQueue == null || placementQueue.Count == 0)
+            if (_presenting || PendingPlacements.Count == 0)
             {
                 return;
             }
 
-            var placement = placementQueue.Dequeue();
+            var placement = PendingPlacements.Peek();
             var descriptors = BuildDescriptors(placement);
             if (descriptors.Count == 0)
             {
-                PresentNextPlacement(placementQueue);
+                PendingPlacements.Dequeue();
+                PresentNextPlacement();
                 return;
             }
 
@@ -142,22 +147,112 @@ namespace FUSE.Patches
             if (placer == null)
             {
                 FuseLog.Warning(
-                    $"FUSE could not present {placementQueue.Count + 1} queued Company starter cut(s): " +
+                    $"FUSE could not present {PendingPlacements.Count} queued Company starter cut(s): " +
                     "the game's consist placer is unavailable.");
                 return;
             }
 
-            placer.Present(
-                descriptors,
-                null,
-                _ => placer.StartCoroutine(PresentAfterFrame(placementQueue)));
+            _presenting = true;
+            var trainController = TrainController.Shared;
+            if (trainController != null)
+            {
+                // The current game build reports `placed=true` even when its
+                // caught PlaceTrain call failed. Clearing and checking this
+                // public result prevents that false callback from consuming
+                // the retained starter cut.
+                trainController.LastPlacedTrain = null;
+            }
+            try
+            {
+                placer.Present(
+                    descriptors,
+                    null,
+                    placed =>
+                    {
+                        _presenting = false;
+                        var placedCount = TrainController.Shared?
+                            .LastPlacedTrain?.Count ?? 0;
+                        if (!WasPlacementCommitted(
+                                placed,
+                                descriptors.Count,
+                                placedCount))
+                        {
+                            FuseLog.Info(
+                                "FUSE retained "
+                                + PendingPlacements.Count
+                                + " Appalachian Railway starter cut(s) after "
+                                + (placed
+                                    ? "the game did not confirm every car was created."
+                                    : "placement was cancelled."));
+                            Toast.Present(
+                                "Starter equipment retained. Run /fuse.starters "
+                                + "when you are ready to place it.",
+                                ToastPosition.Middle);
+                            return;
+                        }
+
+                        if (PendingPlacements.Count > 0
+                            && ReferenceEquals(
+                                PendingPlacements.Peek(),
+                                placement))
+                        {
+                            PendingPlacements.Dequeue();
+                        }
+                        placer.StartCoroutine(PresentAfterFrame());
+                    });
+            }
+            catch (Exception ex)
+            {
+                _presenting = false;
+                FuseLog.Exception(
+                    "FUSE could not open Appalachian Railway starter placement; "
+                    + "the cut remains queued.",
+                    ex);
+                Toast.Present(
+                    "Starter equipment retained. Run /fuse.starters when "
+                    + "placement is available.",
+                    ToastPosition.Middle);
+            }
         }
 
-        private static IEnumerator PresentAfterFrame(
-            Queue<SetupDescriptor.CarPlacement> placementQueue)
+        internal static bool WasPlacementCommitted(
+            bool callbackReportedPlaced,
+            int expectedCarCount,
+            int placedCarCount)
+        {
+            return callbackReportedPlaced
+                   && expectedCarCount > 0
+                   && placedCarCount == expectedCarCount;
+        }
+
+        private static IEnumerator PresentAfterFrame()
         {
             yield return null;
-            PresentNextPlacement(placementQueue);
+            PresentNextPlacement();
+        }
+
+        internal static string ResumePendingPlacements()
+        {
+            if (PendingPlacements.Count == 0)
+                return "No Appalachian Railway starter equipment is pending.";
+            if (_presenting)
+            {
+                return "Starter equipment placement is already active ("
+                       + PendingPlacements.Count
+                       + " cut(s) remaining).";
+            }
+            if (InteractiveBookWindow.Shared != null
+                && InteractiveBookWindow.Shared.IsShown)
+            {
+                return "Close the tutorial, then run /fuse.starters again. "
+                       + PendingPlacements.Count
+                       + " starter cut(s) are safely retained.";
+            }
+
+            PresentNextPlacement();
+            return "Opened Appalachian Railway starter equipment placement ("
+                   + PendingPlacements.Count
+                   + " cut(s) remaining).";
         }
 
         private static List<CarDescriptor> BuildDescriptors(

--- a/FUSE/Patches/FuseCustomIndustryTitlePatch.cs
+++ b/FUSE/Patches/FuseCustomIndustryTitlePatch.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using Model.Ops;
+using StrangeCustoms.Tracks.Industries;
+using UI;
+
+namespace FUSE.Patches
+{
+    [HarmonyPatch]
+    internal static class FuseCustomIndustryTitlePatch
+    {
+        internal static MethodBase TargetMethod()
+        {
+            return AccessTools.GetDeclaredMethods(typeof(DropdownLocationPickerRowData))
+                .FirstOrDefault(method =>
+                    method.Name.IndexOf(
+                        "TitleForComponent",
+                        StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        internal static bool Prefix(IndustryComponent ic, ref string __result)
+        {
+            if (!(ic is ICustomIndustryTitle titled)
+                || string.IsNullOrWhiteSpace(titled.Title))
+            {
+                return true;
+            }
+
+            __result = titled.Title;
+            return false;
+        }
+    }
+}

--- a/FUSE/Patches/FuseCustomIndustryTitlePatch.cs
+++ b/FUSE/Patches/FuseCustomIndustryTitlePatch.cs
@@ -14,22 +14,38 @@ namespace FUSE.Patches
         internal static MethodBase TargetMethod()
         {
             return AccessTools.GetDeclaredMethods(typeof(DropdownLocationPickerRowData))
-                .FirstOrDefault(method =>
-                    method.Name.IndexOf(
-                        "TitleForComponent",
-                        StringComparison.OrdinalIgnoreCase) >= 0);
+                .SingleOrDefault(method =>
+                {
+                    if (!method.IsStatic ||
+                        method.ReturnType != typeof(string) ||
+                        method.Name.IndexOf("TitleForComponent", StringComparison.Ordinal) < 0)
+                    {
+                        return false;
+                    }
+
+                    var parameters = method.GetParameters();
+                    return parameters.Length == 1 &&
+                           parameters[0].ParameterType == typeof(IndustryComponent);
+                });
         }
 
-        internal static bool Prefix(IndustryComponent ic, ref string __result)
+        internal static bool Prefix(
+            [HarmonyArgument(0)] IndustryComponent component,
+            ref string __result)
         {
-            if (!(ic is ICustomIndustryTitle titled)
-                || string.IsNullOrWhiteSpace(titled.Title))
+            if (!TryGetCustomTitle(component as ICustomIndustryTitle, out var title))
             {
                 return true;
             }
 
-            __result = titled.Title;
+            __result = title;
             return false;
+        }
+
+        internal static bool TryGetCustomTitle(ICustomIndustryTitle titled, out string title)
+        {
+            title = titled?.Title;
+            return !string.IsNullOrWhiteSpace(title);
         }
     }
 }

--- a/FUSE/Patches/FuseEquipmentCatalogWarmup.cs
+++ b/FUSE/Patches/FuseEquipmentCatalogWarmup.cs
@@ -26,6 +26,11 @@ namespace FUSE.Patches
         private static int _nextStore;
         private static int _failedStores;
         private static long _elapsedTicks;
+        private static long _worstStoreTicks;
+        private static string _worstStoreIdentifier = string.Empty;
+        private static int _slowStores;
+
+        private const double SlowStoreMilliseconds = 25d;
 
         internal static int PendingStoreCount => Math.Max(0, _stores.Length - _nextStore);
 
@@ -37,6 +42,9 @@ namespace FUSE.Patches
             _nextStore = 0;
             _failedStores = 0;
             _elapsedTicks = 0;
+            _worstStoreTicks = 0;
+            _worstStoreIdentifier = string.Empty;
+            _slowStores = 0;
 
             if (_stores.Length > 0)
             {
@@ -76,7 +84,18 @@ namespace FUSE.Patches
                 }
                 finally
                 {
-                    _elapsedTicks += Stopwatch.GetTimestamp() - started;
+                    var elapsedTicks = Stopwatch.GetTimestamp() - started;
+                    _elapsedTicks += elapsedTicks;
+                    if (elapsedTicks > _worstStoreTicks)
+                    {
+                        _worstStoreTicks = elapsedTicks;
+                        _worstStoreIdentifier = store.Identifier ?? "<unknown>";
+                    }
+
+                    if (elapsedTicks * 1000d / Stopwatch.Frequency >= SlowStoreMilliseconds)
+                    {
+                        _slowStores++;
+                    }
                 }
             }
 
@@ -86,9 +105,13 @@ namespace FUSE.Patches
             }
 
             var elapsedMs = _elapsedTicks * 1000d / Stopwatch.Frequency;
+            var worstStoreMs = _worstStoreTicks * 1000d / Stopwatch.Frequency;
             FuseLog.Info(
                 $"FUSE Equipment catalogue warm-up completed stores={_stores.Length} " +
-                $"failed={_failedStores} cumulativeWorkMs={elapsedMs:0.0}. " +
+                $"failed={_failedStores} cumulativeWorkMs={elapsedMs:0.0} " +
+                $"slowStores={_slowStores} slowThresholdMs={SlowStoreMilliseconds:0} " +
+                $"worstStore='{_worstStoreIdentifier}' worstStoreMs={worstStoreMs:0.0} " +
+                $"legoUnrelatedContainersSkipped={FuseLegosLibraryCompatibility.ContainersSkippedByFastPath}. " +
                 "Opening the buy menu will reuse the prepared containers.");
         }
 

--- a/FUSE/Patches/FuseEquipmentCatalogWarmup.cs
+++ b/FUSE/Patches/FuseEquipmentCatalogWarmup.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using AssetPack.Runtime;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model.Database;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Spreads the Equipment catalogue's cold Definitions.json work over
+    /// multiple frames. AssetPackRuntimeStore caches Container(), so touching
+    /// one store per frame performs exactly the same deserialization and legacy
+    /// Harmony edits the stock EquipmentWindow would trigger, without doing the
+    /// entire mounted set synchronously when the player clicks Buy.
+    /// </summary>
+    internal static class FuseEquipmentCatalogWarmup
+    {
+        private static readonly FieldInfo StoresField =
+            AccessTools.Field(typeof(PrefabStore), "_stores");
+
+        private static PrefabStore _owner;
+        private static AssetPackRuntimeStore[] _stores = Array.Empty<AssetPackRuntimeStore>();
+        private static int _nextStore;
+        private static int _failedStores;
+        private static long _elapsedTicks;
+
+        internal static int PendingStoreCount => Math.Max(0, _stores.Length - _nextStore);
+
+        internal static void Schedule(PrefabStore owner)
+        {
+            FusePrefabStoreAllCarDefinitionInfosFilterPatch.InvalidateCache();
+            _owner = owner;
+            _stores = SnapshotStores(owner);
+            _nextStore = 0;
+            _failedStores = 0;
+            _elapsedTicks = 0;
+
+            if (_stores.Length > 0)
+            {
+                FuseLog.Info(
+                    $"FUSE scheduled Equipment catalogue warm-up stores={_stores.Length}; " +
+                    "one cold definition store will be prepared per frame.");
+            }
+        }
+
+        internal static void Update()
+        {
+            if (_owner == null || _nextStore >= _stores.Length)
+            {
+                return;
+            }
+
+            if (ReadStoreCount(_owner) != _stores.Length)
+            {
+                Schedule(_owner);
+                return;
+            }
+
+            var store = _stores[_nextStore++];
+            if (store != null)
+            {
+                var started = Stopwatch.GetTimestamp();
+                try
+                {
+                    store.Container();
+                }
+                catch (Exception ex)
+                {
+                    _failedStores++;
+                    FuseLog.Warning(
+                        $"FUSE Equipment catalogue warm-up skipped store='{store.Identifier ?? "<unknown>"}' " +
+                        $"reason='{ex.GetBaseException().Message}'. The remaining stores will still be prepared.");
+                }
+                finally
+                {
+                    _elapsedTicks += Stopwatch.GetTimestamp() - started;
+                }
+            }
+
+            if (_nextStore != _stores.Length)
+            {
+                return;
+            }
+
+            var elapsedMs = _elapsedTicks * 1000d / Stopwatch.Frequency;
+            FuseLog.Info(
+                $"FUSE Equipment catalogue warm-up completed stores={_stores.Length} " +
+                $"failed={_failedStores} cumulativeWorkMs={elapsedMs:0.0}. " +
+                "Opening the buy menu will reuse the prepared containers.");
+        }
+
+        private static AssetPackRuntimeStore[] SnapshotStores(PrefabStore owner)
+        {
+            if (owner == null || StoresField == null)
+            {
+                return Array.Empty<AssetPackRuntimeStore>();
+            }
+
+            try
+            {
+                if (!(StoresField.GetValue(owner) is IEnumerable<AssetPackRuntimeStore> stores))
+                {
+                    return Array.Empty<AssetPackRuntimeStore>();
+                }
+
+                return new List<AssetPackRuntimeStore>(stores).ToArray();
+            }
+            catch
+            {
+                return Array.Empty<AssetPackRuntimeStore>();
+            }
+        }
+
+        private static int ReadStoreCount(PrefabStore owner)
+        {
+            if (owner == null || StoresField == null)
+            {
+                return -1;
+            }
+
+            try
+            {
+                return StoresField.GetValue(owner) is System.Collections.ICollection stores
+                    ? stores.Count
+                    : -1;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseFallFromGraceCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseFallFromGraceCompatibilityPatch.cs
@@ -43,7 +43,7 @@ namespace FUSE.Patches
     {
         private static void Postfix(UIPanelBuilder builder, Waybill waybill)
         {
-            if (waybill.PaymentOnArrival <= 0)
+            if (waybill == null || waybill.PaymentOnArrival <= 0)
             {
                 return;
             }

--- a/FUSE/Patches/FuseFallFromGraceCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseFallFromGraceCompatibilityPatch.cs
@@ -43,7 +43,7 @@ namespace FUSE.Patches
     {
         private static void Postfix(UIPanelBuilder builder, Waybill waybill)
         {
-            if (waybill == null || waybill.PaymentOnArrival <= 0)
+            if (waybill.PaymentOnArrival <= 0)
             {
                 return;
             }

--- a/FUSE/Patches/FuseFallFromGraceCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseFallFromGraceCompatibilityPatch.cs
@@ -1,0 +1,81 @@
+using System;
+using FUSE.Infrastructure;
+using Game;
+using HarmonyLib;
+using Model.Ops;
+using Track;
+using UI.Builder;
+using UI.CarInspector;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Native FUSE implementation of the small public behavior contract exposed
+    /// by ZAMU FallFromGrace. The default transform is an identity operation, so
+    /// advertising the replacement cannot silently alter an existing railroad.
+    /// </summary>
+    [HarmonyPatch(typeof(OpsController), "CalculateGraceDays", new[] { typeof(Location), typeof(Location) })]
+    internal static class FuseFallFromGraceCalculationPatch
+    {
+        private static void Postfix(ref int __result)
+        {
+            __result = AdjustGraceDays(
+                __result,
+                FuseSettings.GraceMinimumDays,
+                FuseSettings.GraceMultiplier,
+                FuseSettings.GraceAddedDays);
+        }
+
+        internal static int AdjustGraceDays(int baseDays, int minimumDays, int multiplier, int addedDays)
+        {
+            var adjusted = ((long)baseDays * multiplier) + addedDays;
+            adjusted = Math.Max(minimumDays, adjusted);
+            return adjusted > int.MaxValue
+                ? int.MaxValue
+                : adjusted < int.MinValue
+                    ? int.MinValue
+                    : (int)adjusted;
+        }
+    }
+
+    [HarmonyPatch(typeof(CarInspector), "PopulateWaybillPanel", new[] { typeof(UIPanelBuilder), typeof(Waybill) })]
+    internal static class FuseFallFromGraceInspectorPatch
+    {
+        private static void Postfix(UIPanelBuilder builder, Waybill waybill)
+        {
+            if (waybill.PaymentOnArrival <= 0)
+            {
+                return;
+            }
+
+            try
+            {
+                var row = builder.AddField(
+                    "Due",
+                    () => FormatDue(waybill, TimeWeather.Now),
+                    UIPanelBuilder.Frequency.Periodic);
+                row.RectTransform.SetSiblingIndex(2);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE contained a FallFromGrace-compatible inspector-row error; " +
+                    $"the rest of the car inspector remains usable: {ex.GetBaseException().Message}");
+            }
+        }
+
+        internal static string FormatDue(Waybill waybill, GameDateTime now)
+        {
+            if (waybill.Completed)
+            {
+                return "Completed";
+            }
+
+            var due = waybill.Created.AddingDays(waybill.GraceDays);
+            var interval = due.IntervalString(now, GameDateTimeInterval.Style.Full);
+            return due.TotalSeconds >= now.TotalSeconds
+                ? interval + " remaining"
+                : interval + " overdue";
+        }
+    }
+}

--- a/FUSE/Patches/FuseForYourConvenienceCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseForYourConvenienceCompatibilityPatch.cs
@@ -1,0 +1,297 @@
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using HarmonyLib;
+using Model;
+using Model.Ops;
+using RollingStock;
+using UI;
+using UI.Map;
+using UI.Tags;
+using TMPro;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    internal static class FuseForYourConveniencePolicy
+    {
+        internal static bool IsActive()
+        {
+            return FuseLegacyCapabilityActivation.IsRequested(
+                "Zamu.ForYourConvenience",
+                "ForYourConvenience");
+        }
+
+        internal static string FormatSpeed(float metersPerSecond)
+        {
+            return Math.Abs(metersPerSecond * 2.23694f)
+                .ToString("0.0", CultureInfo.InvariantCulture) + " MPH";
+        }
+
+        internal static string FormatLoad(float quantity, float capacity, string description)
+        {
+            var percentage = capacity > 0.001f
+                ? Mathf.Clamp01(quantity / capacity) * 100f
+                : 0f;
+            return percentage.ToString("0", CultureInfo.InvariantCulture) + "% " +
+                   (description ?? "Unknown load");
+        }
+    }
+
+    [HarmonyPatch(typeof(Car), nameof(Car.Setup))]
+    internal static class FuseForYourConvenienceCabooseMapIconPatch
+    {
+        private static readonly FieldInfo MapIconField = AccessTools.Field(typeof(Car), "MapIcon");
+
+        private static void Postfix(Car __instance, Car.SetupPrefabs prefabs, bool isGhost)
+        {
+            if (!FuseForYourConveniencePolicy.IsActive() ||
+                !FuseSettings.ForYourConvenienceShowCabooseIcons ||
+                isGhost || __instance == null || __instance.CarType != "NE" ||
+                prefabs.LocomotiveMapIcon == null || MapIconField == null ||
+                MapIconField.GetValue(__instance) != null)
+            {
+                return;
+            }
+
+            try
+            {
+                var icon = UnityEngine.Object.Instantiate(prefabs.LocomotiveMapIcon, __instance.transform);
+                icon.SetText(__instance.Ident.RoadNumber);
+                icon.OnClick = () => CarPickable.HandleShowInspector(__instance);
+                MapIconField.SetValue(__instance, icon);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not add the optional caboose map icon for '" +
+                    __instance.DisplayName + "': " + ex.GetBaseException().Message);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(TagController), "UpdateTag")]
+    internal static class FuseForYourConvenienceCarTagPatch
+    {
+        private static void Postfix(Car car, TagCallout tagCallout)
+        {
+            if (!FuseForYourConveniencePolicy.IsActive() || car == null || tagCallout?.callout == null ||
+                (!FuseSettings.ForYourConvenienceShowCarTagMph &&
+                 !FuseSettings.ForYourConvenienceShowCarTagLoads))
+            {
+                return;
+            }
+
+            try
+            {
+                var text = new StringBuilder(tagCallout.callout.Text ?? string.Empty);
+                if (FuseSettings.ForYourConvenienceShowCarTagMph)
+                {
+                    AppendLine(text, FuseForYourConveniencePolicy.FormatSpeed(car.velocity));
+                }
+
+                if (FuseSettings.ForYourConvenienceShowCarTagLoads && car.Definition?.LoadSlots != null)
+                {
+                    for (var slotIndex = 0; slotIndex < car.Definition.LoadSlots.Count; slotIndex++)
+                    {
+                        var info = car.GetLoadInfo(slotIndex);
+                        if (!info.HasValue)
+                        {
+                            continue;
+                        }
+
+                        var load = CarPrototypeLibrary.instance?.LoadForId(info.Value.LoadId);
+                        var description = load == null
+                            ? info.Value.LoadId
+                            : info.Value.LoadString(load);
+                        AppendLine(
+                            text,
+                            FuseForYourConveniencePolicy.FormatLoad(
+                                info.Value.Quantity,
+                                car.Definition.LoadSlots[slotIndex].MaximumCapacity,
+                                description));
+                    }
+                }
+
+                tagCallout.callout.Text = text.ToString();
+                tagCallout.callout.Layout();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not append optional information to car tag '" +
+                    car.DisplayName + "': " + ex.GetBaseException().Message);
+            }
+        }
+
+        private static void AppendLine(StringBuilder builder, string value)
+        {
+            if (builder.Length > 0)
+            {
+                builder.AppendLine();
+            }
+
+            builder.Append(value);
+        }
+    }
+
+    [HarmonyPatch(typeof(MapBuilder), nameof(MapBuilder.Rebuild))]
+    internal static class FuseForYourConvenienceStationMapPatch
+    {
+        private const float MaximumStationDistance = 250f;
+        private static readonly string[] IdentityRoleSuffixes =
+        {
+            "stationagent",
+            "station",
+            "depot",
+            "agent",
+            "area"
+        };
+        private static readonly FieldInfo AreaIdField = AccessTools.Field(typeof(StationAgent), "areaId");
+        private static readonly FieldInfo PassengerStopIdField = AccessTools.Field(typeof(StationAgent), "passengerStopId");
+
+        private static void Postfix()
+        {
+            if (!FuseForYourConveniencePolicy.IsActive())
+            {
+                return;
+            }
+
+            try
+            {
+                var agents = UnityEngine.Object.FindObjectsOfType<StationAgent>(true);
+                if (agents == null || agents.Length == 0)
+                {
+                    return;
+                }
+
+                foreach (var icon in UnityEngine.Object.FindObjectsOfType<MapIcon>(true))
+                {
+                    if (icon == null || icon.OnClick != null || icon.GetComponentInParent<Car>() != null)
+                    {
+                        continue;
+                    }
+
+                    var nearest = FindNearest(
+                        icon.transform.position,
+                        BuildIconIdentity(icon),
+                        agents);
+                    if (nearest != null)
+                    {
+                        icon.OnClick = () => nearest.Activate(default(PickableActivateEvent));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not attach optional station-map actions: " +
+                    ex.GetBaseException().Message);
+            }
+        }
+
+        internal static bool IsStationIdentityMatch(
+            string iconIdentity,
+            string areaId,
+            string passengerStopId)
+        {
+            var normalizedIcon = NormalizeIdentity(iconIdentity);
+            if (normalizedIcon.Length < 3)
+            {
+                return false;
+            }
+
+            return IdentityMatches(normalizedIcon, areaId) ||
+                   IdentityMatches(normalizedIcon, passengerStopId);
+        }
+
+        private static bool IdentityMatches(string normalizedIcon, string stationIdentity)
+        {
+            var normalizedStation = NormalizeIdentity(stationIdentity);
+            return normalizedStation.Length >= 3 &&
+                   string.Equals(normalizedIcon, normalizedStation, StringComparison.Ordinal);
+        }
+
+        private static string NormalizeIdentity(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            var normalized = new StringBuilder(value.Length);
+            for (var index = 0; index < value.Length; index++)
+            {
+                if (char.IsLetterOrDigit(value[index]))
+                {
+                    normalized.Append(char.ToLowerInvariant(value[index]));
+                }
+            }
+
+            var result = normalized.ToString();
+            for (var index = 0; index < IdentityRoleSuffixes.Length; index++)
+            {
+                var suffix = IdentityRoleSuffixes[index];
+                if (result.Length > suffix.Length + 2 &&
+                    result.EndsWith(suffix, StringComparison.Ordinal))
+                {
+                    return result.Substring(0, result.Length - suffix.Length);
+                }
+            }
+
+            return result;
+        }
+
+        private static string BuildIconIdentity(MapIcon icon)
+        {
+            var identity = new StringBuilder();
+            var label = icon.GetComponentInChildren<TMP_Text>(true);
+            if (label != null && !string.IsNullOrWhiteSpace(label.text))
+            {
+                return label.text;
+            }
+
+            for (var current = icon.transform; current != null; current = current.parent)
+            {
+                identity.Append(' ').Append(current.name);
+            }
+
+            return identity.ToString();
+        }
+
+        private static StationAgent FindNearest(
+            Vector3 position,
+            string iconIdentity,
+            StationAgent[] agents)
+        {
+            StationAgent nearest = null;
+            var best = MaximumStationDistance * MaximumStationDistance;
+            for (var index = 0; index < agents.Length; index++)
+            {
+                var candidate = agents[index];
+                if (candidate == null || !candidate.isActiveAndEnabled ||
+                    !IsStationIdentityMatch(
+                        iconIdentity,
+                        AreaIdField?.GetValue(candidate) as string,
+                        PassengerStopIdField?.GetValue(candidate) as string))
+                {
+                    continue;
+                }
+
+                var offset = candidate.transform.position - position;
+                offset.y = 0f;
+                var distance = offset.sqrMagnitude;
+                if (distance < best)
+                {
+                    nearest = candidate;
+                    best = distance;
+                }
+            }
+
+            return nearest;
+        }
+    }
+}

--- a/FUSE/Patches/FuseInterchangePatches.cs
+++ b/FUSE/Patches/FuseInterchangePatches.cs
@@ -1,6 +1,7 @@
 using System;
 using FUSE.Runtime.API;
 using FUSE.Infrastructure;
+using Game.State;
 using HarmonyLib;
 using Model.Ops;
 
@@ -23,6 +24,20 @@ namespace FUSE.Patches
                 {
                     var componentContext = unloader.CreateContext(ctx.Now, 0f);
                     unloader.ServeInterchange(componentContext, __instance);
+                }
+
+                // C1CD compatibility: continuous service means an interchange
+                // receives another extra-service slot even when this pass did
+                // not leave any pending orders. Scheduling here avoids the old
+                // brittle IL edit inside OpsController.CheckServiceInterchanges.
+                if (FuseSettings.InterchangeContinuousService && StateManager.IsHost)
+                {
+                    __instance.ScheduleExtra(new Game.GameDateTime?(
+                        FuseC1CdSchedulePolicy.CalculateNextServiceTime(
+                            ctx.Now,
+                            FuseSettings.InterchangeServiceIntervalMinutes,
+                            FuseSettings.InterchangeNotBeforeHour,
+                            FuseSettings.InterchangeNotAfterHour)));
                 }
             }
             catch (Exception ex)

--- a/FUSE/Patches/FuseInterchangeToInterchangeCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseInterchangeToInterchangeCompatibilityPatch.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using HarmonyLib;
+using Model.Ops;
+using Model.Ops.Definition;
+using UI.CarInspector;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    internal static class FuseInterchangeToInterchangePolicy
+    {
+        internal static bool IsActive()
+        {
+            return FuseLegacyCapabilityActivation.IsRequested(
+                "Zamu.Interchange2Interchange",
+                "Interchange2Interchange");
+        }
+
+        internal static int ScaleMaximumCars(int configuredMaximum, float contractMultiplier)
+        {
+            if (configuredMaximum <= 0 || contractMultiplier <= 0f || float.IsNaN(contractMultiplier))
+            {
+                return 0;
+            }
+
+            return Mathf.Clamp(
+                Mathf.RoundToInt(configuredMaximum * contractMultiplier),
+                0,
+                200);
+        }
+    }
+
+    [HarmonyPatch(typeof(OpsController), "RebuildCollections")]
+    internal static class FuseInterchangeToInterchangeContractSetupPatch
+    {
+        private static void Postfix(OpsController __instance)
+        {
+            if (!FuseInterchangeToInterchangePolicy.IsActive() || __instance?.AllInterchanges == null)
+            {
+                return;
+            }
+
+            foreach (var interchange in __instance.AllInterchanges)
+            {
+                if (interchange?.Industry != null)
+                {
+                    interchange.Industry.usesContract = true;
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(Interchange), nameof(Interchange.OrderCars))]
+    internal static class FuseInterchangeToInterchangeOrderPatch
+    {
+        private const string LastOrderTimeKey = "fuse.i2i.lastOrderTime";
+
+        private static void Postfix(Interchange __instance, IIndustryContext ctx)
+        {
+            if (!FuseInterchangeToInterchangePolicy.IsActive() || __instance == null || ctx == null)
+            {
+                return;
+            }
+
+            try
+            {
+                AddInterchangeOrders(__instance, ctx);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    $"FUSE could not create interchange-to-interchange orders for " +
+                    $"'{__instance.DisplayName}'; normal interchange service remains available: " +
+                    ex.GetBaseException().Message);
+            }
+        }
+
+        private static void AddInterchangeOrders(Interchange source, IIndustryContext ctx)
+        {
+            if (source.Industry == null)
+            {
+                return;
+            }
+
+            source.Industry.usesContract = true;
+            var multiplier = source.Industry.GetContractMultiplier();
+            var maximumCars = FuseInterchangeToInterchangePolicy.ScaleMaximumCars(
+                FuseSettings.InterchangeToInterchangeMaximumCars,
+                multiplier);
+            if (maximumCars <= 0 ||
+                ctx.Now.DaysSince(ctx.GetDateTime(LastOrderTimeKey, Game.GameDateTime.Zero)) < 1f)
+            {
+                return;
+            }
+
+            var controller = OpsController.Shared;
+            var destinations = (controller?.EnabledInterchanges ?? Enumerable.Empty<Interchange>())
+                .Where(candidate => candidate != null && candidate != source && candidate.Industry != null)
+                .ToArray();
+            var cargo = CollectCargo(controller).ToArray();
+            if (destinations.Length == 0 || cargo.Length == 0)
+            {
+                return;
+            }
+
+            var added = 0;
+            foreach (var destination in destinations)
+            {
+                var remaining = UnityEngine.Random.Range(0, maximumCars + 1);
+                while (remaining > 0)
+                {
+                    var count = UnityEngine.Random.Range(1, Math.Min(3, remaining) + 1);
+                    remaining -= count;
+                    var selection = cargo[UnityEngine.Random.Range(0, cargo.Length)];
+                    source.AddOrder(new Order(
+                        new CarTypeFilter(selection.CarFilter),
+                        selection.Load,
+                        destination,
+                        count,
+                        null,
+                        false));
+                    added += count;
+                }
+            }
+
+            if (added > 0)
+            {
+                ctx.SetDateTime(LastOrderTimeKey, ctx.Now);
+                FuseLog.Info(
+                    $"FUSE scheduled {added} interchange-to-interchange car(s) from '{source.DisplayName}'.");
+            }
+        }
+
+        private static IEnumerable<CargoTarget> CollectCargo(OpsController controller)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var industry in controller?.AllIndustries ?? Array.Empty<Industry>())
+            {
+                if (industry == null || industry.ProgressionDisabled)
+                {
+                    continue;
+                }
+
+                foreach (var component in industry.Components ?? Array.Empty<IndustryComponent>())
+                {
+                    if (component == null || component.ProgressionDisabled || component.carTypeFilter == null ||
+                        component.carTypeFilter.Matches("PB") || component.carTypeFilter.Matches("PBO"))
+                    {
+                        continue;
+                    }
+
+                    var load = LoadFor(component);
+                    var filter = component.carTypeFilter.queryString;
+                    var key = (filter ?? string.Empty) + "\n" + (load?.id ?? string.Empty);
+                    if (load != null && !string.IsNullOrWhiteSpace(filter) && seen.Add(key))
+                    {
+                        yield return new CargoTarget(filter, load);
+                    }
+                }
+            }
+        }
+
+        private static Load LoadFor(IndustryComponent component)
+        {
+            if (component is IndustryLoaderBase loader)
+            {
+                return loader.load;
+            }
+
+            if (component is IndustryUnloader unloader)
+            {
+                return unloader.load;
+            }
+
+            return (component as TeleportLoadingIndustry)?.load;
+        }
+
+        private readonly struct CargoTarget
+        {
+            internal CargoTarget(string carFilter, Load load)
+            {
+                CarFilter = carFilter;
+                Load = load;
+            }
+
+            internal string CarFilter { get; }
+            internal Load Load { get; }
+        }
+    }
+
+    [HarmonyPatch]
+    internal static class FuseInterchangeToInterchangeInspectorPatch
+    {
+        private static MethodBase TargetMethod()
+        {
+            return AccessTools.GetDeclaredMethods(typeof(CarInspector))
+                .FirstOrDefault(method => method.Name.IndexOf("ShouldShowIndustry", StringComparison.Ordinal) >= 0);
+        }
+
+        private static void Postfix(Industry industry, ref bool __result)
+        {
+            if (!__result && FuseInterchangeToInterchangePolicy.IsActive() &&
+                industry != null && !industry.ProgressionDisabled &&
+                industry.Components.OfType<Interchange>().Any())
+            {
+                __result = true;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseInterchangeToInterchangeCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseInterchangeToInterchangeCompatibilityPatch.cs
@@ -31,7 +31,7 @@ namespace FUSE.Patches
             return Mathf.Clamp(
                 Mathf.RoundToInt(configuredMaximum * contractMultiplier),
                 0,
-                200);
+                FuseSettings.InterchangeToInterchangeMaximumCarsLimit);
         }
     }
 
@@ -198,8 +198,11 @@ namespace FUSE.Patches
     {
         private static MethodBase TargetMethod()
         {
-            return AccessTools.GetDeclaredMethods(typeof(CarInspector))
-                .FirstOrDefault(method => method.Name.IndexOf("ShouldShowIndustry", StringComparison.Ordinal) >= 0);
+            var method = AccessTools.DeclaredMethod(
+                typeof(CarInspector),
+                "ShouldShowIndustry",
+                new[] { typeof(Industry) });
+            return method?.ReturnType == typeof(bool) ? method : null;
         }
 
         private static void Postfix(Industry industry, ref bool __result)

--- a/FUSE/Patches/FuseInterchangeToInterchangeCompatibilityPatch.cs
+++ b/FUSE/Patches/FuseInterchangeToInterchangeCompatibilityPatch.cs
@@ -198,11 +198,18 @@ namespace FUSE.Patches
     {
         private static MethodBase TargetMethod()
         {
-            var method = AccessTools.DeclaredMethod(
-                typeof(CarInspector),
-                "ShouldShowIndustry",
-                new[] { typeof(Industry) });
-            return method?.ReturnType == typeof(bool) ? method : null;
+            return AccessTools.GetDeclaredMethods(typeof(CarInspector))
+                .SingleOrDefault(method =>
+                {
+                    if (method.Name.IndexOf("ShouldShowIndustry", StringComparison.Ordinal) < 0 ||
+                        method.ReturnType != typeof(bool))
+                    {
+                        return false;
+                    }
+
+                    var parameters = method.GetParameters();
+                    return parameters.Length == 1 && parameters[0].ParameterType == typeof(Industry);
+                });
         }
 
         private static void Postfix(Industry industry, ref bool __result)

--- a/FUSE/Patches/FuseLegosLibraryCompatibility.cs
+++ b/FUSE/Patches/FuseLegosLibraryCompatibility.cs
@@ -60,6 +60,11 @@ namespace FUSE.Patches
             return "installed";
         }
 
+        internal static void ResetAfterSuccessfulUnpatch()
+        {
+            _installed = false;
+        }
+
         private static bool CloneItemPrefix(ContainerItem item, ref ContainerItem __result)
         {
             if (item == null)

--- a/FUSE/Patches/FuseLegosLibraryCompatibility.cs
+++ b/FUSE/Patches/FuseLegosLibraryCompatibility.cs
@@ -4,6 +4,7 @@ using FUSE.Infrastructure;
 using HarmonyLib;
 using Model.Definition;
 using Newtonsoft.Json;
+using UnityEngine;
 
 namespace FUSE.Patches
 {
@@ -17,47 +18,175 @@ namespace FUSE.Patches
     {
         private const string PatchTypeName =
             "LegosLibraryOfStuff.ContainerSerializationDeserializePatch";
+        private const string DetailModelPatchTypeName =
+            "LegosLibraryOfStuff.DetailModelConditionPatch";
+        private const string ComponentGroupHandlerTypeName =
+            "LegosLibraryOfStuff.ComponentGroupHandler";
 
         private static readonly MethodInfo SerializerSettingsMethod =
             AccessTools.Method(typeof(ContainerSerialization), "JsonSerializerSettings");
 
-        private static bool _installed;
+        private static bool _cloneCompatibilityInstalled;
+        private static bool _detailModelCompatibilityInstalled;
         private static int _cloneFailures;
+        private static int _detailModelFailures;
 
         internal static string EnsureInstalled(Harmony harmony)
         {
-            if (_installed)
-            {
-                return "installed";
-            }
-
             if (harmony == null)
             {
                 return "unavailable (no harmony)";
             }
 
             var patchType = AccessTools.TypeByName(PatchTypeName);
-            if (patchType == null)
+            var detailModelPatchType = AccessTools.TypeByName(DetailModelPatchTypeName);
+            if (patchType == null && detailModelPatchType == null)
             {
                 return "idle (not present)";
             }
 
-            var cloneItem = AccessTools.DeclaredMethod(
-                patchType,
-                "CloneItem",
-                new[] { typeof(ContainerItem) });
-            if (cloneItem == null || SerializerSettingsMethod == null)
+            if (!_cloneCompatibilityInstalled && patchType != null)
             {
-                return "idle (surface changed)";
+                var cloneItem = AccessTools.DeclaredMethod(
+                    patchType,
+                    "CloneItem",
+                    new[] { typeof(ContainerItem) });
+                if (cloneItem != null && SerializerSettingsMethod != null)
+                {
+                    harmony.Patch(
+                        cloneItem,
+                        prefix: new HarmonyMethod(
+                            typeof(FuseLegosLibraryCompatibility),
+                            nameof(CloneItemPrefix)));
+                    _cloneCompatibilityInstalled = true;
+                }
             }
 
-            harmony.Patch(
-                cloneItem,
-                prefix: new HarmonyMethod(
-                    typeof(FuseLegosLibraryCompatibility),
-                    nameof(CloneItemPrefix)));
-            _installed = true;
-            return "installed";
+            if (detailModelPatchType != null)
+            {
+                _detailModelCompatibilityInstalled = TryEnsureDetailModelCompatibility(
+                    harmony,
+                    detailModelPatchType,
+                    installFusePostfix: !_detailModelCompatibilityInstalled);
+            }
+
+            if (_cloneCompatibilityInstalled && _detailModelCompatibilityInstalled)
+            {
+                return "installed";
+            }
+
+            if (_cloneCompatibilityInstalled || _detailModelCompatibilityInstalled)
+            {
+                return $"partial (clone={_cloneCompatibilityInstalled} detailModel={_detailModelCompatibilityInstalled})";
+            }
+
+            return "idle (surface changed)";
+        }
+
+        private static bool TryEnsureDetailModelCompatibility(
+            Harmony harmony,
+            Type patchType,
+            bool installFusePostfix)
+        {
+            var targetResolver = AccessTools.DeclaredMethod(patchType, "TargetMethod");
+            var originalPostfix = AccessTools.DeclaredMethod(patchType, "Postfix");
+            var handlerType = AccessTools.TypeByName(ComponentGroupHandlerTypeName);
+            var handlerMethod = handlerType == null
+                ? null
+                : AccessTools.DeclaredMethod(handlerType, "DetailModelLoaded");
+            if (targetResolver == null || originalPostfix == null || handlerMethod == null)
+            {
+                return false;
+            }
+
+            MethodBase target;
+            try
+            {
+                target = targetResolver.Invoke(null, null) as MethodBase;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE could not resolve Lego's detail-model completion target: " +
+                    ex.GetBaseException().Message);
+                return false;
+            }
+
+            if (target == null)
+            {
+                return false;
+            }
+
+            // Lego's callback checks only the managed reference before calling
+            // GetComponentInParent. Unity objects can retain that reference after
+            // their native GameObject has been destroyed, which throws while a
+            // detail model is cancelled or torn down. Remove that one callback and
+            // retain its live-object behavior through the guarded postfix below.
+            harmony.Unpatch(target, originalPostfix);
+            if (installFusePostfix)
+            {
+                harmony.Patch(
+                    target,
+                    postfix: new HarmonyMethod(
+                        typeof(FuseLegosLibraryCompatibility),
+                        nameof(DetailModelConfigurePostfix)));
+            }
+            return true;
+        }
+
+        private static void DetailModelConfigurePostfix(object __instance)
+        {
+            if (__instance == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var iteratorType = __instance.GetType();
+                var stateField = iteratorType.GetField(
+                    "<>1__state",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (stateField == null || !IsCompletedIteratorState(stateField.GetValue(__instance)))
+                {
+                    return;
+                }
+
+                var controllerField = iteratorType.GetField(
+                    "<>4__this",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                var controller = controllerField?.GetValue(__instance) as UnityEngine.Component;
+                if (controller == null)
+                {
+                    return;
+                }
+
+                var handlerType = AccessTools.TypeByName(ComponentGroupHandlerTypeName);
+                var handler = handlerType == null
+                    ? null
+                    : controller.GetComponentInParent(handlerType) as UnityEngine.Component;
+                if (handler == null)
+                {
+                    return;
+                }
+
+                AccessTools.DeclaredMethod(handlerType, "DetailModelLoaded")?.Invoke(handler, null);
+            }
+            catch (Exception ex)
+            {
+                _detailModelFailures++;
+                if (FuseGuardLog.ShouldLog(_detailModelFailures))
+                {
+                    FuseLog.Exception(
+                        "FUSE skipped an unsafe Lego detail-model component-group refresh",
+                        ex);
+                }
+            }
+        }
+
+        internal static bool IsCompletedIteratorState(object value)
+        {
+            return value is int state && state == -2;
         }
 
         internal static void ResetAfterSuccessfulUnpatch()

--- a/FUSE/Patches/FuseLegosLibraryCompatibility.cs
+++ b/FUSE/Patches/FuseLegosLibraryCompatibility.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Reflection;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model.Definition;
+using Newtonsoft.Json;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Gives LegosLibraryOfStuff's definition clone operation the same Unity
+    /// value converters used by the game. The library's default Newtonsoft
+    /// clone walks calculated Vector2/Vector3 properties and can report a
+    /// self-referencing loop, aborting the remainder of its catalog edits.
+    /// </summary>
+    internal static class FuseLegosLibraryCompatibility
+    {
+        private const string PatchTypeName =
+            "LegosLibraryOfStuff.ContainerSerializationDeserializePatch";
+
+        private static readonly MethodInfo SerializerSettingsMethod =
+            AccessTools.Method(typeof(ContainerSerialization), "JsonSerializerSettings");
+
+        private static bool _installed;
+        private static int _cloneFailures;
+
+        internal static string EnsureInstalled(Harmony harmony)
+        {
+            if (_installed)
+            {
+                return "installed";
+            }
+
+            if (harmony == null)
+            {
+                return "unavailable (no harmony)";
+            }
+
+            var patchType = AccessTools.TypeByName(PatchTypeName);
+            if (patchType == null)
+            {
+                return "idle (not present)";
+            }
+
+            var cloneItem = AccessTools.DeclaredMethod(
+                patchType,
+                "CloneItem",
+                new[] { typeof(ContainerItem) });
+            if (cloneItem == null || SerializerSettingsMethod == null)
+            {
+                return "idle (surface changed)";
+            }
+
+            harmony.Patch(
+                cloneItem,
+                prefix: new HarmonyMethod(
+                    typeof(FuseLegosLibraryCompatibility),
+                    nameof(CloneItemPrefix)));
+            _installed = true;
+            return "installed";
+        }
+
+        private static bool CloneItemPrefix(ContainerItem item, ref ContainerItem __result)
+        {
+            if (item == null)
+            {
+                return true;
+            }
+
+            try
+            {
+                var settings = SerializerSettingsMethod.Invoke(null, null) as JsonSerializerSettings;
+                if (settings == null)
+                {
+                    return true;
+                }
+
+                var json = JsonConvert.SerializeObject(item, Formatting.None, settings);
+                var clone = JsonConvert.DeserializeObject<ContainerItem>(json, settings);
+                if (clone == null)
+                {
+                    return true;
+                }
+
+                __result = clone;
+                return false;
+            }
+            catch (Exception ex)
+            {
+                _cloneFailures++;
+                if (FuseGuardLog.ShouldLog(_cloneFailures))
+                {
+                    FuseLog.Exception(
+                        $"FUSE could not safely clone Lego definition '{item.Identifier}'; " +
+                        "the library's original clone path will be attempted",
+                        ex);
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseLegosLibraryCompatibility.cs
+++ b/FUSE/Patches/FuseLegosLibraryCompatibility.cs
@@ -191,7 +191,10 @@ namespace FUSE.Patches
 
         internal static void ResetAfterSuccessfulUnpatch()
         {
-            _installed = false;
+            _cloneCompatibilityInstalled = false;
+            _detailModelCompatibilityInstalled = false;
+            _cloneFailures = 0;
+            _detailModelFailures = 0;
         }
 
         private static bool CloneItemPrefix(ContainerItem item, ref ContainerItem __result)

--- a/FUSE/Patches/FuseLegosLibraryCompatibility.cs
+++ b/FUSE/Patches/FuseLegosLibraryCompatibility.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Reflection;
 using FUSE.Infrastructure;
 using HarmonyLib;
@@ -22,14 +24,23 @@ namespace FUSE.Patches
             "LegosLibraryOfStuff.DetailModelConditionPatch";
         private const string ComponentGroupHandlerTypeName =
             "LegosLibraryOfStuff.ComponentGroupHandler";
+        private const string LibraryTypeName =
+            "LegosLibraryOfStuff.LibraryOfStuff";
 
         private static readonly MethodInfo SerializerSettingsMethod =
             AccessTools.Method(typeof(ContainerSerialization), "JsonSerializerSettings");
 
         private static bool _cloneCompatibilityInstalled;
         private static bool _detailModelCompatibilityInstalled;
+        private static bool _containerFastPathInstalled;
         private static int _cloneFailures;
         private static int _detailModelFailures;
+        private static MethodInfo _loadJsonDefinitionsMethod;
+        private static FieldInfo _definitionIdentifiersField;
+        private static HashSet<string> _definitionIdentifiers;
+        private static int _definitionIdentifierCount = -1;
+        private static bool _definitionsPrimed;
+        private static int _containersSkipped;
 
         internal static string EnsureInstalled(Harmony harmony)
         {
@@ -60,6 +71,27 @@ namespace FUSE.Patches
                             nameof(CloneItemPrefix)));
                     _cloneCompatibilityInstalled = true;
                 }
+
+                var originalPostfix = AccessTools.DeclaredMethod(patchType, "Postfix");
+                var libraryType = AccessTools.TypeByName(LibraryTypeName);
+                _loadJsonDefinitionsMethod = libraryType == null
+                    ? null
+                    : AccessTools.DeclaredMethod(libraryType, "LoadJsonDefinitions");
+                _definitionIdentifiersField = libraryType == null
+                    ? null
+                    : AccessTools.Field(libraryType, "definitionIdentifiers");
+                if (!_containerFastPathInstalled &&
+                    originalPostfix != null &&
+                    _loadJsonDefinitionsMethod != null &&
+                    _definitionIdentifiersField != null)
+                {
+                    harmony.Patch(
+                        originalPostfix,
+                        prefix: new HarmonyMethod(
+                            typeof(FuseLegosLibraryCompatibility),
+                            nameof(ContainerPostfixPrefix)));
+                    _containerFastPathInstalled = true;
+                }
             }
 
             if (detailModelPatchType != null)
@@ -70,14 +102,16 @@ namespace FUSE.Patches
                     installFusePostfix: !_detailModelCompatibilityInstalled);
             }
 
-            if (_cloneCompatibilityInstalled && _detailModelCompatibilityInstalled)
+            if (_cloneCompatibilityInstalled &&
+                _detailModelCompatibilityInstalled &&
+                _containerFastPathInstalled)
             {
                 return "installed";
             }
 
             if (_cloneCompatibilityInstalled || _detailModelCompatibilityInstalled)
             {
-                return $"partial (clone={_cloneCompatibilityInstalled} detailModel={_detailModelCompatibilityInstalled})";
+                return $"partial (clone={_cloneCompatibilityInstalled} detailModel={_detailModelCompatibilityInstalled} containerFastPath={_containerFastPathInstalled})";
             }
 
             return "idle (surface changed)";
@@ -193,8 +227,104 @@ namespace FUSE.Patches
         {
             _cloneCompatibilityInstalled = false;
             _detailModelCompatibilityInstalled = false;
+            _containerFastPathInstalled = false;
             _cloneFailures = 0;
             _detailModelFailures = 0;
+            _loadJsonDefinitionsMethod = null;
+            _definitionIdentifiersField = null;
+            _definitionIdentifiers = null;
+            _definitionIdentifierCount = -1;
+            _definitionsPrimed = false;
+            _containersSkipped = 0;
+        }
+
+        internal static int ContainersSkippedByFastPath => _containersSkipped;
+
+        internal static bool ContainerMayContainEditedDefinition(
+            Container container,
+            ISet<string> identifiers)
+        {
+            if (container?.Objects == null || identifiers == null || identifiers.Count == 0)
+            {
+                return false;
+            }
+
+            for (var index = 0; index < container.Objects.Count; index++)
+            {
+                var identifier = container.Objects[index]?.Identifier;
+                if (!string.IsNullOrEmpty(identifier) && identifiers.Contains(identifier))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ContainerPostfixPrefix(ref Container __0)
+        {
+            try
+            {
+                if (!TryGetDefinitionIdentifiers(out var identifiers))
+                {
+                    return true;
+                }
+
+                if (ContainerMayContainEditedDefinition(__0, identifiers))
+                {
+                    return true;
+                }
+
+                _containersSkipped++;
+                return false;
+            }
+            catch
+            {
+                // The optimization is optional. Lego's original postfix remains
+                // the compatibility authority whenever its reflected surface moves.
+                return true;
+            }
+        }
+
+        private static bool TryGetDefinitionIdentifiers(out HashSet<string> identifiers)
+        {
+            identifiers = null;
+            if (_loadJsonDefinitionsMethod == null || _definitionIdentifiersField == null)
+            {
+                return false;
+            }
+
+            if (!_definitionsPrimed)
+            {
+                _loadJsonDefinitionsMethod.Invoke(null, null);
+                _definitionsPrimed = true;
+            }
+
+            if (!(_definitionIdentifiersField.GetValue(null) is IEnumerable source))
+            {
+                return false;
+            }
+
+            var count = source is ICollection collection ? collection.Count : -1;
+            if (_definitionIdentifiers != null && count >= 0 && count == _definitionIdentifierCount)
+            {
+                identifiers = _definitionIdentifiers;
+                return true;
+            }
+
+            var rebuilt = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var value in source)
+            {
+                if (value is string identifier && !string.IsNullOrEmpty(identifier))
+                {
+                    rebuilt.Add(identifier);
+                }
+            }
+
+            _definitionIdentifiers = rebuilt;
+            _definitionIdentifierCount = count >= 0 ? count : rebuilt.Count;
+            identifiers = rebuilt;
+            return true;
         }
 
         private static bool CloneItemPrefix(ContainerItem item, ref ContainerItem __result)

--- a/FUSE/Patches/FuseLocationPickerDeduplicationPatch.cs
+++ b/FUSE/Patches/FuseLocationPickerDeduplicationPatch.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model.Ops;
+using UI.Builder;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Removes semantically duplicate destinations from the car inspector's
+    /// automatic-waybill picker. Legacy packages can leave multiple runtime
+    /// component objects with the same identifier; Railroader otherwise shows
+    /// every object as a separate, indistinguishable picker row.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FuseLocationPickerDeduplicationPatch
+    {
+        private const string EmptyDestinationKey = "\u0000none";
+        private static int _reported;
+
+        private static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(
+                typeof(UIPanelBuilder),
+                nameof(UIPanelBuilder.AddLocationPicker),
+                new[]
+                {
+                    typeof(string),
+                    typeof(List<ValueTuple<IndustryComponent, Area>>),
+                    typeof(IndustryComponent),
+                    typeof(Action<IndustryComponent>)
+                });
+        }
+
+        private static void Prefix(
+            ref List<ValueTuple<IndustryComponent, Area>> options,
+            ref IndustryComponent selected)
+        {
+            var selectedKey = SelectedDestinationKey(selected, options);
+            var removed = DeduplicateByKey(options, DestinationKey, out var deduplicated);
+            if (removed == 0)
+            {
+                return;
+            }
+
+            options = deduplicated;
+            selected = ResolveCanonicalSelection(selected, selectedKey, deduplicated);
+
+            if (Interlocked.Exchange(ref _reported, 1) == 0)
+            {
+                FuseLog.Info(
+                    $"FUSE removed {removed} duplicate automatic-waybill destination row(s). " +
+                    "The first matching destination remains selectable; runtime industry data was not deleted.");
+            }
+        }
+
+        private static string DestinationKey(ValueTuple<IndustryComponent, Area> option)
+        {
+            var component = option.Item1;
+            var identifier = DestinationKey(component);
+            if (component == null || identifier == null)
+            {
+                return identifier;
+            }
+
+            try
+            {
+                var spanIds = (component.trackSpans ?? Array.Empty<Track.TrackSpan>())
+                    .Where(span => span != null && !string.IsNullOrWhiteSpace(span.id))
+                    .Select(span => span.id.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                var displayName = component.DisplayName?.Trim();
+                if (spanIds.Length == 0 || string.IsNullOrWhiteSpace(displayName))
+                {
+                    return identifier;
+                }
+
+                return string.Join(
+                    "\u001f",
+                    "semantic",
+                    component.GetType().FullName ?? component.GetType().Name,
+                    option.Item2?.identifier?.Trim() ?? string.Empty,
+                    displayName,
+                    string.Join("\u001e", spanIds));
+            }
+            catch
+            {
+                return identifier;
+            }
+        }
+
+        private static string DestinationKey(IndustryComponent component)
+        {
+            if (component == null)
+            {
+                return EmptyDestinationKey;
+            }
+
+            try
+            {
+                var identifier = component.Identifier?.Trim();
+                return string.IsNullOrWhiteSpace(identifier) ? null : identifier;
+            }
+            catch
+            {
+                // A malformed component must not be allowed to break the UI.
+                // A null key tells the helper to preserve that row unchanged.
+                return null;
+            }
+        }
+
+        private static string SelectedDestinationKey(
+            IndustryComponent selected,
+            IList<ValueTuple<IndustryComponent, Area>> options)
+        {
+            if (selected == null || options == null)
+            {
+                return DestinationKey(selected);
+            }
+
+            foreach (var option in options)
+            {
+                if (ReferenceEquals(option.Item1, selected) || option.Item1 == selected)
+                {
+                    return DestinationKey(option);
+                }
+            }
+
+            return DestinationKey(selected);
+        }
+
+        private static IndustryComponent ResolveCanonicalSelection(
+            IndustryComponent selected,
+            string selectedKey,
+            IList<ValueTuple<IndustryComponent, Area>> options)
+        {
+            if (selected == null || selectedKey == null || options == null)
+            {
+                return selected;
+            }
+
+            foreach (var option in options)
+            {
+                if (string.Equals(
+                    selectedKey,
+                    DestinationKey(option),
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return option.Item1;
+                }
+            }
+
+            return selected;
+        }
+
+        internal static int DeduplicateByKey<T>(
+            IList<T> source,
+            Func<T, string> keySelector,
+            out List<T> result)
+        {
+            result = source == null ? new List<T>() : new List<T>(source.Count);
+            if (source == null || source.Count == 0 || keySelector == null)
+            {
+                return 0;
+            }
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var item in source)
+            {
+                var key = keySelector(item);
+                if (key == null || seen.Add(key))
+                {
+                    result.Add(item);
+                }
+            }
+
+            return source.Count - result.Count;
+        }
+
+        internal static T ResolveCanonicalByKey<T>(
+            T selected,
+            IList<T> options,
+            Func<T, string> keySelector)
+        {
+            if (ReferenceEquals(selected, null) || options == null || keySelector == null)
+            {
+                return selected;
+            }
+
+            var selectedKey = keySelector(selected);
+            if (selectedKey == null)
+            {
+                return selected;
+            }
+
+            foreach (var option in options)
+            {
+                var optionKey = keySelector(option);
+                if (string.Equals(selectedKey, optionKey, StringComparison.OrdinalIgnoreCase))
+                {
+                    return option;
+                }
+            }
+
+            return selected;
+        }
+    }
+}

--- a/FUSE/Patches/FuseLocationPickerDeduplicationPatch.cs
+++ b/FUSE/Patches/FuseLocationPickerDeduplicationPatch.cs
@@ -165,8 +165,14 @@ namespace FUSE.Patches
             out List<T> result)
         {
             result = source == null ? new List<T>() : new List<T>(source.Count);
-            if (source == null || source.Count == 0 || keySelector == null)
+            if (source == null || source.Count == 0)
             {
+                return 0;
+            }
+
+            if (keySelector == null)
+            {
+                result.AddRange(source);
                 return 0;
             }
 

--- a/FUSE/Patches/FuseMessengerIsolationPatch.cs
+++ b/FUSE/Patches/FuseMessengerIsolationPatch.cs
@@ -34,11 +34,11 @@ namespace FUSE.Patches
     ///
     /// Generic-method caveat: this targets the CONSTRUCTED <c>WeakAction&lt;T&gt;</c>
     /// methods, one instantiation per event type. That is only reliable because
-    /// every lifecycle event is a struct: each value-type instantiation gets its own
+    /// every guarded event is a struct: each value-type instantiation gets its own
     /// unshared method body, so the patch lands on exactly that instantiation.
     /// Reference-type arguments share one canonical body — patching it is unreliable
     /// and can bleed into unrelated instantiations — so a class-typed event must
-    /// never be added to <see cref="LifecycleEventTypeNames"/>; TargetMethods
+    /// never be added to <see cref="GuardedEventTypeNames"/>; TargetMethods
     /// enforces this with an IsValueType guard.
     /// </summary>
     [HarmonyPatch]
@@ -83,20 +83,17 @@ namespace FUSE.Patches
             var targets = new HashSet<MethodBase>();
             foreach (var eventTypeName in GuardedEventTypeNames)
             {
-                // WeakAction<T> and the lifecycle event structs are defined in the
-                // SAME assembly: MvvmLight is compiled into the game's Assembly-CSharp
-                // rather than shipped as a separate DLL, so only the namespace differs
-                // (GalaSoft.MvvmLight.Helpers vs Game.Events), not the assembly. That
-                // makes typeof(WeakAction<>).Assembly.GetType the path actually taken;
-                // AccessTools.TypeByName is a cross-assembly fallback that only engages
-                // if a future game build relocates the events.
+                // WeakAction<T> and the map lifecycle event structs are defined in
+                // Assembly-CSharp, so the assembly lookup resolves those types. The
+                // Railloader debug-report event lives in a separate assembly and
+                // intentionally uses the cross-assembly AccessTools fallback.
                 var eventType = typeof(WeakAction<>).Assembly.GetType(eventTypeName)
                                 ?? AccessTools.TypeByName(eventTypeName);
                 if (eventType == null)
                 {
                     FuseLog.Warning(
-                        $"FUSE messenger isolation could not resolve lifecycle event type '{eventTypeName}'; " +
-                        "listeners for that event stay unguarded. Remaining lifecycle events are still patched.");
+                        $"FUSE messenger isolation could not resolve guarded event type '{eventTypeName}'; " +
+                        "listeners for that event stay unguarded. Remaining guarded events are still patched.");
                     continue;
                 }
 

--- a/FUSE/Patches/FuseMessengerIsolationPatch.cs
+++ b/FUSE/Patches/FuseMessengerIsolationPatch.cs
@@ -8,7 +8,7 @@ using HarmonyLib;
 namespace FUSE.Patches
 {
     /// <summary>
-    /// Contains exceptions thrown by map lifecycle event listeners so one broken
+    /// Contains exceptions thrown by guarded messenger event listeners so one broken
     /// listener can never disturb delivery to anyone else — and so the offender is
     /// actually NAMED in the log.
     ///
@@ -28,9 +28,9 @@ namespace FUSE.Patches
     /// (throttled) with the recipient type and handler method name, and dispatch
     /// continues so later-registered listeners still receive the event.
     ///
-    /// Deliberately scoped to the four map lifecycle events only — this is not a
-    /// blanket "never throw from Messenger" patch; every other event keeps its
-    /// stock semantics.
+    /// Deliberately scoped to map lifecycle events and the legacy debug-report
+    /// contribution event — this is not a blanket "never throw from Messenger"
+    /// patch; every other event keeps its stock semantics.
     ///
     /// Generic-method caveat: this targets the CONSTRUCTED <c>WeakAction&lt;T&gt;</c>
     /// methods, one instantiation per event type. That is only reliable because
@@ -49,12 +49,13 @@ namespace FUSE.Patches
         // whole patch class. (If EVERY entry failed to resolve, the empty target
         // set would make Harmony reject the class as a whole — FusePatchResilience
         // contains that to a logged skip of this one class.)
-        private static readonly string[] LifecycleEventTypeNames =
+        private static readonly string[] GuardedEventTypeNames =
         {
             "Game.Events.MapWillLoadEvent",
             "Game.Events.MapDidLoadEvent",
             "Game.Events.MapWillUnloadEvent",
-            "Game.Events.MapDidUnloadEvent"
+            "Game.Events.MapDidUnloadEvent",
+            "Railloader.Events.WillCopyDebugInformation"
         };
 
         private static long _suppressed;
@@ -80,7 +81,7 @@ namespace FUSE.Patches
         internal static IEnumerable<MethodBase> TargetMethods()
         {
             var targets = new HashSet<MethodBase>();
-            foreach (var eventTypeName in LifecycleEventTypeNames)
+            foreach (var eventTypeName in GuardedEventTypeNames)
             {
                 // WeakAction<T> and the lifecycle event structs are defined in the
                 // SAME assembly: MvvmLight is compiled into the game's Assembly-CSharp
@@ -168,7 +169,7 @@ namespace FUSE.Patches
                 // BEFORE the throttle decision so every containment is counted
                 // even when its log line below is suppressed.
                 FuseModExceptionRegistry.RecordContained(
-                    __exception, ResolveRecipientType(__instance), "map lifecycle listener");
+                    __exception, ResolveRecipientType(__instance), "messenger listener");
 
                 // First few individually, every previously-unseen offender once, then
                 // heartbeat only — a permanently-broken listener re-throws on every
@@ -180,7 +181,7 @@ namespace FUSE.Patches
                 if (_suppressed <= 5 || newOffender || _suppressed % 100 == 0)
                 {
                     FuseLog.Exception(
-                        $"FUSE contained map lifecycle listener exception #{_suppressed} from {listener}; " +
+                        $"FUSE contained messenger listener exception #{_suppressed} from {listener}; " +
                         "the exception was suppressed and dispatch continued, so later-registered listeners " +
                         "still received the event", __exception);
                     _logged++;

--- a/FUSE/Patches/FuseOutboundIndustryRoutingPatch.cs
+++ b/FUSE/Patches/FuseOutboundIndustryRoutingPatch.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Infrastructure;
+using FUSE.Loading;
+using FUSE.Runtime.Events;
+using Game;
+using HarmonyLib;
+using Model.Ops;
+using Model.Ops.Definition;
+using Track;
+using Track.Search;
+using UnityEngine;
+
+namespace FUSE.Patches
+{
+    internal enum FuseOutboundRoutingMode
+    {
+        Disabled,
+        Absolute,
+        Configurable,
+    }
+
+    [HarmonyPatch]
+    internal static class FuseOutboundIndustryRoutingPatch
+    {
+        private const float MinimumTripDistanceMeters = 200f;
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(OpsController), nameof(OpsController.AddOrderForOutboundEmptyCar))]
+        private static bool RouteEmpty(
+            OpsController __instance,
+            IOpsCar car,
+            OpsCarPosition carPosition,
+            string orderTag,
+            bool noPayment)
+        {
+            return TryRoute(__instance, car, carPosition, orderTag, noPayment, loaded: false);
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(OpsController), nameof(OpsController.AddOrderForOutboundLoadedCar))]
+        private static bool RouteLoaded(
+            OpsController __instance,
+            IOpsCar car,
+            OpsCarPosition carPosition,
+            string orderTag,
+            bool noPayment)
+        {
+            return TryRoute(__instance, car, carPosition, orderTag, noPayment, loaded: true);
+        }
+
+        private static bool TryRoute(
+            OpsController controller,
+            IOpsCar car,
+            OpsCarPosition origin,
+            string orderTag,
+            bool noPayment,
+            bool loaded)
+        {
+            var mode = ResolveMode(
+                FuseSettings.EnableOutboundIndustryRerouting,
+                FuseLegacyCapabilityActivation.IsRequested("Zamu.AbsoluteMadness", "AbsoluteMadness"),
+                FuseLegacyCapabilityActivation.IsRequested("Zamu.SomeKindOfMadness", "SomeKindOfMadness"));
+            if (mode == FuseOutboundRoutingMode.Disabled || controller == null || car == null)
+            {
+                return true;
+            }
+
+            if (mode == FuseOutboundRoutingMode.Configurable &&
+                UnityEngine.Random.value >= FuseSettings.OutboundIndustryRerouteChance)
+            {
+                return true;
+            }
+
+            try
+            {
+                var candidates = CollectCandidates(controller, car, origin, loaded, mode);
+                var context = new FuseOutboundRoutingContext(car, origin, loaded, candidates);
+                FuseOutboundRoutingEvents.RaisePreparing(context);
+                var selectedIndex = SelectWeightedIndex(
+                    candidates.Select(candidate => candidate.Weight).ToArray(),
+                    UnityEngine.Random.value);
+                if (selectedIndex < 0 || selectedIndex >= candidates.Count)
+                {
+                    return true;
+                }
+
+                var selected = candidates[selectedIndex];
+                var destination = selected.Component;
+                var multiplier = mode == FuseOutboundRoutingMode.Absolute
+                    ? 1f
+                    : FuseSettings.OutboundIndustryPaymentMultiplier;
+                var payment = noPayment
+                    ? 0
+                    : Mathf.RoundToInt(
+                        selected.ProposedPayment ??
+                        (controller.PaymentForMove(origin, destination, car.WeightInTons) * multiplier));
+                var graceDays = selected.ProposedGraceDays ?? controller.CalculateGraceDays(origin, destination);
+                var waybill = new Waybill(
+                    TimeWeather.Now,
+                    origin,
+                    destination,
+                    payment,
+                    false,
+                    orderTag,
+                    graceDays);
+
+                car.SetWaybill(waybill, destination, "FUSE outbound industry routing");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Warning(
+                    "FUSE outbound industry routing failed safely; the base-game interchange route will be used: " +
+                    ex.GetBaseException().Message);
+                return true;
+            }
+        }
+
+        internal static FuseOutboundRoutingMode ResolveMode(
+            bool explicitOptIn,
+            bool absoluteRequested,
+            bool configurableRequested)
+        {
+            if (explicitOptIn || configurableRequested)
+            {
+                return FuseOutboundRoutingMode.Configurable;
+            }
+
+            return absoluteRequested ? FuseOutboundRoutingMode.Absolute : FuseOutboundRoutingMode.Disabled;
+        }
+
+        private static List<FuseOutboundRoutingCandidate> CollectCandidates(
+            OpsController controller,
+            IOpsCar car,
+            OpsCarPosition origin,
+            bool loaded,
+            FuseOutboundRoutingMode mode)
+        {
+            var candidates = new List<FuseOutboundRoutingCandidate>();
+            var fillFactor = mode == FuseOutboundRoutingMode.Absolute
+                ? 1f
+                : FuseSettings.OutboundIndustryFillFactor;
+            var allowShortTrips = mode == FuseOutboundRoutingMode.Absolute || FuseSettings.OutboundIndustryAllowShortTrips;
+
+            foreach (var industry in controller.AllIndustries ?? Array.Empty<Industry>())
+            {
+                if (industry == null || industry.ProgressionDisabled ||
+                    (mode == FuseOutboundRoutingMode.Configurable && !industry.ShouldOrderCars()))
+                {
+                    continue;
+                }
+
+                foreach (var pair in industry.EnumerateComponentContexts(0f))
+                {
+                    var component = pair.Item1;
+                    var componentContext = pair.Item2;
+                    if (component == null || component.ProgressionDisabled ||
+                        !component.carTypeFilter.Matches(car.CarType) ||
+                        !TryGetTarget(component, loaded, out var load, out var maxStorage))
+                    {
+                        continue;
+                    }
+
+                    if (loaded && car.QuantityOfLoad(load).Item1 <= load.ZeroThreshold)
+                    {
+                        continue;
+                    }
+
+                    if (!allowShortTrips && !IsLongEnoughTrip(origin, component))
+                    {
+                        continue;
+                    }
+
+                    var committed = componentContext.QuantityInStorage(load) +
+                                    componentContext.QuantityOnOrder(load) +
+                                    componentContext.AvailableCapacityInCars(component.carTypeFilter, load);
+                    var remaining = (maxStorage * fillFactor) - committed;
+                    if (remaining > load.ZeroThreshold)
+                    {
+                        candidates.Add(new FuseOutboundRoutingCandidate(component, remaining));
+                    }
+                }
+            }
+
+            return candidates;
+        }
+
+        private static bool TryGetTarget(
+            IndustryComponent component,
+            bool loaded,
+            out Load load,
+            out float maxStorage)
+        {
+            load = null;
+            maxStorage = 0f;
+            if (!loaded && component is IndustryLoaderBase loader && loader.orderEmpties)
+            {
+                load = loader.load;
+                maxStorage = loader.maxStorage;
+                return load != null;
+            }
+
+            if (loaded && component is IndustryUnloader unloader && unloader.orderLoads)
+            {
+                load = unloader.load;
+                maxStorage = unloader.maxStorage;
+                return load != null;
+            }
+
+            return false;
+        }
+
+        private static bool IsLongEnoughTrip(OpsCarPosition origin, IndustryComponent destination)
+        {
+            if (origin.Spans == null || origin.Spans.Length == 0 ||
+                destination.trackSpans == null || destination.trackSpans.Length == 0)
+            {
+                return false;
+            }
+
+            return Graph.Shared.TryFindDistance(
+                       (Location)origin,
+                       (Location)(OpsCarPosition)destination,
+                       out var distance,
+                       out _) &&
+                   distance > MinimumTripDistanceMeters;
+        }
+
+        internal static int SelectWeightedIndex(IReadOnlyList<float> weights, float unitSample)
+        {
+            if (weights == null || weights.Count == 0)
+            {
+                return -1;
+            }
+
+            var minimum = weights.Min();
+            var offset = minimum < 0f ? -minimum : 0f;
+            var total = weights.Sum(weight => Math.Max(0f, weight + offset));
+            if (total <= 0f || float.IsNaN(total))
+            {
+                return Math.Min(weights.Count - 1, Mathf.FloorToInt(Mathf.Clamp01(unitSample) * weights.Count));
+            }
+
+            var cursor = Mathf.Clamp01(unitSample) * total;
+            for (var index = 0; index < weights.Count; index++)
+            {
+                cursor -= Math.Max(0f, weights[index] + offset);
+                if (cursor <= 0f)
+                {
+                    return index;
+                }
+            }
+
+            return weights.Count - 1;
+        }
+
+    }
+
+    [HarmonyPatch(typeof(OpsController), "InterchangeForPosition", new[] { typeof(OpsCarPosition), typeof(OpsCarPosition?) })]
+    internal static class FuseOutboundIndustryDirectionPatch
+    {
+        private static void Prefix(ref OpsCarPosition? origin)
+        {
+            var requested = FuseLegacyCapabilityActivation.IsRequested(
+                "Zamu.SomeKindOfMadness",
+                "SomeKindOfMadness");
+            if ((FuseSettings.EnableOutboundIndustryRerouting || requested) &&
+                FuseSettings.OutboundIndustryIgnoreOrigin)
+            {
+                origin = null;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(IndustryContext), "AddOrderedCars")]
+    internal static class FuseOutboundIndustryBlockingPatch
+    {
+        private static readonly object RandomGate = new object();
+        private static readonly System.Random Random = new System.Random();
+
+        private static void Prefix(List<IOrder> orders)
+        {
+            var requested = FuseLegacyCapabilityActivation.IsRequested(
+                "Zamu.SomeKindOfMadness",
+                "SomeKindOfMadness");
+            if (orders == null || orders.Count < 2 ||
+                !(FuseSettings.EnableOutboundIndustryRerouting || requested) ||
+                !FuseSettings.OutboundIndustryPreventBlocking)
+            {
+                return;
+            }
+
+            lock (RandomGate)
+            {
+                Shuffle(orders, Random);
+            }
+        }
+
+        internal static void Shuffle<T>(IList<T> items, System.Random random)
+        {
+            if (items == null || random == null)
+            {
+                return;
+            }
+
+            for (var index = items.Count - 1; index > 0; index--)
+            {
+                var swap = random.Next(index + 1);
+                var value = items[index];
+                items[index] = items[swap];
+                items[swap] = value;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FuseOutboundIndustryRoutingPatch.cs
+++ b/FUSE/Patches/FuseOutboundIndustryRoutingPatch.cs
@@ -157,6 +157,7 @@ namespace FUSE.Patches
                     var component = pair.Item1;
                     var componentContext = pair.Item2;
                     if (component == null || component.ProgressionDisabled ||
+                        component.carTypeFilter == null ||
                         !component.carTypeFilter.Matches(car.CarType) ||
                         !TryGetTarget(component, loaded, out var load, out var maxStorage))
                     {

--- a/FUSE/Patches/FusePassengerStopInvalidSpanGuardPatch.cs
+++ b/FUSE/Patches/FusePassengerStopInvalidSpanGuardPatch.cs
@@ -39,7 +39,7 @@ namespace FUSE.Patches
                 return;
             }
 
-            foreach (var span in spans.Where(span => !IsUsable(span)))
+            foreach (var span in spans.Where(span => span != null && !IsUsable(span)))
             {
                 var id = span?.id ?? "<unknown>";
                 try

--- a/FUSE/Patches/FusePassengerStopInvalidSpanGuardPatch.cs
+++ b/FUSE/Patches/FusePassengerStopInvalidSpanGuardPatch.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FUSE.Infrastructure;
+using HarmonyLib;
+using Model.Ops;
+using Track;
+
+namespace FUSE.Patches
+{
+    /// <summary>
+    /// Prevents PassengerStop.OnEnable from interpolating a span whose segment
+    /// was removed by a conflicting track package. Railroader only checks that
+    /// nullable endpoints have values before calling Graph.Lerp; a resolved
+    /// location can still contain a null segment and throw from Location.Flipped.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class FusePassengerStopInvalidSpanGuardPatch
+    {
+        private static MethodInfo TargetMethod()
+        {
+            return AccessTools.Method(typeof(PassengerStop), "OnEnable");
+        }
+
+        private static void Prefix(PassengerStop __instance)
+        {
+            if (__instance == null)
+            {
+                return;
+            }
+
+            TrackSpan[] spans;
+            try
+            {
+                spans = __instance.GetComponentsInChildren<TrackSpan>(true);
+            }
+            catch
+            {
+                return;
+            }
+
+            foreach (var span in spans.Where(span => !IsUsable(span)))
+            {
+                var id = span?.id ?? "<unknown>";
+                try
+                {
+                    // Keep the TrackSpan object available for diagnostics, but
+                    // clear endpoints so PassengerStop's own null checks skip it.
+                    span.lower = null;
+                    span.upper = null;
+                    var count = FuseRuntimeGuardCounters.RecordPassengerStopSpanSanitized();
+                    if (count <= 10)
+                    {
+                        FuseLog.Warning(
+                            $"FUSE sanitized invalid passenger-stop span '{id}' on " +
+                            $"'{__instance.identifier ?? __instance.name}'. A conflicting track package removed " +
+                            "an endpoint segment; the stop remains loaded without that span.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        $"FUSE could not sanitize invalid passenger-stop span '{id}': " +
+                        ex.GetBaseException().Message);
+                }
+            }
+        }
+
+        private static bool IsUsable(TrackSpan span)
+        {
+            if (span == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                return span.IsValid;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/FUSE/Patches/FusePrefabStoreAllCarDefinitionInfosFilterPatch.cs
+++ b/FUSE/Patches/FusePrefabStoreAllCarDefinitionInfosFilterPatch.cs
@@ -36,23 +36,47 @@ namespace FUSE.Patches
     [HarmonyPatch]
     internal static class FusePrefabStoreAllCarDefinitionInfosFilterPatch
     {
+        private static readonly FieldInfo StoresField =
+            AccessTools.Field(typeof(PrefabStore), "_stores");
+        private static PrefabStore _cachedOwner;
+        private static int _cachedStoreCount = -1;
+        private static TypedContainerItem<CarDefinition>[] _cachedDefinitions;
+
         private static MethodInfo TargetMethod()
         {
             return AccessTools.PropertyGetter(typeof(PrefabStore), "AllCarDefinitionInfos");
         }
 
+        private static bool Prefix(
+            PrefabStore __instance,
+            ref System.Collections.Generic.IEnumerable<TypedContainerItem<CarDefinition>> __result,
+            out bool __state)
+        {
+            __state = TryGetCached(__instance, out var cached);
+            if (__state)
+            {
+                __result = cached;
+                return false;
+            }
+
+            return true;
+        }
+
         private static void Postfix(
             PrefabStore __instance,
-            ref System.Collections.Generic.IEnumerable<TypedContainerItem<CarDefinition>> __result)
+            ref System.Collections.Generic.IEnumerable<TypedContainerItem<CarDefinition>> __result,
+            bool __state)
         {
-            if (__result == null)
+            if (__state || __result == null)
             {
                 return;
             }
 
             try
             {
-                __result = FilterLoserDefinitions(__instance, __result);
+                var filtered = FilterLoserDefinitions(__instance, __result).ToArray();
+                PublishCache(__instance, filtered);
+                __result = filtered;
             }
             catch (Exception ex)
             {
@@ -81,15 +105,14 @@ namespace FUSE.Patches
                 loserIdentifiers = null;
             }
 
-            if (loserIdentifiers == null || loserIdentifiers.Count == 0)
-            {
-                // No collisions recorded, or we failed to compute the
-                // set — keep the original enumeration verbatim so we
-                // never silently drop content the game expected.
-                return source;
-            }
-
-            return EnumerateNonLoser(source, loserIdentifiers);
+            // Always put the game/third-party enumeration behind the resilient
+            // boundary, even when no duplicate-pack losers were recorded. A
+            // malformed car provider can otherwise throw lazily while the
+            // Equipment window builds its purchase catalogue and leave the
+            // entire window unusable. The empty set preserves every valid item.
+            return EnumerateNonLoser(
+                source,
+                loserIdentifiers ?? new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal));
         }
 
         private static System.Collections.Generic.IEnumerable<TypedContainerItem<CarDefinition>>
@@ -112,6 +135,8 @@ namespace FUSE.Patches
             // going" semantics for free.
             using (var enumerator = source.GetEnumerator())
             {
+                var consecutiveFailures = 0;
+                var reportedFailure = false;
                 while (true)
                 {
                     bool hasNext;
@@ -124,17 +149,35 @@ namespace FUSE.Patches
                             current = enumerator.Current;
                         }
                     }
-                    catch (Model.Database.PrefabStore.UnknownIdentifierException)
+                    catch (Model.Database.PrefabStore.UnknownIdentifierException ex)
                     {
                         // Loser identifier the filter rejected.
                         // Move past it and keep going.
+                        consecutiveFailures++;
+                        ReportEnumerationFailureOnce(ex, ref reportedFailure);
+                        if (consecutiveFailures >= 16)
+                        {
+                            FuseLog.Warning(
+                                "FUSE stopped a repeatedly failing car-definition provider after 16 consecutive errors; " +
+                                "valid definitions already enumerated remain available in the Equipment window.");
+                            yield break;
+                        }
                         continue;
                     }
-                    catch
+                    catch (Exception ex)
                     {
                         // Any other failure inside the selector —
                         // skip the item but don't tear the whole
                         // enumeration down.
+                        consecutiveFailures++;
+                        ReportEnumerationFailureOnce(ex, ref reportedFailure);
+                        if (consecutiveFailures >= 16)
+                        {
+                            FuseLog.Warning(
+                                "FUSE stopped a repeatedly failing car-definition provider after 16 consecutive errors; " +
+                                "valid definitions already enumerated remain available in the Equipment window.");
+                            yield break;
+                        }
                         continue;
                     }
 
@@ -142,9 +185,9 @@ namespace FUSE.Patches
                     {
                         yield break;
                     }
+                    consecutiveFailures = 0;
                     if (current == null || current.Identifier == null)
                     {
-                        yield return current;
                         continue;
                     }
                     if (loserIdentifiers.Contains(current.Identifier))
@@ -154,6 +197,83 @@ namespace FUSE.Patches
                     yield return current;
                 }
             }
+        }
+
+        internal static void InvalidateCache(PrefabStore owner = null)
+        {
+            if (owner != null && !ReferenceEquals(owner, _cachedOwner))
+            {
+                return;
+            }
+
+            _cachedOwner = null;
+            _cachedStoreCount = -1;
+            _cachedDefinitions = null;
+        }
+
+        private static bool TryGetCached(
+            PrefabStore owner,
+            out TypedContainerItem<CarDefinition>[] definitions)
+        {
+            definitions = null;
+            if (owner == null || !ReferenceEquals(owner, _cachedOwner) || _cachedDefinitions == null)
+            {
+                return false;
+            }
+
+            var storeCount = ReadStoreCount(owner);
+            if (storeCount < 0 || storeCount != _cachedStoreCount)
+            {
+                InvalidateCache(owner);
+                return false;
+            }
+
+            definitions = _cachedDefinitions;
+            return true;
+        }
+
+        private static void PublishCache(
+            PrefabStore owner,
+            TypedContainerItem<CarDefinition>[] definitions)
+        {
+            var storeCount = ReadStoreCount(owner);
+            if (owner == null || definitions == null || storeCount < 0)
+            {
+                return;
+            }
+
+            _cachedOwner = owner;
+            _cachedStoreCount = storeCount;
+            _cachedDefinitions = definitions;
+        }
+
+        private static int ReadStoreCount(PrefabStore owner)
+        {
+            try
+            {
+                return StoresField?.GetValue(owner) is System.Collections.ICollection stores
+                    ? stores.Count
+                    : -1;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+
+        private static void ReportEnumerationFailureOnce(Exception exception, ref bool reported)
+        {
+            if (reported)
+            {
+                return;
+            }
+
+            reported = true;
+            var cause = exception?.GetBaseException();
+            FuseLog.Warning(
+                "FUSE contained a broken car-definition provider while building the Equipment catalogue: " +
+                $"{cause?.GetType().Name ?? "Exception"}: {cause?.Message ?? "unknown error"}. " +
+                "The invalid entry was skipped so remaining equipment stays purchasable.");
         }
 
         /// <summary>
@@ -171,13 +291,12 @@ namespace FUSE.Patches
                 return result;
             }
 
-            var storesField = AccessTools.Field(typeof(PrefabStore), "_stores");
-            if (storesField == null)
+            if (StoresField == null)
             {
                 return result;
             }
 
-            if (!(storesField.GetValue(prefabStore) is System.Collections.Generic.IList<AssetPackRuntimeStore> stores))
+            if (!(StoresField.GetValue(prefabStore) is System.Collections.Generic.IList<AssetPackRuntimeStore> stores))
             {
                 return result;
             }

--- a/FUSE/Patches/FusePrefabStoreAssetPackPatch.cs
+++ b/FUSE/Patches/FusePrefabStoreAssetPackPatch.cs
@@ -29,6 +29,7 @@ namespace FUSE.Patches
             {
                 // Even a partial store add changes the identifier population.
                 FUSE.Runtime.API.SceneryAPI.InvalidateKnownSceneryIdentifierIndex();
+                FuseEquipmentCatalogWarmup.Schedule(__result);
             }
         }
     }

--- a/FUSE/Patches/FusePrefabStoreAssetPackPatch.cs
+++ b/FUSE/Patches/FusePrefabStoreAssetPackPatch.cs
@@ -28,8 +28,27 @@ namespace FUSE.Patches
             finally
             {
                 // Even a partial store add changes the identifier population.
-                FUSE.Runtime.API.SceneryAPI.InvalidateKnownSceneryIdentifierIndex();
-                FuseEquipmentCatalogWarmup.Schedule(__result);
+                try
+                {
+                    FUSE.Runtime.API.SceneryAPI.InvalidateKnownSceneryIdentifierIndex();
+                }
+                catch (System.Exception ex)
+                {
+                    FuseLog.Exception(
+                        "FUSE direct asset pack identifier invalidation failed softly",
+                        ex);
+                }
+
+                try
+                {
+                    FuseEquipmentCatalogWarmup.Schedule(__result);
+                }
+                catch (System.Exception ex)
+                {
+                    FuseLog.Exception(
+                        "FUSE equipment catalog warmup scheduling failed softly",
+                        ex);
+                }
             }
         }
     }

--- a/FUSE/Patches/FusePrefabStoreDefinitionCheckPerformancePatch.cs
+++ b/FUSE/Patches/FusePrefabStoreDefinitionCheckPerformancePatch.cs
@@ -15,12 +15,11 @@ namespace FUSE.Patches
     /// active, so malformed assets still fail at their actual point of use.
     /// </summary>
     [HarmonyPatch(typeof(PrefabStore), "CheckDefinitions")]
-    // AssetLoader 1.0.1 performs all UMM mod-folder asset-store discovery in
-    // its own CheckDefinitions prefix. If this skip prefix runs first,
-    // Harmony suppresses AssetLoader's state-mutating prefix along with the
-    // original method: UMM reports the rolling-stock mods active, but their
-    // Definitions.json files never enter PrefabStore. Run after AssetLoader so
-    // its discovery completes before FUSE skips only the stock diagnostic pass.
+    // Keep this ordering marker for transitional installs that still contain
+    // AssetLoader.dll. FUSE normally disables that mod's patches and performs
+    // catalog plus definitions-only discovery itself. If an older FUSE build
+    // leaves AssetLoader active, running after its prefix avoids suppressing
+    // the legacy discovery side effect along with the stock diagnostic pass.
     [HarmonyAfter("AssetLoader")]
     internal static class FusePrefabStoreDefinitionCheckPerformancePatch
     {

--- a/FUSE/Patches/FuseThirdPartyGuardInstaller.cs
+++ b/FUSE/Patches/FuseThirdPartyGuardInstaller.cs
@@ -175,6 +175,39 @@ namespace FUSE.Patches
                 bmanLocomotiveAudioStatus = "failed";
             }
 
+            string legosLibraryStatus;
+            try
+            {
+                legosLibraryStatus = FuseLegosLibraryCompatibility.EnsureInstalled(_harmony);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE Legos Library compatibility failed to install", ex);
+                legosLibraryStatus = "failed";
+            }
+
+            string assetLoaderStatus;
+            try
+            {
+                assetLoaderStatus = FuseAssetLoaderReplacementCompatibility.EnsureInstalled(_harmony);
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE AssetLoader replacement compatibility failed", ex);
+                assetLoaderStatus = "failed";
+            }
+
+            string alinasUtilitiesStatus;
+            try
+            {
+                alinasUtilitiesStatus = FuseAlinasUtilitiesCompatibility.EnsureInstalled();
+            }
+            catch (Exception ex)
+            {
+                FuseLog.Exception("FUSE Alina Utilities compatibility failed", ex);
+                alinasUtilitiesStatus = "failed";
+            }
+
             var summary =
                 $"FUSE third-party guards: mapEnhancerCulling='{mapEnhancerStatus}' " +
                 $"rebillIndustryCars='{rebillStatus}' brssModMenu='{brssStatus}' " +
@@ -183,7 +216,10 @@ namespace FUSE.Patches
                 $"utilitiesMapLoad='{utilitiesMapLoadStatus}' " +
                 $"realisticRerail='{realisticRerailStatus}' " +
                 $"memoryLeakFps='{memoryLeakFpsStatus}' " +
-                $"bmanLocomotiveAudio='{bmanLocomotiveAudioStatus}'.";
+                $"bmanLocomotiveAudio='{bmanLocomotiveAudioStatus}' " +
+                $"legosLibrary='{legosLibraryStatus}' " +
+                $"assetLoader='{assetLoaderStatus}' " +
+                $"alinasUtilities='{alinasUtilitiesStatus}'.";
             if (!string.Equals(summary, _lastSummary, StringComparison.Ordinal))
             {
                 _lastSummary = summary;
@@ -210,7 +246,15 @@ namespace FUSE.Patches
                 assemblyName,
                 "GP38Scripts",
                 StringComparison.Ordinal);
-            if (!isRealisticRerail && !isUtilities && !isMemoryLeakFps && !isBmanLocomotiveAudio)
+            var isLegosLibrary = string.Equals(
+                assemblyName,
+                "LegosLibraryOfStuff",
+                StringComparison.Ordinal);
+            var isAssetLoader = FuseAssetLoaderReplacementCompatibility.IsTargetAssemblyName(assemblyName);
+            var isAlinasUtilities = FuseAlinasUtilitiesCompatibility.IsTargetAssemblyName(assemblyName);
+            if (!isRealisticRerail && !isUtilities && !isMemoryLeakFps &&
+                !isBmanLocomotiveAudio && !isLegosLibrary && !isAssetLoader &&
+                !isAlinasUtilities)
             {
                 return;
             }

--- a/FUSE/Runtime/API/FuseCaptiveConversionIndustryComponents.cs
+++ b/FUSE/Runtime/API/FuseCaptiveConversionIndustryComponents.cs
@@ -1,0 +1,230 @@
+using System;
+using FUSE.Infrastructure;
+using Game;
+using Model.Ops;
+using Model.Ops.Definition;
+using UnityEngine;
+
+namespace FUSE.Runtime.API
+{
+    /// <summary>
+    /// FUSE-owned implementation of the legacy captive conversion loader
+    /// contract. A source material held in industry storage is converted into
+    /// a different load while it is transferred into captive-service cars.
+    /// The public field names intentionally match the legacy JSON surface so
+    /// <see cref="IndustryAPI"/> can bind converted definitions without the
+    /// Confusing Supplements assembly being installed.
+    /// </summary>
+    public sealed class FuseCaptiveConversionLoader : IndustryLoaderBase
+    {
+        public Load convertedLoad;
+        public float carLoadRate = 1f;
+        public string title;
+
+        public override string DisplayName => string.IsNullOrWhiteSpace(title) ? name : title;
+
+        public override void OrderCars(IIndustryContext ctx)
+        {
+            // Captive service never requests cars from an interchange.
+        }
+
+        public override bool WantsAutoDestination(AutoDestinationType type)
+        {
+            return type == AutoDestinationType.Empty;
+        }
+
+        public override bool AcceptsCarsWithLoad(Load checkLoad)
+        {
+            return convertedLoad != null && checkLoad == convertedLoad;
+        }
+
+        public override void Service(IIndustryContext ctx)
+        {
+            if (ctx == null || Industry == null || load == null || convertedLoad == null)
+            {
+                return;
+            }
+
+            var available = ctx.QuantityInStorage(load);
+            if (available <= load.ZeroThreshold)
+            {
+                return;
+            }
+
+            var contractMultiplier = Industry.GetContractMultiplier();
+            var transferBudget = RateToValue(Mathf.Max(0f, carLoadRate) * contractMultiplier, ctx.DeltaTime);
+            if (transferBudget <= 0f)
+            {
+                return;
+            }
+
+            foreach (var car in EnumerateCars(ctx, requireWaybill: true))
+            {
+                if (car == null || !car.IsEmptyOrContains(convertedLoad))
+                {
+                    continue;
+                }
+
+                var requested = Mathf.Min(available, transferBudget);
+                if (requested <= load.ZeroThreshold)
+                {
+                    break;
+                }
+
+                var transferred = car.Load(convertedLoad, requested);
+                if (transferred > 0f)
+                {
+                    ctx.RemoveFromStorage(load, transferred);
+                    available -= transferred;
+                    transferBudget -= transferred;
+                }
+
+                if (car.IsFull(convertedLoad))
+                {
+                    car.SetWaybill(null, this, "Full");
+                }
+
+                if (available <= load.ZeroThreshold || transferBudget <= 0f)
+                {
+                    break;
+                }
+            }
+        }
+
+        protected override void ValidateIndustryComponent()
+        {
+            base.ValidateIndustryComponent();
+            ValidateLoads("loader", load, convertedLoad);
+        }
+
+        internal static void ValidateLoads(string role, Load source, Load converted)
+        {
+            if (source == null || converted == null)
+            {
+                FuseLog.Warning($"FUSE captive conversion {role} is missing its source or converted load and will remain inert.");
+                return;
+            }
+
+            if (source.units != converted.units)
+            {
+                FuseLog.Warning(
+                    $"FUSE captive conversion {role} cannot convert '{source.id}' to '{converted.id}' because their units differ.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// FUSE-owned counterpart to <see cref="FuseCaptiveConversionLoader"/>.
+    /// It removes the captive-car load, deposits the configured source
+    /// material in industry storage, and settles the converted load's daily
+    /// receivable through the game's industry context.
+    /// </summary>
+    public sealed class FuseCaptiveConversionUnloader : IndustryComponent
+    {
+        public Load load;
+        public Load convertedLoad;
+        public float maxStorage;
+        public float carUnloadRate = 1f;
+        public string title;
+
+        public override string DisplayName => string.IsNullOrWhiteSpace(title) ? name : title;
+
+        private string UnloadedCounterKey => "fuse-captive-unloaded-" + (convertedLoad?.id ?? subIdentifier ?? "load");
+
+        public override bool WantsAutoDestination(AutoDestinationType type)
+        {
+            return type == AutoDestinationType.Load;
+        }
+
+        public override bool AcceptsCarsWithLoad(Load checkLoad)
+        {
+            return convertedLoad != null && checkLoad == convertedLoad;
+        }
+
+        public override void OrderCars(IIndustryContext ctx)
+        {
+            // Captive service never orders cars; it only services cars placed
+            // on its configured spans.
+        }
+
+        public override void Service(IIndustryContext ctx)
+        {
+            if (ctx == null || Industry == null || load == null || convertedLoad == null)
+            {
+                return;
+            }
+
+            var contractMultiplier = Industry.GetContractMultiplier();
+            var transferBudget = RateToValue(Mathf.Max(0f, carUnloadRate) * contractMultiplier, ctx.DeltaTime);
+            var effectiveStorage = Mathf.Max(0f, maxStorage * contractMultiplier);
+            var zeroThreshold = Mathf.Max(load.ZeroThreshold, convertedLoad.ZeroThreshold);
+            if (transferBudget > 0f && transferBudget < zeroThreshold)
+            {
+                transferBudget = zeroThreshold * 2f;
+            }
+
+            var unloadedThisTick = 0f;
+            foreach (var car in EnumerateCars(ctx, requireWaybill: true))
+            {
+                if (car == null || !car.IsEmptyOrContains(convertedLoad))
+                {
+                    continue;
+                }
+
+                var remainingStorage = effectiveStorage - ctx.QuantityInStorage(load);
+                var requested = Mathf.Min(transferBudget, remainingStorage);
+                if (requested < zeroThreshold)
+                {
+                    break;
+                }
+
+                var transferred = car.Unload(convertedLoad, requested);
+                if (transferred > 0f)
+                {
+                    ctx.AddToStorage(load, transferred, effectiveStorage);
+                    transferBudget -= transferred;
+                    unloadedThisTick += transferred;
+                }
+
+                var remainingLoad = car.QuantityOfLoad(convertedLoad).Item1;
+                if (remainingLoad < zeroThreshold)
+                {
+                    car.SetWaybill(null, this, "Empty completed");
+                }
+
+                if (transferBudget <= 0f)
+                {
+                    break;
+                }
+            }
+
+            if (unloadedThisTick > 0f && convertedLoad.payPerQuantity > 0f)
+            {
+                ctx.CounterIncrement(UnloadedCounterKey, unloadedThisTick);
+            }
+        }
+
+        public override void DailyReceivables(GameDateTime now, IIndustryContext ctx)
+        {
+            if (ctx == null || convertedLoad == null || convertedLoad.payPerQuantity <= 0f)
+            {
+                return;
+            }
+
+            var unloaded = ctx.CounterIncrement(UnloadedCounterKey, 0f);
+            if (unloaded < 1f)
+            {
+                return;
+            }
+
+            ctx.PayLoad(convertedLoad, unloaded);
+            ctx.CounterClear(UnloadedCounterKey);
+        }
+
+        protected override void ValidateIndustryComponent()
+        {
+            base.ValidateIndustryComponent();
+            FuseCaptiveConversionLoader.ValidateLoads("unloader", load, convertedLoad);
+        }
+    }
+}

--- a/FUSE/Runtime/API/FuseDefinitionKind.cs
+++ b/FUSE/Runtime/API/FuseDefinitionKind.cs
@@ -15,6 +15,7 @@ namespace FUSE.Runtime.API
         public const string Scenery = "world.scenery";
         public const string SpawnPoint = "world.spawnPoint";
         public const string Spliney = "world.spliney";
+        public const string WaterSurface = "world.waterSurface";
         public const string TelegraphPoles = "world.telegraphPoles";
         public const string MapLabel = "world.mapLabel";
         public const string MapMask = "world.mapMask";

--- a/FUSE/Runtime/API/FuseLegacyPlaceholderIndustryComponent.cs
+++ b/FUSE/Runtime/API/FuseLegacyPlaceholderIndustryComponent.cs
@@ -5,10 +5,18 @@ namespace FUSE.Runtime.API
 {
     public sealed class FuseLegacyPlaceholderIndustryComponent : IndustryComponent
     {
-        public override bool IsVisible => false;
-
         protected override void ValidateIndustryComponent()
         {
+        }
+
+        public override bool WantsAutoDestination(AutoDestinationType type)
+        {
+            // Confusing Supplements' Empty component is a visible, span-bound
+            // destination marker. It performs no service work, but accepts
+            // every automatic destination class so authors can reserve/highlight
+            // tracks such as "Loaded Coal Output Tracks: KEEP CLEAR!" without
+            // creating a loader whose null Load later throws during Industry.Tick.
+            return true;
         }
 
         public override void Service(IIndustryContext ctx)

--- a/FUSE/Runtime/API/FuseObjectLineLayout.cs
+++ b/FUSE/Runtime/API/FuseObjectLineLayout.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Authoring.Data;
+using UnityEngine;
+
+namespace FUSE.Runtime.API
+{
+    internal static class FuseObjectLineLayout
+    {
+        internal sealed class Placement
+        {
+            internal Vector3 Position;
+            internal Vector3 Forward;
+        }
+
+        internal static IReadOnlyList<Placement> Build(
+            IReadOnlyList<FuseSplineyPoint> points,
+            float spacing,
+            bool placeAtEnd,
+            int maximumInstances)
+        {
+            if (points == null || points.Count < 2)
+                throw new InvalidOperationException("An object line requires at least two points.");
+            if (spacing <= 0f)
+                throw new InvalidOperationException("Object-line spacing must be greater than zero.");
+            if (maximumInstances < 1 || maximumInstances > 4096)
+                throw new InvalidOperationException("Object-line maximumInstances must be between 1 and 4096.");
+
+            var segments = new List<Segment>();
+            var totalLength = 0f;
+            for (var index = 1; index < points.Count; index++)
+            {
+                if (points[index - 1] == null || points[index] == null)
+                    continue;
+                var start = points[index - 1].Position;
+                var end = points[index].Position;
+                var delta = end - start;
+                var length = delta.magnitude;
+                if (length <= 0.001f)
+                    continue;
+                segments.Add(new Segment(start, end, delta / length, totalLength, length));
+                totalLength += length;
+            }
+            if (segments.Count == 0)
+                throw new InvalidOperationException("Object-line points must describe a non-zero path.");
+
+            var distances = new List<float>();
+            for (var distance = 0f; distance <= totalLength + 0.0001f; distance += spacing)
+            {
+                distances.Add(Mathf.Min(distance, totalLength));
+                if (distances.Count > maximumInstances)
+                    throw TooManyInstances(maximumInstances, spacing, totalLength);
+            }
+            if (placeAtEnd && totalLength - distances[distances.Count - 1] > 0.001f)
+            {
+                distances.Add(totalLength);
+                if (distances.Count > maximumInstances)
+                    throw TooManyInstances(maximumInstances, spacing, totalLength);
+            }
+
+            var placements = new List<Placement>(distances.Count);
+            var segmentIndex = 0;
+            foreach (var distance in distances)
+            {
+                while (segmentIndex + 1 < segments.Count
+                       && distance > segments[segmentIndex].EndDistance + 0.0001f)
+                {
+                    segmentIndex++;
+                }
+                var segment = segments[segmentIndex];
+                var local = Mathf.Clamp(distance - segment.StartDistance, 0f, segment.Length);
+                placements.Add(new Placement
+                {
+                    Position = segment.Start + segment.Forward * local,
+                    Forward = segment.Forward,
+                });
+            }
+            return placements;
+        }
+
+        private static InvalidOperationException TooManyInstances(
+            int maximumInstances,
+            float spacing,
+            float length)
+        {
+            return new InvalidOperationException(
+                $"Object line would exceed its {maximumInstances} instance safety limit "
+                + $"(path {length:0.##} m, spacing {spacing:0.##} m). Increase spacing or maximumInstances.");
+        }
+
+        private sealed class Segment
+        {
+            internal Segment(
+                Vector3 start,
+                Vector3 end,
+                Vector3 forward,
+                float startDistance,
+                float length)
+            {
+                Start = start;
+                End = end;
+                Forward = forward;
+                StartDistance = startDistance;
+                Length = length;
+            }
+
+            internal Vector3 Start { get; }
+            internal Vector3 End { get; }
+            internal Vector3 Forward { get; }
+            internal float StartDistance { get; }
+            internal float Length { get; }
+            internal float EndDistance => StartDistance + Length;
+        }
+    }
+}

--- a/FUSE/Runtime/API/FusePay4ResourceIndustryComponent.cs
+++ b/FUSE/Runtime/API/FusePay4ResourceIndustryComponent.cs
@@ -35,7 +35,8 @@ namespace FUSE.Runtime.API
     /// <see cref="IndustryAPI.ApplyCustomIndustryComponentFields"/> — keep
     /// the names intact.
     /// </summary>
-    public class FusePay4ResourceIndustryComponent : IndustryComponent
+    public class FusePay4ResourceIndustryComponent : IndustryComponent,
+        StrangeCustoms.Tracks.Industries.ICustomIndustryTitle
     {
         [Tooltip("Load the component will fill cars with (e.g. 'coal' for a locomotive-fuelling depot).")]
         public Load load;
@@ -83,6 +84,17 @@ namespace FUSE.Runtime.API
         private readonly Dictionary<string, float> _pendingUnitsPerCar = new Dictionary<string, float>();
 
         public override string DisplayName => string.IsNullOrWhiteSpace(title) ? name : title;
+
+        public string Title
+        {
+            get
+            {
+                var resourceName = load == null || string.IsNullOrWhiteSpace(load.description)
+                    ? "resource"
+                    : load.description;
+                return $"Acquire {resourceName} at {DisplayName}";
+            }
+        }
 
         public override bool IsVisible
         {

--- a/FUSE/Runtime/API/FuseRuntimeDefinitionCache.cs
+++ b/FUSE/Runtime/API/FuseRuntimeDefinitionCache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FUSE.Authoring.Data;
+using FUSE.Authoring.Data.Common;
 using FUSE.Infrastructure;
 
 namespace FUSE.Runtime.API
@@ -84,6 +85,12 @@ namespace FUSE.Runtime.API
                     return CloneStation(station) as T;
                 if (definition is FuseTurntable turntable)
                     return CloneTurntable(turntable) as T;
+                if (definition is FuseSpan span)
+                    return CloneSpan(span) as T;
+                if (definition is FuseSpliney spliney)
+                    return CloneSpliney(spliney) as T;
+                if (definition is FuseWaterSurface waterSurface)
+                    return CloneWaterSurface(waterSurface) as T;
 
                 // Unknown type — return original (best-effort, same as before).
                 return definition;
@@ -223,6 +230,82 @@ namespace FUSE.Runtime.API
                     ControllerType        = src.Visuals.ControllerType,
                     InteractionRadius     = src.Visuals.InteractionRadius,
                 },
+            };
+        }
+
+        private static FuseWaterSurface CloneWaterSurface(FuseWaterSurface src)
+        {
+            if (src == null) return null;
+            return new FuseWaterSurface
+            {
+                Points = src.Points?.ToArray(),
+                SourceLakePath = src.SourceLakePath,
+                MaterialName = src.MaterialName,
+                LockHeight = src.LockHeight,
+                SnapToTerrain = src.SnapToTerrain,
+                EnableCollider = src.EnableCollider,
+                UvScale = src.UvScale,
+                TriangleDensity = src.TriangleDensity,
+                MaximumTriangleArea = src.MaximumTriangleArea,
+                YOffset = src.YOffset,
+            };
+        }
+
+        private static FuseSpliney CloneSpliney(FuseSpliney src)
+        {
+            if (src == null) return null;
+            return new FuseSpliney
+            {
+                Type = src.Type,
+                Profile = src.Profile,
+                Style = src.Style,
+                OffsetY = src.OffsetY,
+                HeadStyle = src.HeadStyle,
+                TailStyle = src.TailStyle,
+                AssetIdentifier = src.AssetIdentifier,
+                Prefab = src.Prefab,
+                Spacing = src.Spacing,
+                InstanceScale = src.InstanceScale,
+                RotationOffset = src.RotationOffset,
+                LateralOffset = src.LateralOffset,
+                VerticalOffset = src.VerticalOffset,
+                SnapToTerrain = src.SnapToTerrain,
+                AlignToSlope = src.AlignToSlope,
+                PlaceAtEnd = src.PlaceAtEnd,
+                MaximumInstances = src.MaximumInstances,
+                Points = src.Points?.Select(point => point == null
+                    ? null
+                    : new FuseSplineyPoint
+                    {
+                        Position = point.Position,
+                        Rotation = point.Rotation,
+                        Width = point.Width,
+                    }).ToArray(),
+            };
+        }
+
+        private static FuseSpan CloneSpan(FuseSpan src)
+        {
+            if (src == null) return null;
+            return new FuseSpan
+            {
+                Upper = CloneTrackLocation(src.Upper),
+                Lower = CloneTrackLocation(src.Lower),
+                Normalize = src.Normalize,
+                GroupId = src.GroupId,
+            };
+        }
+
+        private static FuseTrackLocation CloneTrackLocation(FuseTrackLocation src)
+        {
+            if (src == null) return null;
+            return new FuseTrackLocation
+            {
+                SegmentId = src.SegmentId,
+                Normalized = src.Normalized,
+                Distance = src.Distance,
+                End = src.End,
+                Offset = src.Offset,
             };
         }
 

--- a/FUSE/Runtime/API/IndustryAPI.Cache.cs
+++ b/FUSE/Runtime/API/IndustryAPI.Cache.cs
@@ -404,6 +404,61 @@ namespace FUSE.Runtime.API
             return pruned;
         }
 
+        internal static int ReplaceTrackSpanReferences(TrackSpan previousSpan, TrackSpan replacementSpan, string source)
+        {
+            if (previousSpan == null || replacementSpan == null || ReferenceEquals(previousSpan, replacementSpan))
+            {
+                return 0;
+            }
+
+            var rebound = 0;
+            foreach (var component in UnityEngine.Object.FindObjectsOfType<IndustryComponent>(true))
+            {
+                if (!IsLiveIndustryComponent(component) || component.trackSpans == null || component.trackSpans.Length == 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var spans = component.trackSpans;
+                    var changed = false;
+                    for (var index = 0; index < spans.Length; index++)
+                    {
+                        if (!TrackSpanReferencesRemovedInstance(spans[index], previousSpan))
+                        {
+                            continue;
+                        }
+
+                        spans[index] = replacementSpan;
+                        changed = true;
+                        rebound++;
+                    }
+
+                    if (changed)
+                    {
+                        component.trackSpans = spans;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Exception(
+                        $"FUSE could not rebind industry component '{DescribeComponent(component)}' to replacement TrackSpan " +
+                        $"spanId='{SafeTrackSpanId(replacementSpan)}' after '{source ?? "unspecified"}'",
+                        ex);
+                }
+            }
+
+            if (rebound > 0)
+            {
+                FuseLog.Info(
+                    $"FUSE rebound {rebound} industry component TrackSpan reference(s) to replacement " +
+                    $"spanId='{SafeTrackSpanId(replacementSpan)}' after '{source ?? "unspecified"}'.");
+            }
+
+            return rebound;
+        }
+
         private static bool TrackSpanReferencesRemovedInstance(TrackSpan candidate, TrackSpan removedSpan)
         {
             if (ReferenceEquals(candidate, removedSpan))

--- a/FUSE/Runtime/API/IndustryAPI.Reflection.cs
+++ b/FUSE/Runtime/API/IndustryAPI.Reflection.cs
@@ -105,6 +105,16 @@ namespace FUSE.Runtime.API
                 return typeof(FusePay4ResourceIndustryComponent);
             }
 
+            if (string.Equals(normalized, "ConfusingSupplements.IndustryComponents.CaptiveConversionLoader", StringComparison.OrdinalIgnoreCase))
+            {
+                return typeof(FuseCaptiveConversionLoader);
+            }
+
+            if (string.Equals(normalized, "ConfusingSupplements.IndustryComponents.CaptiveConversionUnloader", StringComparison.OrdinalIgnoreCase))
+            {
+                return typeof(FuseCaptiveConversionUnloader);
+            }
+
             var reflected = TryResolveIndustryComponentType(normalized);
             if (reflected == null && !string.Equals(normalized, type, StringComparison.OrdinalIgnoreCase))
             {
@@ -225,6 +235,21 @@ namespace FUSE.Runtime.API
             if (component is FuseLegacyPlaceholderIndustryComponent)
             {
                 return LegacyEmptyComponentType;
+            }
+
+            if (component is FuseCaptiveConversionLoader)
+            {
+                return "ConfusingSupplements.IndustryComponents.CaptiveConversionLoader";
+            }
+
+            if (component is FuseCaptiveConversionUnloader)
+            {
+                return "ConfusingSupplements.IndustryComponents.CaptiveConversionUnloader";
+            }
+
+            if (component is FusePay4ResourceIndustryComponent)
+            {
+                return "ConfusingSupplements.IndustryComponents.Pay4Resource";
             }
 
             return component.GetType().FullName;
@@ -515,6 +540,14 @@ namespace FUSE.Runtime.API
                     continue;
                 }
 
+                if (!IsUsableTrackSpan(span))
+                {
+                    FuseLog.Warning(
+                        $"FUSE track span '{id}' has a missing or invalid endpoint after graph conflict resolution; " +
+                        "it was omitted from the industry component so opening operations UI cannot crash.");
+                    continue;
+                }
+
                 spans.Add(span);
             }
 
@@ -537,7 +570,7 @@ namespace FUSE.Runtime.API
             var result = new List<TrackSpan>();
             foreach (var span in existing.Concat(additions))
             {
-                if (span == null)
+                if (!IsUsableTrackSpan(span))
                 {
                     continue;
                 }
@@ -550,6 +583,23 @@ namespace FUSE.Runtime.API
             }
 
             return result.ToArray();
+        }
+
+        internal static bool IsUsableTrackSpan(TrackSpan span)
+        {
+            if (span == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                return span.IsValid;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private static Load ResolveLoad(string loadId)

--- a/FUSE/Runtime/API/MapAPI.cs
+++ b/FUSE/Runtime/API/MapAPI.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -8,6 +9,7 @@ using Map.Runtime.MaskComponents;
 using FUSE.Runtime.Cache;
 using FUSE.Authoring.Data;
 using FUSE.Infrastructure;
+using FUSE.Loading;
 using TelegraphPoles;
 using TMPro;
 using UI.Map;
@@ -48,6 +50,70 @@ namespace FUSE.Runtime.API
         private static Transform _worldRoot;
         private static Transform _indexedDecoupledMaskRoot;
         private static Sprite _speedLimitCircleSprite;
+
+        /// <summary>
+        /// Registers or refreshes one package-owned terrain tile folder and
+        /// mounts it into the active map store. This is primarily useful to
+        /// authoring tools that create the first tile in a previously empty
+        /// overlay folder while the game is running.
+        /// </summary>
+        public static int RegisterMapTileSource(
+            string packageId,
+            string packageFolder,
+            string sourceId,
+            string directory,
+            string sourceFolder,
+            int priority = 100)
+        {
+            RequireId(packageId, nameof(packageId));
+            RequireId(sourceId, nameof(sourceId));
+            if (string.IsNullOrWhiteSpace(packageFolder))
+            {
+                throw new ArgumentException(
+                    "Package folder is required.",
+                    nameof(packageFolder));
+            }
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                throw new ArgumentException(
+                    "Map directory is required.",
+                    nameof(directory));
+            }
+            if (string.IsNullOrWhiteSpace(sourceFolder))
+            {
+                throw new ArgumentException(
+                    "Tile source folder is required.",
+                    nameof(sourceFolder));
+            }
+
+            var fullPackageFolder = Path.GetFullPath(packageFolder);
+            if (!Directory.Exists(fullPackageFolder))
+            {
+                throw new DirectoryNotFoundException(
+                    "Package folder was not found: "
+                    + fullPackageFolder);
+            }
+
+            var registered = FuseMapTileRegistry.RegisterTileSource(
+                packageId,
+                fullPackageFolder,
+                sourceId,
+                new FuseMapTileSource
+                {
+                    Directory = directory,
+                    SourceFolder = sourceFolder,
+                    Priority = priority
+                });
+            if (!registered)
+            {
+                throw new InvalidOperationException(
+                    "FUSE rejected the map tile source. Keep sourceFolder "
+                    + "inside the package directory.");
+            }
+
+            return FuseMapTileRegistry.MountForActiveMapIfLoaded(
+                "MapAPI.RegisterMapTileSource");
+        }
 
         public static MapLabel AddMapLabel(string id, FuseMapLabel definition)
         {

--- a/FUSE/Runtime/API/SceneryAPI.cs
+++ b/FUSE/Runtime/API/SceneryAPI.cs
@@ -17,6 +17,8 @@ namespace FUSE.Runtime.API
     public static class SceneryAPI
     {
         private static Transform _fallbackRoot;
+        private static readonly HashSet<string> LoggedUnverifiedLegacyAssets =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private static readonly Dictionary<string, string> LegacySceneryAssetAliases =
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -49,7 +51,11 @@ namespace FUSE.Runtime.API
                 "rlw Spen"
             };
 
-        public static SceneryAssetInstance AddScenery(string id, FuseScenery definition, Action onDeferredActivated = null)
+        public static SceneryAssetInstance AddScenery(
+            string id,
+            FuseScenery definition,
+            Action onDeferredActivated = null,
+            bool allowUnverifiedLegacyAsset = false)
         {
             RequireId(id, nameof(id));
             if (definition == null)
@@ -63,12 +69,23 @@ namespace FUSE.Runtime.API
             }
 
             string assetIdentifier;
-            if (!TryResolveAssetIdentifier(id, definition, out assetIdentifier))
+            if (!TryResolveAssetIdentifier(id, definition, out assetIdentifier) &&
+                !(allowUnverifiedLegacyAsset && TryGetLegacyUnverifiedAssetIdentifier(definition, out assetIdentifier)))
             {
                 FuseLog.Warning(
                     $"FUSE skipped AddScenery '{id}' because no valid asset identifier could be resolved " +
                     $"(AssetIdentifier='{definition.AssetIdentifier ?? string.Empty}', Model='{definition.Model ?? string.Empty}').");
                 return null;
+            }
+
+            if (allowUnverifiedLegacyAsset && !IsCachedKnownResolution(assetIdentifier))
+            {
+                if (LoggedUnverifiedLegacyAssets.Add(assetIdentifier))
+                {
+                    FuseLog.Info(
+                        $"FUSE legacy scenery will attempt guarded runtime asset '{assetIdentifier}' (first placement '{id}') even though it is not in the mounted asset-pack index. " +
+                        "A genuine load failure will be reported and quarantined without stopping other scenery or menus.");
+                }
             }
 
             var gameObject = new GameObject(id);
@@ -171,7 +188,10 @@ namespace FUSE.Runtime.API
             public bool IsPriorityStructure;
         }
 
-        public static void UpdateScenery(string id, FuseScenery definition)
+        public static void UpdateScenery(
+            string id,
+            FuseScenery definition,
+            bool allowUnverifiedLegacyAsset = false)
         {
             var scenery = RequireScenery(id);
             if (definition == null)
@@ -180,7 +200,8 @@ namespace FUSE.Runtime.API
             }
 
             string assetIdentifier;
-            if (!TryResolveAssetIdentifier(id, definition, out assetIdentifier))
+            if (!TryResolveAssetIdentifier(id, definition, out assetIdentifier) &&
+                !(allowUnverifiedLegacyAsset && TryGetLegacyUnverifiedAssetIdentifier(definition, out assetIdentifier)))
             {
                 FuseLog.Warning(
                     $"FUSE skipped UpdateScenery '{id}' because no valid asset identifier could be resolved " +
@@ -341,6 +362,26 @@ namespace FUSE.Runtime.API
             return false;
         }
 
+        private static bool TryGetLegacyUnverifiedAssetIdentifier(
+            FuseScenery definition,
+            out string assetIdentifier)
+        {
+            assetIdentifier = NormalizeSceneryIdentifier(definition?.AssetIdentifier);
+            if (!string.IsNullOrWhiteSpace(assetIdentifier))
+            {
+                return true;
+            }
+
+            assetIdentifier = NormalizeSceneryIdentifier(definition?.Model);
+            return !string.IsNullOrWhiteSpace(assetIdentifier);
+        }
+
+        private static bool IsCachedKnownResolution(string candidate)
+        {
+            return TryGetCachedIdentifierResolution(candidate, out var resolved) &&
+                   !string.IsNullOrWhiteSpace(resolved);
+        }
+
         public static bool IsKnownOptionalLegacyAssetReference(FuseScenery definition)
         {
             if (definition == null)
@@ -350,6 +391,31 @@ namespace FUSE.Runtime.API
 
             return IsKnownOptionalLegacyAssetReference(definition.AssetIdentifier) ||
                    IsKnownOptionalLegacyAssetReference(definition.Model);
+        }
+
+        /// <summary>
+        /// Identifies editor-only legacy helper models that must never be
+        /// instantiated in a playable map. Alina's editor used the bright
+        /// yellow turntable measurement plate as an authoring aid; loading it
+        /// as ordinary scenery leaves the yellow "Pac-Man" shape reported at
+        /// Stryker/Bryson and East Whittier.
+        /// </summary>
+        public static bool IsEditorOnlyLegacySceneryReference(FuseScenery definition)
+        {
+            if (definition == null)
+            {
+                return false;
+            }
+
+            return IsEditorOnlyLegacySceneryReference(definition.AssetIdentifier) ||
+                   IsEditorOnlyLegacySceneryReference(definition.Model);
+        }
+
+        private static bool IsEditorOnlyLegacySceneryReference(string value)
+        {
+            var key = NormalizeLegacyAssetKey(value);
+            return string.Equals(key, "TurntableMeasurementTool", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(key, "ALW_ModRes_TurntableMeasurementTool", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool TryResolveKnownSceneryAssetIdentifier(string candidate, out string resolvedIdentifier)

--- a/FUSE/Runtime/API/SplineyAPI.cs
+++ b/FUSE/Runtime/API/SplineyAPI.cs
@@ -17,6 +17,7 @@ namespace FUSE.Runtime.API
         private static readonly FieldInfo RiverBuilderSplineProfileField = typeof(RiverBuilder).GetField("splineProfile", BindingFlags.Instance | BindingFlags.NonPublic);
         private static Transform _fallbackRiverRoot;
         private static Transform _fallbackTrestleRoot;
+        private static Transform _fallbackObjectLineRoot;
         private static List<SplineProfile> _splineProfiles;
         private static List<AutoTrestleProfile> _autoTrestleProfiles;
 
@@ -34,10 +35,19 @@ namespace FUSE.Runtime.API
             }
 
             var root = new GameObject(id);
-            ApplyDefinition(root, id, definition, false);
-            FuseSplineyRuntimeIndex.Instance.Set(id, root);
-            FuseApiPersistence.RecordDefinition(FuseDefinitionKind.Spliney, id, definition);
-            return root;
+            try
+            {
+                ApplyDefinition(root, id, definition, false);
+                FuseSplineyRuntimeIndex.Instance.Set(id, root);
+                FuseApiPersistence.RecordDefinition(FuseDefinitionKind.Spliney, id, definition);
+                return root;
+            }
+            catch
+            {
+                root.SetActive(false);
+                UnityEngine.Object.Destroy(root);
+                throw;
+            }
         }
 
         public static void UpdateSpliney(string id, FuseSpliney definition)
@@ -196,6 +206,9 @@ namespace FUSE.Runtime.API
                 case SplineyKind.Trestle:
                     ConfigureTrestle(root, definition, points);
                     break;
+                case SplineyKind.ObjectLine:
+                    ConfigureObjectLine(root, id, definition, points);
+                    break;
                 default:
                     throw new NotSupportedException($"Unsupported spliney kind '{kind}'.");
             }
@@ -218,6 +231,9 @@ namespace FUSE.Runtime.API
                 trestle?.Generate();
                 return;
             }
+
+            if (kind == SplineyKind.ObjectLine)
+                return;
 
             var builder = root.GetComponent<RiverBuilder>();
             builder?.BuildSpline();
@@ -500,6 +516,168 @@ namespace FUSE.Runtime.API
             }
         }
 
+        private static void ConfigureObjectLine(
+            GameObject root,
+            string id,
+            FuseSpliney definition,
+            IReadOnlyList<FuseSplineyPoint> points)
+        {
+            if (string.IsNullOrWhiteSpace(definition.AssetIdentifier)
+                && string.IsNullOrWhiteSpace(definition.Prefab))
+            {
+                throw new InvalidOperationException(
+                    $"Object-line spliney '{id}' requires assetIdentifier or prefab.");
+            }
+            if (!string.IsNullOrWhiteSpace(definition.AssetIdentifier)
+                && !string.IsNullOrWhiteSpace(definition.Prefab))
+            {
+                throw new InvalidOperationException(
+                    $"Object-line spliney '{id}' must use either assetIdentifier or prefab, not both.");
+            }
+
+            string assetIdentifier = null;
+            GameObject prefab = null;
+            if (!string.IsNullOrWhiteSpace(definition.AssetIdentifier))
+            {
+                var scenery = new FuseScenery
+                {
+                    AssetIdentifier = definition.AssetIdentifier,
+                };
+                if (!SceneryAPI.TryResolveAssetIdentifier(id, scenery, out assetIdentifier))
+                {
+                    throw new InvalidOperationException(
+                        $"Object-line scenery asset '{definition.AssetIdentifier}' was not found for '{id}'.");
+                }
+            }
+            else
+            {
+                prefab = FusePrefabResolver.Resolve(definition.Prefab);
+                if (prefab == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Object-line prefab '{definition.Prefab}' was not found for '{id}'.");
+                }
+            }
+
+            var placements = FuseObjectLineLayout.Build(
+                points,
+                definition.Spacing,
+                definition.PlaceAtEnd,
+                definition.MaximumInstances);
+            root.transform.SetParent(GetObjectLineRoot(), false);
+            root.transform.localPosition = Vector3.zero;
+            root.transform.localRotation = Quaternion.identity;
+            root.transform.localScale = Vector3.one;
+
+            var instances = root.transform.Find("FUSE Object Line Instances");
+            if (instances == null)
+            {
+                var container = new GameObject("FUSE Object Line Instances");
+                container.transform.SetParent(root.transform, false);
+                instances = container.transform;
+            }
+
+            // Older object-line builds placed generated modules directly on
+            // the root. Remove only those named instances during migration;
+            // editor overlays and other helper children must survive a live
+            // UpdateSpliney call.
+            var generatedPrefix = id + ":";
+            for (var childIndex = root.transform.childCount - 1; childIndex >= 0; childIndex--)
+            {
+                var child = root.transform.GetChild(childIndex);
+                if (child == null
+                    || ReferenceEquals(child, instances)
+                    || !child.name.StartsWith(generatedPrefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                child.gameObject.SetActive(false);
+                UnityEngine.Object.Destroy(child.gameObject);
+            }
+
+            for (var childIndex = instances.childCount - 1; childIndex >= 0; childIndex--)
+            {
+                var child = instances.GetChild(childIndex);
+                if (child == null)
+                    continue;
+                child.gameObject.SetActive(false);
+                UnityEngine.Object.Destroy(child.gameObject);
+            }
+
+            for (var index = 0; index < placements.Count; index++)
+            {
+                var placement = placements[index];
+                var position = placement.Position;
+                var forward = placement.Forward;
+                if (definition.SnapToTerrain
+                    && TrySnapObjectLineToTerrain(position, out var snapped))
+                {
+                    position.y = snapped.y;
+                }
+                if (!definition.AlignToSlope)
+                {
+                    forward.y = 0f;
+                    if (forward.sqrMagnitude <= 0.0001f)
+                        forward = Vector3.forward;
+                    else
+                        forward.Normalize();
+                }
+
+                var rotation = Quaternion.LookRotation(forward, Vector3.up);
+                var right = rotation * Vector3.right;
+                position += right * definition.LateralOffset;
+                position.y += definition.VerticalOffset;
+
+                GameObject instance;
+                if (prefab != null)
+                {
+                    instance = UnityEngine.Object.Instantiate(prefab, instances);
+                }
+                else
+                {
+                    instance = new GameObject();
+                    instance.SetActive(false);
+                    instance.transform.SetParent(instances, false);
+                    instance.AddComponent<SceneryAssetInstance>().identifier = assetIdentifier;
+                }
+                instance.name = id + ":" + index.ToString("D4");
+                instance.transform.localPosition = position;
+                instance.transform.localRotation = rotation * Quaternion.Euler(definition.RotationOffset);
+                instance.transform.localScale = definition.InstanceScale == default
+                    ? Vector3.one
+                    : definition.InstanceScale;
+                instance.SetActive(true);
+            }
+
+            FuseLog.Info(
+                $"FUSE built object-line spliney '{id}' with {placements.Count} instance(s) "
+                + $"at {definition.Spacing:0.##} m spacing.");
+        }
+
+        private static bool TrySnapObjectLineToTerrain(Vector3 position, out Vector3 snapped)
+        {
+            var hits = Physics.RaycastAll(
+                    position + Vector3.up * 500f,
+                    Vector3.down,
+                    1500f)
+                .OrderBy(hit => hit.distance);
+            foreach (var hit in hits)
+            {
+                if (hit.collider == null)
+                    continue;
+                var layerName = LayerMask.LayerToName(hit.collider.gameObject.layer) ?? string.Empty;
+                if (layerName.IndexOf("terrain", StringComparison.OrdinalIgnoreCase) < 0
+                    && layerName.IndexOf("ground", StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    continue;
+                }
+                snapped = hit.point;
+                return true;
+            }
+            snapped = position;
+            return false;
+        }
+
         private static SplineProfile ResolveSplineProfile(string profileName, SplineyKind kind)
         {
             return ResolveNamedObject(
@@ -638,6 +816,26 @@ namespace FUSE.Runtime.API
             return _fallbackTrestleRoot;
         }
 
+        private static Transform GetObjectLineRoot()
+        {
+            var existing = GameObject.Find("World/FUSE Object Lines");
+            if (existing != null)
+                return existing.transform;
+            var world = GameObject.Find("World");
+            if (world != null)
+            {
+                var root = new GameObject("FUSE Object Lines");
+                root.transform.SetParent(world.transform, false);
+                return root.transform;
+            }
+            if (_fallbackObjectLineRoot == null)
+            {
+                _fallbackObjectLineRoot = new GameObject("FUSE Object Lines").transform;
+                UnityEngine.Object.DontDestroyOnLoad(_fallbackObjectLineRoot.gameObject);
+            }
+            return _fallbackObjectLineRoot;
+        }
+
         private static Vector3 AveragePosition(IReadOnlyList<FuseSplineyPoint> points)
         {
             var center = Vector3.zero;
@@ -651,6 +849,13 @@ namespace FUSE.Runtime.API
 
         private static SplineyKind ParseKind(string value)
         {
+            if (string.Equals(value, "objectLine", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "object-line", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "fence", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "retainingWall", StringComparison.OrdinalIgnoreCase))
+            {
+                return SplineyKind.ObjectLine;
+            }
             if (string.Equals(value, "trestle", StringComparison.OrdinalIgnoreCase))
             {
                 return SplineyKind.Trestle;
@@ -755,7 +960,8 @@ namespace FUSE.Runtime.API
             River,
             TerrainRoad,
             Waterfall,
-            Trestle
+            Trestle,
+            ObjectLine
         }
     }
 

--- a/FUSE/Runtime/API/TrackAPI.Areas.cs
+++ b/FUSE/Runtime/API/TrackAPI.Areas.cs
@@ -309,7 +309,9 @@ namespace FUSE.Runtime.API
 
         private static void ApplyAreaDefinition(Area area, FuseArea definition)
         {
-            var displayName = string.IsNullOrWhiteSpace(definition.Name) ? area.identifier : definition.Name;
+            var displayName = string.IsNullOrWhiteSpace(definition.Name)
+                ? (string.IsNullOrWhiteSpace(area.name) ? area.identifier : area.name)
+                : definition.Name;
             area.name = displayName;
             area.gameObject.name = displayName;
             if (definition.Position.HasValue)

--- a/FUSE/Runtime/API/TrackAPI.Graph.cs
+++ b/FUSE/Runtime/API/TrackAPI.Graph.cs
@@ -412,6 +412,7 @@ namespace FUSE.Runtime.API
             Location? bestLower = null;
             var bestLength = float.PositiveInfinity;
             var bestFacing = string.Empty;
+            var validCandidateCount = 0;
 
             for (var trial = 1; trial <= 3; trial++)
             {
@@ -433,7 +434,13 @@ namespace FUSE.Runtime.API
                     var points = span.GetPoints();
                     var length = span.Length;
                     if (points == null || points.Count < 2 ||
-                        length <= SpanDistanceTolerance || length >= bestLength)
+                        length <= SpanDistanceTolerance)
+                    {
+                        continue;
+                    }
+
+                    validCandidateCount++;
+                    if (length >= bestLength)
                     {
                         continue;
                     }
@@ -451,10 +458,17 @@ namespace FUSE.Runtime.API
                 }
             }
 
-            if (!bestUpper.HasValue || !bestLower.HasValue)
+            if (!bestUpper.HasValue || !bestLower.HasValue || validCandidateCount != 1)
             {
                 span.upper = originalUpper;
                 span.lower = originalLower;
+                if (validCandidateCount > 1)
+                {
+                    FuseLog.Warning(
+                        $"FUSE refused to auto-repair track span '{spanId}' because {validCandidateCount} endpoint-facing " +
+                        "combinations resolved through the switch graph. Choosing the shortest route is ambiguous and can bind " +
+                        "an industry track to a neighboring track; correct the authored endpoint directions instead.");
+                }
                 return false;
             }
 
@@ -567,6 +581,7 @@ namespace FUSE.Runtime.API
             var id = span.id ?? string.Empty;
             var displayName = span.name ?? string.Empty;
             UnregisterSpanWithGraph(Graph.Shared, id);
+            span.id = CreateRetiredSpanId(id);
             RemoveRuntimeObject(span);
             if (!string.IsNullOrWhiteSpace(id))
             {

--- a/FUSE/Runtime/API/TrackAPI.Helpers.cs
+++ b/FUSE/Runtime/API/TrackAPI.Helpers.cs
@@ -46,6 +46,7 @@ namespace FUSE.Runtime.API
                 Position = definition.Position,
                 Rotation = definition.Rotation,
                 FlipSwitchStand = definition.FlipSwitchStand,
+                IsDiamond = definition.IsDiamond,
                 GroupId = definition.GroupId,
                 Tags = definition.Tags?.ToArray()
             };
@@ -69,8 +70,12 @@ namespace FUSE.Runtime.API
                 GroupId = definition.GroupId,
                 Tags = definition.Tags?.ToArray(),
                 Gauge = definition.Gauge,
+                BridgeSupportsSteel = definition.BridgeSupportsSteel,
+                Yard = definition.Yard,
                 Partial = definition.Partial,
                 PreserveStyle = definition.PreserveStyle,
+                PreserveBridgeSupportsSteel = definition.PreserveBridgeSupportsSteel,
+                PreserveYard = definition.PreserveYard,
                 PreserveTrackClass = definition.PreserveTrackClass,
                 PreserveSpeedLimit = definition.PreserveSpeedLimit,
                 PreservePriority = definition.PreservePriority,

--- a/FUSE/Runtime/API/TrackAPI.Nodes.cs
+++ b/FUSE/Runtime/API/TrackAPI.Nodes.cs
@@ -9,6 +9,7 @@ using FUSE.Authoring.Data;
 using FUSE.Authoring.Data.Common;
 using FUSE.Runtime.Events;
 using FUSE.Infrastructure;
+using FUSE.Compatibility;
 using Track;
 using Track.Signals;
 using UnityEngine;
@@ -49,6 +50,7 @@ namespace FUSE.Runtime.API
             }
 
             var node = AddNode(id, definition.Position, definition.Rotation, definition.FlipSwitchStand, definition.GroupId);
+            RailroaderTrackContract.SetNodeIsDiamond(node, definition.IsDiamond);
             FuseApiPersistence.RecordDefinition(FuseDefinitionKind.TrackNode, id, definition);
             return node;
         }
@@ -78,6 +80,7 @@ namespace FUSE.Runtime.API
             }
 
             UpdateNode(id, definition.Position, definition.Rotation, definition.FlipSwitchStand);
+            RailroaderTrackContract.SetNodeIsDiamond(RequireNode(id), definition.IsDiamond);
             FuseApiPersistence.RecordDefinition(FuseDefinitionKind.TrackNode, id, definition);
         }
 
@@ -126,6 +129,7 @@ namespace FUSE.Runtime.API
             definition.Position = node.transform.localPosition;
             definition.Rotation = node.transform.localEulerAngles;
             definition.FlipSwitchStand = node.flipSwitchStand;
+            definition.IsDiamond = RailroaderTrackContract.GetNodeIsDiamond(node);
             return definition;
         }
     }

--- a/FUSE/Runtime/API/TrackAPI.Segments.cs
+++ b/FUSE/Runtime/API/TrackAPI.Segments.cs
@@ -9,6 +9,7 @@ using FUSE.Authoring.Data;
 using FUSE.Authoring.Data.Common;
 using FUSE.Runtime.Events;
 using FUSE.Infrastructure;
+using FUSE.Compatibility;
 using Track;
 using Track.Signals;
 using UnityEngine;
@@ -63,6 +64,11 @@ namespace FUSE.Runtime.API
                 definition.GroupId,
                 ParseTrackClass(definition.TrackClass),
                 definition.Priority);
+            RailroaderTrackContract.ApplyStructure(
+                segment,
+                definition.Style,
+                definition.BridgeSupportsSteel,
+                definition.Yard);
             FuseApiPersistence.RecordDefinition(FuseDefinitionKind.TrackSegment, id, definition);
             return segment;
         }
@@ -110,6 +116,11 @@ namespace FUSE.Runtime.API
                 ParseTrackClass(definition.TrackClass),
                 definition.Priority,
                 definition.GroupId);
+            RailroaderTrackContract.ApplyStructure(
+                RequireSegment(id),
+                definition.Style,
+                definition.BridgeSupportsSteel,
+                definition.Yard);
             FuseApiPersistence.RecordDefinition(FuseDefinitionKind.TrackSegment, id, definition);
         }
 
@@ -154,7 +165,9 @@ namespace FUSE.Runtime.API
             definition = definition ?? new FuseSegment();
             definition.StartNodeId = segment.a != null ? segment.a.id : null;
             definition.EndNodeId = segment.b != null ? segment.b.id : null;
-            definition.Style = segment.style.ToString();
+            definition.Style = RailroaderTrackContract.GetStyleName(segment);
+            definition.BridgeSupportsSteel = RailroaderTrackContract.GetBridgeSupportsSteel(segment);
+            definition.Yard = RailroaderTrackContract.GetYard(segment);
             definition.TrackClass = segment.trackClass == TrackClass.Mainline ? "main" : segment.trackClass.ToString();
             definition.SpeedLimit = segment.speedLimit;
             definition.Priority = segment.priority;

--- a/FUSE/Runtime/API/TrackAPI.Spans.cs
+++ b/FUSE/Runtime/API/TrackAPI.Spans.cs
@@ -46,6 +46,10 @@ namespace FUSE.Runtime.API
             }
             catch
             {
+                // Unity destruction is deferred. Do not leave a failed temporary
+                // object discoverable under the requested id for the remainder
+                // of this frame, or a later retry can be mistaken for a duplicate.
+                span.id = CreateRetiredSpanId(id);
                 RemoveRuntimeObject(span);
                 throw;
             }
@@ -121,11 +125,55 @@ namespace FUSE.Runtime.API
         {
             var span = RequireSpan(id);
             UnregisterSpanWithGraph(Graph.Shared, id);
+            // Retire the identity before scheduling Unity destruction. A package
+            // can legitimately recreate this id in the same apply pass.
+            span.id = CreateRetiredSpanId(id);
             RemoveRuntimeObject(span);
             FuseSpanRuntimeIndex.Instance.Remove(id);
             FuseRuntimeDefinitionCache.Remove(FuseDefinitionKind.TrackSpan, id);
             FuseEvents.RaiseSpanRemoved(id);
             RequestRebuild();
+        }
+
+        /// <summary>
+        /// Recreates a span whose endpoint topology changed without exposing two
+        /// live scene objects under the same identifier. Existing industry and
+        /// interchange components are rebound to the replacement instance before
+        /// Unity retires the old component at the end of the frame.
+        /// </summary>
+        public static TrackSpan ReplaceSpan(string id, FuseSpan definition)
+        {
+            RequireId(id, nameof(id));
+            if (definition == null)
+            {
+                throw new ArgumentNullException(nameof(definition));
+            }
+
+            var graph = RequireGraph();
+            var previousSpan = RequireSpan(id);
+            UnregisterSpanWithGraph(graph, id);
+            FuseSpanRuntimeIndex.Instance.Remove(id);
+            previousSpan.id = CreateRetiredSpanId(id);
+
+            TrackSpan replacementSpan;
+            try
+            {
+                replacementSpan = AddSpan(id, definition);
+            }
+            catch
+            {
+                // The previous component has not been destroyed yet, so a failed
+                // replacement can be rolled back without losing the working span.
+                previousSpan.id = id;
+                FuseSpanRuntimeIndex.Instance.Set(id, previousSpan);
+                RegisterSpanWithGraph(graph, previousSpan);
+                throw;
+            }
+
+            IndustryAPI.ReplaceTrackSpanReferences(previousSpan, replacementSpan, "TrackAPI.ReplaceSpan");
+            RemoveRuntimeObject(previousSpan);
+            FuseLog.Info($"FUSE atomically replaced track span id='{id}' and rebound its runtime consumers.");
+            return replacementSpan;
         }
 
         public static TrackSpan GetSpan(string id)
@@ -169,6 +217,31 @@ namespace FUSE.Runtime.API
         {
             return UnityEngine.Object.FindObjectsOfType<TrackSpan>(true)
                 .Where(span => span != null && !string.IsNullOrWhiteSpace(span.id));
+        }
+
+        /// <summary>
+        /// Returns only spans owned by the live graph dictionary. Scene-wide
+        /// searches also find prefab/template components and objects waiting for
+        /// Unity's deferred destruction; those are useful to compatibility code
+        /// but are not broken runtime track and must not become audit findings.
+        /// </summary>
+        internal static IEnumerable<TrackSpan> GetRegisteredSpansForDiagnostics()
+        {
+            var graph = Graph.Shared;
+            var spans = graph != null
+                ? GraphSpansField?.GetValue(graph) as Dictionary<string, TrackSpan>
+                : null;
+            if (spans != null)
+            {
+                return spans.Values
+                    .Where(span => span != null && !string.IsNullOrWhiteSpace(span.id))
+                    .Distinct()
+                    .ToArray();
+            }
+
+            return GetAllSpans()
+                .Where(span => graph != null && ReferenceEquals(graph.SpanForId(span.id), span))
+                .ToArray();
         }
 
         private static TrackSpan[] GetRegisteredGraphSpans()
@@ -268,9 +341,28 @@ namespace FUSE.Runtime.API
 
             FuseRuntimeDefinitionCache.TryGet(FuseDefinitionKind.TrackSpan, span.id, out FuseSpan definition);
             definition = definition ?? new FuseSpan();
-            definition.Upper = span.upper.HasValue ? ToDefinition(span.upper.Value) : null;
-            definition.Lower = span.lower.HasValue ? ToDefinition(span.lower.Value) : null;
+
+            // Railroader's TrackSpan location getters can temporarily return
+            // null when Graph.TryResolveLocation cannot resolve an otherwise
+            // valid serialized endpoint. Keep the authored/cache endpoint in
+            // that case. The audit can then distinguish a genuinely missing
+            // endpoint from an endpoint whose referenced segment was removed.
+            if (span.upper.HasValue)
+            {
+                definition.Upper = ToDefinition(span.upper.Value);
+            }
+
+            if (span.lower.HasValue)
+            {
+                definition.Lower = ToDefinition(span.lower.Value);
+            }
+
             return definition;
+        }
+
+        private static string CreateRetiredSpanId(string id)
+        {
+            return $"__FUSE_RETIRED_SPAN__{id ?? string.Empty}__{Guid.NewGuid():N}";
         }
     }
 }

--- a/FUSE/Runtime/API/WaterSurfaceAPI.cs
+++ b/FUSE/Runtime/API/WaterSurfaceAPI.cs
@@ -1,0 +1,371 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FUSE.Authoring.Data;
+using FUSE.Infrastructure;
+using FUSE.Runtime.Cache;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace FUSE.Runtime.API
+{
+    /// <summary>
+    /// Creates FUSE-owned lake polygons from native world data. The runtime
+    /// uses Railroader's public LakePolygon contract and loaded water assets;
+    /// it does not embed or duplicate game implementation code.
+    /// </summary>
+    public static class WaterSurfaceAPI
+    {
+        private static Transform _fallbackRoot;
+        private static Material _fallbackMaterial;
+
+        public static GameObject AddWaterSurface(string id, FuseWaterSurface definition)
+        {
+            RequireId(id);
+            if (definition == null)
+                throw new ArgumentNullException(nameof(definition));
+            if (GetWaterSurface(id) != null)
+                throw new InvalidOperationException($"Water surface '{id}' already exists.");
+
+            var root = new GameObject(id);
+            try
+            {
+                ApplyDefinition(root, id, definition);
+                FuseWaterSurfaceRuntimeIndex.Instance.Set(id, root);
+                FuseApiPersistence.RecordDefinition(FuseDefinitionKind.WaterSurface, id, definition);
+                return root;
+            }
+            catch
+            {
+                root.SetActive(false);
+                ReleaseGeneratedMesh(root);
+                UnityEngine.Object.Destroy(root);
+                throw;
+            }
+        }
+
+        public static void UpdateWaterSurface(string id, FuseWaterSurface definition)
+        {
+            var root = RequireWaterSurface(id);
+            if (definition == null)
+                throw new ArgumentNullException(nameof(definition));
+
+            ApplyDefinition(root, id, definition);
+            FuseWaterSurfaceRuntimeIndex.Instance.Set(id, root);
+            FuseApiPersistence.RecordDefinition(FuseDefinitionKind.WaterSurface, id, definition);
+        }
+
+        public static GameObject GetWaterSurface(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                return null;
+            if (FuseWaterSurfaceRuntimeIndex.Instance.TryGetValue(id, out var cached))
+                return cached as GameObject;
+            if (FuseCacheRegistry.IsReady)
+                return null;
+
+            return UnityEngine.Object.FindObjectsOfType<FuseWaterSurfaceMarker>(true)
+                .FirstOrDefault(marker => string.Equals(marker.Id, id, StringComparison.OrdinalIgnoreCase))
+                ?.gameObject;
+        }
+
+        public static IEnumerable<GameObject> GetAllWaterSurfaces()
+        {
+            return UnityEngine.Object.FindObjectsOfType<FuseWaterSurfaceMarker>(true)
+                .Where(marker => marker != null)
+                .Select(marker => marker.gameObject);
+        }
+
+        public static FuseWaterSurface GetWaterSurfaceDefinition(string id)
+        {
+            return GetDefinition(GetWaterSurface(id));
+        }
+
+        public static FuseWaterSurface GetDefinition(GameObject root)
+        {
+            if (root == null)
+                return null;
+            var marker = root.GetComponent<FuseWaterSurfaceMarker>();
+            var id = marker != null ? marker.Id : root.name;
+            FuseRuntimeDefinitionCache.TryGet(
+                FuseDefinitionKind.WaterSurface,
+                id,
+                out FuseWaterSurface definition);
+            definition = definition ?? new FuseWaterSurface();
+
+            var lake = root.GetComponent<LakePolygon>();
+            if (lake != null)
+            {
+                definition.Points = (lake.points ?? new List<Vector3>())
+                    .Select(root.transform.TransformPoint)
+                    .ToArray();
+                definition.LockHeight = lake.lockHeight;
+                definition.SnapToTerrain = lake.snapToTerrain;
+                definition.EnableCollider = root.GetComponent<MeshCollider>() != null;
+                definition.UvScale = lake.uvScale;
+                definition.TriangleDensity = lake.traingleDensity;
+                definition.MaximumTriangleArea = lake.maximumTriangleSize;
+                definition.YOffset = lake.yOffset;
+            }
+
+            if (marker != null)
+            {
+                definition.SourceLakePath = marker.SourceLakePath;
+                definition.MaterialName = marker.MaterialName;
+            }
+            return definition;
+        }
+
+        public static void RemoveWaterSurface(string id)
+        {
+            if (!TryRemoveWaterSurface(id))
+                throw new InvalidOperationException($"Water surface '{id}' was not found.");
+        }
+
+        public static bool TryRemoveWaterSurface(string id)
+        {
+            var root = GetWaterSurface(id);
+            if (root == null)
+            {
+                FuseLog.Warning($"FUSE world removal skipped missing water surface '{id}'.");
+                return false;
+            }
+
+            root.SetActive(false);
+            ReleaseGeneratedMesh(root);
+            UnityEngine.Object.Destroy(root);
+            FuseWaterSurfaceRuntimeIndex.Instance.Remove(id);
+            FuseRuntimeDefinitionCache.Remove(FuseDefinitionKind.WaterSurface, id);
+            FuseLog.Info($"FUSE removed water surface '{id}'.");
+            return true;
+        }
+
+        private static void ApplyDefinition(GameObject root, string id, FuseWaterSurface definition)
+        {
+            var points = definition.Points ?? Array.Empty<Vector3>();
+            if (points.Length < 3)
+                throw new InvalidOperationException($"Water surface '{id}' requires at least three boundary points.");
+            if (definition.TriangleDensity <= 0f || definition.TriangleDensity > 1f)
+                throw new InvalidOperationException($"Water surface '{id}' triangleDensity must be greater than 0 and at most 1.");
+            if (definition.MaximumTriangleArea <= 0f)
+                throw new InvalidOperationException($"Water surface '{id}' maximumTriangleArea must be greater than 0.");
+
+            var source = ResolveSourceLake(definition.SourceLakePath);
+            var material = ResolveMaterial(source, definition.MaterialName);
+            root.SetActive(false);
+            try
+            {
+                root.name = id;
+                root.transform.SetParent(GetWaterRoot(), false);
+                root.transform.localPosition = Vector3.zero;
+                root.transform.localRotation = Quaternion.identity;
+                root.transform.localScale = Vector3.one;
+                var waterLayer = LayerMask.NameToLayer("Water");
+                if (waterLayer >= 0)
+                    root.layer = waterLayer;
+
+                var lake = root.GetComponent<LakePolygon>() ?? root.AddComponent<LakePolygon>();
+                var renderer = root.GetComponent<MeshRenderer>() ?? root.AddComponent<MeshRenderer>();
+                renderer.sharedMaterial = material;
+
+                ApplySourceLakeProfile(source, lake);
+                lake.points = points.ToList();
+                lake.lockHeight = definition.LockHeight;
+                lake.snapToTerrain = definition.SnapToTerrain;
+                lake.uvScale = definition.UvScale;
+                lake.traingleDensity = definition.TriangleDensity;
+                lake.maximumTriangleSize = definition.MaximumTriangleArea;
+                lake.yOffset = definition.YOffset;
+
+                var collider = root.GetComponent<MeshCollider>();
+                if (definition.EnableCollider && collider == null)
+                    collider = root.AddComponent<MeshCollider>();
+                else if (!definition.EnableCollider && collider != null)
+                    UnityEngine.Object.Destroy(collider);
+
+                var previousMesh = root.GetComponent<MeshFilter>()?.sharedMesh;
+                // A source lake's painted per-vertex flow map belongs to its old
+                // triangulation. Generate a fresh automatic map for this polygon
+                // while retaining the source profile's flow speed and noise.
+                lake.overrideFlowMap = false;
+                lake.colorsFlowMap.Clear();
+                lake.GeneratePolygon(false);
+                if (collider != null)
+                    collider.sharedMesh = root.GetComponent<MeshFilter>()?.sharedMesh;
+                ReleaseReplacedMesh(previousMesh, lake.currentMesh);
+
+                var marker = root.GetComponent<FuseWaterSurfaceMarker>()
+                             ?? root.AddComponent<FuseWaterSurfaceMarker>();
+                marker.Id = id;
+                marker.SourceLakePath = definition.SourceLakePath;
+                marker.MaterialName = definition.MaterialName;
+            }
+            finally
+            {
+                root.SetActive(true);
+            }
+        }
+
+        private static void ApplySourceLakeProfile(LakePolygon source, LakePolygon target)
+        {
+            if (ReferenceEquals(target, null))
+                throw new ArgumentNullException(nameof(target));
+
+            if (ReferenceEquals(source, null))
+            {
+                target.currentProfile = null;
+                target.receiveShadows = false;
+                target.shadowCastingMode = ShadowCastingMode.Off;
+                return;
+            }
+
+            // These are public LakePolygon rendering/profile controls. Copying
+            // them preserves the loaded map's water appearance without copying
+            // the game's mesh-generation implementation or terrain mutations.
+            target.currentProfile = source.currentProfile;
+            target.distSmooth = source.distSmooth;
+            target.terrainSmoothMultiplier = source.terrainSmoothMultiplier;
+            target.overrideLakeRender = source.overrideLakeRender;
+            target.receiveShadows = source.receiveShadows;
+            target.shadowCastingMode = source.shadowCastingMode;
+            target.automaticFlowMapScale = source.automaticFlowMapScale;
+            target.noiseflowMap = source.noiseflowMap;
+            target.noiseMultiplierflowMap = source.noiseMultiplierflowMap;
+            target.noiseSizeXflowMap = source.noiseSizeXflowMap;
+            target.noiseSizeZflowMap = source.noiseSizeZflowMap;
+            target.floatSpeed = source.floatSpeed;
+            target.flowSpeed = source.flowSpeed;
+            target.flowDirection = source.flowDirection;
+            target.normalFromRaycast = source.normalFromRaycast;
+            target.snapMask = source.snapMask;
+        }
+
+        private static void ReleaseReplacedMesh(Mesh previous, Mesh current)
+        {
+            if (previous != null && previous != current)
+                UnityEngine.Object.Destroy(previous);
+        }
+
+        private static void ReleaseGeneratedMesh(GameObject root)
+        {
+            if (root == null)
+                return;
+
+            var lake = root.GetComponent<LakePolygon>();
+            var filter = root.GetComponent<MeshFilter>();
+            var collider = root.GetComponent<MeshCollider>();
+            var mesh = lake?.currentMesh ?? filter?.sharedMesh;
+            if (collider != null && collider.sharedMesh == mesh)
+                collider.sharedMesh = null;
+            if (filter != null && filter.sharedMesh == mesh)
+                filter.sharedMesh = null;
+            if (lake != null)
+            {
+                lake.currentMesh = null;
+                lake.meshfilter = null;
+            }
+            if (mesh != null)
+                UnityEngine.Object.Destroy(mesh);
+        }
+
+        private static LakePolygon ResolveSourceLake(string path)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                var sourceObject = FusePrefabResolver.ResolveScenePath(path.Trim());
+                var source = sourceObject != null
+                    ? sourceObject.GetComponent<LakePolygon>()
+                      ?? sourceObject.GetComponentInChildren<LakePolygon>(true)
+                    : null;
+                if (source == null)
+                    throw new InvalidOperationException($"Source lake path '{path}' was not found or has no LakePolygon component.");
+                return source;
+            }
+
+            return Resources.FindObjectsOfTypeAll<LakePolygon>()
+                .FirstOrDefault(candidate => candidate != null
+                    && candidate.GetComponent<FuseWaterSurfaceMarker>() == null
+                    && candidate.GetComponent<MeshRenderer>()?.sharedMaterial != null);
+        }
+
+        private static Material ResolveMaterial(LakePolygon source, string materialName)
+        {
+            if (!string.IsNullOrWhiteSpace(materialName))
+            {
+                var material = Resources.FindObjectsOfTypeAll<Material>()
+                    .FirstOrDefault(candidate => candidate != null
+                        && string.Equals(candidate.name, materialName.Trim(), StringComparison.OrdinalIgnoreCase));
+                if (material == null)
+                    throw new InvalidOperationException($"Water material '{materialName}' was not found among loaded game assets.");
+                return material;
+            }
+
+            var sourceMaterial = source?.GetComponent<MeshRenderer>()?.sharedMaterial;
+            if (sourceMaterial != null)
+                return sourceMaterial;
+
+            var loadedWater = Resources.FindObjectsOfTypeAll<Material>()
+                .FirstOrDefault(candidate => candidate != null
+                    && (candidate.name.IndexOf("lake", StringComparison.OrdinalIgnoreCase) >= 0
+                        || candidate.name.IndexOf("water", StringComparison.OrdinalIgnoreCase) >= 0));
+            if (loadedWater != null)
+                return loadedWater;
+
+            if (_fallbackMaterial == null)
+            {
+                var shader = Shader.Find("Universal Render Pipeline/Lit") ?? Shader.Find("Standard");
+                if (shader == null)
+                    throw new InvalidOperationException("No loaded lake material or fallback render shader was available.");
+                _fallbackMaterial = new Material(shader)
+                {
+                    name = "FUSE Fallback Water",
+                    color = new Color(0.08f, 0.32f, 0.48f, 0.82f),
+                    hideFlags = HideFlags.HideAndDontSave,
+                };
+                FuseLog.Warning("FUSE could not find a stock lake material; using the simple fallback water material.");
+            }
+            return _fallbackMaterial;
+        }
+
+        private static Transform GetWaterRoot()
+        {
+            var existing = GameObject.Find("World/Water Surfaces");
+            if (existing != null)
+                return existing.transform;
+            var world = GameObject.Find("World");
+            if (world != null)
+            {
+                var root = new GameObject("Water Surfaces");
+                root.transform.SetParent(world.transform, false);
+                return root.transform;
+            }
+            if (_fallbackRoot == null)
+            {
+                _fallbackRoot = new GameObject("FUSE Water Surfaces").transform;
+                UnityEngine.Object.DontDestroyOnLoad(_fallbackRoot.gameObject);
+            }
+            return _fallbackRoot;
+        }
+
+        private static GameObject RequireWaterSurface(string id)
+        {
+            var root = GetWaterSurface(id);
+            if (root == null)
+                throw new InvalidOperationException($"Water surface '{id}' was not found.");
+            return root;
+        }
+
+        private static void RequireId(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentException("ID is required.", nameof(id));
+        }
+    }
+
+    public sealed class FuseWaterSurfaceMarker : MonoBehaviour
+    {
+        public string Id;
+        public string SourceLakePath;
+        public string MaterialName;
+    }
+}

--- a/FUSE/Runtime/Cache/FuseCacheRegistry.cs
+++ b/FUSE/Runtime/Cache/FuseCacheRegistry.cs
@@ -41,6 +41,7 @@ namespace FUSE.Runtime.Cache
             Register(new FuseStationRuntimeIndex());
             Register(new FuseSceneryRuntimeIndex());
             Register(new FuseSplineyRuntimeIndex());
+            Register(new FuseWaterSurfaceRuntimeIndex());
             Register(new FuseMapLabelRuntimeIndex());
         }
 
@@ -70,6 +71,7 @@ namespace FUSE.Runtime.Cache
             FuseStationRuntimeIndex.Instance.Rebuild();
             FuseSceneryRuntimeIndex.Instance.Rebuild();
             FuseSplineyRuntimeIndex.Instance.Rebuild();
+            FuseWaterSurfaceRuntimeIndex.Instance.Rebuild();
             FuseMapLabelRuntimeIndex.Instance.Rebuild();
             // Full rebuilds mark session boundaries (map load, manual reload) where
             // SceneryAssetManager.Shared and its catalog may have been replaced
@@ -80,7 +82,7 @@ namespace FUSE.Runtime.Cache
             _fullRebuildCount++;
             FusePerformanceMetrics.RecordCount("cache full rebuilds", _fullRebuildCount);
             FuseLog.Info(
-                $"FUSE cache full rebuild #{_fullRebuildCount} (16 indexes) elapsedMs={stopwatch.ElapsedMilliseconds}.");
+                $"FUSE cache full rebuild #{_fullRebuildCount} (17 indexes) elapsedMs={stopwatch.ElapsedMilliseconds}.");
         }
 
         /// <summary>
@@ -128,6 +130,7 @@ namespace FUSE.Runtime.Cache
             FuseStationRuntimeIndex.Instance.Clear();
             FuseSceneryRuntimeIndex.Instance.Clear();
             FuseSplineyRuntimeIndex.Instance.Clear();
+            FuseWaterSurfaceRuntimeIndex.Instance.Clear();
             FuseMapLabelRuntimeIndex.Instance.Clear();
             _isReady = false;
         }

--- a/FUSE/Runtime/Cache/FuseRuntimeCaches.cs
+++ b/FUSE/Runtime/Cache/FuseRuntimeCaches.cs
@@ -243,6 +243,19 @@ namespace FUSE.Runtime.Cache
         }
     }
 
+    public sealed class FuseWaterSurfaceRuntimeIndex : FuseRuntimeIndex<FuseWaterSurfaceRuntimeIndex>
+    {
+        public override void Rebuild()
+        {
+            Clear();
+            foreach (var marker in Object.FindObjectsOfType<FUSE.Runtime.API.FuseWaterSurfaceMarker>(true)
+                         .Where(marker => marker != null && !string.IsNullOrWhiteSpace(marker.Id)))
+            {
+                Set(marker.Id, marker.gameObject);
+            }
+        }
+    }
+
     public sealed class FuseMapLabelRuntimeIndex : FuseRuntimeIndex<FuseMapLabelRuntimeIndex>
     {
         public override void Rebuild()

--- a/FUSE/Runtime/Events/FuseOutboundRoutingEvents.cs
+++ b/FUSE/Runtime/Events/FuseOutboundRoutingEvents.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using FUSE.Infrastructure;
+using Model.Ops;
+
+namespace FUSE.Runtime.Events
+{
+    public sealed class FuseOutboundRoutingCandidate
+    {
+        public FuseOutboundRoutingCandidate(
+            IndustryComponent component,
+            float weight,
+            float? proposedPayment = null,
+            int? proposedGraceDays = null)
+        {
+            Component = component ?? throw new ArgumentNullException(nameof(component));
+            Weight = weight;
+            ProposedPayment = proposedPayment;
+            ProposedGraceDays = proposedGraceDays;
+        }
+
+        public IndustryComponent Component { get; }
+        public float Weight { get; set; }
+        public float? ProposedPayment { get; set; }
+        public int? ProposedGraceDays { get; set; }
+    }
+
+    public sealed class FuseOutboundRoutingContext
+    {
+        internal FuseOutboundRoutingContext(
+            IOpsCar car,
+            OpsCarPosition origin,
+            bool loaded,
+            IList<FuseOutboundRoutingCandidate> candidates)
+        {
+            Car = car;
+            Origin = origin;
+            IsLoaded = loaded;
+            Candidates = candidates;
+        }
+
+        public IOpsCar Car { get; }
+        public OpsCarPosition Origin { get; }
+        public bool IsLoaded { get; }
+        public IList<FuseOutboundRoutingCandidate> Candidates { get; }
+    }
+
+    public static class FuseOutboundRoutingEvents
+    {
+        public static event Action<FuseOutboundRoutingContext> Preparing;
+
+        internal static void RaisePreparing(FuseOutboundRoutingContext context)
+        {
+            var handlers = Preparing;
+            if (handlers == null)
+            {
+                return;
+            }
+
+            foreach (Action<FuseOutboundRoutingContext> handler in handlers.GetInvocationList())
+            {
+                try
+                {
+                    handler(context);
+                }
+                catch (Exception ex)
+                {
+                    FuseLog.Warning(
+                        "FUSE contained an outbound-routing extension error; " +
+                        $"other extensions and base routing remain available: {ex.GetBaseException().Message}");
+                }
+            }
+        }
+    }
+}

--- a/FUSE/Runtime/Lifecycle/FuseFrameSpikeDiagnostic.cs
+++ b/FUSE/Runtime/Lifecycle/FuseFrameSpikeDiagnostic.cs
@@ -219,6 +219,12 @@ namespace FUSE.Runtime.Lifecycle
                             var decalRegistry = FuseDecalCullingScrubPatch.TryGetRegistryCount(out var registryCount)
                                 ? registryCount.ToString()
                                 : "n/a";
+                            var pumpContext = FuseMainThreadWorkTracker.TryGet(
+                                Time.frameCount - 1,
+                                out var pumpPhase,
+                                out var pumpMilliseconds)
+                                ? $"fusePumpWorstPhase='{pumpPhase}' fusePumpWorstMs={pumpMilliseconds:F1} "
+                                : "fusePumpWorstPhase='none measured' fusePumpWorstMs=0.0 ";
                             FuseLog.Warning(
                                 $"FUSE frame spike #{spikeCount}: {frameMs:F0}ms{(isNewWorst ? " (session worst)" : string.Empty)} " +
                                 $"(adaptive baseline {observation.BaselineMs:F1}ms, absolute floor {absoluteFloorMs:F0}ms, " +
@@ -231,6 +237,7 @@ namespace FUSE.Runtime.Lifecycle
                                 $"trackDestroyQueue={FuseTrackRebuilderQueueProcessor.DestroyQueueDepth} " +
                                 $"equipmentCullQueue={FuseCarCullerPendingProcessor.QueueDepth} " +
                                 $"equipmentCompletionQueue={FuseCarModelCompletionScheduler.QueueDepth} " +
+                                pumpContext +
                                 $"decalRegistry={decalRegistry}. " +
                                 "Correlate this timestamp with surrounding FUSE.log/Player.log activity; " +
                                 "a positive GC delta points at allocation pressure, a deep scenery queue " +

--- a/FUSE/Runtime/Lifecycle/FuseMainThreadWorkTracker.cs
+++ b/FUSE/Runtime/Lifecycle/FuseMainThreadWorkTracker.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics;
+
+namespace FUSE.Runtime.Lifecycle
+{
+    /// <summary>
+    /// Keeps a two-frame ring of the slowest measured FUSE runtime-pump phase.
+    /// Time.unscaledDeltaTime observed by the spike detector describes the
+    /// preceding frame, so retaining both frames makes the attribution stable
+    /// regardless of Unity component Update ordering.
+    /// </summary>
+    internal static class FuseMainThreadWorkTracker
+    {
+        private static int _currentFrame = -1;
+        private static string _currentPhase = string.Empty;
+        private static double _currentMilliseconds;
+        private static int _previousFrame = -1;
+        private static string _previousPhase = string.Empty;
+        private static double _previousMilliseconds;
+
+        internal static long Start() => Stopwatch.GetTimestamp();
+
+        internal static void Record(int frame, string phase, long started)
+        {
+            var elapsed = (Stopwatch.GetTimestamp() - started) * 1000d
+                / Stopwatch.Frequency;
+            RecordElapsed(frame, phase, elapsed);
+        }
+
+        internal static void RecordElapsed(
+            int frame,
+            string phase,
+            double elapsedMilliseconds)
+        {
+            if (_currentFrame != frame)
+            {
+                _previousFrame = _currentFrame;
+                _previousPhase = _currentPhase;
+                _previousMilliseconds = _currentMilliseconds;
+                _currentFrame = frame;
+                _currentPhase = string.Empty;
+                _currentMilliseconds = 0d;
+            }
+            if (elapsedMilliseconds <= _currentMilliseconds)
+                return;
+            _currentPhase = phase ?? string.Empty;
+            _currentMilliseconds = elapsedMilliseconds;
+        }
+
+        internal static bool TryGet(
+            int frame,
+            out string phase,
+            out double elapsedMilliseconds)
+        {
+            if (_currentFrame == frame)
+            {
+                phase = _currentPhase;
+                elapsedMilliseconds = _currentMilliseconds;
+                return !string.IsNullOrEmpty(phase);
+            }
+            if (_previousFrame == frame)
+            {
+                phase = _previousPhase;
+                elapsedMilliseconds = _previousMilliseconds;
+                return !string.IsNullOrEmpty(phase);
+            }
+            phase = string.Empty;
+            elapsedMilliseconds = 0d;
+            return false;
+        }
+
+        internal static void Reset()
+        {
+            _currentFrame = -1;
+            _currentPhase = string.Empty;
+            _currentMilliseconds = 0d;
+            _previousFrame = -1;
+            _previousPhase = string.Empty;
+            _previousMilliseconds = 0d;
+        }
+    }
+}

--- a/FUSE/Runtime/Lifecycle/FuseRuntimePump.cs
+++ b/FUSE/Runtime/Lifecycle/FuseRuntimePump.cs
@@ -16,7 +16,9 @@ namespace FUSE.Runtime.Lifecycle
     /// zero records, toasts, or quarantines, while the enqueue-side counters
     /// kept climbing). Queue-consuming work now lives here, on a host created
     /// unconditionally at plugin load, so a UI refactor can never silently
-    /// starve it again. Cost when idle: two lock-free queue-empty snapshots.
+    /// starve it again. Every driven subsystem has a constant-time idle guard;
+    /// the pump does not enumerate packages, scene objects, or asset stores while
+    /// no work is pending.
     /// </summary>
     internal static class FuseRuntimePump
     {
@@ -83,6 +85,11 @@ namespace FUSE.Runtime.Lifecycle
                 // discovery and Harmony mutation are coalesced and replayed here.
                 FUSE.Patches.FuseThirdPartyGuardInstaller.DrainPending();
 
+                // RailLoader plugins that implement IUpdateHandler expect their
+                // callback every Unity frame. Hosting only OnEnable made those
+                // plugins appear loaded while their runtime behavior stayed inert.
+                FUSE.Loading.FuseLegacyAssemblyHost.UpdateHostedPlugins();
+
                 // TimeSync Mod's ten-minute System.Threading.Timer callback
                 // arrives on a worker thread. Replay it here before it can
                 // touch StateManager and the Unity-backed in-game console.
@@ -113,6 +120,13 @@ namespace FUSE.Runtime.Lifecycle
                 // teleport. Finish only a bounded number of car bodies,
                 // trucks, unique materials, and load models per frame.
                 FUSE.Patches.FuseCarModelCompletionScheduler.Update();
+
+                // EquipmentWindow synchronously enumerates every mounted
+                // Definitions.json the first time it opens. Warm one cold
+                // store per frame so legacy container edit patches (notably
+                // Lego's large definition set) cannot produce a multi-second
+                // buy-menu stall.
+                FUSE.Patches.FuseEquipmentCatalogWarmup.Update();
             }
         }
     }

--- a/FUSE/Runtime/Lifecycle/FuseRuntimePump.cs
+++ b/FUSE/Runtime/Lifecycle/FuseRuntimePump.cs
@@ -54,6 +54,8 @@ namespace FUSE.Runtime.Lifecycle
 
         internal static void Shutdown()
         {
+            FuseMainThreadWorkTracker.Reset();
+
             if (_host == null)
             {
                 return;
@@ -83,50 +85,106 @@ namespace FUSE.Runtime.Lifecycle
             {
                 // AssemblyLoad can run on a loader thread. Third-party guard
                 // discovery and Harmony mutation are coalesced and replayed here.
+                var measure = FuseSettings.EnableFrameSpikeDiagnostics;
+                var frame = Time.frameCount;
+                var started = measure ? FuseMainThreadWorkTracker.Start() : 0L;
                 FUSE.Patches.FuseThirdPartyGuardInstaller.DrainPending();
+                if (measure)
+                    FuseMainThreadWorkTracker.Record(
+                        frame,
+                        "third-party guard installation",
+                        started);
 
                 // RailLoader plugins that implement IUpdateHandler expect their
                 // callback every Unity frame. Hosting only OnEnable made those
                 // plugins appear loaded while their runtime behavior stayed inert.
+                started = measure ? FuseMainThreadWorkTracker.Start() : 0L;
                 FUSE.Loading.FuseLegacyAssemblyHost.UpdateHostedPlugins();
+                if (measure)
+                    FuseMainThreadWorkTracker.Record(
+                        frame,
+                        "hosted legacy plugin updates",
+                        started);
 
                 // TimeSync Mod's ten-minute System.Threading.Timer callback
                 // arrives on a worker thread. Replay it here before it can
                 // touch StateManager and the Unity-backed in-game console.
+                started = measure ? FuseMainThreadWorkTracker.Start() : 0L;
                 FUSE.Patches.FuseTimeSyncMainThreadGuardPatches.DrainPending();
+                if (measure)
+                    FuseMainThreadWorkTracker.Record(
+                        frame,
+                        "time synchronization",
+                        started);
 
                 // Scenery load-failure records + broken-scenery quarantines:
                 // queued from task continuations / the log hook / the bundle
                 // audit (any thread), resolved and applied here.
+                started = measure ? FuseMainThreadWorkTracker.Start() : 0L;
                 FUSE.Patches.FuseSceneryLoadFailurePatch.DrainPending();
+                if (measure)
+                    FuseMainThreadWorkTracker.Record(
+                        frame,
+                        "scenery failure containment",
+                        started);
 
                 // Scenery models are destroyed at the end of the frame. Release
                 // their asset references on the following frame so a load/unload
                 // race cannot keep a bundle alive or unload it too early.
+                started = measure ? FuseMainThreadWorkTracker.Start() : 0L;
                 FUSE.Patches.FuseDeferredAssetReferenceReleaseQueue.Update();
+                if (measure)
+                    FuseMainThreadWorkTracker.Record(
+                        frame,
+                        "deferred asset release",
+                        started);
 
                 // Mod health exception observations: first-seen signatures
                 // queued by the threaded log hook (any thread), attributed and
                 // recorded (with throttled log lines) here.
+                started = measure ? FuseMainThreadWorkTracker.Start() : 0L;
                 FuseModExceptionLogHook.DrainPending();
+                if (measure)
+                    FuseMainThreadWorkTracker.Record(
+                        frame,
+                        "exception attribution",
+                        started);
 
                 // Completed FUSE asset requests whose reference count reached
                 // zero are removed individually by the store patch. Reclaim
                 // their now-unreachable Unity assets only after streaming has
                 // remained quiet long enough to avoid load/unload thrashing.
+                started = measure ? FuseMainThreadWorkTracker.Start() : 0L;
                 FuseUnusedAssetReclaimer.Update();
+                if (measure)
+                    FuseMainThreadWorkTracker.Record(
+                        frame,
+                        "unused asset reclaim",
+                        started);
 
                 // AssetBundle requests may all complete together after a
                 // teleport. Finish only a bounded number of car bodies,
                 // trucks, unique materials, and load models per frame.
+                started = measure ? FuseMainThreadWorkTracker.Start() : 0L;
                 FUSE.Patches.FuseCarModelCompletionScheduler.Update();
+                if (measure)
+                    FuseMainThreadWorkTracker.Record(
+                        frame,
+                        "equipment model completion",
+                        started);
 
                 // EquipmentWindow synchronously enumerates every mounted
                 // Definitions.json the first time it opens. Warm one cold
                 // store per frame so legacy container edit patches (notably
                 // Lego's large definition set) cannot produce a multi-second
                 // buy-menu stall.
+                started = measure ? FuseMainThreadWorkTracker.Start() : 0L;
                 FUSE.Patches.FuseEquipmentCatalogWarmup.Update();
+                if (measure)
+                    FuseMainThreadWorkTracker.Record(
+                        frame,
+                        "equipment catalogue warm-up",
+                        started);
             }
         }
     }

--- a/FUSE/Runtime/Lifecycle/FuseUnusedAssetReclaimer.cs
+++ b/FUSE/Runtime/Lifecycle/FuseUnusedAssetReclaimer.cs
@@ -75,6 +75,15 @@ namespace FUSE.Runtime.Lifecycle
                 return;
             }
 
+            // This method is driven every Unity frame. Texture.currentTextureMemory
+            // crosses into Unity's native runtime, but it cannot influence the
+            // decision when there are no evicted requests waiting to be reclaimed.
+            // Keep the overwhelmingly common idle path entirely managed and cheap.
+            if (pending <= 0)
+            {
+                return;
+            }
+
             var textureCurrentBytes = ToSignedBytes(Texture.currentTextureMemory);
             if (!HasEnoughPressureToSweep(pending, textureCurrentBytes) ||
                 Time.realtimeSinceStartup - _lastPendingChangeRealtime < QuietSeconds ||

--- a/FUSE/Runtime/Registry/FuseRegistry.cs
+++ b/FUSE/Runtime/Registry/FuseRegistry.cs
@@ -296,7 +296,62 @@ namespace FUSE.Runtime.Registry
             }
         }
 
+        /// <summary>
+        /// Records a conflict discovered while constructing a merged final
+        /// state, before either package can create a normal runtime claim. This
+        /// is used for delete-vs-definition collisions where the later delete
+        /// removes the earlier package from the plan entirely.
+        /// </summary>
+        internal static void RecordPlannedConflict(
+            FuseClaimKind kind,
+            string id,
+            string ownerPackageId,
+            string attemptedPackageId,
+            string resolution)
+        {
+            if (string.IsNullOrWhiteSpace(id) ||
+                string.IsNullOrWhiteSpace(ownerPackageId) ||
+                string.IsNullOrWhiteSpace(attemptedPackageId) ||
+                string.Equals(ownerPackageId, attemptedPackageId, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            lock (Sync)
+            {
+                if (ConflictHistory.Any(existing =>
+                    existing.Kind == kind &&
+                    string.Equals(existing.Id, id, StringComparison.OrdinalIgnoreCase) &&
+                    ((string.Equals(existing.OwnerPackageId, ownerPackageId, StringComparison.OrdinalIgnoreCase) &&
+                      string.Equals(existing.AttemptedPackageId, attemptedPackageId, StringComparison.OrdinalIgnoreCase)) ||
+                     (string.Equals(existing.OwnerPackageId, attemptedPackageId, StringComparison.OrdinalIgnoreCase) &&
+                      string.Equals(existing.AttemptedPackageId, ownerPackageId, StringComparison.OrdinalIgnoreCase)))))
+                {
+                    return;
+                }
+
+                RecordConflictLocked(
+                    kind,
+                    id,
+                    ownerPackageId,
+                    attemptedPackageId,
+                    string.IsNullOrWhiteSpace(resolution)
+                        ? "merged plan collision"
+                        : resolution);
+            }
+        }
+
         private static void RecordConflictLocked(FuseClaimKind kind, string id, string owner, string attempted)
+        {
+            RecordConflictLocked(kind, id, owner, attempted, "claim skipped; existing owner retained");
+        }
+
+        private static void RecordConflictLocked(
+            FuseClaimKind kind,
+            string id,
+            string owner,
+            string attempted,
+            string resolution)
         {
             ConflictHistory.Add(new FuseRegistryConflict
             {
@@ -305,7 +360,7 @@ namespace FUSE.Runtime.Registry
                 Id = id,
                 OwnerPackageId = owner,
                 AttemptedPackageId = attempted,
-                Resolution = "claim skipped; existing owner retained",
+                Resolution = resolution,
                 AtUtc = DateTime.UtcNow
             });
 
@@ -317,7 +372,7 @@ namespace FUSE.Runtime.Registry
             FuseLog.Warning(
                 $"FUSE registry conflict package='{attempted}' operation='claim runtime object' " +
                 $"target='{kind}' kind='{kind}' id='{id}' owner='{owner}' " +
-                "resolution='claim skipped; existing owner retained'.");
+                $"resolution='{resolution}'.");
         }
 
         private static string MakeKey(FuseClaimKind kind, string id)

--- a/FUSE/Runtime/Registry/FuseRegistryConflict.cs
+++ b/FUSE/Runtime/Registry/FuseRegistryConflict.cs
@@ -4,7 +4,8 @@ namespace FUSE.Runtime.Registry
 {
     /// <summary>
     /// A recorded attempt by a package to claim a resource that is already
-    /// owned exclusively by another package.
+    /// owned by another package. Some records are blocking exclusive claims;
+    /// others describe an allowed shared merge that authors still need to see.
     /// </summary>
     public sealed class FuseRegistryConflict
     {
@@ -15,6 +16,24 @@ namespace FUSE.Runtime.Registry
         public string AttemptedPackageId { get; internal set; }
         public string Resolution { get; internal set; }
         public DateTime AtUtc { get; internal set; }
+
+        /// <summary>
+        /// True when the record documents a successful cumulative merge rather
+        /// than one package losing ownership or having an operation skipped.
+        /// These records remain useful to authors, but are not load-health
+        /// failures and must not inflate the user-facing conflict count.
+        /// </summary>
+        public bool IsCooperativeMerge =>
+            Contains("shared industry destination overlap") ||
+            Contains("definitions merged into the same runtime location") ||
+            Contains("shared industry component removal overlap") ||
+            Contains("shared merge");
+
+        private bool Contains(string value)
+        {
+            return !string.IsNullOrWhiteSpace(Resolution) &&
+                   Resolution.IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
 
         public override string ToString()
         {

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ reports, scenery benchmarks, and Runtime Actions (`Reload Track/Data`,
 `Reload Terrain`, `Rebuild Caches`) for testing and recovery. Check `FUSE.log`
 after using a reload action.
 
+The Dependency Graph includes equipment and asset/code packages, not only FUSE
+map data. It reads local FUSE, UMM, RailLoader, and AssetLoader metadata plus the
+installer's offline Nexus cache, and shows missing/disabled/incompatible
+requirements with their version bounds. The in-game menu does not contact
+Nexus.
+
 Useful console commands:
 
 - `/fuse.report` - show the current human-readable load report

--- a/docs/AUTHORING_RECIPES.md
+++ b/docs/AUTHORING_RECIPES.md
@@ -1,0 +1,195 @@
+# FUSE Authoring Recipes
+
+This page answers the common “how do I do this?” questions. The
+[JSON schema reference](../schemas/FUSE_JSON_SCHEMA.md) remains the field-by-field
+contract.
+
+## Start A Package
+
+The easiest route is Tile Editor → **New Mod**. For hand-authored native data,
+create one package folder containing `Info.json` and one or more
+`*.fuse.json` files. Point `FuseDataFiles` at every fragment:
+
+```json
+{
+  "Id": "Author.Route",
+  "DisplayName": "Author Route",
+  "Author": "Author",
+  "Version": "1.0.0",
+  "ManagerVersion": "0.27.10",
+  "Requirements": ["FUSE"],
+  "LoadAfter": ["FUSE"],
+  "FuseDataFiles": ["track.fuse.json", "industry.fuse.json"]
+}
+```
+
+Use `FuseRequires` for a hard data-package dependency. Use `FuseLoadAfter` or
+`FuseLoadBefore` only for ordering. A missing hard dependency faults/skips the
+affected package and appears in `/fuse.report`; it must not break unrelated
+packages or game menus.
+
+## Move Or Replace Track
+
+1. Open the package in Tile Editor and connect to the game.
+2. Press `F9`, open **Geo**, then select the node or segment in the world.
+3. Use the node/segment transform controls. The relationship list shows every
+   segment using a selected node and both endpoints of a selected segment.
+4. Save and force a track reload if the live preview ever differs from the
+   selected JSON. The editor now rebuilds affected track objects after topology
+   changes so stale copies do not accumulate.
+5. Reopen the package and verify the same IDs and geometry before release.
+
+Do not create a second segment with the same ID to replace the first one. FUSE
+uses atomic replacement for existing span/segment IDs so industries keep their
+references, but duplicate definitions inside one package are still authoring
+errors.
+
+## Remove A Base-Game Industry
+
+Use the exact runtime industry ID, not its company-window display name:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "id": "Author.Route.industry-removals",
+  "name": "Industry removals",
+  "modVersion": "1.0.0",
+  "operations": {
+    "removals": {
+      "industries": ["exact-runtime-industry-id"]
+    }
+  }
+}
+```
+
+Run `/fuse.dumpgraph` and `/fuse.dumpruntimegraph` to find and compare IDs. The
+Tile Editor Operations page can discover/select industries, but manual JSON is
+still the safest way to remove a stock industry when the editor cannot identify
+an unambiguous owning layer.
+
+## Add Freight Loading Or Unloading
+
+A rail industry component changes freight on cars spotted over a TrackSpan. It
+does **not** place a visible coal chute, water column, or fuel stand.
+
+1. Create/select a town and industry in Tile Editor → `F9` → **Operations**.
+2. Create a whole, partial, or multi-segment TrackSpan from selected track.
+3. Add a `loader`, `unloader`, `formulaic`, `teamTrack`, `interchange`, or other
+   component to the industry.
+4. Select the span and load ID, then configure capacity/rates.
+5. Verify `/fuse.operations` and the company window in a new sandbox save.
+
+## Place A Visible Service Loader
+
+Choose the implementation that matches the asset:
+
+- An existing vanilla-style loader prefab that already contains Railroader's
+  loader components can use native `operations.loaders`.
+- A custom coal/water/diesel/bunker-C/wood facility should be placed through
+  `world.scenery`, then bound with `ToolshedServiceFacilities.json`. Toolshed owns
+  its outlet, animation, transfer, storage, and interaction behavior.
+
+Do not split one custom facility between a scenery clone and an unrelated
+operations loader. That creates the “tank in one place, loading point in another”
+failure. The visible object and its service points must share the same placed
+root/transform contract.
+
+## Move A Base-Game Object Or Town Sign
+
+Open `F9` → **Objects**, disable Track Geometry if it blocks selection, then click
+the object. Save its move/rotate/scale/visibility override as a scene clone or
+mandela entry. Thin signs have a screen-space picking halo, and shared town/map
+roots are blocked so one click cannot move an entire scene hierarchy.
+
+## Edit Roads And Other Mandelas
+
+Use **Spliney** for roads, rivers, bridges, and trestles. Base-game spline control
+points are editable; the first change writes a same-name override into the active
+layer. A legacy scene path such as `World/Roads Sylva/Chipper Curve` remains a
+scene path—it is not an asset identifier.
+
+Use **Objects/Mandela** for individual scene objects and **Scenery** for asset-pack
+models. They have different ownership and runtime rebuild paths.
+
+## Build A Fence, Retaining Wall, Or Other Repeated Object Line
+
+Use a native `world.splineys` entry with `type: "objectLine"`. This samples a
+path at uniform spacing and places rigid modules; it does not stretch a fence
+panel or retaining-wall block into a distorted mesh.
+
+```json
+{
+  "world": {
+    "splineys": {
+      "yard:fence:north": {
+        "type": "objectLine",
+        "assetIdentifier": "your-pack:fence-panel",
+        "spacing": 3.0,
+        "instanceScale": { "x": 1, "y": 1, "z": 1 },
+        "rotationOffset": { "x": 0, "y": 90, "z": 0 },
+        "lateralOffset": 0,
+        "verticalOffset": 0,
+        "snapToTerrain": true,
+        "alignToSlope": false,
+        "placeAtEnd": true,
+        "maximumInstances": 1024,
+        "points": [
+          { "position": { "x": 10, "y": 2, "z": 15 } },
+          { "position": { "x": 55, "y": 3, "z": 22 } }
+        ]
+      }
+    }
+  }
+}
+```
+
+Choose exactly one source: `assetIdentifier` is portable and recommended;
+`prefab` accepts a safe FUSE prefab/scene-path URI for advanced stock-object
+cloning. The Tile Editor exposes this as **Geo → Spliney → Fence / Wall** and
+rebuilds the repeated modules while its point handles remain editable. This is
+native FUSE only; the legacy RailLoader spline schema has no equivalent.
+
+## Conditional Legacy Mixins
+
+Converted conditional fragments use `mixinto.requires`:
+
+```json
+{
+  "mixinto": {
+    "target": "game-graph",
+    "sourceFile": "OptionalYard.json",
+    "requires": [
+      { "id": "Author.BaseYard", "notBefore": "1.2.0" }
+    ]
+  }
+}
+```
+
+When the dependency is missing or outside the allowed range, FUSE skips this
+fragment and reports the package, folder, source file, dependency ID, and action.
+`loadAfter` is ordering and must not be flattened into a hard requirement.
+
+## Package Options And Modular Mods
+
+Top-level `settings` creates controls in FUSE's per-mod settings page. Native
+code can read them through `FuseModSettingsAPI`. The current v1 data schema does
+not yet make arbitrary JSON sections conditional on a setting, so do not imply
+that a slider automatically enables track/spans. Until a declarative condition
+format is released, use separate optional data packages/fragments with explicit
+dependencies, or a small independently authored code component that reads the
+setting and applies supported API operations.
+
+## Diagnose Bad JSON
+
+Run `/fuse.report` for a readable report or `/fuse.report json` for structured
+output. A definition failure includes:
+
+- package ID
+- absolute package folder and source file
+- JSON path
+- line and column when Newtonsoft can provide them
+- validation code/message
+- suggested action
+
+FUSE isolates the bad definition and continues loading unrelated packages. Fix
+the first syntax error first; later errors can be consequences of that one.

--- a/docs/BASE_GAME_MAP_AUTHORING_AUDIT.md
+++ b/docs/BASE_GAME_MAP_AUTHORING_AUDIT.md
@@ -1,0 +1,83 @@
+# Railroader base-game map-authoring audit
+
+This audit compares the observable Railroader map contract in the decompiled
+2026.1 source with FUSE native schema, FUSE runtime behavior, and both Tile
+Editor surfaces. Decompiled code is used only to identify public data shapes,
+identifiers, initialization order, and observable behavior; no implementation
+code is copied.
+
+The installed game on the audit machine still exposes the earlier Unity
+`TrackSegment.Style` contract. The 2026.1 source changes track objects and uses
+combinable structure flags. Compatibility therefore has two distinct gates:
+
+1. Native documents must retain every known field now.
+2. A FUSE/editor binary compiled for a released game generation must pass its
+   own live acceptance run. A source audit is not evidence that an unreleased
+   binary contract already works in game.
+
+## Coverage matrix
+
+| Base-game concern | Observable contract | FUSE/editor coverage | Remaining acceptance |
+|---|---|---|---|
+| Map identity and launch | `MapDefinition` supplies map data, terrain tile sets, layers, and attribution; a session selects one registered map | Native `map` declaration, registered-map browser, launch command, map identity/start-state authoring, standalone-map golden fixture | Launch the generated fixture, save, reload, and reopen it in both editors |
+| Layering | Base data plus JSON merge-patch layers; tombstones remove inherited values | FUSE owns its canonical native document and explicit removals; legacy mixintos convert at the boundary; native modular feature rules conditionally apply authored objects | Mixed native/legacy live reload and one full generated-map round trip |
+| Folders | Map folders group objects/spawns and folder enabled state gates them | FUSE feature groups provide stronger package-owned conditional gating; editor retains unknown official-map fields when editing | Add an official-map import crosswalk so folder names/enabled state are visible instead of opaque retained data |
+| Map objects | Registered DTO kinds include scenery, circle/rectangle/curve masks, and built-ins | Native scenery, masks, labels, scene clones, telegraph, water, splineys, and object lines; selectable base objects and town signs | Dense-scene object picking and stock-object move/remove live pass |
+| Built-in car loader | Built-in id + track anchor + parameters, including infinite or industry supply | Native operations loaders plus Toolshed custom service bindings, track/span snap, offsets, source industry and load points | Live loading/unloading, storage, payment, and custom-model pass |
+| Built-in spline loft | Ordered control points, point width/rotation, width/Y offsets, end extension, cap falloff, and generated mesh; used by road/river content | Deformable road/river splineys plus rigid repeated-object lines for fences, walls, guardrails, and pipes | Profile/material family inventory, cap/falloff UI acceptance, and in-game save/reload |
+| Terrain tiles | Height, splat, vegetation, statistics, streaming and map tile-set ownership | Tile import/download workflow, sculpt/paint, categorical vegetation masks, atomic save/backup, statistics rebuild, cache invalidation, terrain registration | Seam/falloff/undo fidelity and live paint-save-reload across adjacent tiles |
+| Water | Lake polygons/flat water surfaces reuse game material/profile data; rivers can also be spline-driven | Native water surfaces with CRUD, stock replacement, point editing, schema, validation, diagnostics; river spline authoring | Reflection/collider/material behavior and save/reload in game |
+| Track nodes | Position, rotation, switch-stand flip, and diamond-crossing state | Native position/rotation/flip plus additive `isDiamond`; converter and editor preserve the field | Diamond routing/rendering in the game build that exposes it |
+| Track segments | Endpoints, group, priority, speed, class, style or newer bridge/steel/tunnel/yard flags | Existing `style` stays canonical for released builds; additive steel-support and independent-yard metadata preserve the newer contract; gauge metadata, groups, grade labels, validation | Compile/run against the released flags-era assembly; live bridges, tunnels, yards, and DKW/crossing geometry |
+| Turntables | Transform, radius, subdivisions, node ids, default stop and bridge group | Native turntable authoring and editor workflow | Custom model/track alignment, roundhouse, save/reload live pass |
+| Track spans and areas | Locations anchor by segment/end/distance; areas group spans and UI/operations identity | Native spans/areas, normalization, node/segment relationships, orphan validation, legacy repair/rebinding | Sylva/Kater base-span cases and delivery/highlight/payment agreement |
+| Industry operations | Areas, industries, loads, contracts, components, storage, loaders/unloaders, teams, interchange, passenger/timetable services | Native models, editors, schema, pre-publish cross-file validation, package-local fault reporting | Every component kind, EOD processing, contract changes and company-window live pass |
+| Passenger service | Stops, span membership, agents/timetables and neighboring-stop caches | Native passenger/station models, invalid-span sanitation, editor workflows and validation | Neighbor reconciliation, timetable/UI, save/reload and modded-map live pass |
+| Interchanges | Industry/service components, track/span routing and exchange behavior | Native interchange editor/runtime models and compatibility shims | Multi-interchange ordering, inbound/outbound/EOD and legacy interchange corpus |
+| Signals and CTC | Signals, heads/aspects, blocks, routes, switch locks, interlockings and CTC panel components | Portable signal/CTC schema and runtime, editor placement/routes/blocks/dispatcher panel, cross-file validation | Native FUSE ownership, broader signal/custom-asset families, and a complete live territory |
+| Progression | Map features, milestones, gating, industry/track availability and starting state | Native progression, transfer diagnostics, feature options and start-equipment scoping | Fresh career/sandbox reload behavior and complete generated-map progression pass |
+| Starting equipment | Session setup places starting cuts and tutorial owns early UI flow | Package/map-scoped equipment pool; tutorial wait; cancellation retains queued cuts; successful placement requires full car count | Unrelated-new-save test and tutorial/Escape/cancel/resume/place live pass |
+| Spawns/portals | Spawn DTOs and map bootstrap locations; interchange/portal concepts participate in session creation | Native spawn/start-point and interchange authoring in the complete-map fixture | Multiple spawn choices and portal/interchange launch behavior in game |
+| Save identity | Stable object ids, graph ids, KVO/save identities and post-load binding are required | Stable native ids, duplicate/collision validation, atomic writes, backups, undo/redo, runtime definition cache | Generated map save, reload, edit, re-export and second reload |
+| Runtime caches | Terrain, graph, scenery, operations and UI caches have subsystem-specific invalidation/rebuild order | Targeted track rebuild, terrain invalidation, scenery/asset indexes, operations refresh, live diagnostics and test bridge | Every-tab live acceptance using the newest deployed DLL |
+| Multiplayer authority | Several operations/signals/session changes are authority-sensitive | Signal/CTC portable model includes multiplayer state; most authoring runs on local editor/session | Host/client ownership and synchronization pass |
+
+## Canonical FUSE track additions from this audit
+
+The following properties are additive and do not change existing native
+documents:
+
+- `tracks.nodes.<id>.isDiamond`
+- `tracks.segments.<id>.bridgeSupportsSteel`
+- `tracks.segments.<id>.yard`
+- the corresponding `preserveBridgeSupportsSteel` and `preserveYard` controls
+  for partial legacy overlays
+
+Legacy numeric flags are decoded at conversion time. Existing `style` values
+remain valid and continue to drive the installed released game. Editors update
+copies of node/segment objects so unknown companion and future fields survive
+ordinary position/property edits.
+
+## What a from-scratch map must prove
+
+A map-authoring release is accepted only when one fixture completes this whole
+sequence without hand-editing:
+
+1. Create map identity, attribution and coordinate/tile set.
+2. Acquire/import adjacent terrain tiles and preserve source/licensing data.
+3. Sculpt terrain, paint texture/vegetation, add/edit water, then save/reload.
+4. Lay main, branch, yard, bridge/tunnel, turnout, crossing, span, group,
+   turntable and interchange track; inspect grades and node relationships.
+5. Add roads/rivers plus rigid fence/wall/guardrail/pipe object lines.
+6. Add scenery, masks, labels, town signs, loaders and custom Toolshed models.
+7. Configure areas, loads, industries, contracts, storage, delivery/payment,
+   passenger service, interchange service and progression.
+8. Build a working signal territory and CTC panel with routes/interlockings.
+9. Configure spawn/start state and package-scoped starting equipment.
+10. Validate, export, install, launch, operate, save, reload, reopen in the
+    editor, change content, re-export and reload again.
+11. Repeat from the published wiki using a clean installation.
+
+Automated fixtures currently prove document creation, validation, export and
+reopen. The live stages remain deliberately separate so a green unit test can
+never be mistaken for rendered/operational proof.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+- Installer 0.8.0 and **Tools > Dependency Graph** now cover locomotive,
+  railcar, code-plugin, asset-pack, native FUSE, UMM, and RailLoader dependency
+  sources. UMM version suffixes are parsed correctly; verified Nexus
+  file-version requirements can fill otherwise empty manifests at install time
+  and are cached offline without storing the API key. Local explicit metadata
+  remains authoritative, stale cache entries are ignored, and Nexus OR-choice
+  groups are never misreported as multiple hard requirements.
+
 - Installer 0.7.0 repairs UMM startup order for installed code mods that
   reference FUSE-replaced RailLoader/Strange Customs assemblies. It inspects
   DLL metadata without loading code, backs up each manifest, and adds FUSE to

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+- Installer 0.7.0 repairs UMM startup order for installed code mods that
+  reference FUSE-replaced RailLoader/Strange Customs assemblies. It inspects
+  DLL metadata without loading code, backs up each manifest, and adds FUSE to
+  `Requirements`/`LoadAfter`, fixing Alina Utilities failing before FUSE's
+  assembly resolver could run.
+
+- Completed the author-help catalog for native feature rules, rigid object-line
+  splineys, and water surfaces. Every validation code emitted by either
+  validator now has a title, cause, concrete fix, and example, enforced by the
+  Core coverage gate; two obsolete mixinto help keys were removed.
+
+- Added native ForYourConvenience parity without shipping the old code:
+  dependency-scoped station-map actions, off-by-default caboose icons and
+  speed/load car-tag additions, persisted Legacy Gameplay toggles, and a
+  read-only **Tools > Industry Dashboard** built from the current operations
+  controller.
+
+- Added native, dependency-scoped replacements for AbsoluteMadness and
+  SomeKindOfMadness. Outbound industry routing remains disabled for normal
+  profiles, activates when an enabled package requests either retired id (or
+  through an explicit Legacy Gameplay setting), exposes a contained native
+  candidate event, and includes bounded capacity/payment/short-trip/origin and
+  order-shuffle controls.
+- Added a native Interchange2Interchange replacement with dependency-scoped
+  activation, contracted interchange visibility, daily cross-interchange cargo
+  orders, bounded cut sizes, and a persisted maximum-cars control.
+
+- Added native FallFromGrace parity: FUSE now owns the configurable grace-day transform, exposes its settings under **Settings > Legacy Gameplay**, and adds the due-time row to paid waybills without requiring the old DLL. Default settings leave the base-game calculation unchanged.
+- Added native C1CD parity: configurable interchange intervals, daily or overnight service windows, and continuous extra-service scheduling now live under **Settings > Legacy Gameplay**. Invalid intervals are bounded instead of allowing the legacy scheduling loop to hang.
+
+- Added the legacy `/cs-livery-refresh` command and a FUSE-owned
+  `/fuse.liveries` diagnostic report. Refresh now clears only FUSE's cached
+  livery textures and reapplies each live car's saved `cs.livery` selection.
+- Replaced the Strange Customs `FileCache` ABI stub with a FUSE-owned loose-file
+  cache for PNG/JPEG textures and WAV/OGG/MP3/AIFF clips. It coalesces audio
+  callbacks, invalidates changed files, contains callback failures, and cleans
+  up cached Unity objects when FUSE unloads.
+- Replaced the Strange Customs `FlowyThingBuilder` ABI stub with a native
+  adapter that converts legacy road/river data at the compatibility boundary
+  and creates or updates the live spline through `SplineyAPI`.
+- Wired RailLoader's `WillCopyDebugInformation` compatibility event into copied
+  FUSE health reports. Contributions are bounded and normalized, and listener
+  exceptions are isolated at the messenger-listener boundary.
+- Completed the ADRFDR data contract: `ADRFDR.Pay4Resource` now resolves to
+  FUSE's native pay-for-resource component and location pickers display its
+  custom "Acquire …" title through the compatibility interface.
+
+## Unreleased audit accuracy follow-up (2026-08-20)
+
+- Prevents the runtime definition cache from returning the stored `FuseSpan`
+  object by reference. Span endpoints are now deep-cloned, so diagnostics and
+  other read paths cannot mutate or erase the authored definition.
+- Preserves cached authored span endpoints when Railroader temporarily cannot
+  resolve a `TrackSpan` location. The audit now distinguishes that transient
+  runtime state from a genuinely missing endpoint and still reports referenced
+  segments that were actually removed.
+- Stops reporting an empty `Industry` container as a defect by itself. The game
+  legitimately uses componentless industries for base locations, passenger or
+  scenery-only places, fictional destinations, and disabled content.
+- Omits successful `shared-extension` registry merges from audit findings; they
+  remain available as informational records on the dedicated Mod Conflicts
+  page.
+
 All notable changes to FUSE are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and FUSE uses
 [semantic versioning](https://semver.org/) with the mod and the external editor
@@ -9,13 +72,97 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
 
 ### Added
 
+- Native `world.splineys` now supports `objectLine` definitions for fences,
+  retaining walls, guardrails, pipes, and other rigid repeating modules. FUSE
+  places a loaded scenery asset or safe prefab along a uniformly sampled path
+  with scale, rotation, lateral/vertical offset, terrain snap, slope alignment,
+  endpoint, and instance-cap controls. Live updates preserve editor helper
+  children, and failed creation cleans up its partial runtime root.
+
+- Installer 0.6 now preflights the complete selected batch before writing:
+  unsafe/case-colliding ZIP members, ambiguous nested manifests, duplicate
+  package ids and `.FUSE` aliases, UMM/FUSE/RailLoader requirements, version
+  bounds, forward references, and dependency-failure propagation. Explicit
+  FUSE replacement contracts satisfy only the legacy ids FUSE actually owns;
+  reports preserve every dependency and corrective failure message.
+
+- Package faults now carry package id/name, source root, relative and absolute
+  file names, JSON property/line/position, validation code, expected shape,
+  received value, and a concrete action. Native, manifest, and legacy-converter
+  failures share the format; health JSON and selected-mod **Copy Mod Info**
+  preserve the complete author-facing diagnostic without crowding Status.
+
+- Native package `featureRules` connect existing FUSE settings to exact authored
+  track, operations, world, progression, and audio objects. Boolean, choice,
+  and numeric comparisons are evaluated on map load without mutating source
+  definitions; validation, Mods-page state, schema examples, and Tile Editor
+  authoring make the reload-required behavior explicit.
+
+- Native `world.waterSurfaces` authoring and runtime support creates, updates,
+  removes, inspects, caches, and reports polygonal lake planes without depending
+  on Alina's map runtime. Authors can reuse a stock lake by scene path, select a
+  loaded material, or use FUSE's guarded fallback; schema and validation reject
+  underspecified or unsafe tessellation data before map apply.
+
+- The Mods page now groups packages by actual runtime state and distinguishes
+  disabled, skipped, missing-dependency, incompatible, invalid-data, partially
+  applied, loaded-awaiting-map, and successfully applied packages. Optional
+  conditional mixintos remain green with a note instead of being presented as
+  whole-mod failures; copied mod info includes the same state and reason.
+- Legacy top-level `ConflictsWith` checks now see enabled code-only and
+  asset-only packages in the Mods folder, as well as retired package ids
+  provided by FUSE compatibility. Disabled and active-profile-excluded mods no
+  longer satisfy conditional or top-level compatibility checks.
+- Successful shared industry destination/component merges are now displayed in
+  **Mod Conflicts** under an informational **Shared Extension Targets** section.
+  They no longer count as ownership conflicts or load-health failures; actual
+  skipped/replaced ownership and spatial warnings remain separate and visible.
+- Human and JSON load reports now distinguish package folders from resident and
+  applied definitions. Missing optional mixinto companions are listed as
+  inactive conditional fragments, while only actionable skips contribute to
+  unhealthy status; legacy JSON count aliases remain for report consumers.
+
+- **Tools > Mod Conflicts** groups runtime ownership records by package pair and
+  shows exactly which nodes, segments, spans, industries, scenery, or other
+  targets the two packages share, plus the resolution FUSE used. A full report
+  can be copied for authors. Conservative spatial track-layout warnings appear
+  on this page separately from proven ownership conflicts; they retain both
+  packages and do not inflate the main Status conflict count.
+
+- Reduced always-on runtime overhead for large legacy mod sets: hosted RailLoader
+  update callbacks are now discovered once when the plug-in is hosted instead of
+  rebuilding a dictionary snapshot and repeating interface reflection every Unity
+  frame. The unused-asset reclaimer also avoids querying Unity texture-memory
+  counters while no evictions are pending.
+
+- Asset overlap diagnostics now collapse hundreds of keys shared by the same
+  winner/overridden source set into one source group. The panel and clipboard
+  summary state whether definitions are identical or behaviorally different and
+  explain the impact, while the exported JSON retains every individual key.
+
+- FUSE now completes AssetLoader 1.0.1's data-loading contract without running
+  its DLL. Direct discovery includes package-root, child, catalog-only, and
+  normal bundled stores. Definitions-only immediate child folders used by
+  tender/rolling-stock swaps are routed to their exact existing store, while
+  native packages can declare nested overrides with `FuseDefinitionOverrides`.
+  Malformed overrides fall back to the original store definitions and appear in
+  the Assets report instead of breaking equipment/customization menus. The
+  installer backs up old AssetLoader folders/ZIPs, verifies the runtime DLL is
+  absent, and creates a data-only `AssetLoader` UMM alias requiring FUSE so old
+  manifest dependencies remain valid.
+
 - `FUSE-Installer.exe` now bundles the FUSE framework and installs it on a
   manual (double-click) run, so players can get FUSE running without unzipping
   anything. Dragging mod `.zip` files onto the exe still installs exactly those
   mods and leaves FUSE untouched. A no-argument run also still processes any
   loose zips beside the exe; pass `--no-fuse` to skip installing FUSE. The
-  release build bundles the core mod zip it just built and self-checks, via a
-  dry run, that a manual run will install FUSE.
+  release build bundles the core mod zip it just built and performs a real
+  install into a throwaway Railroader tree to prove a manual run writes
+  `Mods/FUSE/Info.json`. The build gate waits for PyInstaller's extracted GUI
+  child process, avoiding a false failure while the files are still being
+  written. A drag-and-drop GUI launch leaves the bundled framework unchecked so
+  its scope matches the documented "install the dropped archives" behavior;
+  `--with-fuse` opts it back in.
 - A pytest suite for the installer and its legacy JSON reader
   (`tools/tests/`), run in CI by a new Python Tests workflow.
 - FUSE checks GitHub on startup for a newer stable release and, if the running
@@ -42,6 +189,158 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
 
 ### Fixed
 
+- Both converter entry points now reject code-only, asset-only, map-tile, and
+  already-native packages with specific installer guidance instead of reporting
+  a successful zero-fragment conversion. Mixed packages can still convert their
+  recognized top-level RailLoader JSON while keeping DLL behavior explicitly
+  unsupported. Failed reports are stored under `_conversion-reports` rather
+  than creating a report-only `.FUSE` package. Batch detection includes
+  manifest/code packages and no longer mistakes nested schema examples inside a
+  compiled mod for route content.
+
+- World labels no longer render over the pause menu or normal game windows.
+  The debug overlay pauses its IMGUI rendering while the game is paused or any
+  managed game window is shown, then resumes without rebuilding user settings.
+
+- Legacy package ordering now resolves object- or string-form `requires` and
+  `loadAfter` identifiers through the same `.FUSE` alias rules before building
+  the topological order. Conditional mixinto requirements both control whether
+  each fragment applies and add an optional package-order edge when their
+  dependency is present; a missing optional layer does not fault the package.
+  When a resolved later package explicitly requires or
+  loads after a base package, its intentional overrides are no longer presented
+  as mods fighting; unrelated packages remain conflict records. The Dependency
+  Graph labels retired runtime dependencies such as Strange Customs, Alina's
+  Map Mod, AssetLoader, and RailLoader services as `PROVIDED BY FUSE`, while
+  content packs such as Alina's SW expansion remain real dependencies.
+  Hosted legacy code plugins now also initialize in resolved
+  `requires`/`loadAfter`/`loadBefore` order rather than alphabetical Mods-folder
+  order. Cycles retain every plugin in deterministic order and emit one
+  actionable warning.
+
+- Legacy `conflictsWith` declarations are no longer discarded. Complete-package
+  conflicts retain inclusive version bounds in `FuseConflictsWith` and prevent
+  only the declaring package from loading; conditional mixinto conflicts skip
+  only that fragment. Tools > Mod Conflicts shows these separately as
+  author-declared incompatibilities instead of mixing them into detected runtime
+  ownership collisions. Hosted legacy mod definitions also expose their real
+  requires/load-order/conflict metadata to old plug-ins.
+
+- The merged graph planner now records definition-versus-definition ownership
+  collisions for nodes, segments, spans, and turntables, not only removals that
+  displaced earlier definitions. This makes competing route layouts visible
+  even when the last package wins a shared identifier. Independent layouts
+  using different IDs are covered by a non-blocking nearby-node advisory.
+
+- Passenger stops no longer throw during activation when another route package
+  removed a segment referenced by one of their child spans. FUSE sanitizes the
+  invalid span endpoints so Railroader's nullable checks skip that track. The
+  Strange Customs span facade likewise omits invalid endpoints, preventing
+  Signals Everywhere serialization from failing after graph collisions.
+
+- Duplicate automatic-waybill destinations are collapsed by their semantic
+  component type, area, display name, and track spans before the base-game
+  picker is built. Multiple live component instances can no longer produce the
+  same Whittier destination several times in the car Operations menu.
+
+- Legacy JSON control-character repair is still reported with the exact source
+  file, but the same warning is emitted only once per file and session instead
+  of repeating on each conversion pass.
+
+- A stale, partially bound Alina Utilities assembly can no longer make the
+  legacy host record a package error before UMM recovery activates the working
+  entry. Unloadable compiler-generated types are skipped locally, and the
+  recovered UMM plug-in remains the sole active instance.
+
+- If an older dual-entry Alina Utilities install still leaves a legacy
+  singleton alive without its RailLoader context, FUSE now connects that
+  instance to Alina Utilities' UMM settings object. This prevents its tile
+  distance, damage, and main-menu hooks from throwing while leaving the
+  separately installed utility mod in control of its original features.
+
+- Legacy Alina map packages no longer materialize the editor-only
+  `TurntableMeasurementTool` scenery helper in gameplay. This removes the
+  bright yellow measurement overlay that covered Stryker's Bryson turntable;
+  native FUSE scenery identifiers are unchanged.
+
+- Synthetic legacy map-tile definitions are no longer sent through the
+  game-graph patch expander, removing the misleading “source JSON could not be
+  resolved” warning emitted once per Alina map expansion.
+
+- Corrected the public schema's track gauge contract: `gauge` belongs to track
+  segments (matching the runtime model, converter, editor, and documentation),
+  not nodes. The schema now accepts the native editor's explicit
+  `DualGauge_L`, `DualGauge_R`, and `DualGauge_T` transition values and includes
+  the documented reserved `fuse://` URI scheme.
+
+- Legacy area objects used only as namespaces around `industries` no longer
+  become track-area updates with an invented `(0,0,0)` position or identifier
+  display name. ARC Whittier/KWIX-style packages can patch the base Whittier
+  industries without moving the live area/operations hierarchy away from its
+  tracks. Explicit authored area position, radius, color, order, spans, and
+  group metadata still convert normally. (#210, #239)
+
+- Confusing Supplements' `IndustryComponents.Empty` now has a complete
+  FUSE-owned behavior: it remains a visible span-bound track marker, accepts
+  every automatic destination class, and performs no service or ordering work.
+  Output-track warnings such as "KEEP CLEAR" no longer degrade into a stock
+  loader with a null load that repeatedly throws during `Industry.Tick`.
+
+- Alina's bright-yellow `TurntableMeasurementTool` is treated as an editor-only
+  authoring helper and is not instantiated in a playable map. Stryker's Bryson
+  keeps its actual cloned turntable while the yellow measurement plate is
+  omitted. The separate `ALWHouses_CabooseHouse` message in that report is an
+  ALW asset-pack catalog entry whose prefab is absent from the bundle; FUSE
+  quarantines that asset without blaming or hiding the turntable. (#235)
+
+- The Diagnostics Report no longer labels Railroader's endpoint-less base-game
+  placeholder/progression spans as invalid mod track. Span validation now applies
+  only to spans owned by a FUSE-hosted package. An actual package-owned malformed
+  span still names its owner, while a span removed by a competing route overhaul
+  is presented as a package collision with compatibility guidance instead of a
+  false base-track failure.
+
+- Legacy Strange Customs scenery is no longer discarded merely because its
+  identifier was absent from FUSE's mounted asset-pack index. Legacy-hosted
+  packages receive RailLoader-compatible guarded runtime resolution, with the
+  first attempted placement logged per identifier and real failures quarantined.
+  Native FUSE packages remain strictly validated so bad JSON cannot destabilize
+  unrelated content or game menus.
+
+- The Assets Report now distinguishes identical duplicate definitions from
+  conflicting definitions and shows package-relative source paths. Two installed
+  copies such as `RTM Objects pack` and `RTM_Objects_pack` can therefore be told
+  apart instead of appearing as a nonsensical self-override.
+
+- Live Diagnostics auto-refresh now preserves the right-hand detail/log scroll
+  position, including the bottom position, instead of snapping the page back to
+  the top once per second. The menu now identifies the detail pane when a page
+  also contains a separate navigation `ScrollRect`.
+
+- Opening the Equipment Purchase window no longer performs every cold asset-pack
+  `Definitions.json` load in one frame. FUSE warms one prefab store per frame and
+  caches the filtered car catalog for the active `PrefabStore`, avoiding the
+  multi-second buy-menu lock seen with large Lego/custom-equipment installations.
+
+- Runtime ownership collisions are now recorded when a later package removes a
+  node, segment, or span defined by an earlier package. These removal-versus-
+  definition collisions previously disappeared while FUSE built the merged plan,
+  leaving `/fuse.conflicts` at zero even when route overhauls were deleting one
+  another's graph. Package faults now also retain the source folder and definition
+  file in the report.
+
+- Asset-pack component kinds registered after a store was first inspected now
+  invalidate only the affected cold store and reload its untouched definitions
+  without re-running old-loader mutation postfixes. Toolshed storage/load-point
+  definitions on the ALW tank loader are therefore retained even when Toolshed
+  initializes after FUSE asset discovery; the visible tank and functional loader
+  no longer split into unrelated objects.
+
+- Legacy-install detection and the installer cleanup list now include
+  `Railloader.Injector.dll`. It is the managed legacy loader and Harmony owner,
+  not a harmless native bootstrap file, so leaving it in `Managed` could run the
+  old and FUSE loading pipelines together.
+
 - Updating FUSE through Unity Mod Manager failed with "Error when unpacking"
   and installed nothing, for every release from 1.0.0 through 1.0.2. The
   published zips stored entry names with backslashes, because
@@ -61,6 +360,36 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
   (a locked file, a bad path, a full disk) no longer leaves a half-written mod
   folder behind, and a failed `--replace` reinstall leaves the existing install
   untouched.
+
+- The standalone converter now keeps legacy hard `Requirements` as native FUSE
+  requirements and normalizes object-form `LoadAfter` entries to their ids.
+  Requirements for the loader systems FUSE itself replaces (Alina's Map Mod and
+  editor, RailLoader Injector/Interchange, and other core compatibility layers)
+  are removed instead of becoming impossible hard dependencies. (#240)
+
+- A concurrently installed legacy `AssetLoader` no longer patches the game's
+  prefab stores after FUSE has mounted and quarantined the same asset packs.
+  FUSE detects that exact legacy assembly and removes only its Harmony owner;
+  asset-pack problems remain isolated and the locomotive customization/buy-menu
+  path no longer receives a second set of stores. (#238)
+
+- Replacing a named TrackSpan now atomically rebinds every live industry and
+  interchange component from the old Unity component to the replacement before
+  the old object is retired. ARC Whittier-style base-track replacements no
+  longer leave Whittier Saw Mill without its customer/components or collapse
+  multiple unloading positions onto the surviving span. Strange Customs array-
+  wrapped additions such as Sylva Industries Boosted's
+  `trackSpans: [{ "$add": "Piei" }]` retain the vanilla R2 span and append R3,
+  restoring highlighting, delivery credit, and EOD payment on both tracks.
+  (#236, #239)
+
+- The Appalachian Railway starter-equipment placement pool is now activated
+  only by that package's Whittier start definition. It waits until the tutorial
+  overlay is out of the way, keeps an item queued when placement is cancelled
+  with Escape, and removes it only after `LastPlacedTrain` confirms that the
+  complete expected cut spawned. This also contains the current game's
+  false-success callback when `PlaceTrain` catches a failure. Other new games
+  no longer inherit the pool.
 
 - Legacy map mods collapsed onto the world origin on comma-decimal locales
   (pt-BR, de-DE, fr-FR, ...): spaghetti track on the map, "zero length" track
@@ -100,12 +429,12 @@ versioned independently (`mod-v*` and `externaleditor-v*` tags).
   after it stopped resolving and buildings went missing across the map. Such a
   store is now quarantined by itself, its path is logged once, and later packs
   resolve normally; the bad file itself is still the mod author's to fix. (#196)
-- The Status page's "Mod Health" row flagged a mod as needing review after a
-  single one-off third-party exception (for example another mod's
-  first-frame-after-load `NullReferenceException`), contradicting the health
-  report, which only counts a mod as a problem once it recurs (3+ episodes or
-  10+ occurrences). Both surfaces now share that one threshold; anything
-  below it is listed as informational. (#208)
+- Runtime guards and observed Unity/third-party exceptions no longer make the
+  Status page or readiness summary look unhealthy. They remain captured in the
+  structured health report and now have a dedicated **Tools > Live
+  Diagnostics** page with level/text filtering, copy/export actions, a bounded
+  in-memory view, optional auto-refresh, and an optional RailLoader-style live
+  Windows console that mirrors `FUSE.log`. (#208)
 - A single unloadable type in some other assembly (typically a stray, real
   `Railloader.dll` still being loaded from a mod folder) aborted FUSE's scan for
   legacy `ISplineyBuilder` implementations, so every queued builder task —

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,10 @@
   profiles enable every available package by default, and toggles update the
   persisted profile instead of a detached UI copy. Disabling a package blocks
   its data definitions, asset packs, hosted legacy assembly, and conditional
-  mixinto fragments at their shared package-admission boundary.
+  mixinto fragments at their shared package-admission boundary. Disabled
+  packages no longer validate their own dependencies or appear as actionable
+  skips, so an intentionally small profile does not report false package
+  faults.
 
 - Installer 0.8.0 and **Tools > Dependency Graph** now cover locomotive,
   railcar, code-plugin, asset-pack, native FUSE, UMM, and RailLoader dependency

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+- Installer 0.8.1 sizes and centers its window against the current display and
+  reserves the status and action rows before the expanding results pane. The
+  Install button therefore remains visible on 768p and other short desktops
+  without requiring the user to resize or move the window.
+
 - Reduced equipment-catalog main-thread work for installations using Lego's
   Library of Stuff. FUSE now bypasses Lego's expensive definition-edit postfix
   only for containers that cannot contain a requested edit; targeted

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+- Reduced equipment-catalog main-thread work for installations using Lego's
+  Library of Stuff. FUSE now bypasses Lego's expensive definition-edit postfix
+  only for containers that cannot contain a requested edit; targeted
+  locomotive and railcar containers still run Lego's original behavior. The
+  incremental warm-up report now records skipped unrelated containers, slow
+  stores, and the worst store so low-end performance can be verified in-game.
+- Live Diagnostics auto-refresh now updates the visible count and log text in
+  place instead of rebuilding the complete FUSE window once per second. This
+  preserves scroll position and removes a periodic UI-layout/main-thread hitch.
+
 - Fixed FUSE Profiles omitting auto-converted RailLoader data packages. Native
   FUSE and converted legacy packages now appear beside UMM-active mods, new
   profiles enable every available package by default, and toggles update the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+- Fixed FUSE Profiles omitting auto-converted RailLoader data packages. Native
+  FUSE and converted legacy packages now appear beside UMM-active mods, new
+  profiles enable every available package by default, and toggles update the
+  persisted profile instead of a detached UI copy. Disabling a package blocks
+  its data definitions, asset packs, hosted legacy assembly, and conditional
+  mixinto fragments at their shared package-admission boundary.
+
 - Installer 0.8.0 and **Tools > Dependency Graph** now cover locomotive,
   railcar, code-plugin, asset-pack, native FUSE, UMM, and RailLoader dependency
   sources. UMM version suffixes are parsed correctly; verified Nexus

--- a/docs/CHOOSING_A_WORKFLOW.md
+++ b/docs/CHOOSING_A_WORKFLOW.md
@@ -1,0 +1,51 @@
+# Install, Convert, Or Author?
+
+These are three different jobs. Choose the row that matches what you are trying
+to do before downloading a tool.
+
+| Goal | Use | What happens |
+| --- | --- | --- |
+| Play with one or many downloaded mods | `FUSE-Installer.exe` | Inspects each archive and installs native FUSE, UMM, or supported RailLoader packages. It does not rewrite the mod. |
+| Keep using an existing legacy data mod | Install it normally | FUSE can host supported RailLoader/Strange Customs data and compatibility APIs in memory. Conversion is optional while the package works correctly. |
+| Turn legacy JSON into native FUSE JSON | FUSE Converter | Converts route, graph, scenery, operations, and supported audio JSON, then writes a conversion report. |
+| Install an asset pack or Alina map-tile package | `FUSE-Installer.exe` | Installs the original package so FUSE can load it directly; these packages are not converter inputs. |
+| Convert a DLL/code mod | Do **not** use the converter | A converter cannot translate compiled program logic. Install the original package for FUSE compatibility hosting, or port its behavior as new independently written code. |
+| Build or edit a map visually | Railroader Tile Editor | Authors track, scenery, roads, operations, signals, and related JSON. Players do not need the Editor. |
+| Hand-author a native package | FUSE schema + author guide | Create `Info.json` and one or more `*.fuse.json` files. |
+| Add working coal/water/diesel/bunker-C/wood service | Toolshed authoring guide | FUSE places the world/operations data; Toolshed owns the service-facility behavior. |
+| Render narrow or dual gauge | FUSE Narrow Gauge | Optional runtime companion. It is not part of the Editor and is not required by ordinary FUSE packages. |
+
+## What The Converter Does Not Do
+
+The converter reads data. It does not decompile, translate, patch, or rebuild a
+`.dll`, `.pdb`, executable, Harmony patch, UMM entry point, or arbitrary C# mod.
+If a package contains code and data, only the recognized data can be converted.
+The report lists code binaries as manual/unsupported work so they cannot be
+mistaken for converted behavior.
+
+FUSE's compatibility host is a separate runtime feature. It independently
+implements supported legacy contracts so an installed legacy code mod can call
+familiar APIs. That is why installing an old package and converting its JSON are
+not the same operation.
+
+## Recommended Release Shape
+
+For players, distribute one FUSE Suite download/installer with clearly marked
+components:
+
+- FUSE Core — required
+- Toolshed — optional gameplay companion
+- FUSE Narrow Gauge — optional gauge renderer
+- Tile Editor — optional authoring tool; never required to play a FUSE map
+
+Keep those as separate assemblies and projects. A bug in an authoring tool or
+optional gameplay feature should not prevent FUSE Core from loading a save or
+opening a game menu.
+
+## Next
+
+- Players: [Getting Started](GETTING_STARTED.md)
+- Existing mods: [Migrating From Legacy Mods](MIGRATION_FROM_LEGACY.md)
+- Conversion: [FUSE Converter](FUSE_CONVERTER.md)
+- Authors: [Package Author Guide](PACKAGE_AUTHOR_GUIDE.md)
+- Common tasks: [Authoring Recipes](AUTHORING_RECIPES.md)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -136,6 +136,13 @@ rather than fixing it. See [SETTINGS.md](SETTINGS.md#performance-diagnostics).
 Note that load time scales with how much your packages actually change: track
 segments, scenery, and industries all cost time to apply.
 
+Current builds also name the slowest measured FUSE runtime-pump phase on a
+logged spike. `fusePumpWorstPhase='none measured'` means the detector did not
+find expensive work in FUSE's own per-frame pump; correlate that timestamp with
+the surrounding game and third-party logs instead. Equipment warm-up completion
+lines include the slowest asset store and how many stores crossed the slow-store
+threshold, which is the useful evidence for a buy-menu delay report.
+
 ### Should I leave the debug overlays on?
 
 No. The track, scenery, and world-label overlays draw every frame and exist for

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -17,7 +17,8 @@ The `2025.1.x` line. FUSE logs its version report at startup in `FUSE.log`.
 ### Do I need Railloader as well?
 
 No. FUSE replaces it. Running both means two loaders are live at once, and FUSE
-warns when it finds a leftover `Railloader.dll` or `Railloader.Interchange.dll`.
+warns when it finds a leftover `Railloader.dll`, `Railloader.Injector.dll`, or
+`Railloader.Interchange.dll`.
 
 ### Is FUSE free and open source?
 
@@ -58,8 +59,11 @@ No. A package that faults is reported and skipped; unrelated packages still load
 
 ### Can I run my old mods?
 
-Data mods convert. Run them through the converter to produce a `*.FUSE` package —
-see [MIGRATION_FROM_LEGACY.md](MIGRATION_FROM_LEGACY.md).
+RailLoader JSON data mods can convert. Run them through the converter to produce
+a `*.FUSE` package — see
+[MIGRATION_FROM_LEGACY.md](MIGRATION_FROM_LEGACY.md). Asset packs and Alina
+map-tile packages install directly because FUSE loads their supported legacy
+formats; converting them would only create a misleading empty wrapper.
 
 Script mods that ship `.dll` logic do not convert. Neither do rolling stock,
 locomotive, and car mods, except audio definitions FUSE can import.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -143,6 +143,9 @@ the surrounding game and third-party logs instead. Equipment warm-up completion
 lines include the slowest asset store and how many stores crossed the slow-store
 threshold, which is the useful evidence for a buy-menu delay report.
 
+For a release-quality before/after run, follow
+[Performance Acceptance Testing](PERFORMANCE_TESTING.md).
+
 ### Should I leave the debug overlays on?
 
 No. The track, scenery, and world-label overlays draw every frame and exist for

--- a/docs/FUSE_CONVERTER.md
+++ b/docs/FUSE_CONVERTER.md
@@ -2,6 +2,11 @@
 
 Official drag-and-drop converter for legacy Railroader data mods.
 
+> **Data only:** this tool does not convert DLLs or code mods. It can convert
+> recognized JSON/data from a mixed package, but compiled behavior must remain an
+> installed compatibility-hosted mod or be independently reimplemented. Use
+> [Install, Convert, Or Author?](CHOOSING_A_WORKFLOW.md) if you are unsure.
+
 ## Download
 
 Prebuilt binaries are published on the GitHub Releases page rather than tracked in this repo:
@@ -21,10 +26,14 @@ Drag any of these onto `ConvertToFUSE.cmd` at the repo root:
 - a legacy route / track mod folder
 - a legacy route / track mod `.zip`
 - a legacy horn / whistle / bell folder or `.zip`
-- a legacy asset-pack folder or `.zip`
 - a single legacy JSON data file
 
 `ConvertToFUSE.cmd` launches the official FUSE converter.
+
+Drag asset packs, Alina map-tile packages, native FUSE packages, and compatible
+code mods onto `FUSE-Installer.exe` instead. The converter identifies those
+inputs and explains the correct install path; it does not make empty wrapper
+packages for them.
 
 The repository also includes the FUSE converter icon at:
 
@@ -72,7 +81,7 @@ dotnet run --project FUSE.ConverterCli -- "C:\Path\To\LegacyMod" --out "C:\Steam
 ```
 
 ```text
-fuse-convert <inputs...> [--out <dir>] [--kind auto|route|audio|asset] [--clean] [--batch]
+fuse-convert <inputs...> [--out <dir>] [--kind auto|route|audio] [--clean] [--batch]
              [--no-validate] [--strict] [--format console|json|markdown|all] [--quiet]
 ```
 
@@ -81,10 +90,10 @@ fuse-convert <inputs...> [--out <dir>] [--kind auto|route|audio|asset] [--clean]
 | `--out <dir>` | Output root; each mod converts into `<dir>\<ModFolder>.FUSE`. Default: `.\FUSEConverted`. |
 | `--kind <kind>` | Force a package kind instead of auto-detection. |
 | `--clean` | Replace an existing `.FUSE` output folder. |
-| `--batch` | Treat each input as a container and convert every recognized child folder. |
+| `--batch` | Treat each input as a container. Convert JSON packages and report the correct install guidance for code, asset, tile, or native packages. |
 | `--no-validate` | Skip validation (it is on by default). |
 | `--strict` | Validation warnings also fail the run (exit 2), not just errors. |
-| `--format <fmt>` | `console` (default) prints to stdout; `json` / `markdown` also write `conversion-report.json` / `conversion-report.md` into each output folder; `all` writes both. |
+| `--format <fmt>` | `console` (default) prints to stdout; `json` / `markdown` also write reports. Successful reports live in the output package; failed/unsupported reports live under `<out>\_conversion-reports`. |
 | `--quiet` | Suppress per-diagnostic output; print only summaries. |
 
 Exit codes (CI can gate conversion and validation separately):
@@ -146,7 +155,6 @@ Useful options:
 | `--clean` | Replace an existing generated `.FUSE` output folder under the output root. |
 | `--kind route` | Force route/track/data conversion. |
 | `--kind audio` | Force horn/whistle/bell conversion. |
-| `--kind asset` | Force asset-pack wrapper conversion. |
 | `--batch` | Recursively convert every recognized child mod, zip, or JSON in the input folder. |
 
 ## Outputs
@@ -155,7 +163,7 @@ Each converted package gets:
 
 - `Info.json`
 - one or more `*.fuse.json` files, or `audio.fuse.json`
-- copied audio files or asset pack folders when needed
+- copied audio files and asset folders carried by a converted route package when needed
 - `conversion-report.json`
 - `conversion-report.md`
 
@@ -174,8 +182,12 @@ The report is the important bit. It records:
 | Track / route JSON folders | One FUSE data file per source JSON, preserving file-per-concern structure. |
 | Single route JSON file | One standalone FUSE package fragment. |
 | Horn / whistle / bell packs | FUSE audio package with copied audio files. |
-| Strange Customs asset packs | FUSE asset wrapper with `FuseAssetPacks` in `Info.json`. |
 | Zip files | Extracted to a temporary folder, detected, converted, then cleaned up. |
+
+Asset-pack-only, Alina map-tile, native FUSE, and compiled-code packages are not
+conversion inputs. Install the original package with the FUSE installer. A
+mixed legacy package may still convert its recognized top-level JSON data; its
+DLL behavior remains unconverted and is called out in the report.
 
 ## Known Lossy Areas
 
@@ -210,5 +222,9 @@ Current intentional unsupported/deferred areas:
 - arbitrary legacy script logic from `.dll` files
 - rolling stock/car/locomotive packages outside FUSE audio definitions
 - unknown custom component types when their owning assembly is not installed or not converted to a FUSE component package
+
+The presence of a `.dll` is never a successful code conversion. The report must
+keep that binary visible as manual/unsupported work even when the package's JSON
+converted successfully.
 
 Unsupported entries must remain visible in `conversion-report.json` and `conversion-report.md`. A clean conversion is allowed to have `info` entries, but a supported package should not rely on hidden unsupported runtime behavior.

--- a/docs/FUSE_INSTALLER.md
+++ b/docs/FUSE_INSTALLER.md
@@ -57,7 +57,7 @@ Each archive is inspected and staged before anything replaces an installed mod.
 One bad archive does not stop the remaining archives. The final table lists every
 package as `INSTALLED`, `UPDATED`, `SKIPPED`, or `FAILED`.
 
-Before writing any package, installer 0.7 scans the complete batch and checks:
+Before writing any package, installer 0.8 scans the complete batch and checks:
 
 - unsafe, absolute, parent-traversing, duplicate, or case-colliding ZIP paths;
 - ambiguous layouts where one package manifest contains another package;
@@ -67,6 +67,10 @@ Before writing any package, installer 0.7 scans the complete batch and checks:
 - dependencies already installed or supplied later in the same batch; and
 - dependency failure propagation, so a package that fails preflight cannot
   satisfy another package just by being present in the batch.
+
+UMM's versioned string form is understood as well: for example,
+`GP38SoundMod-4.4.1` means package id `GP38SoundMod`, minimum version `4.4.1`.
+It is not treated as one literal package id.
 
 Missing dependency results name the requester, dependency id, version bounds,
 and corrective action. FUSE satisfies only the legacy contracts it explicitly
@@ -108,6 +112,39 @@ screenshot of the installer window. The report's `compatibilityActions` list
 records each AssetLoader backup, alias installation, verification failure, or
 blocked migration with its source and destination paths. Each package record
 also preserves the dependency ids and version bounds used by preflight.
+
+### Equipment dependencies and Nexus fallback
+
+The same preflight and **Tools > Dependency Graph** now include locomotives,
+railcars, and other AssetLoader-style packages. FUSE combines four sources in
+this order:
+
+1. native FUSE fields in `Info.json`;
+2. UMM `Requirements`/`LoadAfter` plus RailLoader `Definition.json`;
+3. AssetLoader `Definitions.json` to identify the package as equipment (asset
+   identifiers are not guessed to be package dependencies); and
+4. Nexus file-version requirements only when the local manifests have no hard
+   requirements.
+
+The installer performs Nexus lookup only when the archive manifest contains an
+actual `https://www.nexusmods.com/<game>/mods/<id>` homepage and a Nexus API key
+is supplied. It will not guess a mod page from numbers in an archive filename.
+The GUI key field is optional and masked; the key is used only for that run and
+is never written to a report or cache. CLI users should prefer the
+`NEXUS_API_KEY` environment variable instead of putting a key in shell history.
+
+Successful provenance and dependency results are written atomically to
+`Mods\.fuse-metadata\dependencies.json`. The in-game graph reads that cache
+offline; opening or refreshing a FUSE menu never contacts Nexus. Local explicit
+metadata always wins over a cached Nexus edge, and cache records for removed
+mod folders are ignored. Nexus dependency definitions containing multiple
+alternative mods are reported but are not converted into a false hard
+requirement.
+
+Nexus API v3 currently marks the file-version dependency endpoints as
+experimental. See the [official API v3 specification](https://github.com/Nexus-Mods/Vortex/blob/master/packages/nexus-api-v3/schema/openapi.yaml),
+[authentication guidance](https://github.com/Nexus-Mods/node-nexus-api/blob/master/docs/README.md),
+and [acceptable-use policy](https://help.nexusmods.com/article/114-api-acceptable-use-policy).
 
 ## Removing the old loader safely
 
@@ -187,6 +224,15 @@ Archive processed zips after successful installs:
 
 ```powershell
 .\FUSE-Installer.exe --archive-zips
+```
+
+Fill genuine manifest gaps from Nexus for linked packages, without saving the
+key:
+
+```powershell
+$env:NEXUS_API_KEY = "your personal key"
+.\FUSE-Installer.exe --cli .\EquipmentPack.zip
+Remove-Item Env:NEXUS_API_KEY
 ```
 
 ## Building the exe

--- a/docs/FUSE_INSTALLER.md
+++ b/docs/FUSE_INSTALLER.md
@@ -263,7 +263,6 @@ powershell -ExecutionPolicy Bypass -File .\tools\build_installer_exe.ps1 -FusePa
 
 The release workflow does this automatically, passing the zip it just built. If
 you build without `-FusePayload`, the exe still installs mods from dragged zips,
-but a no-argument run has no FUSE to install and reports that instead. After a
-bundled build, the script performs a real install into a throwaway fake game
-folder and confirms `Mods\FUSE\Info.json` was written. Installer tests also
-verify AssetLoader backup, DLL removal, and dependency-alias creation.
+but a no-argument run has no FUSE to install and reports that instead. The
+bundled-build smoke test verifies FUSE installation and AssetLoader migration
+in a throwaway game folder.

--- a/docs/FUSE_INSTALLER.md
+++ b/docs/FUSE_INSTALLER.md
@@ -15,9 +15,9 @@ works two ways:
 
 A no-argument run also installs any loose `.zip` files sitting beside the exe (in
 addition to FUSE), so the "drop several zips in the folder and run once" workflow
-still works. FUSE is skipped by default if it is already installed; pass
-`--replace` to back up and reinstall it. Pass `--no-fuse` to process only the
-loose zips without (re)installing FUSE.
+still works. Existing mod folders are backed up and updated by default. Pass
+`--skip-existing` to leave them alone, or `--no-fuse` to process only the loose
+zips without installing the bundled FUSE package.
 
 ## Download
 
@@ -28,31 +28,127 @@ so building locally produces a private copy at `dist\FUSE-Installer.exe`.
 The installer inspects zip structure and manifest JSON only. It does not import,
 execute, or depend on any package code.
 
+When FUSE is installed, the installer also creates a data-only UMM entry with
+the historical id `AssetLoader`. This entry contains no DLL and runs no patches;
+it exists so older mod manifests that require `AssetLoader` still pass UMM's
+dependency check before their content is loaded through FUSE.
+
+UMM code mods are reflected before their entry method runs. The installer also
+checks each installed code DLL (without executing it) for references to the
+RailLoader Interchange/Injector or Strange Customs contracts that FUSE replaces.
+When found, it adds `FUSE` to that mod's `Requirements` and `LoadAfter` fields so
+FUSE's compatibility resolver is active before UMM reflects the DLL. The
+original `Info.json` is copied to a dated
+`Mods\ModBackups\FUSEInstaller\CompatibilityManifests-*` folder first. This is
+what allows separately installed UMM packages such as Alina Utilities to start
+with the old loader DLLs absent. RailLoader-hosted data/code packages such as
+Signals Everywhere follow the separate hosted-package path described below.
+
 ## Supported zips
 
 - UMM packages with `Info.json`.
 - FUSE data packages with `Info.json` and FUSE data markers such as
   `FuseDataFiles`, `FuseAssetPacks`, or a FUSE requirement.
-- Supported legacy data packages with `Definition.json` plus data JSON containing
-  world, track, operations, or progression entries.
+- RailLoader packages with `Definition.json`, including data packages and
+  code-only hosted plugins such as Signals Everywhere.
 - Multi-package zips laid out as `Mods/PackageA/...` and `Mods/PackageB/...`.
+
+Each archive is inspected and staged before anything replaces an installed mod.
+One bad archive does not stop the remaining archives. The final table lists every
+package as `INSTALLED`, `UPDATED`, `SKIPPED`, or `FAILED`.
+
+Before writing any package, installer 0.7 scans the complete batch and checks:
+
+- unsafe, absolute, parent-traversing, duplicate, or case-colliding ZIP paths;
+- ambiguous layouts where one package manifest contains another package;
+- duplicate package ids across all selected ZIPs (including `.FUSE` aliases);
+- `Requirements`, `FuseRequires`, and RailLoader `requires`, including
+  `NotBefore`/`NotAfter` version bounds;
+- dependencies already installed or supplied later in the same batch; and
+- dependency failure propagation, so a package that fails preflight cannot
+  satisfy another package just by being present in the batch.
+
+Missing dependency results name the requester, dependency id, version bounds,
+and corrective action. FUSE satisfies only the legacy contracts it explicitly
+replaces (for example Alina's Map Mod, Strange Customs, Confusing Supplements,
+RailLoader Injector/Interchange, and AssetLoader); it does not broadly waive
+unrelated ZAMU or third-party requirements. Retired legacy version bounds are
+ignored only for those explicit FUSE replacement contracts. If an installed
+dependency has no readable version, the installer keeps the package eligible
+but records that the bound could not be verified.
 
 ## User flow
 
 To install FUSE:
 
-1. Put `FUSE-Installer.exe` in the base folder.
-2. Double-click it.
-3. FUSE is written to `Mods\FUSE`.
+1. Install Unity Mod Manager for Railroader.
+2. Double-click `FUSE-Installer.exe`. It searches registered Steam libraries for
+   Railroader; use **Browse** if you have more than one copy or a non-Steam
+   install.
+3. Leave **Install/update the bundled FUSE framework** checked.
+4. Add any mod zips you also want to install, then click **Install**.
+5. Read the package-by-package result list before closing the window.
 
-To install a mod:
+FUSE is written to `Mods\FUSE`.
 
-1. Drag its `.zip` onto `FUSE-Installer.exe` (or drop several at once).
-2. Each package is written to `Mods\<package id>`.
+To install mods:
 
-Existing folders are skipped by default. Run with `--replace` to move an existing
-folder into `Mods\ModBackups\FUSEInstaller\<timestamp>` before installing the new
-copy.
+1. Drag one or more `.zip` files onto `FUSE-Installer.exe`, or open the installer
+   and use **Add zips**.
+2. Confirm the detected Railroader folder and click **Install**.
+3. Each package is written to `Mods\<package id>`. Native FUSE, UMM, and hosted
+   RailLoader-format packages can be selected together.
+
+Existing folders are moved to
+`Mods\ModBackups\FUSEInstaller\<timestamp>` before the new copy is installed.
+Use `--skip-existing` only when you intentionally do not want updates.
+Every non-dry run writes a machine-readable result under
+`Mods\FUSEInstaller\Reports` so a failed package can be diagnosed without a
+screenshot of the installer window. The report's `compatibilityActions` list
+records each AssetLoader backup, alias installation, verification failure, or
+blocked migration with its source and destination paths. Each package record
+also preserves the dependency ids and version bounds used by preflight.
+
+## Removing the old loader safely
+
+Before installing, the tool checks the actual game folder, verifies Unity Mod
+Manager is present, and looks for known legacy loader files in
+`Railroader_Data\Managed`: `Railloader.dll`, `Railloader.Injector.dll`,
+`Railloader.Interchange.dll`, and `StrangeCustoms.dll`.
+
+If any are found, the installer stops and asks permission to move only those
+exact files into a dated backup under
+`Mods\ModBackups\FUSEInstaller\LegacyLoader-<timestamp>`. It does not silently
+delete or patch game files. For an unattended repair, pass
+`--repair-legacy-loader`.
+
+Steam's **Verify integrity of game files** is useful if a game-owned file was
+modified, but it may leave extra third-party DLLs behind. Verification therefore
+does not replace the installer's explicit legacy-file check.
+
+### Replacing AssetLoader
+
+FUSE owns all three behaviors exposed by AssetLoader 1.0.1: package-root and
+child `Catalog.json` store discovery, direct mod-folder store paths, and
+definitions-only child-folder overrides used by rolling-stock/tender swaps.
+
+During a FUSE install or update, the installer checks `Mods` for:
+
+- an old `AssetLoader` UMM folder or any immediate mod folder containing
+  `AssetLoader.dll`;
+- a loose `Mods\AssetLoader.dll`;
+- a loose `Mods\AssetLoader.zip`.
+
+With approval, those exact paths are moved to
+`Mods\ModBackups\FUSEInstaller\AssetLoader-<timestamp>`, then the installer
+creates `Mods\AssetLoader\Info.json` as the data-only dependency alias. It
+verifies that no old AssetLoader runtime remains. Use
+`--repair-asset-loader` for an unattended migration. Dragging the old
+AssetLoader ZIP onto the FUSE installer does not reinstall its DLL.
+
+Do not simply delete AssetLoader by hand while older packages still declare it
+as a UMM requirement. Either use the FUSE installer so the alias is created, or
+update those package manifests to require `FUSE` instead.
 
 ## Command examples
 
@@ -66,6 +162,13 @@ Install explicit zips:
 
 ```powershell
 .\FUSE-Installer.exe .\MyPackage.zip .\OtherPackage.zip
+```
+
+Force command-line mode (the published executable opens the graphical installer
+by default):
+
+```powershell
+.\FUSE-Installer.exe --cli .\MyPackage.zip .\OtherPackage.zip --with-fuse
 ```
 
 Inspect without writing:
@@ -115,5 +218,6 @@ powershell -ExecutionPolicy Bypass -File .\tools\build_installer_exe.ps1 -FusePa
 The release workflow does this automatically, passing the zip it just built. If
 you build without `-FusePayload`, the exe still installs mods from dragged zips,
 but a no-argument run has no FUSE to install and reports that instead. After a
-bundled build, the script runs a `--dry-run` self-check to confirm a manual run
-would install FUSE.
+bundled build, the script performs a real install into a throwaway fake game
+folder and confirms `Mods\FUSE\Info.json` was written. Installer tests also
+verify AssetLoader backup, DLL removal, and dependency-alias creation.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -23,13 +23,18 @@ operations matters there.
 3. Start Railroader.
 4. Check that FUSE appears in Unity Mod Manager's mod list and is enabled.
 
-`FUSE-Installer.exe` can do this for you: drop it and your mod zips in the game's
-base folder and run it. See [FUSE_INSTALLER.md](FUSE_INSTALLER.md).
+`FUSE-Installer.exe` can do this for you: put it beside `Railroader.exe`, then
+double-click it or drag one or more mod zips onto it. It validates the game/UMM
+install, backs up updates, reports each package separately, and detects leftover
+legacy loader DLLs. It also replaces the old AssetLoader runtime with a
+data-only dependency alias, so use the installer when migrating an existing
+AssetLoader-based setup. See [FUSE_INSTALLER.md](FUSE_INSTALLER.md).
 
 ## Install Packages
 
-FUSE packages are folders ending in `.FUSE` that go in `Railroader/Mods`
-alongside FUSE itself.
+Native FUSE, UMM, and hosted RailLoader packages all go in `Railroader/Mods`
+alongside FUSE itself. A native package does not have to use `.FUSE` in its
+folder name; its `Info.json` and declared data files identify it.
 
 1. Place each `*.FUSE` package folder in `Railroader/Mods`.
 2. Install any asset packs the package requires — route packages usually depend on
@@ -37,8 +42,8 @@ alongside FUSE itself.
 3. Start the game and load a map.
 
 FUSE respects UMM's enabled checkbox for any package folder UMM can see. Unchecking
-a converted route, audio, or asset package there marks it disabled in FUSE too, and
-its track and data files are not loaded.
+a converted route/audio package or a directly installed asset package there marks
+it disabled in FUSE too, and its track, data, or assets are not loaded.
 
 Converting a legacy mod into a `*.FUSE` package is the converter's job — see
 [FUSE_CONVERTER.md](FUSE_CONVERTER.md).
@@ -62,17 +67,24 @@ Then confirm your packages are actually present:
 
 Every package you installed should be listed and applied. A package that is
 missing here was never discovered — check that it is in `Railroader/Mods` and
-enabled in UMM. A package listed as faulted was found but failed to apply; check
-`FUSE.log` for the package id and phase.
+enabled in UMM. A package listed as faulted was found but isolated.
+`/fuse.report` names the package and source file; `/fuse.report json` includes
+structured paths and JSON locations for mod authors.
 
 ## The FUSE Menu
 
 The FUSE icon in the top bar opens the in-game menu.
 
 - **Status** — the latest load report.
-- **Tools** — the Object Inspector, dependency/asset/diagnostics reports, scenery
-  benchmarks, and Runtime Actions (`Reload Track/Data`, `Reload Terrain`,
-  `Rebuild Caches`).
+- **Tools** — the Object Inspector, dependency/asset reports, **Live
+  Diagnostics**, scenery benchmarks, and Runtime Actions (`Reload Track/Data`,
+  `Reload Terrain`, `Rebuild Caches`). Live Diagnostics can filter/copy the
+  recent FUSE log or open an optional continuously scrolling Windows console.
+
+Routine Unity exceptions and compatibility-guard counters belong under **Tools
+→ Live Diagnostics**. They do not by themselves make the Status page unhealthy;
+use the symptom and package/asset/graph findings to decide whether a report is
+actionable.
 
 Runtime Actions are recovery and testing tools. Check `FUSE.log` after using one.
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -49,7 +49,8 @@ Off by default. Enabling one is a testing decision — back up your save first. 
   `/fuse.conflicts` reports the collision.
 - **Legacy loaders, AMM, Strange Customs, and RailLoader can create duplicate
   objects** when used alongside converted packages for the same route. FUSE warns
-  when it finds a leftover `Railloader.dll` or `Railloader.Interchange.dll`.
+  when it finds a leftover `Railloader.dll`, `Railloader.Injector.dll`, or
+  `Railloader.Interchange.dll`.
 - **Custom industry components load only when the owning assembly is installed.**
   A package referencing a component type from an assembly you do not have reports
   the missing dependency rather than silently dropping the component.

--- a/docs/LEGACY_REPLACEMENT_PARITY.md
+++ b/docs/LEGACY_REPLACEMENT_PARITY.md
@@ -1,0 +1,157 @@
+# Legacy replacement parity audit
+
+This file is the release gate for claims that FUSE replaces an older loader or
+library. A package is not "replaced" merely because FUSE satisfies its dependency
+identifier, skips its DLL, or can deserialize some of its data. Every observable
+data contract and runtime behavior must have a FUSE-owned implementation, tests,
+and an in-game verification result.
+
+The decompiled projects are used only to identify wire formats and observable
+behavior. FUSE does not copy, ship, or execute their implementations.
+
+Status meanings:
+
+- **Verified**: FUSE-owned implementation, automated coverage, and in-game check.
+- **Implemented**: FUSE-owned implementation and automated coverage; in-game check pending.
+- **Partial**: useful support exists, but at least one listed behavior is absent or unverified.
+- **Missing**: no FUSE-owned equivalent exists.
+- **Hosted only**: FUSE can run the old code; this is not native replacement parity.
+- **N/A**: build-time dependency or retired UI that is intentionally superseded by a named native workflow.
+
+Do not move a row to Verified without recording the test and in-game fixture.
+
+## AssetLoader
+
+| Legacy contract | FUSE-owned implementation | Status | Release evidence still required |
+|---|---|---|---|
+| Register enabled UMM package roots/children containing `Catalog.json` (bundle optional) | Direct asset-pack registry | Implemented | Catalog-only and normal bundle in-game corpus; disabled-package behavior |
+| Resolve mod-folder base paths without copying to LocalLow | `fuseasset://` direct stores and runtime-store path patches | Implemented | In-game pack/bundle fixture on every supported install path |
+| Definitions-only child folder override keyed by store identifier | Native compatibility override registry plus `FuseDefinitionOverrides` | Implemented | Tender/rolling-stock swap in-game corpus; malformed and duplicate targets covered automatically |
+| Legos/other `ContainerSerialization.Deserialize` edits | One cold native deserialize per direct store | Implemented | Full LLW/customization/save-reload in-game fixture |
+| Historical UMM dependency id `AssetLoader` when old DLL is absent | Installer-generated data-only UMM alias requiring FUSE | Implemented | Real UMM startup with an old dependent package and no AssetLoader DLL |
+| Coexistence with old AssetLoader | Runtime disables only the old Harmony owner; installer moves the old runtime to backup and supplies a data-only dependency alias | Implemented | Test manual coexistence in both load orders plus installer migration to a real no-DLL setup |
+
+
+## Confusing Supplements
+
+| Legacy contract | FUSE-owned implementation | Status | Release evidence still required |
+|---|---|---|---|
+| `ConfusingSupplements.Bodygroups` asset component, `cs.bodygroups.*` save keys, model-path switching, Customize UI | `FuseConfusingSupplementsBodygroups*` | Implemented | Asset-pack fixture with multiple groups; save/reload and multiplayer permission check |
+| `ConfusingSupplements.LabelPrinter` asset component and `cs.labelprinter.*` text dictionaries | `FuseConfusingSupplementsLabelPrinter*` | Implemented | Road-number and lettering templates; save/reload; malformed group/name fixture |
+| `ConfusingSupplements.Refiller` rolling-stock transfer component | `FuseConfusingSupplementsRefiller*` | Implemented | Coupled diesel/steam/tender transfer fixture; host/client behavior; air connection changes |
+| `ConfusingSupplements.DestinationSign` model, decal, picker cycling, culling | `FuseConfusingSupplementsDestinationSign*` | Implemented | Real destination-sign prefab fixture; culling and destroy/reload check |
+| `CS.LiverySwap`, `livery:<carId>` directory mixintos, `cs.livery` save key, Customize UI | `FuseConfusingSupplementsLivery*` | Implemented | Multi-car isolation, repeated switching, texture cleanup, save/reload fixture |
+| Captive conversion loader/unloader | `FuseCaptiveConversionIndustryComponents` and component type normalization | Implemented | In-game production/storage/payment golden fixture |
+| Pay-for-resource loader | `FusePay4ResourceIndustryComponent` | Implemented | In-game hours, rate, cost, book reason, and EOD golden fixture |
+| Empty placeholder component, visible track marker, all auto-destination classes, inert service/order behavior | `FuseLegacyPlaceholderIndustryComponent` plus `IndustryAPI` legacy-empty handling | Implemented | In-game output-track highlighting/destination fixture and neighboring component ordering |
+| `/cs-livery-refresh` and texture inspection diagnostics | `/cs-livery-refresh` and `/fuse.liveries` | Implemented | In-game texture edit/refresh and report fixture |
+
+Automated coverage: `FUSE.Tests/Compatibility/FuseConfusingSupplementsCompatibilityTests.cs`,
+`FUSE.Tests/Data/FuseIndustryComponentTypesTests.cs`,
+`FUSE.Tests/API/FuseLegacyPlaceholderIndustryComponentTests.cs`, and the legacy
+industry converter tests.
+
+## RailLoader.Interchange public contract
+
+| Contract | FUSE surface | Status | Known gap |
+|---|---|---|---|
+| `PluginBase`, `SingletonPluginBase`, enable/disable lifecycle | `RailloaderLegacySupport` + `FuseLegacyAssemblyHost` | Partial | Constructor/lifecycle matrix is not yet tested against every ZAMU/third-party assembly |
+| `IModDefinition`, `IMod`, `ModReference`, version ranges | Compatibility models and manifest discovery | Partial | Full version-bound/load-order golden set pending |
+| `IModdingContext.Mods`, `Requires`, `LoadAfter`, `LoadBefore`, `ConflictsWith` | Legacy manifest discovery and requirement resolver | Partial | Top-level conflict ids/bounds, conditional eligibility/ordering, and intentional-layer classification are covered; full hosted/version-bound in-game corpus remains open |
+| File/directory/managed-object mixintos | Legacy host mixinto enumeration | Partial | Native/runtime-converted file mixintos preserve conditional requires/conflicts; managed-object and some hosted conditional shapes are not proven |
+| Console command registration | Reflection bridge to game console | Partial | Command availability timing and command exception containment matrix pending |
+| Settings load/save | FUSE legacy settings bridge | Implemented | Cross-version/in-game save fixture pending |
+| JSON subtype and component-builder registration | `FuseLegacyTypeRegistry` | Implemented | Late-registration direct-store fixture pending |
+| `IUIHelper` windows and panel population | `FuseLegacyUIHelper` | Partial | All overloads, resize, callbacks, and disposal need in-game verification |
+| `IModTabHandler` | Hosted-plugin Mods UI integration | Partial | Rebuild/disposal and one-bad-tab containment fixture pending |
+| `IUpdateHandler` | Hosted plugin update dispatch | Implemented | Per-frame fault isolation/in-game fixture pending |
+| `WillCopyDebugInformation` event | Guarded event dispatch appended to copied `/fuse.report` health output | Implemented | Real hosted subscriber contribution and one-bad-listener in-game fixture |
+| `UIPanelBuilderCompatibility` helpers | Compatibility extensions | Partial | Every original overload/arity needs a reflection test |
+
+## RailLoader.Injector
+
+| Injector responsibility | FUSE replacement | Status |
+|---|---|---|
+| Locate and parse legacy `Definition.json` packages | `FuseDataPackageDiscovery`, legacy converter, legacy assembly host | Partial |
+| Dependency ordering, enable/disable, faults, conflicts | resolver, load report, package fault registry | Partial |
+| Mixinto parsing including conditional requires/conflicts | legacy converter/host | Partial (data/runtime conversion implemented; hosted managed-object matrix pending) |
+| Load old code mods without the injector assembly | assembly resolver and host | Partial |
+| Register component builders and JSON discriminators | `FuseLegacyTypeRegistry` | Implemented |
+| Console, mod settings, mod tabs, update handlers | legacy host/UI bridge | Partial |
+| Loader status/settings window | FUSE Status/Mods/Settings tools | Partial |
+| Live logging console | FUSE Live Diagnostics/live console | Implemented |
+| Bulletin/update system | FUSE version check only | Partial |
+| Drag-and-drop package installation | FUSE installer | Partial |
+| Legacy patch-file detection/removal guidance | installer/install detector | Partial |
+
+## Strange Customs
+
+| Capability | FUSE replacement | Status | Known gap |
+|---|---|---|---|
+| Track node/segment/span patching and removals | legacy converter + `TrackAPI` apply planner | Partial | Conditional mixinto eligibility/order is covered; base-span ownership and destructive-edit in-game fixtures remain |
+| Industries, loads, areas, operations components | legacy converter + native operations APIs | Partial | Complete custom component matrix and live payment/service fixtures |
+| Scenery and mandelas/scene transforms | legacy converter + `SceneryAPI`/`SceneCloneAPI` | Partial | Road mandelas and several clone/path edge cases still reported |
+| Roads/rivers/generic splineys | legacy converter + `SplineyAPI` + plugin host | Partial | Every handler/profile/end-style and hosted builder fixture |
+| Auto trestles | world conversion/runtime bridge | Partial | Geometry golden fixture |
+| Custom horns, whistles, and bells | FUSE audio API/patches | Partial | Full Strange Customs profile/keyframe compatibility matrix |
+| Conditional visual controls/sliders | FUSE visual-condition patches | Partial | All condition combinations and save keys need fixtures |
+| Direct asset-pack mounting and clone mixintos | direct-store registry/container mixinto registry | Partial | Duplicate-provider and late-registration stress fixtures |
+| `FileCache` loose audio/texture runtime service | FUSE-owned timestamp-invalidating texture/audio cache with contained completion callbacks | Implemented | Real loose WAV/OGG/PNG package, edit-on-disk refresh, and unload fixture |
+| `FlowyThingBuilder` ABI runtime build | Legacy DTO adapter backed by native `SplineyAPI` add/update | Implemented | Hosted plugin direct-build road/river fixture and parent-transform check |
+| Graph-change events for hosted plugins | spliney plugin host and compatibility messages | Partial | Event ordering, mutation merge, and repeat-load fixtures |
+| Legacy patch editor/undo/save API | ABI no-ops | N/A | Superseded by Tile Editor; editor parity is gated separately below |
+| Reload/verify/dump commands | FUSE commands cover only some functions | Partial | Explicit command mapping and docs |
+
+## Alina's Map Mod
+
+| Capability | FUSE replacement | Status | Known gap |
+|---|---|---|---|
+| Nodes, segments, spans, groups, removals | legacy converter + `TrackAPI` | Partial | Full Alina fixture matrix and same-area competing packages |
+| Scenery, map labels, map masks, map features | legacy converter + native world/progression APIs | Partial | Curve-mask and label edge fixtures |
+| Areas, industries, loads, components | legacy converter + native operations APIs | Partial | Component ordering/replacement and disabled-industry fixtures |
+| Loaders | legacy converter + loader API | Partial | Custom loader and track-snap authoring are editor gaps |
+| Passenger stops and station agents | native passenger/station APIs | Partial | Complete timetable/neighbor/area golden fixture |
+| Progressions, sections, delivery phases | native progression API | Partial | Full Alina progression corpus run |
+| Turntables | `TurntableAPI` | Partial | Custom visual/controller and save fixture |
+| Telegraph poles | `MapAPI` | Partial | Add/move/remove fixture |
+| Early map-load application | early loader/lifecycle | Partial | Every supported scene/load entry point |
+| Query tooltip extensions and validation window | FUSE diagnostics/inspector | Partial | One-to-one author-facing error coverage |
+| Alina map editor | Tile Editor | N/A | Tile Editor completion gate below |
+
+## Other ZAMU packages
+
+These packages are not currently in FUSE's suppressed-package set. Most can be
+hosted as old code mods, but hosted execution is not a native replacement.
+
+| Package | Observable behavior inventory | Native FUSE status |
+|---|---|---|
+| AbsoluteMadness | outbound empty/loaded routing overrides; settings tab | Implemented: dependency-scoped native routing, industry capacity weighting, payment/grace calculation, and persisted settings; in-game route-generation fixture pending |
+| ADRFDR | pay-for-resource industry component and picker title | Implemented: `ADRFDR.Pay4Resource` normalizes to the FUSE component and the picker honors `ICustomIndustryTitle`; in-game payment/title fixture pending |
+| C1CD | configurable interchange service interval, hours, continuous delivery | Implemented: native bounded scheduling policy, overnight/daytime service windows, continuous extra-service scheduling, and persisted UI; in-game service-cycle fixture pending |
+| CommandLine | third-party command-line parser dependency | N/A: load packaged dependency for hosted mods; no gameplay replacement |
+| DediSevi | dedicated-server startup, RCON, player list, autosave, instant load, terrain/camera/UI suppression | Missing |
+| FallFromGrace | grace-day calculation and inspector display | Implemented: native identity-safe grace transform, persisted compatibility settings, and due-time inspector row; in-game calculation/inspector fixture pending |
+| ForYourConvenience | caboose map icons, clickable stations, live car tags, industry dashboard/settings | Implemented: dependency-scoped station-map actions, opt-in caboose icons and speed/load tag lines, persisted settings, and native read-only Industry Dashboard; in-game icon/click/tag/dashboard fixture pending |
+| Interchange2Interchange | interchange contracts and car routing between interchanges | Implemented: dependency-scoped contracted interchanges, bounded daily cross-interchange orders, cargo discovery, inspector visibility, and persisted maximum-cut setting; in-game EOD/service fixture pending |
+| SanityInitiative | unit/UI/auto-engineer/equipment/roster/placer/daily-report fixes | Missing |
+| SerialTrafficControl | serial/TCP CTC protocol bridge and settings | Missing |
+| SomeKindOfMadness | outbound routing hooks, target overrides, shuffle/prevent-blocking behavior/settings | Implemented: native candidate event, configurable chance/fill/payment/short-trip/origin behavior, safe order shuffling, and dependency-scoped activation; in-game route-generation and extension-event fixture pending |
+
+## Tile Editor completion gate
+
+The editor's canonical output is native FUSE schema. A visible export-mode
+switch may select RailLoader legacy schema, but controls that cannot be expressed
+faithfully must be disabled with a reason; native schema must never be reduced to
+fit legacy limitations.
+
+Completion requires a documented end-to-end fixture that starts with no map and:
+
+1. acquires/imports terrain tiles and defines a new map;
+2. sculpts terrain and paints vegetation, saves, reloads, and compares the result;
+3. lays track, switches, spans, groups, grades, and interchanges;
+4. places scenery, town labels/signs, roads/water, loaders, and custom loaders;
+5. creates industries, operations, passenger stops, station agents, and progressions;
+6. creates signals, routes, CTC logic, and a working CTC panel;
+7. authors package feature/options groups for modular configurations;
+8. launches the generated map under FUSE and validates save/reload behavior;
+9. repeats the workflow from the published editor wiki without undocumented steps.

--- a/docs/MASTER_WORK_CHECKLIST.md
+++ b/docs/MASTER_WORK_CHECKLIST.md
@@ -289,6 +289,12 @@ is suppressed.
   existing string/object/list shapes. The installed Alina Utilities manifest
   was repaired and its original retained under
   `Mods\ModBackups\FUSEInstaller\CompatibilityManifests-*`.
+- [x] Profiles list native FUSE and auto-converted legacy data packages in
+  addition to UMM-active entries. New profiles start with every available
+  package enabled; existing profiles can toggle converted packages by id or
+  folder. The persisted profile gate excludes disabled package data files,
+  asset packs, hosted legacy code, dependency inventory, and conditional
+  mixinto fragments before runtime application.
 - [ ] Verify UMM drag-and-drop behavior and the previously reported 1.0.2 install
   failure.
 

--- a/docs/MASTER_WORK_CHECKLIST.md
+++ b/docs/MASTER_WORK_CHECKLIST.md
@@ -9,11 +9,11 @@ Status key: **Open**, **Investigating**, **Implemented**, **Needs in-game test**
 
 ## Current automated release gate (2026-08-20)
 
-- FUSE net48 suite: **2,205 passed, 9 opt-in real-pack fixtures skipped, 0 failed**.
-- FUSE Core/schema/help suite: **122 passed, 0 failed**.
+- FUSE net48 suite: **2,269 passed, 9 opt-in real-pack fixtures skipped, 0 failed**.
+- FUSE Core/schema/help suite: **126 passed, 0 failed**.
 - External editor UI suite: **96 passed, 0 failed**.
-- Tile Editor desktop suite: **126 passed, 0 failed**.
-- Installer/tools suite: **79 passed, 0 failed**.
+- Tile Editor desktop suite: **128 passed, 0 failed**.
+- Installer/tools suite: **88 passed, 0 failed**.
 - FUSE editor bridge, Toolshed, Narrow Gauge, and Railroad Operations validation
   harness all build/validate successfully; companion-mod builds were run with
   deployment disabled.
@@ -44,6 +44,62 @@ is suppressed.
   explain the JSON/schema/dependency problem, and leave game menus usable.
 - [x] Separate genuine package/load failures from ordinary Unity/runtime
   diagnostics so normal exceptions do not alarm users.
+
+## Performance and main-thread acceptance targets
+
+These targets apply to FUSE, Tile Editor, and Toolshed. Narrow Gauge is outside
+this performance pass. Measurements must include a large real-world mod set and
+a representative low-end system; a fast developer PC is not sufficient proof.
+
+- [ ] Attribute recurring 2–4 second game-tick stalls to a named FUSE,
+  companion-mod, game, or third-party phase. No FUSE-owned periodic callback may
+  perform an unbounded scene scan, package scan, file read, JSON parse, report
+  rebuild, or asset-store traversal on Unity's main thread.
+  FUSE frame-spike logs now include the slowest measured runtime-pump phase;
+  Toolshed's exact two-second facility/interchange scans were made
+  change-driven, lookup-cached, and exponentially backed off. A fresh field
+  capture is still required to attribute any stall that remains.
+- [ ] Move thread-safe file I/O, JSON/schema parsing, dependency indexing, IPC
+  decoding, report preparation, and pure calculations off the Unity main
+  thread where ordering permits. Marshal only the final Unity/game-database
+  mutation back to the main thread.
+- [ ] Keep Unity objects, scene hierarchy access, game databases, Harmony
+  mutation, and AssetBundle/renderer operations on the main thread, but make
+  them change-driven, cached, nearest-first where visual priority matters, and
+  bounded by a measured per-frame budget.
+  Current implementation keeps Unity access on the main thread, shares lazy
+  scene indexes across unresolved Toolshed definitions, drains waybill repair
+  in a two-car-per-frame queue, and centralizes Tile Editor grade-label camera
+  work at 20 Hz.
+- [ ] Eliminate the cold buy-menu freeze with the full equipment corpus while
+  preserving Lego definition edits, locomotive/railcar availability, and
+  customization behavior. Record total warm-up work, worst store, slow-store
+  count, and click-to-open latency.
+  The warm-up now skips Lego's expensive container postfix for stores that
+  cannot contain a Lego-authored identifier and logs slow-store count, worst
+  store, and total work. Full-corpus click timing remains an in-game gate.
+- [ ] Improve package discovery, definition load, map apply, track rebuild, and
+  editor save/reload times without changing native FUSE schema behavior or
+  legacy load order.
+- [ ] Prevent FUSE scenery from visibly appearing near or in front of the active
+  camera after player control begins. Loading-screen release and streaming
+  budgets must prioritize camera-near content without creating a single-frame
+  activation spike.
+- [ ] Tile Editor overlays, previews, IPC, caches, vegetation/terrain workflows,
+  and save monitoring must remain responsive on a whole-map project and must
+  not poll or rebuild unchanged state every frame.
+  Grade-label billboarding is centralized, heartbeat disk writes are coalesced
+  off-thread, and the desktop whole-map renderer idles at 15 Hz (5 Hz minimized)
+  while immediately returning to 60 Hz for active editing and generation.
+- [ ] Toolshed facilities, storage/particle animations, turntables, and rolling-
+  stock helpers must avoid duplicate Update/LateUpdate work and unchanged
+  renderer/GameObject writes.
+  Link-and-pin visuals now refresh at 10 Hz and only write changed state;
+  service animations cache normalized storage/transform state; startup loader,
+  facility, and selective-interchange discovery reuse bounded scene scans.
+- [ ] Capture before/after frame-time, main-thread time, load time, worst spike,
+  queue depth, and memory/GC evidence in the in-game performance report. A code
+  review or passing unit suite alone does not close this gate.
 
 ## Live GitHub issue intake (2026-08-19)
 

--- a/docs/MASTER_WORK_CHECKLIST.md
+++ b/docs/MASTER_WORK_CHECKLIST.md
@@ -532,13 +532,16 @@ documented in [`BASE_GAME_MAP_AUTHORING_AUDIT.md`](BASE_GAME_MAP_AUTHORING_AUDIT
 - [x] Rewrite the local FUSE install, getting started, troubleshooting, migration,
   converter scope, package authoring, schema, operations, diagnostics, and
   command documentation.
-- [ ] Complete FUSE wiki and sync published pages.
+- [x] Complete FUSE wiki and sync published pages. Published from source
+  `d9feb6e` as wiki commit `b3c8ac4` on 2026-08-20.
 - [x] Complete the local Tile Editor wiki source: installation/runtime prerequisite, all tabs,
   every key binding, selection, terrain/vegetation, tiles, track/grades,
   scenery/objects, roads/water, industries/operations, loaders/custom loaders,
   passenger, interchanges, signals/CTC, export modes, validation, and examples.
+  Published from source `c711590` as wiki commit `792f21c`.
 - [x] Complete the local Toolshed wiki source including custom-loader authoring and editor catalog
   integration.
+  Published from source `c72cb12` as wiki commit `7a2732b`.
 - [x] Complete the local Narrow Gauge wiki source and identify FUSE/editor integration points.
 - [x] Explain that the converter handles RailLoader JSON/data packages, not
   arbitrary compiled code mods.

--- a/docs/MASTER_WORK_CHECKLIST.md
+++ b/docs/MASTER_WORK_CHECKLIST.md
@@ -307,6 +307,13 @@ is suppressed.
   requester, and where to obtain/enable it when known. Installer batch preflight
   also distinguishes FUSE-provided legacy contracts from unrelated dependencies
   and propagates a failed provider to its dependents before any writes.
+- [x] Equipment dependency reporting covers locomotive/railcar UMM manifests,
+  legacy `Definition.json`, and AssetLoader package classification. Installer
+  0.8 correctly splits UMM ids such as `GP38SoundMod-4.4.1`, can fill a genuinely
+  empty manifest from a verified Nexus page/file-version dependency record, and
+  writes the result to an offline cache. The in-game graph never performs a
+  network request, local metadata wins, and stale/uninstalled cache entries are
+  ignored.
 - [x] Provide a complete package-scoped export suitable for a mod author, while
   keeping the Status page concise and actionable. **Copy Mod Info** now includes
   the full structured diagnostic block for only the selected package; the full

--- a/docs/MASTER_WORK_CHECKLIST.md
+++ b/docs/MASTER_WORK_CHECKLIST.md
@@ -100,6 +100,8 @@ a representative low-end system; a fast developer PC is not sufficient proof.
 - [ ] Capture before/after frame-time, main-thread time, load time, worst spike,
   queue depth, and memory/GC evidence in the in-game performance report. A code
   review or passing unit suite alone does not close this gate.
+  The reproducible team procedure and required evidence bundle are published in
+  [`PERFORMANCE_TESTING.md`](PERFORMANCE_TESTING.md).
 
 ## Live GitHub issue intake (2026-08-19)
 

--- a/docs/MASTER_WORK_CHECKLIST.md
+++ b/docs/MASTER_WORK_CHECKLIST.md
@@ -1,0 +1,499 @@
+# FUSE ecosystem master work checklist
+
+This is the durable intake list for the FUSE, Tile Editor, Toolshed, and Narrow
+Gauge workstreams. It records reports and requested outcomes; an item being
+listed does not mean the report has been confirmed as a FUSE bug.
+
+Status key: **Open**, **Investigating**, **Implemented**, **Needs in-game test**,
+**External/content issue**, **Complete**.
+
+## Current automated release gate (2026-08-20)
+
+- FUSE net48 suite: **2,205 passed, 9 opt-in real-pack fixtures skipped, 0 failed**.
+- FUSE Core/schema/help suite: **122 passed, 0 failed**.
+- External editor UI suite: **96 passed, 0 failed**.
+- Tile Editor desktop suite: **126 passed, 0 failed**.
+- Installer/tools suite: **79 passed, 0 failed**.
+- FUSE editor bridge, Toolshed, Narrow Gauge, and Railroad Operations validation
+  harness all build/validate successfully; companion-mod builds were run with
+  deployment disabled.
+- Release ZIP validation passed. The bundled `FUSE-Installer.exe` and
+  `FUSE-Converter.exe` build and pass their smoke checks; the installer also
+  completes a throwaway self-install with the DLL-free AssetLoader dependency
+  alias and no obsolete AssetLoader runtime.
+- Slopwatch: **0 findings**. Most remaining unchecked acceptance boxes require a
+  fresh Railroader session or external wiki/release publication. The parity
+  matrix separately identifies the hosted/version-bound compatibility cases
+  that still need broader fixtures; neither category is represented as
+  automated proof.
+
+The detailed legacy behavior release gate lives in
+[`LEGACY_REPLACEMENT_PARITY.md`](LEGACY_REPLACEMENT_PARITY.md). A legacy package
+is not considered replaced just because its dependency is satisfied or its DLL
+is suppressed.
+
+## Non-negotiable compatibility rules
+
+- [x] Keep native FUSE schema canonical and regression-tested.
+- [x] Parse legacy formats only at an isolated compatibility boundary and adapt
+  them into FUSE-owned models/runtime behavior.
+- [x] Do not copy implementation code from decompiled projects. Use observable
+  contracts, identifiers, file formats, and behavior only.
+- [x] Do not claim replacement parity until automated and in-game fixtures pass.
+- [x] A bad package must fail locally, identify the package/folder/file/location,
+  explain the JSON/schema/dependency problem, and leave game menus usable.
+- [x] Separate genuine package/load failures from ordinary Unity/runtime
+  diagnostics so normal exceptions do not alarm users.
+
+## Live GitHub issue intake (2026-08-19)
+
+- [x] #240 Convertor error — converter fix and regression fixture implemented;
+  issue remains open pending release/user confirmation.
+- [x] #239 Whittier Sawmill Trackmod Issue (ARC Whittier) — span rebinding,
+  array-wrapped additions, and industry-only area-wrapper fixes implemented;
+  needs in-game confirmation with ARC Whittier.
+- [x] #238 Not able to customize locomotives — AssetLoader replacement and
+  malformed-store containment implemented. The supplied log also identified a
+  partially-bound Alina Utilities singleton breaking map/camera updates; FUSE
+  now reconnects that instance to its working UMM settings without replacing
+  the mod. Needs the restarted in-game equipment/camera corpus.
+- [x] #236 Multiple unloading areas — real DW5 and Sylva patch shapes covered by
+  converter tests; needs in-game delivery/EOD confirmation.
+- [x] #235 Stryker's Bryson Turntable is yellow/other issues — the supplied log
+  confirms the actual turntable was cloned, sanitized, and applied; the
+  editor-only yellow measurement plate is now filtered. ALW CabooseHouse is a
+  confirmed bad external asset bundle entry. Visual in-game confirmation remains.
+- [ ] #221 FPS drop — logs do not contain a captured frame profile and frame-spike
+  diagnostics were disabled, so a sustained-FPS root cause is not proven. Two
+  always-on costs were removed (legacy update callback reflection/snapshots and
+  zero-work Unity texture-memory polling); needs an in-game before/after capture.
+- [x] #220 Legacy in-game road is not altered — in-place base-road patch and
+  converter fixture implemented; needs in-game confirmation.
+- [x] #210 Whittier Industries assets load but track/location tags do not —
+  root-level spans and industry namespace wrappers fixed in tests; needs
+  in-game confirmation.
+- [x] #206 Issues With Mods — supplied logs show 36 packages/56 definitions
+  applied with zero FUSE faults. Optional mixins were correctly skipped; BRSS
+  threw its own exception, while malformed k50parts/ALW catalogs and missing
+  bundle entries are content faults. Current guarded asset resolution and
+  quarantine paths need in-game confirmation with the same corpus.
+- [x] #198 RMROC451's Tweaks and Things — the real RMROC451 archive now passes
+  the opt-in assembly-load, Interchange-shim, and Harmony-target compatibility
+  fixture against the installed game; needs in-game behavior confirmation.
+- [x] #186 Cross-platform ZIP path separators — archive builder and package
+  validation gate implemented; issue remains open pending release confirmation.
+- [ ] #21 Custom CTC Signaling — portable signal/CTC runtime, editor authoring,
+  authoritative schemas, automatic runtime dependency declaration, and
+  cross-file pre-publish validation are implemented. Native FUSE ownership and
+  an end-to-end in-game territory acceptance run remain open.
+- [ ] Recheck recently closed reports #232, #230, #224, #223, #222, #219,
+  #208, #207, #202, #201, #199, and #196 against the regression suite rather
+  than assuming closure proves the current build.
+
+## FUSE runtime and compatibility reports
+
+- [x] Complete AssetLoader replacement implementation: catalog/bundle stores,
+  catalog-plus-definitions stores without a local bundle, and legacy
+  definitions-only store overrides (including tender/rolling-stock swaps).
+- [x] AssetLoader-dependent packages have an explicit migration/dependency
+  path when the old DLL is absent; merely disabling the old Harmony patches
+  while retaining its assembly is not full replacement. The installer writes a
+  data-only `AssetLoader` UMM alias that requires FUSE.
+- [x] Update the installer to
+  detect old `AssetLoader` folders, ZIPs, DLLs, and active patches; present a
+  clear migration result; and verify the old runtime is no longer installed.
+  Removal/quarantine must be scoped and recoverable, and legacy UMM dependency
+  declarations must remain satisfiable through a FUSE-owned compatibility path.
+  (Offline files are handled by the installer; any still-loaded Harmony owner is
+  handled by FUSE's runtime replacement guard.)
+- [ ] Verify locomotives, rolling stock, tender swaps, native customization
+  controls, Legos library clones, save-car restoration, and the buy menu both
+  with and without the old AssetLoader installed.
+- [ ] Company window/menu lockout: reproduce with malformed and conflicting
+  packages; verify package-local containment and usable buy/company menus.
+- [x] Buy menu freezes for roughly seven seconds: cold prefab stores now warm
+  incrementally and the filtered equipment catalog is cached. Large real-world
+  equipment sets still need an in-game timing comparison.
+- [x] Converter failures: it only converts supported RailLoader JSON,
+  rejects code/native/asset-only/map-tile packages with the correct installer
+  guidance, and provides file/line/path/actionable diagnostics. The C# and
+  Python entry points share this policy; failed reports are written outside the
+  proposed `.FUSE` package so a report-only directory cannot be installed by
+  mistake. A real EFA corpus pass converted 38 JSON packages, produced 93
+  explicit unsupported/failure reports, wrote every report, and produced zero
+  successful output folders without a native fragment.
+- [ ] Conditional `mixInto` patches and `LoadAfter` dependencies (ARC Sylva
+  Terminal and related OttoSeer packages): object-form ids, hard-requirement
+  eligibility, conditional fragment requirements, optional ordering edges,
+  alias matching, and topological ordering are implemented and
+  regression-tested in the runtime and both converters. Hosted legacy code
+  plugins now use the same requires/loadAfter/loadBefore topological order
+  instead of Mods-folder enumeration order, with deterministic cycle fallback.
+  Declared
+  base/extension layering is excluded from Mod Conflicts. Needs an in-game pass
+  with ARC/OttoSeer/Katers packages before acceptance.
+- [ ] Base spans edited by legacy mods must remain renderable/owned correctly;
+  recover missing Sylva interchange tracks including
+  `SInterchange_Track_4` through `_9`.
+- [x] Diagnostics no longer flag unowned base-game placeholder/progression spans
+  as invalid mod content. Audit reads preserve authored FUSE span endpoints when
+  Railroader temporarily cannot resolve a runtime location, and report a true
+  orphan only when the referenced segment is actually gone. Componentless base,
+  passenger/scenery-only, fictional, and disabled location containers are not
+  treated as broken industries; malformed FUSE-owned spans remain actionable.
+- [x] Legacy base-road point replacements preserve and update the scene road in
+  place; broader road/river handler coverage remains in the parity matrix.
+- [ ] DKW nodes/segments that are valid must render; authoring geometry that is
+  too tight must produce an actionable warning rather than a false runtime bug.
+- [x] Preserve the flags-era graph fields found in the 2026.1 base-game audit:
+  diamond nodes, steel bridge supports, and independent yard designation.
+  Native schema/runtime conversion, partial-patch merging, removal snapshots,
+  desktop editor round-trip, and schema tests are implemented without changing
+  the released four-way `style` contract. A flags-era game build still requires
+  its own compile/live acceptance run.
+- [ ] Bjorn/ARC Whittier Sawmill track grouping: S01 cars must not resolve onto
+  S03 tracks; verify 1.0.3/1.0.4 behavior difference.
+- [ ] Sylva Industries Boosted: R2/R3 highlighting, car recognition, delivery
+  greying, and payment must all agree with the configured spans.
+- [ ] Kater interchange packages: preserve/merge referenced base-game spans.
+- [x] East Whittier overlapping/stranded track diagnosis: the supplied profile
+  simultaneously applied East Whittier Crossover, East Whittier Yard Revamp,
+  and AMW East Whittier. These are independent track layouts, not one malformed
+  switch. FUSE now reports cross-package same-ID replacements and separately
+  shows conservative spatial-layout warnings without auto-disabling either mod.
+  The older "PAC-MAN" gap still needs a one-layout-at-a-time in-game retest.
+- [x] Missing-mod visibility: the Mods page now groups and labels disabled,
+  skipped, dependency-missing, invalid, incompatible, partially applied,
+  loaded-but-awaiting-map, and successfully applied packages. Optional mixinto
+  omissions remain a successful apply with an explanatory note rather than a
+  whole-package failure, and the exact state is included by **Copy Mod Info**.
+- [ ] Legacy conflicts: preserve `ConflictsWith`, plus report actual runtime
+  ownership collisions without treating intentional same-package aliases or
+  declared `requires`/`loadAfter` extension layers as user-facing failures.
+  Ownership/layer classification is implemented. Top-level and conditional
+  `ConflictsWith` ids/version bounds are now preserved by both converters and
+  runtime conversion; matching top-level declarations skip the declaring
+  package, conditional declarations skip only their fragment, and Tools > Mod
+  Conflicts labels them as author-declared incompatibilities. Top-level checks
+  now include enabled code-only and asset-only mod manifests plus FUSE runtime
+  replacements, while ignoring disabled/profile-excluded packages. Successful
+  shared industry merges (including the Andrews Coal Power + Tuckasegee Steel
+  Works Kirkland targets from the 2026-08-20 run) are now informational
+  extension layers and do not inflate conflicts/load health. The incompatible-
+  mod in-game corpus remains open.
+- [ ] Test deliberately incompatible track mods that move/delete/claim the same
+  nodes, spans, industries, and scenery; conflict handling must remain
+  deterministic and menus must remain usable. The 2026-08-20 mixed-pack run
+  kept the game/report UI alive with 114 resident definitions and correctly
+  attributed the Bryson delete-vs-definition damage to
+  `jclass.Collie Bryson Removal` versus `StrykerBryson` (1 contained package
+  fault, 11 post-bind graph issues). Seven absent-companion mixintos remained
+  optional inactive fragments. Retest the revised status/conflict counts and
+  the affected in-game menus before closing this stress item.
+- [x] Add **Tools > Mod Conflicts**, grouped by package pair, with object kinds,
+  exact identifiers, resolution behavior, spatial-advisory separation, refresh,
+  and a complete clipboard report. Definition-versus-definition replacement is
+  now recorded in addition to delete-versus-definition conflicts.
+- [x] Asset duplicate reports collapse keys by winner/overridden source set,
+  distinguish identical copies from different definitions, identify the winner,
+  show example keys and impact, and retain every key in the exported report.
+- [ ] Strange Customs asset/audio/animation behavior and third-party rolling
+  stock visuals (including Freeman/Salty reports) need package-specific fixtures.
+- [ ] CLB, LEGO, Joo200, Signals Everywhere, and Alina Utilities must load and
+  operate correctly. A recovered Alina Utilities entry no longer also produces
+  a false legacy-host mod error, and a partially-bound legacy singleton is
+  repaired from the mod's UMM settings so its map-distance/camera patches do not
+  throw every frame. Actual in-game behavior still needs the restarted corpus
+  pass. Griz and Competition are explicitly not replacement gates.
+- [ ] Appy Railway starter equipment pool applies only when its package/map
+  requests it; do not affect unrelated new saves. Definition/setup scoping and
+  regression tests are implemented; the exact installed-game setup coroutine
+  contract has been rechecked with ILSpy. Needs one unrelated-new-save in-game
+  acceptance pass.
+- [ ] Appy starter placement must survive the tutorial and Escape key without
+  consuming/loss of unplaced equipment. Presentation waits for the tutorial,
+  cancellation retains the queued cut, and the queue now consumes a cut only
+  when `TrainController.LastPlacedTrain` confirms the full expected car count;
+  this also guards the current game's false-success callback after a caught
+  placement exception. Needs an in-game cancel/resume/place pass.
+- [x] Live diagnostics auto-refresh preserves the detail/log scroll position,
+  including bottom-follow behavior, instead of selecting the navigation list.
+- [x] World debug labels no longer render above pause/modal/game windows; they
+  resume automatically after the blocking UI closes.
+- [x] Provide a live console/log view comparable to RailLoader's console, with
+  pause/filter/copy/open-folder controls, without putting normal exceptions on
+  the primary Status page.
+- [ ] Validate GP38/Unity errors and mark harmless third-party/engine diagnostics
+  as such instead of load faults.
+- [x] Automatic-waybill location picker removes semantic duplicates caused by
+  multiple runtime component instances without deleting the underlying
+  operations data.
+- [x] Invalid track spans are removed from passenger-stop activation inputs
+  before base-game `PassengerStop.OnEnable` can dereference a removed segment.
+  Strange Customs/Signals Everywhere span serialization also omits invalid
+  endpoints instead of throwing through the graph rebuild.
+- [x] Repaired legacy JSON control-byte warnings are emitted once per source
+  file/session instead of repeating for every conversion pass.
+
+## Legacy replacement audit
+
+- [ ] Complete every row in `LEGACY_REPLACEMENT_PARITY.md` for:
+  - [ ] Alina's Map Mod (Alina Utilities remains an allowed separate dependency).
+  - [ ] RailLoader.Injector.
+  - [ ] RailLoader.Interchange.
+  - [ ] Strange Customs.
+  - [ ] Modular Scenery/asset loading responsibilities.
+  - [ ] Confusing Supplements, including body component groups, label printer,
+    refiller, destination sign, livery swap, and industry components.
+  - [x] AbsoluteMadness (native dependency-scoped routing; in-game fixture remains in the parity row).
+  - [x] ADRFDR (native component/title contract; in-game fixture remains in the parity row).
+  - [x] C1CD (native service scheduling/settings; in-game fixture remains in the parity row).
+  - [ ] CommandLine contract where required by hosted compatibility.
+  - [ ] DediSevi.
+  - [x] FallFromGrace (native grace transform/inspector row; in-game fixture remains in the parity row).
+  - [x] ForYourConvenience (native dashboard, station actions, and optional map/tag additions; in-game fixture remains in the parity row).
+  - [x] Interchange2Interchange (native bounded cross-interchange ordering; in-game fixture remains in the parity row).
+  - [ ] SanityInitiative.
+  - [ ] SerialTrafficControl.
+  - [x] SomeKindOfMadness (native configurable routing/event contract; in-game fixture remains in the parity row).
+- [ ] Verify replacement against real mods in `C:\Railroader mods`,
+  `E:\Backup mods`, Nexus samples, and the decompiled contract inventory under
+  `C:\Hrogers_Railroader_mods_Projects\Decompiled DLLs Not BASE GAME`.
+- [ ] Verify behavior with old DLLs absent; separately verify safe hosted-mode
+  behavior during migration where native parity is not yet complete.
+
+## Installer and user setup
+
+- [x] One clear FUSE installation path that places UMM/FUSE files correctly.
+  The bundled installer installs FUSE on a normal launch and installs only the
+  dropped packages during drag-and-drop use.
+- [x] Multi-file drag-and-drop installer for native FUSE, RailLoader data mods,
+  and UMM mods; recursively inspect ZIP layout rather than guessing by name.
+- [x] Per-package success/failure/skip result and a final batch summary, plus a
+  machine-readable report retaining source root, errors, requirements, and
+  compatibility actions.
+- [x] Detect unsafe archives, ambiguous/nested manifests, duplicate and
+  case-colliding archive members, duplicate/aliased package ids, version
+  conflicts, missing or failed dependencies, and unsupported/unmanifested
+  packages without partial corruption. Healthy packages are staged and swapped
+  atomically; existing installs survive extraction or swap failure.
+- [x] Locate Steam installations robustly, including non-default libraries.
+- [x] Detect old RailLoader-patched game files and provide safe verification or
+  Steam file-verification guidance; do not blindly overwrite game binaries.
+- [x] Explain prerequisites, exact install folders, first launch, upgrading,
+  removal, logs, and recovery in plain language.
+- [x] Repair startup order for separately installed UMM code mods that reference
+  FUSE-replaced RailLoader/Strange Customs assemblies. Installer 0.7.0 scans
+  assembly metadata without executing it, backs up the original manifest, and
+  adds FUSE to `Requirements`/`LoadAfter` while preserving the manifest's
+  existing string/object/list shapes. The installed Alina Utilities manifest
+  was repaired and its original retained under
+  `Mods\ModBackups\FUSEInstaller\CompatibilityManifests-*`.
+- [ ] Verify UMM drag-and-drop behavior and the previously reported 1.0.2 install
+  failure.
+
+## Error reporting and author support
+
+- [x] Every JSON error report includes package id/name, source root, relative and
+  absolute file path, line/column when available, JSON property path, validation
+  code, expected shape/type, received value, and a concrete fix hint. Native,
+  manifest, and legacy-conversion parse paths feed the same structured fault.
+- [x] Every validation code emitted by the game and shared Core validators has a
+  catalogued title, cause, concrete repair, and example. Coverage now includes
+  native modular feature rules, rigid object-line splineys, and water surfaces;
+  the dedicated catalog-coverage suite prevents new cryptic codes or stale help
+  entries.
+- [x] Missing dependency reports name the missing id, required version/range,
+  requester, and where to obtain/enable it when known. Installer batch preflight
+  also distinguishes FUSE-provided legacy contracts from unrelated dependencies
+  and propagates a failed provider to its dependents before any writes.
+- [x] Provide a complete package-scoped export suitable for a mod author, while
+  keeping the Status page concise and actionable. **Copy Mod Info** now includes
+  the full structured diagnostic block for only the selected package; the full
+  health JSON carries the same fields.
+- [x] Distinguish package fault, conflict, warning, suppression, orphan, broken
+  asset, graph issue, and benign runtime diagnostic. Status remains load-health
+  focused; conflicts, audits, assets, and live/third-party diagnostics have
+  separate Tools pages and structured report sections.
+- [ ] Verify health/audit/debug bundle output against Cowboy's and the local
+  stress-test reports.
+
+## Tile Editor — correctness and usability
+
+- [x] Canonical new projects/output use native FUSE schema. Native scenery now
+  writes `world.scenery.<id>.assetIdentifier`; earlier misplaced root scenery is
+  migrated collision-safely. Full-map in-game acceptance remains open below.
+- [x] Visible FUSE Native / RailLoader Legacy export switch.
+- [x] Grey out controls that legacy schema cannot express and show why; never
+  reduce native FUSE capabilities to legacy limitations. The editor identifies
+  limited legacy mode and disables native industry removals, station agents,
+  custom Toolshed bindings, and visible water-surface authoring while retaining
+  the supported RailLoader forms for track, passenger stops, loader builders,
+  roads, and scenery.
+- [x] Fix selection obstruction/priority (track geometry must not hide town signs
+  or intended selectable objects). Track render geometry is filtered; needs
+  in-game object-picking confirmation.
+- [x] Fix stale/accumulating track previews without requiring a full track reload.
+  Targeted rebuild is implemented; needs multi-mod in-game confirmation.
+- [x] Show node-to-segment and segment-to-node relationships and warn about
+  duplicates/covered track.
+- [x] Fix vegetation painting save/reload reversion. Categorical mask persistence
+  and FUSE tile override registration are implemented. Both editor surfaces now
+  describe the 0–7 values truthfully as full-to-clear density levels with
+  approximate percentages/examples, desktop save defensively recalculates tile
+  statistics and clears all render caches, and the in-game save invalidates or
+  rebuilds Railroader's terrain cache. The every-tab live save audit remains
+  open.
+- [x] Fix striped/weird-line terrain deformation artifacts. Interpolated brush
+  sampling is implemented; broader falloff/seam/undo fidelity testing remains
+  part of the whole-map acceptance test.
+- [ ] Complete road/river/spline/mandela authoring and runtime application.
+- [x] Toggle grade labels above track segments.
+- [x] Turnout geometry guidance including minimum practical radii/tightness.
+- [x] Add/move/remove base-game objects including town signs; selection needs
+  in-game confirmation around dense track geometry.
+- [x] Add/edit/remove base-game industries with explicit native operations.
+- [ ] Make industries, areas, loads, components, storage, contracts, delivery,
+  payment, and progression setup understandable and validated. The desktop Mod
+  panel now exposes a copyable pre-publish validator and clean ZIP export;
+  native area/span/load/industry/station/loader/passenger relationships are
+  checked, with dependency-provided add-on references reported as warnings and
+  missing standalone-map references as errors. In-game workflow/behavior
+  acceptance remains open.
+- [ ] Complete passenger stops, station agents, timetable/neighbor relationships,
+  and map/company window integration.
+- [ ] Complete interchange creation, tracks, routing, and service settings.
+- [ ] Complete signals, signal movement, heads/aspects, routes, blocks, logic,
+  complete CTC systems, and CTC panel authoring/runtime wiring. The editor and
+  Railroad Operations now cover base semaphore placement/track locking,
+  multi-head aspects, diamond interlockings, ABS/manual/CTC blocks, power-switch
+  control points, routes, dispatcher UI, multiplayer state, schema files, and
+  full graph/cross-file validation. FUSE-native section ownership, broader
+  signal families/custom assets, and whole-territory in-game acceptance remain.
+- [x] Loader placement can snap to a selected track/span and then adjust lateral,
+  longitudinal, vertical, and rotational offsets manually.
+- [x] Support custom loader models/load points/service definitions. Native FUSE
+  scenery and Toolshed binding are one undoable/save-safe editor action.
+- [x] Import/discover Toolshed-authored custom loaders as a placeable catalog and
+  emit matching native scenery and service-binding data. Industry/load/span
+  operation components remain explicit author choices rather than guessed data.
+- [x] Use
+  `C:\Hrogers_Railroader_mods_Projects\Toolshed\FuseServiceFacilityTest.zip`
+  as the first Toolshed integration fixture (bunker-C tank loader, wood shed,
+  source industry, span binding, authored load points). The editor presets and
+  field contract match the fixture; in-game transfer/storage behavior still
+  needs confirmation with Toolshed installed.
+- [x] Native per-mod feature/options schema and runtime UI for modular packages:
+  booleans/choices/sliders conditionally enable exact authored track, spans,
+  scenery, operations, world, progression, and audio objects. The source
+  definition remains intact, changes are clearly reload-required, FUSE's Mods
+  page reports the active/disabled feature set, and the Editor Options workspace
+  authors and validates the rules. RailLoader mode stays visibly disabled
+  because it has no equivalent contract.
+- [ ] Every tab needs a capability, validation, save/reload, undo/redo, runtime,
+  and documentation audit; Signals and Operations are partial implementations,
+  not empty stubs.
+
+## Tile Editor — whole-map workflow acceptance test
+
+The automated desktop golden test `tests/test_complete_map_workflow.py` now
+creates a native standalone map, imports a tile, authors track/turnout/spans,
+operations, passenger and interchange content, scenery/road/town sign/water,
+modular options, progression, signals/CTC, and a Toolshed binding, then saves,
+reopens, validates against FUSE's authoritative schema, exports a ZIP, and
+checks its contents. The boxes below intentionally remain open until the same
+fixture installs, launches, saves, reloads, and is visually/operationally
+verified in Railroader.
+
+- [ ] Download/acquire terrain tiles with licensing/source metadata.
+- [ ] Create a new map coordinate/tile set from scratch.
+- [ ] Add tiles to an existing map safely.
+- [ ] Sculpt terrain; paint vegetation; save/reload exactly. Both editors now
+  use named 0–7 full-to-clear density levels (not misleading fixed biomes),
+  categorical mask writes, atomic tile saves, backup retention, dirty ownership,
+  render-stat/cache refresh, and Railroader cache invalidation/rebuild; the live
+  paint/save/reload acceptance run remains open.
+- [ ] Create water surfaces and edit/remove existing water/lake planes. Native
+  `world.waterSurfaces`, runtime CRUD/cache/diagnostics, Editor creation and
+  point editing, stock-lake replacement, desktop validation, and schema docs are
+  implemented; in-game material, collider, save/reload, and replacement
+  acceptance remains open.
+- [ ] Lay track, switches, crossings, spans, groups, grades, bridges/trestles,
+  turntables, and yards.
+- [ ] Draw fences, retaining walls, guardrails, pipes, and similar repeated
+  objects. Native `objectLine` schema/runtime/editor support, uniform spacing,
+  terrain snap, offsets, scaling, rotation, endpoint placement, safety caps,
+  undo/save, documentation, and legacy-mode gating are implemented; asset and
+  scene-prefab in-game round-trip acceptance remains open.
+- [ ] Add scenery, roads, labels, town signs, loaders, service facilities,
+  interchanges, industries, passenger facilities, progression, signals, and CTC.
+- [ ] Configure map identity/start state/start equipment correctly.
+- [ ] Export, validate, install, launch, save, reload, and edit the generated map.
+  Desktop Validate/Export ZIP is implemented; install/launch and full generated-
+  map round-trip acceptance remain open.
+- [ ] A new author can repeat the complete workflow from the wiki alone.
+
+## Railroader base-game audit for map completeness
+
+The subsystem-by-subsystem source crosswalk and acceptance boundary are now
+documented in [`BASE_GAME_MAP_AUTHORING_AUDIT.md`](BASE_GAME_MAP_AUTHORING_AUDIT.md).
+
+- [x] Inventory map bootstrap/session creation, coordinate spaces, terrain tiles,
+  texture/vegetation layers, and streaming/culling.
+- [x] Inventory water/lake/river surfaces, materials, reflection/collider behavior,
+  persistence, editing, and creation requirements. The current `LakePolygon`
+  creation contract and source-material/profile reuse are covered by native
+  schema/runtime/editor support; reflection behavior and full in-game persistence
+  acceptance still require golden-master testing.
+- [x] Inventory track graph, render geometry, switches, crossings, bridges,
+  turntables, signals, blocks/routes, CTC, speed limits, grades, and validation.
+- [x] Inventory scenery, buildings, roads, spline systems, signs, labels, map
+  masks/features, telegraph, portals/interchanges, and service points. Rigid
+  repeated-object lines are now covered separately from deformable road/river
+  meshes; remaining spline/profile families still need the full base audit.
+- [x] Inventory areas/towns, industries, loads, contracts, storage, loaders,
+  passenger stops, agents/timetables, progression/milestones, and starting state.
+- [x] Inventory save identifiers, initialization order, cache rebuilds, teardown,
+  multiplayer authority, and UI views required for each authored subsystem.
+- [x] Compare every discovered subsystem with FUSE native schema, runtime APIs,
+  Tile Editor UI, validation, serialization, tests, and wiki coverage.
+
+## Documentation and wikis
+
+- [x] Rewrite the local FUSE install, getting started, troubleshooting, migration,
+  converter scope, package authoring, schema, operations, diagnostics, and
+  command documentation.
+- [ ] Complete FUSE wiki and sync published pages.
+- [x] Complete the local Tile Editor wiki source: installation/runtime prerequisite, all tabs,
+  every key binding, selection, terrain/vegetation, tiles, track/grades,
+  scenery/objects, roads/water, industries/operations, loaders/custom loaders,
+  passenger, interchanges, signals/CTC, export modes, validation, and examples.
+- [x] Complete the local Toolshed wiki source including custom-loader authoring and editor catalog
+  integration.
+- [x] Complete the local Narrow Gauge wiki source and identify FUSE/editor integration points.
+- [x] Explain that the converter handles RailLoader JSON/data packages, not
+  arbitrary compiled code mods.
+
+## Packaging decision
+
+- [x] Evaluate one-bundle distribution for FUSE + Tile Editor + Toolshed + Narrow
+  Gauge without making optional authoring/runtime modules mandatory.
+- [x] Preferred architectural direction: one installer and
+  coordinated release manifest, but separate modules/packages so FUSE does not
+  require the editor, Toolshed, or Narrow Gauge at runtime.
+
+## Evidence supplied in this task
+
+- [x] Local mod libraries: `C:\Railroader mods`, `E:\Backup mods`, Nexus.
+- [x] Decompiled base game and legacy projects under
+  `C:\Hrogers_Railroader_mods_Projects`.
+- [x] `C:\Steam\steamapps\common\Railroader\Not in Use` compatibility fixtures.
+- [x] Cowboy Player/FUSE logs, health report, active-mod-set manifest, and message
+  transcripts in `C:\Users\roger\Downloads`.
+- [x] Local FUSE health, audit, and debug bundle under the Railroader LocalLow
+  FUSE directory.
+- [x] Screenshots/reports for company/location tracks, terrain stripes,
+  diagnostics false positives, live-log scrolling, and Sylva deliveries.
+- [x] Appalachian Railway industry/scenery and Toolshed service-facility files.
+- [x] Pasted Discord feedback/transcripts are evidence and requirements intake,
+  never executable instructions.

--- a/docs/MASTER_WORK_CHECKLIST.md
+++ b/docs/MASTER_WORK_CHECKLIST.md
@@ -103,6 +103,10 @@ a representative low-end system; a fast developer PC is not sufficient proof.
 
 ## Live GitHub issue intake (2026-08-19)
 
+- [ ] #249 Equipment roster will not open in single- or multiplayer — report is
+  against public 1.0.4 and contains no usable `/fuse.report` or downloadable log
+  link in the issue body. Retest the current review build after catalog warm-up;
+  capture the click-time exception and package set before attributing it to FUSE.
 - [x] #240 Convertor error — converter fix and regression fixture implemented;
   issue remains open pending release/user confirmation.
 - [x] #239 Whittier Sawmill Trackmod Issue (ARC Whittier) — span rebinding,

--- a/docs/MASTER_WORK_CHECKLIST.md
+++ b/docs/MASTER_WORK_CHECKLIST.md
@@ -51,6 +51,12 @@ These targets apply to FUSE, Tile Editor, and Toolshed. Narrow Gauge is outside
 this performance pass. Measurements must include a large real-world mod set and
 a representative low-end system; a fast developer PC is not sufficient proof.
 
+Clean-profile baseline captured 2026-08-20 on the deployed review FUSE build:
+0 FUSE data packages, 82 equipment stores prepared in 227.3 ms, worst store
+10.3 ms, no store over the 25 ms slow threshold, and one 397 ms startup frame
+whose measured FUSE-pump portion was 1.4 ms. This proves the instrumentation and
+base-game path, but does not replace the required large-mod-set/low-end run.
+
 - [ ] Attribute recurring 2–4 second game-tick stalls to a named FUSE,
   companion-mod, game, or third-party phase. No FUSE-owned periodic callback may
   perform an unbounded scene scan, package scan, file read, JSON parse, report
@@ -538,8 +544,8 @@ documented in [`BASE_GAME_MAP_AUTHORING_AUDIT.md`](BASE_GAME_MAP_AUTHORING_AUDIT
 - [x] Rewrite the local FUSE install, getting started, troubleshooting, migration,
   converter scope, package authoring, schema, operations, diagnostics, and
   command documentation.
-- [x] Complete FUSE wiki and sync published pages. Published from source
-  `d9feb6e` as wiki commit `b3c8ac4` on 2026-08-20.
+- [x] Complete FUSE wiki and sync published pages. Published 15 pages plus Home
+  and sidebar from source `0447e49` as wiki commit `3e54f4f` on 2026-08-20.
 - [x] Complete the local Tile Editor wiki source: installation/runtime prerequisite, all tabs,
   every key binding, selection, terrain/vegetation, tiles, track/grades,
   scenery/objects, roads/water, industries/operations, loaders/custom loaders,

--- a/docs/MIGRATION_FROM_LEGACY.md
+++ b/docs/MIGRATION_FROM_LEGACY.md
@@ -9,9 +9,10 @@ page. See [GETTING_STARTED.md](GETTING_STARTED.md).
 
 ## What Changes
 
-Legacy data mods are **converted**, not loaded as-is. The converter reads a legacy
-mod folder and writes a `*.FUSE` package next to it, containing the same content
-expressed in the FUSE schema plus a conversion report.
+FUSE can host compatible RailLoader plugins and translate supported legacy data
+in memory. Converting a data mod to native FUSE is still recommended for authors
+because it produces validation and conversion reports, but players do not have
+to convert every compatible package before testing it.
 
 What carries over:
 
@@ -19,16 +20,18 @@ What carries over:
 | --- | --- |
 | Track / route JSON | Converted, one FUSE data file per source JSON |
 | Horn / whistle / bell packs | Converted, audio files copied |
-| Strange Customs asset packs | Converted to a FUSE asset wrapper |
+| Strange Customs asset packs | Installed directly; FUSE discovers supported legacy asset packs |
+| Alina map-tile packages | Installed directly; FUSE's Alina compatibility reads the tile data |
 | World scenery, scene clones, map masks, splines | Converted |
 | Industries, loaders, stations, team/repair tracks | Converted |
 | Progression sections and delivery phases | Converted |
 
 What does not carry over:
 
-- **Arbitrary script mods.** A legacy mod that ships `.dll` logic is not a data
-  package, and the converter cannot translate its behavior. It warns and leaves
-  the binaries alone.
+- **Unknown arbitrary script behavior.** The converter cannot translate DLL
+  logic. FUSE independently implements the legacy host APIs used by supported
+  RailLoader plugins, but a plugin using an unimplemented API is isolated and
+  reported instead of being silently converted.
 - **Rolling stock, locomotive, and car mods**, except audio definitions.
 - **Signals.**
 - **Three-way switches** — Railroader does not support them as standard graph
@@ -45,9 +48,9 @@ this situation, and it is the single most common self-inflicted problem when
 migrating.
 
 The same applies to the loaders themselves. FUSE detects a leftover
-`Railloader.dll` or `Railloader.Interchange.dll` in the install and warns about it,
-both on disk and among loaded assemblies. Take the warning seriously — it means
-two loaders are live at once.
+`Railloader.dll`, `Railloader.Injector.dll`, or `Railloader.Interchange.dll` in
+the install and warns about it, both on disk and among loaded assemblies. Take
+the warning seriously — it means two loaders are live at once.
 
 Loading both is supported only as a deliberate conflict test.
 
@@ -62,7 +65,9 @@ the step people skip and regret.
 
 List your legacy mods and sort them into three groups:
 
-- **Data mods** (routes, scenery, industries, audio, asset packs) — these convert.
+- **Convertible data mods** (routes, scenery, industries, supported audio JSON) — these convert.
+- **Direct-install data** (asset packs and Alina map tiles) — install the original
+  package through the FUSE installer; do not run it through the converter.
 - **Script mods** (`.dll` logic) — these do not convert; check whether a FUSE-native
   equivalent exists.
 - **Rolling stock** — out of scope except audio.
@@ -87,6 +92,8 @@ fuse-convert "C:\Path\To\LegacyMod" --out "C:\Steam\steamapps\common\Railroader\
 ### 4. Read the conversion report
 
 Every converted package gets `conversion-report.json` and `conversion-report.md`.
+Failed or direct-install inputs write their reports under the output root's
+`_conversion-reports` folder so the report cannot be mistaken for a package.
 **Read them.** The converter classifies each source concept rather than silently
 dropping it:
 
@@ -144,13 +151,14 @@ The legacy loader. FUSE reads Railloader's package metadata directly, including
 `RailLoadPriority`, `RailLoadAfter`, and `RailLoadBefore` for load ordering, so
 ordering relationships you already established carry across.
 
-Remove `Railloader.dll` and `Railloader.Interchange.dll` once you have migrated —
+Remove `Railloader.dll`, `Railloader.Injector.dll`, and
+`Railloader.Interchange.dll` once you have migrated —
 FUSE warns while they remain.
 
 ### Strange Customs
 
-Asset packs convert to a FUSE asset wrapper with `FuseAssetPacks` declared in
-`Info.json`. Mixin files convert through the `mixinto` mechanism; a missing mixinto
+Asset packs install directly and remain available to native or converted route
+packages. Mixin files convert through the `mixinto` mechanism; a missing mixinto
 requirement skips only that fragment rather than faulting the whole stack.
 
 ### ConfusingSupplements / For Your Convenience

--- a/docs/PACKAGE_AUTHOR_GUIDE.md
+++ b/docs/PACKAGE_AUTHOR_GUIDE.md
@@ -23,16 +23,39 @@ Every file should include:
 - Do not rename an id just to change display text.
 - Keep display names in `name`; keep identity in `id`.
 
+## Player-Selectable Features
+
+Use top-level `settings` plus `featureRules` when one package should offer
+optional track, scenery, industries, loaders, or other authored sections. The
+Tile Editor's **Options** workspace creates on/off, choice, and slider settings,
+lets you select the exact objects controlled by each option, and writes both
+dictionaries together.
+
+Feature settings must be marked `reloadRequired`; the Editor does this
+automatically. A false rule omits only the targets listed by that rule from the
+runtime definition. It does not delete those objects from the package file.
+Every target must be authored in the same definition, and an industry-component
+target uses `industryId/componentId`. See the schema guide for the full target
+list and JSON example.
+
+RailLoader output has no equivalent contract. The Editor therefore disables
+this workspace in legacy mode instead of creating a lossy or misleading export.
+
 ## Dependencies
 
 Use package metadata for required package ordering and dependencies:
 
-- `RailLoadPriority`
-- `RailLoadAfter`
-- `RailLoadBefore`
-- normal UMM `Requirements` when the mod itself requires FUSE or another mod
+- `FuseLoadPriority`
+- `FuseRequires` for hard FUSE data-package dependencies
+- `FuseLoadAfter`
+- `FuseLoadBefore`
+- `FuseConflictsWith` for explicit package incompatibilities, with optional
+  `NotBefore`/`NotAfter` bounds
+- normal UMM `Requirements`/`LoadAfter` when a UMM code mod requires FUSE or another UMM mod
 
-Use `mixinto` when converting legacy conditional mixin files. Missing mixinto requirements should skip only that fragment, not the whole stack.
+Use `mixinto` when converting legacy conditional mixin files. Missing mixinto
+requirements or matching `mixinto.conflictsWith` references skip only that
+fragment, not the whole stack.
 
 ## Optional References
 
@@ -84,6 +107,38 @@ for a map that intentionally overlays custom terrain on Bushnell/Whittier.
 
 Asset pack objects should keep their real asset identifiers. Do not alias to unrelated assets if the correct pack exists.
 
+### Asset stores and definition overrides
+
+Declare normal asset-pack roots with `FuseAssetPacks`. A runtime store is
+identified by `Catalog.json`; `Bundle` is optional for a definitions-only
+catalog whose assets are supplied by another store. FUSE reports an actual
+missing bundle if an asset from that store is requested.
+
+For the old AssetLoader pattern where a `Definitions.json` file replaces the
+definitions of an existing store (rolling-stock and tender swaps), prefer an
+explicit native manifest entry:
+
+```json
+{
+  "Requirements": ["FUSE"],
+  "FuseDefinitionOverrides": [
+    {
+      "StoreIdentifier": "fm-flatcar03",
+      "Path": "DefinitionOverrides/fm-flatcar03/Definitions.json"
+    }
+  ]
+}
+```
+
+The path must stay inside the package. An object entry names the exact existing
+store id; a string path infers the id from its parent folder. FUSE also detects
+AssetLoader's legacy immediate-child convention automatically, but native
+packages should be explicit. If two packages target the same exact store, FUSE
+chooses deterministically and reports both source files.
+
+New packages should require `FUSE`, not `AssetLoader`. The installer's data-only
+`AssetLoader` alias exists only for old manifests.
+
 ## Diagnostics
 
 Use these commands while authoring:
@@ -100,3 +155,10 @@ Use these commands while authoring:
 - `/fuse.dumpmandelas`
 
 Warnings should name package id, operation, object id, and field whenever possible.
+
+Malformed JSON and validation faults are isolated to the affected definition.
+`/fuse.report` and `/fuse.report json` include the absolute folder/file, JSON
+path, line/column when available, and a suggested action. Treat a report with a
+faulted package as an authoring failure even if unrelated packages still work.
+
+For task-based examples, see [Authoring Recipes](AUTHORING_RECIPES.md).

--- a/docs/PERFORMANCE_TESTING.md
+++ b/docs/PERFORMANCE_TESTING.md
@@ -1,0 +1,78 @@
+# Performance Acceptance Testing
+
+Use this procedure for FUSE, Tile Editor, and Toolshed performance reports. It
+separates load-screen work, ordinary gameplay, streaming, editor work, and
+third-party exceptions so one visible pause is not assigned to the wrong mod.
+
+## Before The Run
+
+1. Restart Railroader after installing the candidate DLLs. Do not hot-replace a
+   DLL in a running process.
+2. Record CPU, GPU, RAM, storage type, display resolution, and the exact enabled
+   profile. Include a lower-end machine when release acceptance is the goal.
+3. Enable **FUSE Settings > Frame Spike Diagnostics**. Keep ordinary debug world
+   labels and overlays off unless that overlay is the feature under test.
+4. Use the same save, camera start, and profile for the before and after runs.
+
+## Required Scenarios
+
+### Load And Track Apply
+
+- Start at the main menu, load the large-mod-set save, and do not move the
+  camera until player control is released.
+- Record package discovery, map apply, track rebuild, scenery activation, and
+  total load times from `FUSE.log`.
+- Fail the run if player control begins while camera-near FUSE scenery still
+  appears in a visible activation wave.
+
+### Equipment Roster And Buy Menu
+
+- Find the `equipment catalog warm-up completed` line. It reports total work,
+  slow-store count, worst store, and Lego containers skipped by the fast path.
+- Open the company equipment roster and the buy menu once before completion and
+  once after completion. Record click time and whether locomotives, railcars,
+  tender swaps, Lego clones, and customization controls are present.
+- A menu that does not open, loses content, or stalls for seconds after warm-up
+  fails even when the frame-rate average looks healthy.
+
+### Recurring Gameplay Stutter
+
+- Stand still for two minutes, then run or drive through a scenery-heavy area
+  for two minutes. Include at least one teleport/camera turn if that reproduced
+  the original report.
+- Any repeating 2–4 second pause must align to a timestamped frame-spike line.
+  Record GC deltas, queue depths, and `fusePumpWorstPhase`.
+- `none measured` is a valid result: it means the expensive phase was outside
+  FUSE's runtime pump and the surrounding Player/FUSE log lines must be used.
+
+### Tile Editor
+
+- Enable whole-map grade labels and compare idle, pan/zoom, node dragging,
+  terrain painting, vegetation painting, save, and reload.
+- Leave the desktop editor idle beside Railroader, then minimize it. Confirm it
+  returns to 60 FPS during input while using the documented 15/5 FPS idle caps.
+- Save and reload terrain and vegetation; unchanged data must not trigger a
+  redraw, heartbeat-write backlog, or reverted mask.
+
+### Toolshed
+
+- Exercise one service facility, selective interchange, link-and-pin car, and
+  storage/particle animation.
+- Leave the game idle for at least one minute after every definition binds. A
+  two-second scene-scan rhythm must not remain.
+- Change maps/scenes and confirm facilities rebind without waiting for the
+  maximum retry delay.
+
+## Evidence Bundle
+
+Attach:
+
+- `FUSE.log` and `Player.log`
+- the FUSE health, audit, and debug-bundle JSON exports
+- `/fuse.report json`, `/fuse.loaded`, and `/fuse.conflicts`
+- the exact mod profile/manifest and hardware details
+- click-to-open timings and a short video for visible pop-in or repeating stalls
+
+Do not close a performance checklist item from an automated suite alone. Unit
+tests protect correctness; this run supplies the frame-time, main-thread, queue,
+memory/GC, menu, and visual evidence required for release acceptance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ New to FUSE, or installing it on a fresh setup.
 | Doc | What it covers |
 | --- | --- |
 | [Getting Started](GETTING_STARTED.md) | Install FUSE and your first packages, verify the load, update, uninstall |
+| [Install, Convert, Or Author?](CHOOSING_A_WORKFLOW.md) | Pick the right installer, converter, editor, or runtime companion |
 | [FAQ](FAQ.md) | Common questions — legacy mods, multiplayer, saves, performance |
 | [Settings](SETTINGS.md) | All 29 settings, their defaults, and where they live |
 | [Console Commands](CONSOLE_COMMANDS.md) | Every `/fuse.*` command |
@@ -27,6 +28,7 @@ Building or converting FUSE packages.
 | Doc | What it covers |
 | --- | --- |
 | [Package Author Guide](PACKAGE_AUTHOR_GUIDE.md) | The authoring contract — ids, dependencies, optional references |
+| [Authoring Recipes](AUTHORING_RECIPES.md) | Move track, remove industries, place loaders, edit roads/signs, diagnose JSON |
 | [JSON Schema Reference](../schemas/FUSE_JSON_SCHEMA.md) | The full data contract |
 | [Converter](FUSE_CONVERTER.md) | Drag-and-drop, batch, and `fuse-convert` CLI conversion |
 | [External Editor](EXTERNAL_EDITOR.md) | The standalone desktop editor |
@@ -69,6 +71,9 @@ conflicts is a clean load.
 
 **A package isn't loading.** `/fuse.loaded` — not listed means undiscovered,
 listed as faulted means it failed to apply.
+
+**Can the converter convert a DLL/code mod?** No. It converts recognized JSON
+and package data only. See [Install, Convert, Or Author?](CHOOSING_A_WORKFLOW.md).
 
 **Filing a bug?** Attach `FUSE.log`, `Player.log`, `/fuse.report json` output, and
 the package's `conversion-report.json`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ New to FUSE, or installing it on a fresh setup.
 | [Install, Convert, Or Author?](CHOOSING_A_WORKFLOW.md) | Pick the right installer, converter, editor, or runtime companion |
 | [FAQ](FAQ.md) | Common questions — legacy mods, multiplayer, saves, performance |
 | [Settings](SETTINGS.md) | All 29 settings, their defaults, and where they live |
+| [Performance Testing](PERFORMANCE_TESTING.md) | Reproducible load, menu, stutter, Tile Editor, and Toolshed acceptance |
 | [Console Commands](CONSOLE_COMMANDS.md) | Every `/fuse.*` command |
 | [Troubleshooting](TROUBLESHOOTING.md) | Symptom → diagnostic → what to attach to a report |
 | [Known Issues](KNOWN_ISSUES.md) | Current limitations and unsupported content |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -42,6 +42,19 @@ The compatibility-guard and observed-exception lists on this page are evidence,
 not automatic bug verdicts. Include them when they repeat alongside a visible
 problem.
 
+### A Two- To Four-Second Stutter Keeps Repeating
+
+Enable **Frame Spike Diagnostics** in FUSE Settings, reproduce for at least a
+minute, then attach `FUSE.log` and `Player.log`. Each retained spike includes GC
+deltas, streaming and track queue depths, equipment completion depth, and the
+slowest measured FUSE runtime-pump phase. Do not infer the cause from ordinary
+Unity exceptions alone. A named phase identifies where to investigate; `none
+measured` is equally useful because it points outside FUSE's pump.
+
+For a buy-menu stall, wait for the equipment-catalog warm-up completion line and
+include its total work, slow-store count, and worst-store fields. Report whether
+the first click happened before or after that line.
+
 ### Faulted Package
 
 Run `/fuse.loaded` and `/fuse.report`. Check `FUSE.log` for the package id and phase. Package failures should not prevent unrelated packages from loading.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -30,9 +30,29 @@ Also include console output or screenshots for:
 
 ## Common Symptoms
 
+### I Want A Live Debug Console
+
+Open **FUSE → Tools → Live Diagnostics → Open Live Console**. On Windows this
+opens a continuously scrolling mirror of `FUSE.log` for a second monitor. Stop
+it from the same page before exiting; the console's Close command is disabled so
+closing that optional diagnostics window cannot terminate Railroader. On other
+platforms, use the filtered in-game viewer or tail `FUSE.log` with a text tool.
+
+The compatibility-guard and observed-exception lists on this page are evidence,
+not automatic bug verdicts. Include them when they repeat alongside a visible
+problem.
+
 ### Faulted Package
 
 Run `/fuse.loaded` and `/fuse.report`. Check `FUSE.log` for the package id and phase. Package failures should not prevent unrelated packages from loading.
+
+For an author-ready report, open **FUSE → Mods**, select the affected package,
+and use **Copy Mod Info**. Its actionable diagnostic names the package and
+source root, shows both relative and absolute filenames, includes JSON
+property/line/position and validation code when available, contrasts the
+expected shape with the received value, and ends with the concrete correction.
+This package-scoped copy is usually easier to send to an author than the full
+health report.
 
 ### Unknown Scenery Asset
 
@@ -45,6 +65,16 @@ Check whether it is a regular asset pack item or a scene clone. For scene clones
 ### Bad Track, Missing Span, Or Broken Segment
 
 Run `/fuse.dumpgraph` and `/fuse.dumpruntimegraph`. The files are written to the main Railroader folder as `FUSE-original-graph.json` and `FUSE-runtime-graph.json`.
+
+Open **FUSE → Tools → Mod Conflicts** before assuming one track mod is broken.
+The page groups conflicts by the two packages involved and lists the exact
+objects and winning/merge behavior. "Potential track-layout overlap" is an
+advisory: FUSE found multiple nearby authored nodes but kept both packages
+because an intentional connection can look similar. If the map contains
+overlapping switches, floating rails, or dead stubs, temporarily enable only one
+primary layout for that area and retest. For example, East Whittier Yard Revamp
+and AMW East Whittier are alternative yard layouts; add East Whittier Crossover
+only when its author declares it compatible with the chosen layout.
 
 ### Company Window Or Location List Looks Wrong
 

--- a/docs/pdf/FUSE-Package-Author-Guide.pdf
+++ b/docs/pdf/FUSE-Package-Author-Guide.pdf
@@ -2,7 +2,7 @@
 %“Œ‹ž ReportLab Generated PDF document (opensource)
 1 0 obj
 <<
-/F1 2 0 R /F2 3 0 R /F3 5 0 R /F4 21 0 R
+/F1 2 0 R /F2 3 0 R /F3 5 0 R /F4 25 0 R
 >>
 endobj
 2 0 obj
@@ -17,7 +17,7 @@ endobj
 endobj
 4 0 obj
 <<
-/Contents 39 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 43 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -32,7 +32,7 @@ endobj
 endobj
 6 0 obj
 <<
-/Contents 40 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 44 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -42,7 +42,7 @@ endobj
 endobj
 7 0 obj
 <<
-/Contents 41 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 45 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -52,7 +52,7 @@ endobj
 endobj
 8 0 obj
 <<
-/Contents 42 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 46 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -62,7 +62,7 @@ endobj
 endobj
 9 0 obj
 <<
-/Contents 43 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 47 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -72,7 +72,7 @@ endobj
 endobj
 10 0 obj
 <<
-/Contents 44 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 48 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -82,7 +82,7 @@ endobj
 endobj
 11 0 obj
 <<
-/Contents 45 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 49 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -92,7 +92,7 @@ endobj
 endobj
 12 0 obj
 <<
-/Contents 46 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 50 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -102,7 +102,7 @@ endobj
 endobj
 13 0 obj
 <<
-/Contents 47 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 51 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -112,7 +112,7 @@ endobj
 endobj
 14 0 obj
 <<
-/Contents 48 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 52 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -122,7 +122,7 @@ endobj
 endobj
 15 0 obj
 <<
-/Contents 49 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 53 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -132,7 +132,7 @@ endobj
 endobj
 16 0 obj
 <<
-/Contents 50 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 54 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -142,7 +142,7 @@ endobj
 endobj
 17 0 obj
 <<
-/Contents 51 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 55 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -152,7 +152,7 @@ endobj
 endobj
 18 0 obj
 <<
-/Contents 52 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 56 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -162,7 +162,7 @@ endobj
 endobj
 19 0 obj
 <<
-/Contents 53 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 57 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -172,7 +172,7 @@ endobj
 endobj
 20 0 obj
 <<
-/Contents 54 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 58 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -182,12 +182,17 @@ endobj
 endobj
 21 0 obj
 <<
-/BaseFont /Symbol /Name /F4 /Subtype /Type1 /Type /Font
+/Contents 59 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 22 0 obj
 <<
-/Contents 55 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 60 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -197,7 +202,7 @@ endobj
 endobj
 23 0 obj
 <<
-/Contents 56 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 61 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -207,7 +212,7 @@ endobj
 endobj
 24 0 obj
 <<
-/Contents 57 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 62 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -217,17 +222,12 @@ endobj
 endobj
 25 0 obj
 <<
-/Contents 58 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
+/BaseFont /Symbol /Name /F4 /Subtype /Type1 /Type /Font
 >>
 endobj
 26 0 obj
 <<
-/Contents 59 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 63 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -237,7 +237,7 @@ endobj
 endobj
 27 0 obj
 <<
-/Contents 60 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 64 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -247,7 +247,7 @@ endobj
 endobj
 28 0 obj
 <<
-/Contents 61 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 65 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -257,7 +257,7 @@ endobj
 endobj
 29 0 obj
 <<
-/Contents 62 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 66 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -267,7 +267,7 @@ endobj
 endobj
 30 0 obj
 <<
-/Contents 63 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 67 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -277,7 +277,7 @@ endobj
 endobj
 31 0 obj
 <<
-/Contents 64 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 68 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -287,7 +287,7 @@ endobj
 endobj
 32 0 obj
 <<
-/Contents 65 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 69 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -297,7 +297,7 @@ endobj
 endobj
 33 0 obj
 <<
-/Contents 66 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 70 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -307,7 +307,7 @@ endobj
 endobj
 34 0 obj
 <<
-/Contents 67 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 71 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -317,7 +317,7 @@ endobj
 endobj
 35 0 obj
 <<
-/Contents 68 0 R /MediaBox [ 0 0 612 792 ] /Parent 38 0 R /Resources <<
+/Contents 72 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -327,234 +327,303 @@ endobj
 endobj
 36 0 obj
 <<
-/PageMode /UseNone /Pages 38 0 R /Type /Catalog
+/Contents 73 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 37 0 obj
 <<
-/Author (Hunter Rogers) /CreationDate (D:20260816011327-04'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260816011327-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
-  /Subject (\(unspecified\)) /Title (FUSE Package Author Guide) /Trapped /False
+/Contents 74 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 38 0 obj
 <<
-/Count 30 /Kids [ 4 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 
-  15 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R 22 0 R 23 0 R 24 0 R 25 0 R 
-  26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R ] /Type /Pages
+/Contents 75 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 39 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 606
+/Contents 76 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
-stream
-Gatn"bAQ&g&4Q?kMS!uA?oWO*?7(5?+@t5+<^/j2);/^LeZ.EFh\Qu,`t&nW!Gt5F.*`gh\KhFd;#AKEi&8FES3R_/1IuSHj8lT?m9$h2ET=O*?(<ETA#jQ4f""!Vne*Kn#pk#.!gEGHeI8)!lt`%Oh!CM)<F`;kY2'hU(F1)MhP7tX>Ai!GEB<rU7r^)F!KV&5AHX&gU<$fS?sM_>.mn$Q\^`*9N8S]bHGtb)YoPn[7U3e;MlaFIS#D>8(cS,gQf&RTVcOUH.BhnIdX%aSn5?scdSE#[mBdtVW"/#s%6.0)>&.?B!4"1tUu`Lt<W6r[j-M@c[t+@(!)[#GHI7_JJEUL;")8-19-?;(*W#uZ@s58-^3`=oku3#@@)T$]YlM`kT]7K1IMt9%7k.]:Mn"fHMFiDsQ>f$ZMlHV!#YcW`*^hC>>u`ecC^)067YZLB=fp!fo"<*:D^8#4[q-mG)?/N(>1kWLA1u7,lI/8)ZAgA4/D[Y5?'u/l821=0lK,Pa-?o+_K@"*^k['"sYK#+(qMNsPgJe8#.ZVOl0teingUp;!Mm'/_%k^Yahfu6R!tJAZ-k<]!:cEO*fetHup@Ysp_#=<=o6Nh~>endstream
 endobj
 40 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1764
+/PageMode /UseNone /Pages 42 0 R /Type /Catalog
 >>
-stream
-Gau0D9lo&I&A@C2lqu"eYX")APb+&X:-[_bZ'CnAPC\Od#b(s-!48MNhZ6<qG%dB8Pe9C=5Wmul/p8>&_?(K<l[R@ri8"Tt:FXWj2Asjf=i0;GS8;fhZZ[Z=OdfO`j!9TC<?/l:^O#&Y1q46/8cf8#LK;:io]sI&HtMUXgEF53Cp#UBW!(.J?ulXD<t=u]ib03n34rH:h#!$UX&T^#5a$@,#76K&8SJgTq1fhj_X1#T>;)<g?:"rqZllFCY6$=g?Y7ormYhGY+B]t#$#)E3Srot&+or8/r:_A6"k;]q4q3#hc6`R77[Xc@qpO@Z:-u_]"+48k]*'%`hiG2Df8]_8?-m^fHbXk3o1^hGm+f#l%+lQ9j@WY/=5-';_!5tI\V!jQX''0\;]9DSm$k=#!h1/QX,6sPRUaGZ&m&dIU9r!-8C-Mp1kZU#h3mDY*&h5o@u'dFc\kSKJ%PLCpQMqmUu_3+HPGVX,_pR8%`BT&Q,2(KihRG7QU](<";rn0gq'gV'<XDe5AA8qhPd!lqE&BaVfD+o;c+ZBjD7'AkI]pr_p;[!Js$C36`Dp9:&0Z+,<g!*a@(R`KJY;VfE:k8V@&?P^^3[*qEl&b<PdW$EF81&(<EijTG2Mb$hN*m28\4hPXnsI#'QI&o-5q<9%8V@&<^,7C4YLQp0-i?)C(J'8&-T,e.Ip]&([<<aO+J:TS4"1j34e0B1K"UXC(,<p&]G=nICqYgn6hn?nPtn<#jd(S0;2r*qn:8Tt6pE>IlI(]i2k/pZMS),^BB>#JLQ5K>2pZ=Z7&,T]dd^fBOI-c2e$KU0p;g*deZ&Je(ZaisD]0n56,T<Y"2S-s0/6`e0==VH!KV6B0FU')-"(lRr&2GPEe3G$@1t3L^Z6c\Wr0^_U?_0R3gGCMKcIFGa@=j9c>eAR5/DEN)l.*(WcHFW9<<R<U_u(&ER#Gu^LT36X-m$p6u&FPnC>?n\8X2a.Ib&WC;U!eI1O)$:cbA-U;?"+p3!S3?WQS3LjD0sseRQ5oIqAFd,t`neuQCDoshg4PI%qRrm^PfCjRF6-M\TY)jkFim.=TgibNEMm&V+k#5j!F(6CA3*q:i+(KXAUe+9n\;/a"ficjR<0<;R!ld\@.CiLU:m97de;VF-fgn_Z@=l?l%qFc[=<OT[O[4/ZhCS^.MWr"(&%.\_H%Gbi9:gL2q^i9QI0sAr&sIFEg3O?9'KaqNu!65:#Sa9fA6*'e9G7*NP(`\RUc;RFGYk347%Jc%fIVcP*ioVIfKGBjd_1eULO/-(.ns]Gb/$AVUH.C^df^E2RB=e==)@JX??9VXPRB_oRM#nU@j2H4ST2M;(>kW!kt7sos<@tF!k6h`q77:D2tnSVkrAqXMH+P\(EO`IJ:UEb3%n+#QkU8+BglNb_)RP!b6@1H;%!%>tD#f+IO^)KA*nI<8`e5#<0MR'hYb5lEs?uK><m/`dQG?H@s]ooU<s.$.n5d%Ua?i]B2S[g!5"i<**aGf\9ZA#(^@MeNbtuBIa[@1N`;!q=o'Vpp=s"T4>!hd\5)TUDHQ>n(,OZa5+23l0A#-1DYEU`e'A(F^IS<b'&c0/V;No>Z[%*:nGMscupIkFX=.<&NC]6PFW(C^N<-@h<lk<Tj2jE+Z&f&^`+h>h_ktg=B/H^>=jfC^&QDm8K,=U%J,h#IV5*6EpcE?A;>_69'L(OH.RV.5gsM'U$`=p";;F=i$/eJRf_Cbj`t%1GWJkHHTY2o^g_gjdaj"!#^PbK#[+$KB]2S)+8N_=5Ma:f)Z~>endstream
 endobj
 41 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1592
+/Author (Hunter Rogers) /CreationDate (D:20260820234331-04'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260820234331-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (FUSE Package Author Guide) /Trapped /False
 >>
-stream
-Gau1/>BB'f&BE]('`1E_M1[J6d'qKb,h&0'H3p"RoL7DJUD$dN,WR=2^*D;H,X;bop.G\4qX=F7]'QR11RN`3s/%*XY:I,npV@AJQ%L0(&Zd&4qeG[_Bh&eSDMFJEmp7u7(NB_Q5@n7M1qGlh^)'$O(pt!RpWlXmiD5WNO94BFXZ&S`6VTB7$!'8uos<'%Rlla@0+N3T_nF+'A?cEW3I"-.Lk>iC,kCmZL;+fW?3K^1hO'<I092]Yq0_<Vg2@Ck-@\`r-dKcN$R"saD[C.BBFX:E7DV)HqntCFfS$&Rl+_\1m.n(C^'OGO?RMF0o9Z]mT0GP5>@QX6Z3e,bRa4KkC*F&85dLt*%s_cl(E&DQN5UPR^;s%7Q#SV\5A33>Xe-,e<#`=lRXFL9*!VbL-M1(;B-g.G!eiM&&P[d*=;-B+#S(*MGQeG4'"P^X_D>"'iBT3\_,Ee4K!JDq.RCTLU>_(cRWT:f@s3n2[:>YKUWAFP?/R0j+>HBC4@O&b\f`<-DMe#s9XQYPZK@UAGQmD:6RqjM8rX]fbm%%<2POe$E1rg_b256eoS.$hM[L!h+&s4-#JIrK[^##g7,JNe=+7[W]!1TkqXc:il*E^\eo'nC=Eq)rIX740$GEMn/*fqlme!A7UgM>\@89MI![q+bVRhbidR7Reo.2o,!TqLE\..ptKp$+!\2n+9bi@Aa-cAqh<Pkmab-P8c\V4"IQ/H99k\Z"\-r4!:i@d>h7=Go11!W07IK?^_Cma$FEQh+<$tTrE0HUn)'-@@Tk%=_>Q6QHRie%6m6C'JR2#Wjk>))&L3UoCk,Z]RjHf=TN--:s:SbO=$)G,2a;*<jKi5>jDU0OHe2hW""_\A)T3&pH%RBjjhNeo/$nX+:TK;1T%FTt<@!](2=/ist^G;1ojZ[$2J(LM6;b7RMZ-U%f;,t/tS.4TQQdpg7:_heoA7$L#ETR>1^lCj)*4?8r,!;UnH1UauGXU1a_`=10uBi,ouhnQR%j)(,>*m)$2(7@fmK&*4?R!=m37T&hHCE>Ekmbp^@lr)aPW4m+2>YKM!d(.A%ft+7K<hn^i=f)ZXF!47$a"TAbr:O7C:&.kcnmJlA/qU_%\rFS8.4!O5cC%S51gpee3EZqc1pUsoR1]__M+@fnq8FZOaYMs"+^&tXKbDUB7os.uN"8c8^)Kj1Pp/`/4oR?5I.alrOLmR-K0HDA-@!-P&+k%a\UF+&BGZ[rfof=L'D6B4;koS1El]-G)EHou'kiG9[:jElD3,MP%AhHcq@Mdr-q.`+VX.`k)!/7jDVV?Q.7g>=5ghTUb1]pc@;AR],GmS>UgRJ,Q5R"l$c'OPdce.-Yq#F9H'PhiiE@FB^Z,L&15u]WFrt/;9*^n/f3NdlK^"?o@?`1h"K6UdA04i;F5%$nKp8Gp@*H.5fOd]>D0qfnN;/<hPCh8qmuEQ_$`.RkF)LjEE%OJa](?2lM,.7eSgepA:kh5O9:#.CV_R+jR4LGi5q_`*P9b#)eH7[@Rd@rtKPGD]*iLgB@jaG_<%<.<BW?Ef_jK-ITZM1@[;0-@,T8Ht*],agYscHO2g_!q,G#U]gitNS]isPS(ejo6jZ6cg~>endstream
 endobj
 42 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 491
+/Count 34 /Kids [ 4 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 
+  15 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 
+  26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 
+  36 0 R 37 0 R 38 0 R 39 0 R ] /Type /Pages
 >>
-stream
-Gau1+9lldX&;KZM(%9Q;AC_$>,`_7cS4a?/6`68W'Td00,VU=bhs\X0.&!2'4(DXET[c6<Ns+Hu&:kpqK`aO$=Dp0DN-l!c80G[fD9`XX*)VrT:j/G.,aDO[=H;2i,b2@aP#I;b%Q&skk3Ko:5+1Dcfi`\>LOIY1DQHJ-%f$e/pOPD!:5's]r(\'7AYc\nP8'ggQE^K?_7>a(ElU`/RJBcq+\2r"UhN6nr)Vj/I:`^Bor'9nidrp"DR'_SHJ4(W10V1VOC:d%<o:GcZejh`*RE[L7Qf[ujB.F8F@aInescf2jRGp,;!f=)olf[RRD--ts/P?+;DQ_QPFCDGPU]2TmQ/hbhsf(a'tmr3(\[,`5?,r-Mk6/7e9caR=O.jlg=j447AdnrE.<_#s8PSa?#aDQX(gkaS*>=^G<PeN1Y*kbE>Is;hPnX:1p-/h:c84Vc/Y!>L?#B*-+9)@90D[F[m+_b[d!\SZ*q$d!rE.P$8'I~>endstream
 endobj
 43 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2575
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 606
 >>
 stream
-Gau0E>B;!t&q9"FFA\;Qc5)@O"rP-oRltc6.;+^nAtP79.5>QSXYnP.Up3Wlq<t4bF"nLc36-KQ@7KOJ^:o$O6kDZjOoLp5!'ecfllq$0LA;IV;)!Ut(&ToWI.,R'-Gc'Uc0FK.E1BUc+[#dC<j\Q`)aP)?0aqQTQ:(-#lg7Jec-e\^6MOZo9H3c;'HI,Vo5?>_5]SeAO%2d'%%jth2jOW2kqjHA+daP(,b@7T)+DpuJX`8n_$D)CW_ttu"j%$j(luRB>(;`Tg\K:nhJ(:q$"B9TP@+N-hYH"7`g*JFL*3K[DI4jrJ"F!)(nq=F&k<'sn!Df/I"pB4_jnOP0%$=a2m;pd=)B]eJm#36$DU`:_=R[3F@S$c$ka$6rtY1gRBWpFP+r&<9;0^ab7OTVXPaA1koY.+jI3taS".%Ia:XUSRDob.l*U*o=rH`J18-Mcd/,tp9X_l($(o5,_S>QMA95)`M]kcHK_-;i$$seCiZQi8YhfN!2li4q]`D.E6j3qhhBs:aikC/G[bOb"aI(t>C'eogM?@nXZl.e3ToDDL[G^ad]`[Pc6D?Vpn9FY&&.VKh\<[%%ipl[@_&+7s?:[0e14rQh"\Tlc9>P1u^7\&O-.at)^$C;&R'M-J#+=k2:qX0\X?dec7]9</(8[+1+=\u7&'uPBUnr2pIp,UYZpNkj+/EKgNU;?KNH/hYdItE?;XmGIQG-HV]-apD7>5@@O7Am9d"4YBWWllC%]=;+L%tiCkbJ<Xd`O!sG"SHI:&7]Gb-3(B6@5Pl/PqUr!bmElOij3I4*jpCKgBLTF6'D&8$5`3WB!9.25a>&HM*qjjBs[npPe/K7^$PE^mS\\?mQW#MLJE00c,m;3=Ru0<\5fd$uF<OTiQhqlesG<KFo8Hggj;oYLbaO*1l<$NU1:q)u2PeC<%ptHm$p:^RQ:R:<T0?aQJA_9"6bVW]C""'O.9aNVZ9\\R1ZI=Ae6bHn6soPai21]Y:2sqrD9N1.l&?g(qn9F9?j?^,T_^EV+QUS=69YiGXgS>=4pB5mWm0<c[TfUN,%Y.Bu;,WeA6o5fG<g[;-caIn0,c+@j=!?,#Gq1iCFQM,i>`<ca),0'%jBj8VS@'_!R#,";D"@7SfC84S<.^&La6R:ce*HiPHbcjJNhnBO[(nW7IAjMCrmopI38jKK2QRJ!/_\2[S,_.L9CS90%uQK8BMY=-ND)]cKO./SPhW'F>[`M*r<MEfM(K+SSPMiC$FWi2p+%mi95MFk?B@eNYSHoiOLMh/fnPb8iM0QjTT\h*4DOV<\0FMC`W\&.#FJplUd4!m)qV7A6e\FMZPH#9ItV@,-ePALp'DT,Hs<?bO!Mh;bTJQGb0G:`KJiorNKf*Hj.jE,sM@NKmC,MM_,J-6p&1'D)Q"[Z'TC8f>gLk`8#]2e,sp=iP]:NH0eZ_+827),[61_bm4f?C;S>+k?38@Eum\QZRefO;ltX%atQk\qHT?[6OC^O_;\:s(pZfHd!4+D"lu4ePGYXu&X_b&CT%XS;5%7eYU3@De-"_,)kK!QS.pC'MCY[U^9tKZg<i):-X.cLjIB.U)Q\YGj-.J=BFsOX&X;=V?Sr_)gITP`"K7$bt+=P?7V>N2TDlP]je%3@]bOl5NJt[J`VC+2258h[4i80APb[[ZPLGZ0oXq3V9FG`<JK]:720g;VE6I#H!+L(c67)NmKW"hZB6:LWXh#0>XDcNj`=EEc@F#Hr)NWet,\["!Xb/aj-B#]Ka`'7fOmNlFq?nol'<H1p&t-VHVfNT>')7+g6954M,`jW>38t57t-,Ll5k(WMi<@Suf@5g&U_,e6pRT+r[Fo+sng!=rQO[%#lAJccRrTZb%Kl^.Vl'HRTBWhu;8LXZT*+Qp\E="YRnYCY&\i'H71_GI[jRekcb7IT.[GjMG(b&ZJ6I/n963*i7\R?MMeHHkoWTnC#mK933L5m@?GL)Ed47p9%m'PjEMVT&=.UoLt9i\tLIQSiPAYlA5&NUY-^OUHrcSCn35HeJ%-!BGST!b_D=+4Jq%9Zp'@T1n=dV%-XHP=FSm0?U*W^4^jE+)0_ik!XU=OiS"j!3HG]+2)FU;VI0H]RPXiTJ:ObVl.'nNY8/C6DXB.6F4bjKcumR6cum[.9/LnOq+S94]uK?cUj+%.d^i5HD_D':Tc_n[9&sZV<d;koReau"q:<PO]BA\<ef0.STI[Mga9ot@,*B]SVB!dHA0eeALMlEbZn_u_0)WC/kDtU@:N-6hac=,X,5?>u'YcD:?CR0Ce+fN+L[EQ0lWLWjHIBHU^AlA?kDP)RJ]npaD0,IfD>)#09]jer;oJnF<1Lfqm"s%rml1E:Zl1K:_Ce8?n^g73"=6<i/!d>(n35JSe':0oaZO8&"3R5-YU2TB_h"?\*u+_.REQq(&cP'57.G@W*7D(`Q*t@TNG@\s;6cG=#mC`BgWo9Cn/t4(/lH&0bh?!+K1,%h[tN2oS2hL-a>M(XIuq4sPgteC$VHk,>8E!CGAukW(XGf^\[,e>[G6u+GLiH;o2F5>110CM)ETGWk-@q:V-<:qIoSkE$NN@kok2IA?@pCBn<YhU5,j+YrrDk@SnJ~>endstream
+Gatn"gMYb"%#46L'YNdUTo(llQX,^f.,&NT]E^,1eT"[FX6/d<p=$k&P#R&q^bBTIPXKus8Kgq)@/*bS^kW!:<sZm?GQ8FG5]HnL,(%VT),6p!>)[pIV90O.;ep0`!QXC2#m8J#Zkgqf?e.mF>ZP4Tg;([Ff_-)`G0S%>KAmK#pHJ#]AgnF6&bk&M?l@@;cF="O>umhn'o6&0rDhu\s3/'A=pUi*ZlgY@q=s[elg2ofCX8s86:I0'iO*%Xi.'%.N!Z#8?lU40PsV-+?SPs2/&eKSl:m&J9-dPr1m$cCd$kBHVqRJ<"f_jVF>]<=#-,E7@I2p%"7EXSqgAO.^IIji984%@#&aVO">g[oZ%W\b"Jj'XF8:(4mX7d.mOF.u6]'XEg_EoO$_mPQ<]3B=0e'!H04H-EKgIc,VdaZj?]'dn?AMJ*bJ"oh2bZah,`;tiU+.6@`q_.6^QI;G+<euI*1?hF1;VK\3%To-^&IX9f%&?Y-/=sp@ng$!nM!!/%o;b$`[3WfJq8e>(dsNqq9.mgasU;/R\?>riH[TlM+j)f2RP-sNOO<D2l84.hf.=g-9@O[=ZTY2Te:/hD$EoJ4+#[1OSo1bo6Nh~>endstream
 endobj
 44 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2324
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2131
 >>
 stream
-Gau0D;/bJQ&q9SY(`4Zi.hY:6D;!2tjY!#H78RgLll?SL51&<1jt9)K8Le'&U&VeC;Ng'2ff4o^-'?1*E9<XXDh^k,L):R'2_P42E=_6a#p^tT(Q_=c.GWgt]DL"=;6r$=B!ep]hFEc4[`BfboY4PXL7gJV/;[8lUnk,GPNrao^4Z/2s2<IoQ^-<="$]h<j58eo,M`;aH67!q9sZ7;m'gVg`1m':O\TL"c*Kj)c68WPP@U9$h2e=E$G2E-7o-$[2MDcUZT),F^Ei_<qIT;EeCcgB;OAi\BF/t;GtYk(3YY+?Ic=Q?)*q0;aa]NMr/kiWPqUS+b!.!9pMM8jdW,`Yf+V7S)4_]mEO*fOhLDkdPKKWiB9AJ&&<i:cO?."e[Z]0Si.8uW:Vgq95n9q6R$=g4\e#KkFC8enLhsWsl[\2`^B"n*56G#4pYce:aMDS0)[)HgnUTO2YgiTpU-!9-]S+<Lr<r./Q+m>@(<sa)C-3"sK)cTPXjLsE:_!hL+K.?-Y*R^P;6EnBes0Z=B_<!MF5i7n**C>B@iXp\s-gjo<)l9FDhl\rpX]%G!+le460=72Z[cCbm_Ck.eCmA80t9[\8iol'PY?u7+_Ur^'e9kI3[`E<T_W%/c'%#I_$Ue&/=s<N7*C<FQd]N96F<9,e(K\#8Wipm$IcsLb2A4"%79U&6+2'IN]gUE*ET^_boriL^3ae&+D733rgjucH61GR!LZ<<:8.mq-"%\'6:0k*r4hq'"CU$#@`K;SpcZF&AqjZd@m]&3"3R28^t@1A*+-Ju<E5&TT<:epo%V1a@>7-GeX*SP%SE1#mRr4hNA'5!Z.-DU.?(B=MDN07GpCn0naF.c*",e=7uI&h:PB3Lc1i<.Y(T))^&Vdq4:qALdBEN?+$EBoBp?ER,FVfWMmCG5HDYRLn)NhQI./cT#]JGiVu(r]b2MT*3KV.-A[W$/rM55saZ!2hV3HL834=tUCT95)qM;\g^1+4n6p<p<(HF2\1BMD\AuiM*Kq#+KmPbD1=!0g9)r-0O(Wm)FT(R\S(PS.:2/O#&&%C,ZTaat*c5^#lU>/AR+B=Td<;ShaEJESICnrmXqqJW^b]ZolW/EW1`kV6sW)`2p8(O>5c_d7P)dPI3`ip@416ZY'&e3Z%!O&q0jMqi$1`>^3:EssdA'$Z3Z@ARQ6E@h%_Kp/'K/1KGK9XTr6eDB4ESs;KTS6:F6iXA&I'=bBJV*it;r;ul$R=I(@#pL"*r!tKO>sdJ%bGCj)jA"`#"p;-"d\>]V)2?*hAT<A-VF#c4=!c4gG#a5@+$1X25MK'mY'Xus/8ieQ[iOomeu!cFrQ[e/04e'2nG1-BCZD'ZH,CCp7^.!#TRnORpKi#dl;]OQm_KC,Wi.f`8K+"3^X6G)SA]uh\mEj.A3#b3.#Ep,ja.-RnU0?)Ni6J.lrL@]FO[pIBl^L4*4PHpS\f<In/uoI8YBhTVu*aU_?RB_u^NB]j?K9@E/d:BIQ\^$qUtMd`>gMet$5HB]EL>XK]W/%N,LW5f&+!GXP[Y(X/SS?O0rKaG*3^B`R(VI/E@AP*(G`aXJORGf*<E!='h@A1;dK7!\7SR50j`Wt^H6,J\@mcrg=>n&*tUe,cpFe(,/ua9:Ij#U,bZ>WD*"B>;8\'42a5d8XGGV:7TDnA(%iY4q"^n'j6cKr,&d/NW/9(3XAqFW1[_#DU;tF-QV1G.K?l(#Nt0:)%/Frr2d.*[-7CX^lkPWR_A)IAV=43nJbp$6c6o]i>2IM5<*`B4!I!pK(tkgC_KPXDCJg(=t+@iDL"pRmI%!ldFbX6q\#nX:6'k[ae!-S1]Z]Qg\k.ci.AR@7%`dN8S@(m:4tVG\%,k=Z!(-ZC@ULDbJ&M73TC<m1T92KZ`9hF6n5:)LUDNplY?e"\GZ,OZ0;ed76:FbsJ,t]dbLi_`O=Gi.t/?Bq2R%jft42IBF=_;jU_N`(ESZkW=Sr.aR<F3@YQAR.S*@ArPSPI,2.TUT=DF^BUM(;',m$h/AM$Qc-qC33'Wg!O<DHKQ7u)\?;'p*2)<*)%D6_]">Vcm0>@Y$7p88(1CUV<$*-c2q+hjF!C%6^AAMe&)2]IKrg,*WSOqFeQK'*!u`)t\cVHhln;gY-Em?Gki]<l.GkHNp$RNU8g`Hb7I/Tn[CY7UJ>@-t-mskgcNjjh"-mJcOO&U#pC"Fc+uAWZkDfj_BLWjVO"]aj4"SaOb54TTIdqr8MJ=rMMuEF^=8fgd<@+G&'C*s@[LJf(J[Xt2P[MG9Smu,d@Jn=cV'L=u4Sf9WYI$5B9^&.*b!S,G3qnuFB"VfgGRqpTP$qd\3S)ZTCUc(p'24?Cc2~>endstream
+Gau0DD0+E#&H;*)Z/8/0=<Jb483]+kh7?>P@[$LYB/56a^tFlG\NAL'hfi-L#r$C11,'ag/D]^\ZS0YmSdRp`EQc*o$LhX3K.@aC%qZ2gIE.,rHaoT:I64LdK[,rk9rmI&BH0]t&Np"k9A8<)dKA+k@-!HW'REhfDD0r^Msf8]_aS!7;ShgUM#"5.]7\ceP.S,Ilj""mCpn[pbFEN,nO@#-69Nd+n^D^<0S#YMcZ&R;=_<`gI4+M-L%0EO9WJ+*\39_J\/HAT>Smr<g_Zg^g_j<npsa<Nf3M3?..nH_H/OEf'@.u"oK&(^hENk'8+iiCo%haH.C^W!HsbTWC@1K"6['HYH_5$Z^"H"k=OOI)?d+C[7R[aH`B4_EYYm-:/Kp:F;(OK,5WqcDjApKl^^R\(MBi3CXa%uZ;CnRejdG'^Loa'&\/N3%#tUtcisb9h4WnHGs1J=*iTomc5;)uME728OYm$g+/;p3J\e.h5=;73rV_WG^"6WG&Ceo`5@G%5nkPgsuZuP`EVVLjaa?$*g[qF$2K@8d],2mLQ@X4<42plaV5C_'#A;7i+;Q9H*.:5)G`-0>?!gV@#854*@G2//KOMkBaE64hS\WA#687K*l4>5$>'$_0p:rH?I$baRq7m1mM.1riG2(TKc=+-#NSoM1+j)K(4N=oLjELC&]Y-j?/rl9mua?HCN#=FsQ#o;!Y)b@MJ0f,oKg#GZf9Fl2YQ,&AZC'XA`+&Lc6j<BMF,3H'jF9j5E__kY]e4IQP_fG-C/HY8:hLBD[mYKa+T6T,-%fhD$.3UT8d6P'Qoab-bJ.>Ogmt@WSiC?0[iXRB3i.OpAiCAH^Z*]-Z`np3<?u"Xj!J<f>Z;>UJS&BYlr9:#B4T/RJCl\K,F4q8:c\X)T_jnV,@G*f"KrpoO:_@WE0p]nLR5@<=%n)u0L)n4n:VCD@O<=8<X$YDmg_@i"*Qn.eCZ&.09I'H@'O8+E,1\UVUMI5FF!P<4.B,0QNb(ak]@)8`S":14/c5mA5L/^W[U\]dYut6F.Eg!Oa)Zus\ko0Se"Npu*s)$r=XKBmfW<_i6fnJRgS4%0A$K-DDipIQ3HZrc,?!W7LFl!En8u*PKHJYY`;\tA_LI=m',V&'MIj^k6K\XfQ/UUp([R!*6J/^8*u"4'>1pZhYH39eo[:L$%;f#V[orSegQ`s!B1A82lUJ-DI<:m[T#hIfKCj@E3ral1i9L4U.5%n7E5e4o<#<AtdqPje7da'4(e3ZN$%Ll)bH/^C_*Luf=402[o`"]@7Be4>4*tpmfZEBH"!sd-aP:1t^_3<&otGjOBEjSe1)s]g&0[06<&O@.kc3%#1ih4\G=F1`ALrd>^GH:END:S=6ec^Jl<^6W3!g`K)iRjd%8bG9AuQIVn!AF('9#Q6BN:P&%gb`1>K[)U+nq;(a1p(O?IN+=S'*'CNTY*81l,9B=NQUrd%PL`LNufB@UoQ4erg^)Npua3m8;m?5;e=!Ta<SC8;X[WGbn*io9LgI.lY''L4:]V3i+.#aWf:h[cK8dWI[g/.4]&SAF7/9/6IK9W\C#0VS\E2Ou;WDCi5VDP-G[oNO>Tc0k7[DPYB8Q<.WPMHlM[2a93C0JSVUVoj[QVU"UbLD`lP9DPh$)-(LB;FF8+V@u_lCOeeF<[lN"8Q<<%ao_L\5BoXWnFg$s]26nBU*JUV<>fVJ/cZKW]_(DjJXM*5jpI%ti9mu&#SO=5Doq?.@MU"'IloD^eE+g]%00e0ji=-IBq_FF&(+([CX;H3c-uL).6?]=]Z"uU*+[[-_(N_*X7>8gh$D:,IU&u%BAC2<71tdP?a=p:)EK3b0\gCpK@'dBrmob=`N\dQ1r-L%r<rr#L_e6t,2tRTfeFU*-*RB"coe-q`e\N7J4E3L<X&*f7A&#aQ.3hDaC#-Fe$=-c&'#Q0T;RYUH`?"cPlX(Rh7i?9L0JP"U5:Ib<S(A[rgrTkRe\[A$.2/e?V-BrB3IA_ECi9j+s6%Xsr:5phH7-)=nDH-MJWh`&AlI:8;,)YkJXRQPZ7j#cVW>oBK*mC3"'*N.;UE.Cfcn8P8H13aW]bBb_/Y/_%8D\<8gff$>U3F4kn<h)GAg[2]f,#*1g>.X5%2gHFqZerb04FZ`D<fCcMe&SN8b<~>endstream
 endobj
 45 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2505
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1637
 >>
 stream
-Gau`VlYkN;'*%C7@QsVqLCs3bFn_li9,;kf]!nYcBQ6!GN&7ur8>JRManib::iBEaVHOZ7@Yr!JBRZK1@n=E:#AEotc2`;r_Y#JalG@QFe0dF2ho!]Znhd<pEtVSQ<4<Mo#T'0>huB^aAZ4Zf#Usc0F02eXVRN0]hS?m/r5dFpD[Wn6$@XROJq&F72d!f!EdQ#]+-P":f]TqcAA20U?3"LW/jaalAF<AW&)mN>$1Ztc+tD-W:I6-Y#Qfc4lF.Hk:B$VC9j/M!`.^4Z>2jAh1a1AB;+T[Chq]r,^p=Nmi;2".l;l3(U%Q_'k"h<).De1BN/Fb7TD-B&FVoBL\kI82%gu!/lRct!&(BVE6#V">@ffb8TcpjVJCu(+`C%dX@&<2"=@::hlG&sqDrFdk%4F';j.rtCEW\N-&in@VnUW5B.Y0H^J-1AcO9#2I6peDX$PItV=M:,!Y^]@pl8Dpqg3+Xe_XSfd82LkU3<^$qJCdKo]I2BRp<!"+?C170HVq/*Bh,HFbkEMM-.hN=*KobA_TONSIK'_tNd&$E)Ud)tWU!gSMeL2:,;Qo6U,V/;"4jG=W(_2+))?*!i7`P\!=_S==X^j,C9kX,KV`3_#NInC%u3?>qnsLX@?Yn94?]duo5)d6X8%<(W"3VO^lRW]e3sVRmU]hr3amb/?;2^nI/J<PhE^n:d!1htK[e,/I+(u`E4%pFE+3g>_dC/X/:O)i;onS>FO#Q2J]ptG_khd1OXa'DMl-(()ob@n+BNTc:hq]&$s8X23<LT@^k<Z+gAVs.AmJ&iJJl+LkR9]>e(n;^,@jL;'l%dsclXrL#\fE4='Vif7?I@'UcV2K<E%J+mV+b!-VSFdNW3ODh=@o_U7S!S1Irfb5cOtSN*W1/=P$JJ8pRHp)S<^%ME)$B4!pVs&LF79`i&^_iH4G_D$XegL`N/\*'c`&KGoBInGsjXQWtA8#,Gp\2O+V)WNbpSQ,8b'rf"Wr5IZ'+PXZ`^g0=?IiI&[d0^Xrb%.EM)Ng"q*OIcXC=g;.B=-Bh9\MmX,Y-_-9D10hS!S1C\5C`\1oui[T`$X.\]:HGhXJ>p+:Vn-qn!IKu<$^E0@jBOt"3^2.B_Qmub\4Iaaj):s1^ngum77>qUZ3ZfEXF*G)m7HbX?B)S'urcnZ);pf_KJ[<_"rRqH<F_Oka53H-B^\7[=q^p\J-I9=h)qQNOufY`m!kc'Ke6S>kHfZ[Q/*DdmA7u4'`S8]"ND>=NX\b'8R$5AG.$Fg\Z\obn0Xba#(=8F*CAL6i=W'H!H$rla;e,[D*P3fltVS@b5"V]HIL[JXEj29k1'M()3oLN%OeSK.KEK^Qm;l4gid_h0/"B!,$BDVU655eu'k_+&P37RSGhSj=Y"mQ/XTs_a)sraUYUf?p7,Lc2^:qFdY:VWDkZ%1ofkH8NV'%CK1#+9uf$0SX'%N@C_=]B7E>dMt%Qsr(er(4G!.j23*;F%>42F2QK$0(oGkt%SsK\p_t8+$PfGmM!^VXqf'PQ,hrS_gG>324r%>i=VVoFh%.O7okqAP\k5>f`kW,K+))G!hO)]>0;TOqdlRdX[:AiYs*&!>Q=.k-;/IK6fX(,d'I&h4,HQup6J7+m\DY5sMDn51&WC0cY>?7qO\mJCF[q`PI;4dk]uk>6NqUBgb(Y)P,J.H3hnIf^V@4rn\@A\:_n*`<VB<ERa>&qAj+6hW7Y),K]fl>qSE<$PVXQ6h8_];UB>=BF;@cI]e[jG^FsiZR_mifU/$/=<$,HHN!R$n@@NsZ"KaEuNTXH4D."Ce_pFh+nD93_pq80`)[sBK.9rDXLF!DmHf7MOWiZm]*4G=lQ!A<B=82*%-_53?0"4!#>[AX"ci!P_iM>!`1De+tW+JaRD/nBo-Ao%te]#\rlm)p0h5$7eAU$uncJuX,l>TgC(UsI4NH<$BXlFNF4[MAFE"aDt>(sBL/b?DV_AkR4!G%[_TiMtV#*rBO81T[Va2jEU0V>320^JD0nhhGU4g\.r"gJZ2'QKIV^gciuKE>sd`DVN?,D+c>8>+4Jo'ZY"DWu>eAWSUgIgNgk(2sjJo*-JAlf,Ah7?J"I"XYbum>C+&1l?hE0,N>&slD^Q3Yr00Ei!7e<JK]_"RTfp,&Q.CEakFoI^&&:0GBk-\=Gg`j"r46,ob)VK5$/+<1=k(N7`s>,^OQ%)c2I4qSn(i'pG>UFgCkJ<`R`XtP'JXlWh_d3'5r%tA7>&GJ3k3!HM:h9Kdf*?6(B^4q235Sl,)Cq=l2neDMRT85,#1Lc!+C1CsiS*Qp;f-<(#gc>@uB\/2IcA@_X4$!Zo^+IhQ%u==[P8^oJ\HNZ,DUDk,J/,:9kg_F5YUaA>f<fG^dJrM)3of@EtSQ%;H\K%VhfSSjZcFf?_H3`"G;.[,Eg<<^h!d*AM<5Up,;_)"^leA1VpR0$nKjerHta#/e0RGDcNC/?eK$HoP7<#`bZ9dOFQ:C.e=Ja9<qdu[lo=S\Y&[&4&8(Al;h/1o1C?,!Sm;&M5Fq*/&.s4I~>endstream
+Gau0D9lo&I&A@sBlr!/g1dP$8e6AB]DJ/<-CWk1"0+\Ff8AG`<?kWG8/jL&3,K[<*aRP4''>W@N&)_neJ<)q5r_?+:h`#Ls9n3ANaalid"IiWj\@HjqkXQ8(Bnk4;HS8XDX#Pd)T<^-Y8<4f*07Y`1BI,44+!3\`h_b9u$O6'(]rNI7Zohj5^udFhIPnV?MjI<-+ei0^*_c0geLCiki$E%o8FRK/P/M<hF+L[4>u[BZ..Z@'8m!]oDq4k8i8NZ;jQ1b_E+4E`f-l;^CUgO;$GN).S=:%oOTZ^%O!MhuDhm8Oi"5hNq0G\lKEgPh>$Z=jHc.;tQlJ8#!K3tD,o,ooG6c^[eTH[s`b*o`SisJdZBA3kon*`qEHO,:[\haT>VgX^(V]9="k6^Il\n,4B-99X"a1i)lY';a*KtX^:3`YOZ+tgIC8(o&,B:$W7Xe6j,b;Sd'^/E!@qA:3SQEBd6StpGY=r\;'d-UEe%L$jER!eVV7(._kCP,nm^Q/,?4T#O@O3t%PZ4PBS1ob=_?gahF2:eWroJHMm#km>PH7ARC%[0=:fh*:H:KjROqu'c4$_ot'gq_2_*D`4VS&8gO-B('rm>c5s1GM\[jLHbk3>"CJC40e@^AR_:JJ%H]jieV(CAu6I5i&KWXWTOn\]/j=\8?g/G>VbND]hqS_f"#>E-5]l;hH"AY:?ERUna('*e`r4fEJC8pVf<9(S33`Y:'UG6eC^$b,29lT/iZ(\jO$YO_NfTP\-3[+iBd[R-J2[ZX<dqb7kH8+pu6%Yo<">0Wd_K)J8PG/A/+b/cU#s#/k.&p:fF8(_qA'@?*"7:%3lQE(l0%H%m2;KXKg#5.[G9D(9H.%$.J!'VF*S22lh.>VW41k8@e8Q/bG%:=?;`eaCG1)ds+@l/MqI+!_J2iL/HRmYs+A99&1Z\(K@VCt"L"`OAm6ZPqlNPnWqKf,EpC#B?,<+0adlr.=IoaV]%dl=Hb:lWR-):fQ6pm6T<`C/8+==F74YHLppCfk)BferK*90^<BWsjlfc;MT&6/A!E/1>,7cE/^4."gET[WermohYnla?qR#@(LC@3)8aeYpgH*rQ)3F.@IbXaI(Q882cD(eR[5#al;b=D\_lL[VW$,`tar'oS$:.R59c+#iq7c9GHpE`G/)-AambOc?oV#&l&*$Hto%EVD_;Tp^46VRk-lgZqXKRPCudD&%"/>FkP903B;ECi5stY.b]i@'Gt6qce"LDn2E&@"dZJV.#tXLG,k#-cI3*t)<hRfPL+$E<tY"9m$f$j,_U4)S6J:)qD+gR[@3/=".t7/A.@YK-CbZC8MDBe!IPMTRaL[`N0Z9>"U@3t,L#4BVE7rrCkP_D@rQDF;fg*!?P+W:@)anZ^aH&Rpo5/JpiAn5J'*S@R:%?rRlrjC_)T\tXCmJ1%X\mqNN<N0Pep=2KMsX9gi23#E2#rZ4GE>lf?FT%GfIh`^aH),o2^\Gj\q*9$b#gJUf\Sej`0hh='mh6(lH<HFgnIsF,A*-7qs[F'J$YEO'Oc/AT6c]PQ^D(FGd-_%im`5q't-c[AS<bHf8slBb+=QQpshYH\#i,Ea-"Yqq%:[kRD]=kta2A(%toX\TKn;!ulD1686k`2AH#i-MA[$$6e_$.Cf-p`AKD+~>endstream
 endobj
 46 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1772
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2244
 >>
 stream
-GauHKgQ(#H&:O:S*!dtX#%"G"^>p_W2Sg.XRWP+oU$)S[)I(?VUdJ%"S07i<OLk4u)^c)H"]dB=SBKm8R?8!j*dmiLXam<j>X%o@#FI1&7rF"U93f^Hmfr1)fT"/,Zs@mn312$8%\IcU%Q&K[,eb3?%#hV%_rkrUY4.=FGAKiq;X7RY]VpaII_kq6k)YJXS\oH3\4O1n51pNha-0(+`c/u?,RMJ0a-#hO'E%Z8i'pfZG[idlga#4?3;2-!ql@Z[i:Z$a@*ckA$/Gl$20_'!VeniNB^,b?Vr9Uk@hT]7LEMEc9r;f[$hGhSMamlEaD4/P.!cZJTZ=:C2+D&6r:EV06HG$u:"_$Dftd8DJ"$-lI."m47M&#V`1V,G4N,0TDTat^L7^MOL4H$F9CJ*$_sT#40M1VU)/uTZY4Bi]m*E%@o+Nm0_c]FR%*n<Bg)1o(#apfsB(/R^Xb80G+foQ@+.O4#GQ_Yh`Sl2$:OG?G:pR1$NS@lh9!;DQI[uo*J%@V`dO_/Yd*BB2#<qVThYjipg(>iubd`!$`e%j2d^#O$YUk%M\o7k>G\/6t6t`[`3\uphGOtn7r`T$n_#aNOdfXt=`2eCVhlc*YD>cB^nb.nsD(;Q#CWa;ZqD@ME^Zt3g2(+iXDZB5(C\tS>j'u$JEST(=nP8/We$f,!.RXf5P"_uR)d`/(o6cDR?^,:KnXc"'.54>$jdL$#`9gc$[@6JKFmM^;1p.fsPW/!#I$gYFStX"C:Jgf6;j24XEP_[Ig^1Gk+.eZViI-Or5*.^0RiP!\@5RDTA3W'uP71H`'K^S\5E6T+%;E^VQU7e[H7besXA`Ctb#!u&i?LmjF-=m1j1*L"nKm/G>%ph_.(q(O*%Ue^\X;O`^OoX==ISt6^_@XSbEkdLeu4BRCM4k["i1M&Q5+BKiY`*+"a!Mj58X$0F3BDsCNuVBeEpummI9[;m`CS"<heMU2.itE`pD"u(a_,I=>QA=d)pV(\9!!ulP7akYl430Cn%)A/6c0aT$=q[cg4M2lkHI'Be3@Y%FDsu&2Pg,I_6Ql#\Sk>N2P/F;jqR-/p(E=F/QTj_L7e$_JjN+<<SND4K=4$N[j&LLJpVYT/Fd@X-N'cTA[)dlubZQo/tnJ_<EX2D9]9mE@YYmdQ-OYV-&5Lc?QD\MJ(4YC4:0N;c'!S6"%CQ+b@$?-OD=@8,!Qs&9qh#=C4H,&K%(;650c9AOqTA[NI>/Ye&<k>2Tg4\3,sh>hkE1Thh\:HA:-P'S:I&VC$"]YsO&3F>&Q5PVm=7KXaODI;8+)b(<4&)_V,'F=L>agETA$4f_[k0Kn?@nn^rh/NMX*i`jO3BBJ>L:Qc`CCmZ#A+Xsh$Vi+E3O@l2\A\1SW8W&Fhpep9L-QG!8e&&:2C9<APp3="2;pDj+d&'#fh6d.N2`9t]V\%WqaRLi5KEPk?(@m(1Dd^`AT"iQB&lq>uijL*K-WP@]*%Mf;gh[Xi5-S")e!?8N0>VtUABf8%9g;bZQKh,q"lFI\q:dq\)-8-5"^e"",tg1!9")mI@QMb*2(^PXP-g(G:fd.Q.CrWM!j\H0h/ke@S^G^FYUc[cmocWMaeQmfSs,mdHFG2@gL8c[eJQ0rZe_<@e1r=PGH@$eV[*3@Occ'sC0$W>PX=0u-HkD/TQ225(8@*2C!Its[@&,Z<R,hpOXsC?nM)d"/t0(oEt.^IWM&N52ZoU#Z@X`":odc[$r8>.%"!t9btCq=c(2F[rO.9^<&`+QWWTr&,)pJ5)dVN38eSn29/-,O]Rn*A~>endstream
+Gau0DhfI7+&:X(TZ.#,1$V]m?EFL<be5FG._qjjX$kERRMCljMgG4rIdUDq.Dca5MVbRQ3CPO?1ChZuJm=*rq*Is4N!rIIF!h>dud9-Ic'[AK?B&3sA?bu@*]rueMS_0F\X^uk8$g5n]$K:-F>185![2oM.'Z);%.q*JlrnVX?c&s_rc/H/e\Q&'m&Li24kF^`21"dR`T$JSk/b[q3K4SB%=A6UmGVON8`qVP%JiJ@k0D9AXj^.%RcXpK?K+d<fhcmJ&$@'&S#35!p(urIm+>6<Cf=es1Q;IW@5;shY+XB<F`+Fn*3H0S+d$]9CW^u*5))aJES$CEjMS,d,\nO/I_gut"b(@BMp2</69\sOpf%n_V#R`;[ooi$0M5M"nEHTggmB')*_ZVZq\N-`G.j.ocH"+,c]50V\AB"4bHRkuhiL6#Om*Z?<*?8Rq-*.&VqTCHK%9JFD$F57$_^eTd&&9U=+_cn?^N(sX\Ufo[*!!$;q\;_kMG.us,Gr$`'u/Jj]K>^Q8X?)f,qdQ9orh*+>AoDZd<H#D'W`3MUu_74"Ya;<?.Ed+^jPYo$D8]2L.brq@,kW,j)K`$:C<td&[DJ83/(oG@2]b]ecduPK<#BGn<-iW/7SIt<pQ>pl5F*Y-WgJ:"P`icX=9+r@5W(AbG^/V[X)?SisY%XL:9hjPRt!Hf6G$5NDP;BXgjNoLkF-C"bZPAH%DWU*"11cXE()7f%5f0\P6@RBKeCS^KB(BJV/5cBlnk8C+._l(N`NUm6,?U)F&!`f45;6\AEK6rX=@Z$t6X)=AKo=>o-RE[</;&V<.s0"CnB9)Ei>cbnujU5^46@)(Y=r;34dtj[?o(A9)9IfX'T5=b/LD4&rL8/;=?0.=3DaW^$;NU[s?Z`R0HG+<.lF<V2E'=/cYg:2BaEGN>,2PCC>E^Hgtf5lmiT+cM,l.U[s/3l#okiO,D!.\W"0=<Xp*&\+_'LhmlC&=KYj6n3nfXd_Lnr_7(4PN)2%MfsIq%/s&GnQQuF!u*FX=<+d;OCt:#QI_9fKjj;>T6.Mtn#m\$>$9g?XsuNs?'A,`RT?1QAU;p@DBg;V)p>Jka.O?p?HHKO+S9e?;cm=b9g6HI>fa>I=go\=2#)1*rhQOA@LH1(O5?T!q28WUY[#%5erD74NNQ^ALR)5&o+.1u`!4^l'd5q<0%s5[/Ado-(K@GV.(W=(>1DZP2!CVIW%6E04,7bQYO$P6:2-E(JkQbRM9A%QUla63Ge0YRB3;:jC7lg0*NS+WH8j8B+rbB*?WkK?)IXRd'nX:o&'%g4]nUNRjrb=+hjBqF&"j/AiNNG2TsZlP]`!Yg]YHG=5'.]=F@"0HKBZ$0l]7)ta*EESXV"6*+q.H'#;0h:&K,$a=E`upaUUFGF,/qu*BOsj4jr2m*MJh+V*Dq[0V6SQ7/i(p#6@_DM81+Z=2ZV9]]WKt:*/cSmTV91p-X2i.u&kMr:X;kmjSS;oJQ@>?^.&tQ8CR*c(XL6Vh;cWcM&AVJGls["k/:#pRf5cqc(K1T+6TkLu$[>rOYuS>!?$mn9s=5DL=t=HeI^CDV3:X6Q-.BVYkE5i9#dGbiH-GMmoJ?cD-kO[_H88a5GRIrqhb9PS;Pri8<^)GU.:N/DG9pGBt%(/CrWWJ)ct^=Ol6B\c9p__@*9hQGTCYds0R_hCl;XHu?O'rLP8*ONokN3$9?kfG.-m)NhIum"_"hWpS)l2Fs^NV(M_ekir@P;:M54/81gBOu4nmN(1D;a<XY2FTPRK7S1Q*/!Df5[gJ!KO$lu%Fs\'I%o/&e?aBl2>*_8cf^B?7*!^X*e1TPG"0B=Y#8s/\(j&$<AFHuBK"@G\gMp`BH`ceq--csdnp6:(C5pYX#>9A$E`(S!&):l_>[iK8p;!]HWmn0BhQM:OE*Zn+%0NtR<5PaOmM\HiiUT0dr@`U[MSG_![rca$D^=6GG46EP*MdCBqkmo@lGAQbfJKJX>[<i4PG*0VF7WU#"SXlS\*?qA2m2+V4S.`[jk9$>'M\g9=->%B`t0'F&9l0gEcrD0l%p8c<n$hJ+s8=pD)o"0Ama@:20X/W+DN:HmM-A&?hCOfL/%%230=;OnhGs\Oj^g0Ms8U`*?rH3I4L46@Qhl<3I-Wj4+`n+%iA8Yr#UJ?L]lt&TYgL,"r6!_#s3c+V9VnPbq;$[b6NtV=PeC0p9hi!R/HFSA*T$1@nbMC:jsJ<iW7S=EW9K&Gh',FYkS56,JJZDE"Ap,6@un#!Ap6C_>~>endstream
 endobj
 47 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2289
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 779
 >>
 stream
-GauHLD/\/g')q<+0edQKh]boK>F+[3$d`aS,)c)^[U.aE?9cfbfO@41.S1rZ*U^ZaL6Q4/;W9Oc4TpROE]EOZbYTIA@18k,TB$!eXPiG#KQ%!n%>7Ri_<Mpk<eG=CC1eU3BPUbQ#LchgLo9b3WOHubo*liQK*b4!`%?blj_pbDi.`PeCl@e_[$fA3[cAn:)-1*QoeZ,T*M,]>&5W&@QS#LN^0"(+1C3.5,+d"%Qq(REO5]-R5nLm25^LgT'Z:UE0Un&S7J0<hVnn/)\&!WUEB"IQ8FjU+6*RFA>"6^*"G5`W5+0[:0M1nF#gm*!`,J>P)I`7/J/F7re"%;qcARn+LUF3D`$FD>2]=VIkKI+'DjY-h+<60[3/!(56[-ga8Tq1U34k]t,4NDU8^-B_[<G(?6`X@1CPM$!?3M0\bgd^Ih&V$><%688kM`K2Qc\a?a[6,^gDm'_1p<fqU->#t8Pa:[]8VMP%efqWqR(fkhC_i/>^d]HnF[YBp<gs^GgJOkQIa+$lM+c3TC=B(rkn=Lgg;Qrk*-tJV9b4Jc7E9)9:n5H8<%$r;OgM&_0@u"U)6r*&5K3ZY$Ho9I5sG3G@)u#b`rL3i50O:FV%;uaV:8W+^l!UK92g!1bUDp6R[>MSZ7$n.9sP@@*0_sB#(t3k>+c$N:Kj_g$W+:O2k\:g#t@UJTY\m#`Zr`d@(q8h6J#o:+++UA"<rb6RU)ibQ8Fr=h4_5cA_u[i?RAL/!cq/aabKk\!e%7!"KlK;$`3%):bs/dU^8'YpUe^ekTn7Wb$3JZPFOV<B"aC=`;qZLNE9P`p+JO/D5SOV+qR[>bDT8'1P"&FM'5!+ZeHaPZEtYXF_,i>(h7!71*f.'be1iU(So:-OhI5-:*K7=1Q^\V/br_Rjj!'EHdq*"%OG&^,0)4!P-HOHeoH?V.!:0iMAlWChCtRpj*R"?[#n%\sUuE3!-]heA,r9rSM$BS4oQ/]?[6;#.mn)*+o26Nh9T5]g__Wf?`<al9'DH;L!hJZFun]\AXq`%Zc[.V*-AM<a;sg3YamRDSK]Dp5rX=!aQu,.,eB$O,g$YCS>9-n4,El.,"cM'Kr?K1fU$c;!mm5L?Uhca_eL#L\42XJ2#@Yi+8/s,YHpe[\t?^K`U-Ek6H!<UK-/6;rqBt"E[59>^Hrtc=Dfap!H\/lHic5DS*j&V,[Zf"CkWAh(`T8NZW7goHIt`d;#`0(p9ZeoJJtaPUgS2dPX37;UfZD4%t3E#"hGp*BT0Ba3'^q?i>VTrqUd<#Ri&GW4G`$NRWq14O[$XBVk'Z1)mAr'cuij]`\%#4DHY/h$s'sXn6IOprh-l>OPYL_dH<N5%h4a;D?OqZomekTrlB=4@Nu[L0'E!Am:-3<XN='P,TLaJ>[?^_h6)l[=tW;8no#kru2D,Ii\`EPcBqq%l_ucpVRHIN!-IC(3<k!KOQBl,tINM17@ls-F:Z!ZM0Pa*(hYZEXN'*OW%"hK1mLG(Qtm(^6cUF;pVFcRKqaI+m%A8gA:M_YMPO<7%*&"9M=F8l8b%+d>RHH5'eW"pKH[4Ou-Z5Y'MtV:DYi!+$^ZK]\[C'(<:jUO+DW^YO35D:\"L_&TVJ\F-isWfM&>dRfNVtP;YeO':7&N'7=$@4'#T1Z_bYoG;mH]"6_;8l@a37*$gdU@$P^6[to_=8Jp9tJf%>`'\s^Yo&Q]s)7:uK7S2Od=C`kZ%<-S_2(c;QTO=2pJYLG"?WBT'.9uL(!e3(S@3KbJ:g2@?`oIn:RRshOh1O=^B33];ed4n4C]g80@m@d9F0^)upCNRX$E[J\i1SO0r(4ms:PN.tp$Jd688Fso-jj%9kt1B7fd*?f[F)XP"a(lWOu.a8jEn=>F!3g/^#mo'0*:nR>r\('[:&R6m3:R_i"c\n(/&eMML%%X7\4*M19K]Jh]kYFUI'i[_::Uq11jcnR&(\G1>ZiYgMWl\OZq3"+$rk4bA=3,d`cWV9<2[S:,`9a;VfLrXu:Fo47VQ';\#-5)JlKfO3Wp.Uh]I>Q9h3(V$YmLFq?ss#<E's,$2[!T1O]p*dh_91M-X%Zc%_A./EKdciN]tJ7CSOcC0fFcak6"6[_TqSN*BEWMLp91pEf"Rp#S_@o;Dodbp3P_6*`X6'pp2QuM+e]rXD*eDFn1m%X;ngV+WqeVsG04Si,=T6G0SSnKimnbrOo"O$cB3'M;4.`cEbm+TGuT8.3q1J/.l"K#G%r/SC/)#a_Jr3Y;OjWA.0]]/lO>hSCUVbM]dGrKTR'7thj?p*lC^qQ@(FY91)nQ46D57Crh5EVC`HN~>endstream
+Gau1,>Aoub'Z],,'^%3?1(o@]al=^*Q)=!#;XJ$K%NL()A#O75IJb)f5r;T,<GE6t#0uW15K<s49DYp]5H=duUp/K,?n4bU?u(6$knRI!hLdah@R"t3c1'L!_C16B3*l46"gB.s`;C>Q/!mAig%P.%!e0_,T'm7T\$i@q>dbis&!5X6qU+Dq"Gc<aVi5,13-"QM,Zt9opb>cS`O)ccM^,aGoZ6pfWP8"Nm71rj+:OTc1>GI2nU?V'OYJ3'Qm?UK&YiO-2&X$1m!PF?>=.CS6=>:F*)G4aack73q1Ik:-/1fr:=mtE/q?hQ[K05nh+RlOm0[H`U,D/tD:Ru1DosG]TBV4kant<@PJ=@Th'sp)r#^4&nUC%hakp3,`Dqq]RkrK%G6k2EF%`lf2-3Sm@+1b-Om4mW8uTE(;qA(p61G;U)31Z:k>4+9\J;NHbM=1N[X1URTFaWpLCt=cU5#O'7dMDsB4S85f#(G'J2tOmf*(bXM(nhHAPqb#F81(Qj*O;haJHs>?mp7MXT>RrM5_f1jC`84,m#_,P!\n'(.&>jmR%4C);Qu%ND6PB?lZF`?+'8Ie;2eKWR^TbTeb<`f^nG8YdFa*/T]F"6:dX@U)Ipm3Coi_Oc`G9\s<GJj?iF.F)rHD9Y92WELM.'lU`sS$[fnVWSen88cE">aSRr5:7\,dh-6:j"PJKFWHC%&"epNJC$^1+7*qO16:s5eqYn^c_p.LSJ1p<B/U]H,2trqfg^jnnj]*PQbe`6-UZ1dH0bY"b;_[_?!@g(D'`~>endstream
 endobj
 48 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1684
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2270
 >>
 stream
-Gat%#>E>7C'Roe[3'sY+7Q(VkA*g[!Rr,Xg7%:9Y4s.Zs9JXhRRDE+:b($ULS*^A,gD=A^gs:B2Je&oIi7G_8!Ut7?2g7I\!GqMgLMdCP#C*_KI%@X/Q+OE!FaNO/Q;JVRi8mmK<hRk+6fbi[/-;lSJEbm^:[d3RP:r:8gf>bg$@]$X8jC5e1MkrN]k>4*0Q=qn,jp"lI-rJEK>eJY<>7s>$J\YFql9udrAJX_Gb0`2Fr7ef#R)cGSf>.W*1eK!-XS77P:JSBQ05b&,fSj1`:Z9C*Vo3qGo<%UI[uXrcHa#CNk_gE#FKBD-=9#:<ff!R$9Wp74Xh!MJ]X`8a@MCZ6RggjWZbr2'#Tb_CicK4$W3n><(\"_ELJ7Q#YHYSBf+G^J;KFmGA3ICb)B;mnNbek9@h-l][8KVf1imo5qRI';A[AVB\0Qle%]o9ehNjY)C@5tP[SSpq6.WqBE5Re9TP:qJH0Hc:^T5QOq\1iP"in(1`<7*^U[Q6lpfS(Zr)+@Ot^^u8@8l>IoF],/Ah7"-n:KUX/*1!+;N(e5X&0G@GCVR6)O9dTQrF>njuk+c"3`Tb+M:\E_e'nVZn,.;%Qj^,aN*P.FDM`oH^I\5lnT=&FG`6i.-E!N_h4Zisq/,e>,#fJ3pb^TQ!2r.sDSJ+E?"MSZfr=(P',(XFfQ^eqC9+n^\8kCH$jUrMp4tD^JMIf2bW%>J.O8K"eR5[T3rB,<n=@g.PGuYgZ*AprZ365nM(Sgm"O-Fjn8+\e+o/ZNoF0dO'lDTq)X_;ZN=$<X1G]Vl3R_+#c@3#S2Ga9$OG`9*OKsB*2pf#0tWLJ:7FWC`lis\(OSU@EL'8fjBb9FgXlqJa(a,58rL+=WbonSG0GC4h@1=_`akd6aF]@Ec0,SAlm'rgkr2YakVr\0lc&)q8"ITh:Nc>A0uLY&4Y9R=e+Eq#2%p`F)uD[j2nTcKF6Y!8A?hT:8H2.!.JUJF(ZUXG2!8!/$*eQRdlQ/>HQ"P?Dc`.F-4^C1SJ>\_V?T+B(QuV%Hk6e6jf\7kG5Q,db^J"Q'1I';R]/\G(3#Ep927'+uAGMa-AGh87>tcj\l]gBUHFK-^X;bDl<Wm0"RV@14MuFq#$#/U$6&UgWAf3].2HSY<V\4c5MQ%Unb\hs#ASN(I:13F"J\oqF0IS0JDJ0_;*A$mg\CpBYtG"1s"*W+1VdRHXN^7.[]V:Z[.Wu4_O-Bm&!C9)_b6U*"@l<\Igq44D:j?G;],"hd<L[2/Jmn.^6-%Y0ocT:bm+@i"U9Ba5%?S6<gp:-Ap03#)"!H!`]QE$6&HWp6QG77j^-\Qo5PCbQ(h3g7VkGkG;7,f-GJC8t+J<'keV(8FXhs?6=C:S2,l.#r]s-)M:W<D("^f%/moA_i[?)o6u6S@g7!*$$7dMT%Zm>7@gkra,fhq'lr%C7df]X'_3j;G[Rfqfs+XVEjBHg'3Su?>hn1lHi&'VhVV>%?3Q#N0.0$sO-W/BI/hMeojTQr7^#IZoRR`/0J>c%48`t!=5K%hj@WHU53.]YbUu$"K"?q%;cr29QJSYNmA5D,.+1SiqWgBr-oiW=9:f;qfPl1VeC!LbI!<#@8k#2uTj,hRa=DkL;Khs(f6MYq5d+FTfClN%Ilc+%FKbU[6EXnu8^Nep,)[';P@@k>'JcaFJq=E.B^c8=Y.n:eI2=71!Qn.HMZ~>endstream
+Gau0D9lo&I&A@sBm*Y3&[&@p+QFLo]SYStrATDI2J4N4!64s\4>#p-$hZ>(*Qr7Imnmj)1.:<s:qtBD06gE]=kl-VuU/uCs^BuD0d!SFD-lCA0*PJ&:Hon<WR0I1#l(WVJ%*+RbA4R4qc&+H5[Im*.$tqV.CDi[LICa\u+%5a$X<bK\Cn_BPWDkEuU%oLns2oMo2NL@l!#F>VPHAE4F>b'H`tV5+FYLet-k*!e\pe^Pea&FS],lr`abV\jO8Hbpr[Xh7PE34THc@KM:A[uVM_[C*`nhE$#,2(nrMBAOc?"FlTQ&&@$pk0[o_4h>s.Gi0OdVkX\WfSGdIu*SG2;0I_+!`Lm"ZC@O</l=nK$&3%nJ\@:Um#EWhcId@qd?W99m\`Ca-tAWs$S@QgTD46`+?E2OUecJKmp)A/ZMndojkT^0CL(O:sek6M>U_SUP5NhY:okD>`.K9/\^j^DauJK`1<DM,'C;.=8R*:q@2@?V6kNhcjKZP4G7Oa$+'g<OXhRFlWN0,pJCsIYj!iIuoVSeYX__$>h>ceV;h2SaLL,<2hDZ+?[C5)2.mJKXeGh!93P8s'RDH6rp+(5KJF#SJ<?S<%eFAK)^oZ;C,8j5R>Z6/4<g9OYB\k6fi;f>-fAh5\$(_c=g(SeFlkuh!pWH&RgsMm[(75S]fg*7]HXciesp4DT)YX3$Y3!4AI_nO$?5H]4SN`,]dZXmMP8[$E_rKl\Z5)'7&YaYdHGZG&=I5/M+30XNXR1CtZs1Y)FbAQu[XSZ&gCr.O84p/,#Egngcr*MSdH?F@U%nAtgEKgh,`2U(fOr?eV;1)4B_n_'TPb=7p`oKbXTmMO!nGYNcL-l4-nDPY!D'U;H6br>h`B!1IEEo%YB6&()0m?TaU^KDsn%gXps?g2Q=[s$YRA=U#'^ooGpmekq\eLR^\Y!eqY?&".euEWB^_3WGC>m^?+BU8X=mRNWn[3am=0i@QSK<k(.<9haghL_;H,n[%qE6_P?P:CkES27bYo"H@:$nHf)$A9p:42oI.B,D#<o>0>9>3Jh;jo=-'A5UST$I`M((+@edPQ;@<&*4N&f,A[)$6gm'l6!_JXY)**)=X3,cd0bKrj26mh_k"s,9p55L5Dm]*V"a[N/<dkK[OL1Vb?;)FTPI6[JDBuh'a98-TlL/OmT.<GhPuCF\q6TkQa9qS9L??m.MD!Z)!Y5#B-_D,:<Ic6-0g(Qe\=Yr2%$kK/i?,(T]3UZhbbGfcFHKpc%3*[-H"lO@Ck[!3,hK9nHFbF/(C/bHu\'IUXA[U=fq3=A?[T=ALF9,-qC5GB$"'8lgXY6SV9cS*#=[F7Ej-d&XH[QBHb`-XI'4;8WDUNm2HLHc\Ph9r!:C.65na*lp-W$QM^YOaaJRG_cUl/aLNKPNQ_EZL)71/X449=j&BdFjQsZpGGDUsM4rh\X;nb\p1.E'R_F`qqf]'iJ<@R2-5E"F,IX5ebi!g;j2a:bL<io1>N83rmoHd*,<FS]W&9_q)&P)i9.<-`K+6%D3ndM<LP,To$lo4FOaE-F`A1%SSVesoY'`Ke,hJ(kUi@-q0sROnL)Xl)V)IP'2r$*#](f?_rTBa<D%*)@e6O$E<3ih6h0u)mUueC^=Zt)@nprd7WlcTRBmTb=;/"n(GgC@6^,Zfa.!WEASumRA*DHB%Jr[/emW2bdTUtV=o1QlPH4"0u&mVVu2KC>-H+7S77"L:b\EQId38]#A-.8W:ATFp03^KTTb7DW-<!ftjHUt5YrCK-S,2%rP3P&fB[)lHg#k,$=Tfg-+_<`P(n4.5(C\p(0fh?4o'%*K*o+X]"5/!e)3N\Q@(cp\h8++4=LhAkbDHSY<n0F[m.^oa2(n+JsT,mup9jrR<VN&VXNBZa#?Cu;.I>7$*>ruYpCV+[]#ld6V;#V!&iU[fSf(]i!d*K`oODbLnrMIZ@fo=C.;K8I>"GS,X3.(/9Gc2-=1EJb*1un,rTXdGZb<>eu$Vuf^%Q-?MTkpGsN&fKtcK8R(&.kW5?"rJgn7#1eldU_\?)2p^Z?%R6n'SdEEHNAGL_O;=]G:iW_2[4F%D#Y`BlrT]WoQURC3HqAqW4@hUfn.CK"2a*\drZ<&LZac[Ag(OdKnH8o?4Cn=c#ON^8"$j]*(TPWtZ9HYCF.8@X[.G&I2O;$D#CRW(2'@40$FYYhi#o>o[Ts]6^[fkTt,*C6GdGF_,oGg%3S?VfMGG0FG/q2G/30B\ZM]<>D?+U#t&\6nE#U8$9Go/s^n&0*gc$h6dM/+BCH@2T2>Rrr=l&\ub~>endstream
 endobj
 49 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1990
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1680
 >>
 stream
-Gb!SlD/\Gm')q<+0ecE\=2]EiA]]*[obP/dHe@Y$2dZ,DgCIe./9*2&b)gZ/47p90W&Hf#2GT/53"uB;M&[$$4>WKDqr!#1If2J`!<0\9pPf^_*4C4`""/WdH[*5pgeQRkaB@5rFZ]"BQJj;u^r%OtG!VnTLX:8-YaAX3"^Jb:FRpD7@/MOP"Q*3+;[dRpOjMunq\cj"=M8@*QbhG`_UEP_5Eg/_eS;g#JeNj=E#sQD"hl(4nF>na$/f\FS%XHi#m2S`\b)Clqj#(DjG1kEjPD&H.uQD?-FXY$h*P9MCMs^.H4eDg98cJIq&k2q[<=m(fiKNQIl"?e]G>igUK>o(mn)m>MBK9qI.`&)YIHi-./ACP'?BkFFm-`\kC#N=nE10lAa+0k/7@Qrk47n'=9%[O\H8-:`qWUuh8&h7^f469O>OimJ8%l#R2n54,Lb<X3>msa)@WqI?7#6h$?V3e`q0,moh_/h1+GC.'@u<5P811.*t_&K8o'"HO]gL7+%Z<Yn,*%Ko\R?rhR7=kc\W1)TAWS+nVburp>*<C*V]D-n(q0QU)E4X+0PX;r]>2AaLYjq2XWPp$.bZBSiMN1IXOKin/(fo^37D:F(`8S>OA!27PSVUM.ul;[-Ol0[bK29gD0&i6_P,%\r&:/%?3+!>3UO9jBL91-MWB@B8$XHeBS=KWIbO#JZ1mX2,l?V:o9KL[]*e4=p%*mM@ua^dV]1))\#Dk0[;iA%EY$ASTT:;T6-bhW+4!g]T0b-n$FDD-ke"sp:(4%4Yb'G1a!HZqY1Q-@3JR_\Ss%UCJ<<5;S18T&$b<6j)hH.1$@*5IM<5R[Ll]fc^"M2aNjVr6,IuA%k'l<j2Q61ck(-G*V&1JJp$R'i-OM2!`$c]M2rV-79u(H`JPu3/E&(lJ2(6@+N@1PZX>?3A/j.&Tt3H<c4fq8E_:<"J9QLeKJA)2IAJWQ=%XOtW%Qa_SA-3G:AM6S7sf#1Y"QN<;<HrDWXQEEQ-.krR-,99#2opkm?BgCd!_b4)Hmk4dhsneZPX/6.Ws;01W<rQOpbY6;%kL91VVIpdHAS*gPd8XQq84S8fCP<,_@I'q%5*E&8QnR)+d)kE&>X&f0efRpR`XU$3_[&2WbNN:f3ZYGmF=c11JUM7KmKSnCZp1*<D?N5#;<m,8d7t%>nS$R>M=A3^)a98So(561CI'(B0r172lFR7L?(O6:oDm,M5sSJ;c8/']5-'h^*T]%&buZCo=9o9rdb`'6'H?+_IRYc&rRd`<IB>0dR8UlO3`n5.;l399^!O1rT5/0Gg^iAYHLL(fc'oH5_'=lNh4-m>M0!b?Tu@1o8X;@NL+=[5faiA)d0D;1mTk247,%J$E7=e8i"^R/?kiWp.%"q.?GcBFOW+bL-.,V@M,9I7G=2h^'P-fF)0C"Is@LVdQr3?g&Kt3V.=p5P=D=M6bt3Q]ZE]bLf1uoXF&h]PElUgZO(Q'7M$+fD3^2h>1sH?aYBOH]'QL07Gl&bq0I$=apf$Me9B73P*-jq*>=$oM<41Y;T</[#HEq/]lqR^WMWm2T3m8YAU;^p*E>b#20rpOBBjC,Kh<_LsMjUD'bR4DkA)>`f_?P+tEQ@6s$Zj/Bi*YZpHJ$R%I73iQY7Okembn"m(Sai#a/Nq68=X"8&.;ZF3O>9e/,P).<S]&%V'`B)N("L2Hi(ZJNgno<iK.b\B;&$[nujoRk]uDat_[5FOIQ>Y$mcaYLnW`8h6hR)Q5MEDU7;/Rlpif32RCKuf>,+I)t9Cr'M8"m3&8nY#YD2R0N3rDFqVYP`CcSocno*899>S=9u;NFg;P2;AM%JW^/D3:&'2K<Q(g:!t=$HdN4Ad4'PT/efWW<(NL<F/[9XL(FSRBc8F%mI+Kd"n'If<I6GE=k@DF?ipXC?"k_W5k]E;$O![3QfGR(r=&<:@R_M*NjINdc=3m@nGck(UZK\(*OWJNK5DrP7UU-7/#-^UXi\pd!j,j#p>b)KW%/]mniq4Q&9n~>endstream
+Gb!SlD/\/e&H;*)EA0)^.h^BYZ"3T5\g9e'+A3@Y`NU'Z,LI9*M,YoRM-'>amuEQIflEU!BKp;e*6R@4W-e<p_dcpgj2\QWiuI"M*+#5Ii-I(aJ/^HKbg56i5576R7NuJ36aNZInL*9PoO55Z9:FcshF#ob_"YoS%\p@;Y>=,?`LkeG_b"E;V;Y,p')j-"DdiWsr,sD_K$ZfElfh9eb_`2qc_#_$iMp4;D;`!&#ZkpKBRN+,p!Q.aKE:-fR>d\No.,IZ_0_,VlQ%?O$9?D:hjH>6c%=X$_o@bMab0_ZA01pc9P7*+a7Q;j/7&b)el<a%7<*-@o[XkfCIJf_,!T=I^/-k'`pi&PBf9qcYr`>!fPS+VN6nJ`JKPjac[;*@okq=IcKIn/cNmpGM[(Db)SUf@2\$\%QeZ!KE63-L][X#RLI^)WV5eX]cU>dpm\buD[st!KLK/UPEaBY1q'@h:lJ.[tmS;=1F!WXrET6Fk,62(Y-kbj-'o!#d/tE@s%80jDaS500L/OGkKT09kFke-fh=C/WB>I]l74)JBILmhh[-G'A\arkA.PI/$2]6hB<+Xc@:DS\#1@q&VDop;.c,eKH)f%LJ_sctKQs#V$DeMPb6qM+e\Et;Too2%6mJ-,Ip\*(0F[WTs_OB'SO^Q`Q^-aUPg-!]tor1*`FIq$^s#<MWF98raG?cAb_5;M*Uq'$Hb='Dt#RM9PR^jSe*'%QaoWHd`!R"(=-#QYl&A/.0E_opjKk)'3I*(@_qE9F.[<p9nq'`ot=_tDSK8.*#QNiP)r>0q4H-`\#`K*4^DKl`mj0@Wje!][Br;N=+7Ot_i2[5Db^egm@*bX+PZk!S(.ZQ<6a0U5NmArKL$0IXPP3E]8R35TeiT-,$7\Q-)Qt=s.r6pC'(0l'3+VnRFAlR^33H/7=KsHBr]n0B%I6cbOAJMD$l-6_8.dP>=lJ$;]jj12!ZQ$'>@u4r`50#9VRG-hcOR*(b+&&;(LEJ*WFVqGdL\Ve26>&c8Cl`q35@'TVh%OZnf!+<%kRTV0H?*+,9td_$*O5q)9!aQ?&@ni^cb@&D9Hj;+aOlC93bm0"e.V`bl'gRu<XV%<asRfXR#\p+&?YPB!(7LH*\;.&n;4>&Gb](51<eOc-7O#$*+P/HC`GQk7i6VD4Bgq*!"\/0h-OhY%S)-O/5W+O0!o;&^NOa)RM?;j/>>Hu/1\t9!h[>Go%:2d"Q"2$I[83MU.Fs2T[*<qB.D'$d@?>FYS-^5@K<7P,gT4[N's@=?nm=AXA(M@(EL+5o2mHMLIn6h:BBDNFdTj/)pbl,JH&'3h4Br28peO!nh\=$+ZlTS[V%kE31b1jFOI.q;b?"_`bt.MiG[odC0,g6/,Wr.OL]:,mhjTp_bAlb_-7g?FjMR#Vdc&(5P?EMI)2i,?5,<K]1/6%MBu>Hd6q!Cd1tOol;l@5Z.dm#\pHDQ7fmmQmH2%\,)\+APp-q($L>%,DD!)EOu,[L9N/CF51D5t0@$sL)(JVSn`Fo&Ug%6\=.3Jrffj!"P]c;n*dpR>Q&-DlCh+]eCYr!k'e1#s"=:&*_Zu>1<*+FW/7G5PDKSu]dU7'RY?J"m/SlLa91WJk'^"Y70(l=[hHg/%J\&d#-!$057>gAXLf5Xe('(oR'K!G$6&C.LT]p3kgY9Ti/`QJg8pU,;$[.;6n2CT[;J?~>endstream
 endobj
 50 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2664
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2154
 >>
 stream
-Gatm=lYd_$'*#,L@NaS/239b#^#e#icj"LK,&&'%`o5;,"2u9p)08B(jBCCUrSJ.'I7X(7@jO)WLnrjp+m8NfLLV1;#ib><cN&Dt_s<3ti\@OD&5T&MXP^q-Fmhu,HF&E>oP.AhO!_4/E^#&PT6<^5V;)pMEAWElR&":I\@B4t#?QlAYoU]B\PKVeT6$.Q&$Z$AlW5A+Lj:m!8(79b4WY]m7>p8J4IJLBQnRX_"[n8_*&$GnrGsW\_S2qjZ_u8c5(sDWZVe*2IS%'6II)CH24%Q9A!eo?B:b@qf<7Z^18E=Y$%9MuVHB+\LuM:ER`DO+]7[q(XmXS_9]3opVKN5`F6@].+R&=k@KO_d:/V94;X]Nd.b*ma>f[%b7F@V]J:r1P=meBXjU?1eQK!98Z-CBid\\m&Daap()aNMe5R2Ypdq?rcYFRB2?]09<rUur=Ju)OF*TY#43gU.h&24chbecCli<t;$d'qh?LS2"%5-%iG,5=rk$@$8tTm$+:^<s<Q`^;Eq*SPiCT-?h]0j[+s>F*GBC[:B=U&XRAS;j8Q/Q?P='W6#q&TfA4"6&-jLKf<bJNH9[)G?5__,[>b>].$0UBBXO3@mN'C2tY0,FE78<UMPtNmcrt7tcp>dAeG.-h2E!pDP@G/2J^l/WgGfPjh#?E0YBXHk;;X"4p4;dL\#*a)%RB?<AK5DqW.HVQkDgHJ!g:M;02s=dn#)&,/a(.9Uq"GmNb8m19ubP\]BK:_%lqHl]?I]G525FTF)a.L8$hd7Cb0(cYHen'Ti6r#:<9K]L#U,6\mt^@gmdV0g%pZXqnu@8@p!h!]"ghJ4X*W:AK)QM<c'@tr.<h`l8IT7"qTG6b<iR)?6N=o!p'bHFMc)#R+S?ILP=.`$m0a2'eO%d9PUW$o$?PQa$'bVG6`[6!WXGl-3t"%i3ci$iW'bbG8oqsnJ3]o1h"+UAT_D(?UiJsQ(.bB.,b^rl`7k:_'t5rF[8O5GWe2&k(0NE0&U>tnCq0gr(a@Q^,W_,Wlf*lE*1MWSkI?S0.g<K@9BWfe@%q^>G<EDtWXZPG6m6iKBfWbo`]U9Bqq^#qcD35u^FO5ahE@92*\llon"BCK!_;1O,b:]DDp*s2)Hj/d_?^H\HF-[^K34Emb;_(dXfQEqaYQBP+^2JEKPF?K1;qWBON6GM`V_dj&O5Nt-)rIjG*mnZHg%WD>qjBOJ*0>/2dT?s<sDTaNMd<FkMkkV0&3dUG"j=$YMn"90#ljC#^Zn')3Ro*GBL"!\?,K`lbfAKQ8Gg%!r>suc5XS*us">cf%R:QDRg4Q[G*.lYt'JhAl*\7qN!K!\te/k,mr9dAd9-53I-Q5V:6l$Bi.]HQ;i'Z"ZFKjuA[R_O%^mX`'`?`5t<>Mql/(]k2<-85Q5>q_fba;3srPbFqb9[hT9:.i5/ik^ISufZ$l<^J9GMX+NF_7uf<opm"V+Fs1N"/#6V?k>u>^;GDY]?-ZfLALh<sN[RgQ]60SX'g4QV?mILb0Mlm+O4Df-]qf?B6XaL:f+/C5:n"[7]=IT"I9jhd`fE"Ae&&cm+=n8TfQs^gaD%=`dDPot7[:h+^+T%b2'VNRt&H*5P)2[H$1S(4gbWG_ueQ_BPmCo/_PkW2!4.51<3b2.Xr&1qX7m7HM:p<?i8).s13Y`BiopaLsO*I>[`;2UF/9@##eJ.V)EtiZbnRV(Bp+j@kH5^]\mqJ\+7F:7&Gtcut8C;aN->l,l#TC-82j0J>=N$=D:G3U@%r83sp:;uj4=[ZL`9.`(f"RmuE<L).8JSVhcY"`/iaK&fV+EY<?LEh7H76R;)aTVuIq11X0i@$X?eR6N,N34!0uT??XcD3pSEp2K'"AZ)@Qf?R`s]iCfobouG]]d'_V3k&u4>9P:m)NMsq6K<cd3"4(.7dE.QHDd$dW]B?(oJ9MJP>4'nUq*@^Fhrk#\>&,J,tTL99K#20e_*FT.OffGg/r4=q?$)Qb\7?*)VCb&4X<ClP;"]KK;%7X>0>u61bMTc=o=EjRTtA/LceF,Fbra']ItYd[p!Wi-e.Q22b$i%fqmDKSpL]l$sFR`AVPfG>\F]<49pgN^25TS$U.n%@X=$q&D]Y0M/r&?j,4]C+$YGF<n,hqnL#XuKF&%@a(Wo#7#0$](:La:<BCWS$66kJKiT@'0)hI^W&8]Z'f+FGG&\3_>(n7h'd1P)>Jab].81*2Y^r])_gKf;b31d*Yf>orZf1itpX/)""g(4A,uU,qo[Ak!.-<]Io0FbO'qn6u/RLgD-UGRrJ8bcHUC;TN!f!r$I@(b!\bYXEHDQn=j67RW_c?qPU[Mn'7)NQabpI+#-(l]R4^%ml9(&^<LmOk^SoejiB$9Ys;BG(Hf$ogLA`$\"b8N?^fX2&BBZh;8<G[X-K7B1/U3,#FhrR@mU#"ZNESt3^D;InTVNj/pBt^*cp+hA*0:7,ViZNhG.c)]VC?;LBn)p-M4XpN?](6/+(ke_Q=>*[/#q0>_lNu26S<f/T&qg<2)93#cWk5\95jDs"$r`KuQ%YP:0O>i%/']h;]9DA\e^!O+=(G[ch7C'lc/u@dH:m-Y*8LC<K46R6G$<oEir0Y?;W6(CDhlo9%M0Ci(i;d^f/%<pr*eO5nMpHWU2)g(WdA](?COG`*)jY@[7(';cSdU?ULtr*O-[+uY_V*8!&g<Mp]~>endstream
+Gatm<gMRrh&:O:S$j78e"(eUbeT.;;`XW[c\_'N4,00ko9?Bm$U6&V16BQcd)00qD=iki=_N#ooB?6JsB+@E<WIphirJa^L5GiOG*E(Odl(#V>d&6,D\sf4<4XjH%_17lljn#-((nM7b[/[-Blk#Jp&&Y&5]e8c>dcpF[gFIRtU+]t!l*@O;\Yb^IMWJb5rCk[Q]^M0XTK`jhA*n`ZAJU6Mcb$jk"XBPk*T=CJL8,pJ]KCc<l6Pskp\Ve2:FQ_WS`%0YPgJg>HfVRJ@t2:l6n+]4j"dBLJ)';JV)RZL#+Sd"q^rBCT9"UJ4m0:Xdeqcia)0p:G:7VSMVT2glDtR,q2et?BfXL^.]ep*4/'Vb&9bq\0Vn[!>rY?-8<=,(34nV+H/P_<ni<WJ<q)Ul[>_InAIHtuT^CoEOdVR_o'2^piZFlSL&k!7H7ABs29YTee_XY-`(VMjm.MRYKVfYf2,.9gjaO8,cK?[>9oE-!7?L^)=C'"fZBe'7iZ%^$:g1l8eW/&OX\[i`rEF=lCn]rbOiTmL4G5s++%O&+=!L+DW.iL(1]CR6j8]\a+t;TX*3IQqBq$:B77QuF*kN+M[ak`C,.m'Jg/Pa-Zp*kq=o$mr74L+*j_?DQh@I+I7CI&oNt8af87kc'2tj3AnmYXq^ngX;ci3h3]%-8aDtUVYdT?5<q$I#f>;Ik#PM^GVB<H<UVk'AkSLpmWIGb(<qq2U?O].OZ(Q6:*D_qmB?:MBW[R1/KZXJnPoX0m=Z'Wr"I8?bZ94AbOO;S:^n+n2SSpIQ)O6[6NgJ,jB[oZ?`?>-^*eC-LArLisjm7qqa(HTta3C.3GEVj69r*C$bf<Nh=?-6sTZr[bNPSNFVC+?hWTW.6>qBFOGUAQ'*Xp<[WZcY)QVH'd_\4p?hE]"%3I?:1Z<F2::X,-.s<mh+-al:0>]uI5>1=*H8WA"R7W(Os!Hrc_3i^S@t>p6d:H)[GN4u>VrmLGL:WJp27,U:`s3'pbJVQ>]"Ff1rqU`f,3-mD$5]L$\1V^.uBQZ-P*P,p*uM.C^A-B*>d^lF(`3gNF,_'W>a55QlUM^4jt1,nMD1LPAZakcQnYeoE'keTLgO<%W62Q%LfP1S'(JH"j-m@.L]nXGNglW!WM:1Nt6T4k=L,U"$UbJI"<6_BR#e^t5Wm@#e%n8q^m:QlUQ%ksWg+D"f0)AidQT)kOd,2Tg6BU6\SG#Q&G>T+C_i%:7F$\oRa/e`NH>9tKQ.Pr"&(i"Y]YCqt=[*[".2/[t?-S,FFRlC#[nsbFdWXFFGa0\_e;.5U!(2NPsd*Wjr&/A*$Me/V,f*[R<W-dA_."1t-W\\q!63\U/i\.:Ah3qII4pH5K1I"R\]m"G&M`%GH-rl22P6:YhHr870$nXQKq(JM\\2V6AKgDWem)BsU8S7&c$uS%Zc(HpL!].@@jO/?,EAY8JX9&VeOF*Kf90XT;14csTl`.Qu.Z&f?;/%(9#*d_r?VMP"`[Zi=h>tiN"\J'J$u(8r`@`ECM@GT-Jk-aakTb`tNBAAQ/,aHVQ)Dm??kI%i;f<I^[EgHF]!8`gSI9b#/7(lGS1!YJiJ"$K%3ccl;:H.Y]_:6"2ItjJf'&jTeQ_tB5RT2V?a>%_!A8UdX\^Xp]FZCb@Y#^/6S"ij5o/muXs*7dAZd']B'aS!8%gJ>2TcN,=ceF03R+8)%$+"Za:72Q=[,fqE%j?*bF!V\5G>Q9han;uXsEe=pd37K]!tZZBO1t8=CTr&1%1Yo1BUdd;O)6KG^.pNNH*;)9t;d=C4L8Y=1s7p&0WH+<_2e,cjP&b^Wk/sq7YREU[5X=Sg=,h1#.U1T^.S^Co665-q</h2-d4.l<1"On(^9I/=V8$iMLFY\rA(b@k353S(#`UNj-A&/]drj:Gl23Nb!mPG<"amL+dS(q=1C#bS2Jka4V7M&WX*Mqu;?0NCYSIGV'^5PKd[5+H#=?kf2Steu5t7#?ug.Lh/<Y*D7g"g#]gP0hJlJ)?;Sg#:@>IEj[?=.H1SFc/@La9Pt8IB2tjs@QmlNUoF1&'*:(@JID2jhrPe=SM_YK12hX;?pZ\T-J:Kl5+;Y@fo`HB_&S4Mp*aPU55Z#8NAgh6o0cpXO'Mm<@Z6'`c(MT_)W3(+oGh?o2[9Q0`2/(%;Wk*=]u]Eu5;O`m^&~>endstream
 endobj
 51 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2412
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2452
 >>
 stream
-GauHLD/\/g')q<+0edRFDilH2/5(0[E'RWDGC)mSga:"K\2u6TBl(&J8<p!6p_Nba%n"%KNh"`NP!afC+c!t'B:bM7)1W5]"Rc;s!-iPk-gq*B6F^8e&:"jmT#"3hK5ZBS-LiE>2/C4FnKa^GA%;Qh.p>d8%3Q.n&B5l-.q&#;e&>*:BB^.8+hXsoXu-&]nI5F)QXA_B#L^5hGS5^:']1JQ`Z&r)17a0[$$]$(NPbn3,RT,KL6"P0]EiBZZJI[#]JtKE-55:+2Lc%C(jm0J)f-B0qlpr'=q&+S]NO:C/=QAXGdDB&:+#%i,l'-IBKG`o32W;d@JRfk'`!aW%S#?l(j7%1HR06P-@_G!>Uj#5CGD;7bm%M4#I?C?qql6Q'+"NORh?\gn&@'Sl>Qp6cfgE*Se8cbY"Kb+_Q[RjTNn2)Yc8ZaD2Lkb30Ef)Qh_Q^XX*O-X_-hJ7EOWfbR@;+?c0a_3Ai+HV\tfC%f`lC5U_r3caF69gFBZ@X$mu([D)&,H%D85"MRl=D=aZdgCam+E3@>U0[#_$SjF"bgB*hc1uIfs9g-kFr40YHRNDJG"Ru'aVU_Ij)HtL+U)8meh5J(G<j/GlgA1X35Ic1^1ekUo-F7D\e,E#RZio5.N":J4g]E'^IErlrB6>gkbW-N2ZP!CFTJ0cRZ;fP0,f0nmG\c%_-8R>%@Wj;I_(@3?[R0#j)6R)QL/c91e/#AP<G;reJ:kFFE(lRVL;=#<kJ,NofJ%:J9R#T,`%%gJ1UNO4:1cdnP,N@'MopXi)p"CX?uf8($n?m;Es0--"])Z4A(LcX\&-pU0b/C-lq5AV3ikXne$_Lee,OcCQm@HP#J@I/$c-@8N>t>CiM(Wf6+nYmNLuQ%9u1@%X-MX<!r`5<gYjSLd1Hf=_c-&c@//X<.>73RZfG@Hm8>:!*ftB4d/AW5-?eNUPVd6N58/h/XJ*NtZ15Z<Ymk`_.I!"t@-5TsL.bPR$W[:Nb?"l`'c6S29<b?Pj75Si^1(hcJN:@)9(1_['THl5g,;\F;[o^o[n4e*6fYagN;ahC8M<E<cnsNWrWEYBfc<69HRP8^?Whs:5FmRVr!JW(oW)!k%'`MW$W\Jj5Y2tIgZ)?H]V&W6nn7HmTd/X>=1O$=5acW&JrH0dh"7*&l-50Na]%f2D/m23]Zcf2ZAKUZd\<NE`<7_GASmVb]I3qjEm.eJJOso6(`9;1)OHt%E`V0387gV7AL.K+Z/^)JMRsp0W/T5>.%&Q_epABlnYA6ip0mu]Q>O/t:tMWL>8nti,qZ>PF#BABIbuIIh`lVir;2g6?T`(pr<Bpq!Zc.c4u+at@N"H4#4Rot9+gVA4_Nj[iRZJcVcJetE?4nBi-qU%EMPZL*^`!K)H3^/\rTlh),$Z!o:<C]1W`[r]hSYE]UkE6==Oc)bDK2*?dG4aj:[1A/a(]*e9b"$r>.l0<W3E*)HH#9h^O[F/o:VnR>M<UL/N#*%3>EbPkA>Q=<ej`Y7[(<n\`DkF&n`n-c5%:0*kpcr#+EC2-67$*LtVmPdj33'Sb&O9o]jD8m"gkCLAtqC3@e-VBE/G>rh]mEk][nK<0q6C'-D"4q:^THg&fj:*r($*=(J!mp)El)OWHnYsA_B=8S3bX%H2]k7,sUTK<$d#:hDt8\sNR[4u@>M.;C+)Z?f;Ca]/EmsU.#U[Wffc!;hb-4R2=CQL'm%G[$o1p3<=UaZHc9>T$s$%L5mn#K<k\*]6l/LW(!:5=H&nCD@*fC;+K-]8CI\RC_'<cuuk8m9IUQ,PmL/<"0Oo^X[ET%_B.D(?,?#b,-A]2&@1^?`V=b+a1:U0p$/HHq9E5q1RQhL!R4-u7Y^MXd''Ap.L0JX*(i>M!/)mA?l*coC,=/l?E.TO\riNmp9A5E8[b&'TRIX>3gt\t-UeaR8KGZC>+n=ekW7@XQEgKr-b((f_O7MMam7Ydfm)Weut]p$iKXRCWEm;YN'O:+)C/4gYQJmg*Ch+'<eMmJ"IWR=7X;<JfH*AitD73]rL^27NVu>Y7@`B'skYpgtf.1-O73.XK`/isX-(g>gU`-<'P9C!Lm?N3Wcd-aTSP<0H#8U8,G1L=5GR/P!EqroPg:n)[eSEedZNPJQBB?I129h&R!YV.AmPl44VnG.1bqle\X@)*:@e8TNR@b41fJBNc:S$D:3RFgXF!2`GVH12b]__efn#]l\+_rnSNX#B)Pc'Iok>`7d@Goo*'p'Y?\%3NR3L0I:HS0*k3i_C)0,b1Up,Lt(d3ltFr(K#hq]"(uQNR'84WrUJ&OJNDo=E!3aL>%Cr*a)#g>GSX>7nrEce08a&6fg9!5l[MLt0),Lm-L%*AT;1#fn5pC7d]C[U8i2P"^f%R,l0=dD6)auR>CHu7Tc+'',@jiIe"L;1LQ*O@@jul-cqmXr,tiG=!Z:hGQc@%a~>endstream
+Gau`VD0+Jj%fYm'JT#Ze?<PeDlFs*/ghA/(>b0,E13YYt>,#i0Pc0[A*<5m<W>2f[Bj\!3c6h*M8:\V\J,h#"0)g\&S!F%=Xl0&1!:aH^!stIt<q"u6lJg"+RM%]U-7/!PNZUa6aG95fnj.IBC[MdS4RbMYXb=le&+ADm5ABs1I:2QUD'"Ca?eQ]65Jl\AXBoVT)kFkhEfd'`Snp6)ioSV[6Z?M!lG[uW#`0e9qrIl`5@%6ZkTFi=!(mMaf3,8K35!$$"6X79(h:J9-.jk&m;2H#QW=KsBtHMe(Hg<.lTZYT2hnc_Hg,D<rj(@N(mUCPI!pEUj<gF`*TE5-,,;2dJBQQ+Z'nZ1X3tWG%@4uBU1sg%p8'>d.p:C&P)JT+M@.SCY&A]X9Va[U3d7cWICFZ@j]t2F.o<T%<;m<N,K'DA6+t;'WBdQ="pqX;_)"o)Sep:SIb'jda$Kh+',ARU!rcZ1#0J6eg%-C&eQ4(:QM(.ijAM5(e!;q=Qrts47>mG4dXn*K.MGV'Q<$MC758eFrtB"1pH4hFE,*%!R%t_#;QO#7<Bu\+nWC3:45af[Nns#i;2NXLF<%g.el'kRaYB^F>0n;5)(ILTA"I$VDjbWRV,:6P_4XU?dt.0&$LZZ#2[d!jXjNoC'm[XV'i^n^phAd8"pUpF5XTf&_oV:o@n[2l8HaW$eGlj/"/K5DWRqm6m6*+#a@*&8&$^&[X>q2r[e-gOVd5$,1Z`+Z)Yi-9`Y9'Z1Yk3ND'etJ'jfdB(pU^CO@Un_nng<!GU(Sud+@t%.SShc1`\)-kQG*QoM?AD=-!NRB/\s0e\a(U>&1dg5atqL'iY,l0YZXhLNt.reQLmc5lsg@-;-8tB;l]#:li6:_bKduJn9O10$"[o-%l+11=O"P;/D^)`&;UsT:^AL3KA\.23N&s:#F(Mi9\(>I,0c/a)gr!Dkb\rBA[bXKHK.<-19i5[Q&W4bEGH_\adHqoV_JI0UQNoJ1oX7i=STJWJ^2c4Z6@LP6e_=\36;cfrP=Y7@V[r:?/%QY5NJ`;[?O<bo:bWSPDH05\DgX$LB!*?LZd&I:&n&o*YJ&1ed;$LjG'91M)]2X?0*WfQBY&g*[nrFF:N9Ij@-p'jKV%i2jhho3$q8OK/9S7/>g0frl[Hq$JP4?g7tt9e3l4)Ae((&GlAt8=nM"?JL$BBnNU).39a5$6*FB2Ceo:.LbKCd0OI@Q`Qla[C]L&"I#?o3o^Np\@o;lBM#6KB<!rpkR.SKL9rO*b^OSP&u9D-PsGU[3Rb=kOL?fr\Nu_])0LC\?E7lpdO-GE^bJd*9Eqg\>[%YPrTH-Q)9p-rKt7U1Ze5S^^RPs61C+*IOoG.hnajQ\7q"W68Oja#--$#^6*YF(GlSpl>1E\T4j\=R`<Hjm1/LMGYUq-\kiuMXQ`ch0[]L7<;1"E8:(9Y(EPA8,1tH43^jEN6H,?cR9i^CeBTM^a'4%/leuMAT"e?<JqQ-PV<%I:\NupUcq<??U7gI^eGJ.s*$&t>$.1W<I>?[^881,o5#'M/^J&hEH1iITU3PA]O-!OE[b7%]"Frj$?P0'hpo7FDR6Ck$p68d4hHP?Ik*`sRc'@!WelSWrXf6bO5Bn7:_V&?!+[E;\'aChUPar3WHeJs5=9?&Y!m\)RPFT8>t0,`9d4P/f*2/h%'[l@@4T,1j<b4S4r"t;#tPi)/>Xf$@jYTqIh`8!S^lJI6h4.UYeLA'<KB>U+!q1AR,<]`>I;pHn+#9\=+cU+$tM,#6tc7qXqn&;tR.uV1)A=FW4[7TB&keR/r4Q[*!F8!ttr=\)\TLm#^"Iaf;IDe=lDc`Z>E;#ReZ(#SZA.)K!QM3`8.pu@]%WONE>f\G28]bbLXn9JYNV@`l9VlD^=(hS<;"p5T=*A_/=Z;qOPs/ifBdLB,V\YW4(?6bu>0Li-!--(V?6F;96ZK"*r7Fi+Er5O/MpkMu^ma(pod4!n+!k*YZC?=CANM2/7>98M7Kbc/q>-=g.[eX1F.bITF'`7Vs"?4^P>#R+bo(#GI0PWd-N5$iSem3Ta*8eXcLg$)CTqf3g":anenS(^rpQF@0Ol)\4BtDA8%k=NOf%+>9BpY-:g<esQY:_>VN8+$kh\j6WLV)DKjZTEN5.KYV!:cgE43]QWk`>1cclB*)0h&QT3+!n"c%n)>#a*ZW#sRklnKKFlj`(J@Iu`p'n_`hCb4q1jaT'[o:r,Rgu%=pmf;Vo*Gk8mQdN^RWR2MkF=gY)'^WX$2uN^O_?mj#'MsPp)894/bngcD3E3OQRaCg*;h]X,3d>)jd@>71Y3&<"Y)INrgS0&H[;u#Kmp#GQV?SrKJQ[lFaeq5uZ8?chVGF^JMS?Rgc*<S2R&?P,SR1urm`En/A>%koI;dE-/B'aE[-g2ZVfbe$B$Qqubrk[+BM_M^BZM:PqYaV2,m^k)FEa4#p:UUR<R\OkJbFlp_8ZES]T@V!~>endstream
 endobj
 52 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2206
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2164
 >>
 stream
-Gau0D>BAQ-&q9SYf]gVJ\f$ta-&Rl>Vd,Zc3qbS:jda%qVR$>*,%;*k!)SQuY<T?978"C:`NB)Jd/\?pfP`DbO?a4/,iPpT!T)VK`VTe$!Sf:M8YZu;0B(O;P:n<NbW$O2e?g6WL8/RJ%H69L?*Z_j2h<N:"u%%$[Lu?mJ"6HEf-p'+8as=bKsC,O/T^apDEl&+/(V<W4A#iURb`lLl-?kR4IHV4,Da@m,TD[c)Q-.^cJ[ioP:2.XM/N#^djRk_K[D3.-LH9iAg`(uHo^GM*(L)Ja%;MI.(eO1@4.TbG\-g2E%qd\@+_Af4Phf0=8-70X8C)SGS5C-68IWZ9=T42KLqEuc;>3%dk!NS[7`Jb)lrPNPG4nmWjjsEY0;bqdbY-`f`#Ref.!@=^oC:qE^1/Dem=XFo*or&g*uYl07gi0(I%!Fk^8456+6ko7Wf952FH3ZjB.8g3IQl05eA^NO98kV$C@]28J\r>9++CqJ9=-r.c[%h.uO$_GCW=E:86t\iR6t>:0_%XCOL'\'>Y6G)C18q]#pN2<^F4ll.Z7k$;WRKFk[o(,"u,Wh1Ys+<pQ8,@)2$^X>T)NbQVd@56_/OiCcJ@ebuQ\#h!6BdAmP\.#a]sW'B?+E0PV!`bR*A3?dh9kGHf2+NA-uN)9^ZdQ%NN<N$p;f&X6K:Q%)6/bRNml9&`:o?S[E/5Rc#Etihg!Ra'&YEb8;qBl4X`g._`TFE`tJgG'ZMVKpcP/5<f``DhTU/GHCM/uSPT,-WuKj#s[LRE,3C?p_*AMgq'Ra#4lI;p\'r'o)[n:Rctnk3+Xs$Ntm*PRh!K@i?m6<^'2LEI"#0(gs'7[)ehV,4)eRDHJ"MB9U61q!%AK@Jb2?rqA;]bo#,Bq;c;`']C3\MBP-lj?l?:kMo5[5',t.rls-)ARM-dscs)2O>=F2:.fGK.ti11NUAJ2b"h?1@pg9P^</Z3U/'<`rJg4#(Tk3+E/=;U`[J$jIau<[ilKXe:s4H1'X]G.7$e<X_/CFJpW_.O*4+o_;Ys&G'P7QU(tWo3eTm=Ja1rKl(uc47\2aeE+;!o,/?Lo0/O?p`mB8Y9Z>^^rR0%*;bGB0D=!rG?)tkhF4M?lE$0#K:g%gL=)Da;r-2T;=/]jDET[XL0T3`:Gfg!,)W'1]C,m"YB>AdCX5.CUlDcV*m4:8-Fuhgs=qk5;%]mDt2GOV"<7)bu@UW!QjuR5b."m#r9*$R-3"L_B,WWpTB]F:Dj&.p6[]':-ZO$o4]erEE%4i*FO?)Q89I$):?`^/J\t?<&=t7c(O0u>T/W;"&Zu/H:P8l2+$H/"r#]:PdnDTpj&iVMBL97ik*bH0@1DUb6;Jh//C469b5C)RQ9?p_.20A"j[S\Qf\D]4@kqr5.do4G!3Z^/4lYn1^gk*-[G@NiM48Wq^3W1T\ae[R&n-+-ZW?Rlp0H+h*.Vk.AmC&*rgsT?gMKM5!#kYU3[(psNP/2S@;r,EjF**,]Olj96o;7*Mmm&WO;)1@g3@Vj^:[.r.O6o>FTu%6XK0cgsODU9nI\6T%h_5]IQ$CNT>?6,2'<^InEpI]1eH$qJeu`(olGos+mQ,fR)cQWPRl-^r[OLj^S#;;JH:,Q6-'P>KEqBW;CPW=Pr-ZGG8_."L2o?I2_6CQ#7FUsE@[^'P!CYDqGVC&@M43%W7Z^BB;$Q4]BaGQYp*ra\%Z,hcKC1I)]@RlThW/%qQ?0Z+mMXVinN.aIL1HZ@Tt<64g,utm_)5<%Xbt@BbP-RG/fFaSk_4jW]=.AiA)Y-7/S[cdB1t`PKVRk(DX(<\9P)JsP&o(8hYA\'goac[De`?e;X2RpH8!D.cU&anJ&UsIY;dCg%//`Qfu*W?Y!(Q9k<"oiLYeaqAX7\OG$X&#P6=(!a,<e.'P/4!r68#+4<A^An_R@md>Vo)+3OW2(VkYhgPl\TP&/k,Vpb3Uor7n_fkXI1j!Ia0O';Ah>aZS7R`Cj=*GCIJ"kVr@Wjh3%W,C+NQ%Y*5kVd3b--E<WLgWe_H&#.nH@)sG$0E@JS+;+R=Mh`FalDmnS:N(Zh"=:qd$Iqia54c2aPE]/r:Rr$EhgAAI$Vgpi-?<]UMMVViH>[.Ss^m3G'\"R?TWRh*oCo)3>W3B,npNEp,4o,S+8]YS#6U4QfC8$QERoJG%($#!o)KS[QS6X*Y1Eh&QR%Z6WcUm?.7;(&5*D:qFF%NZ?ViME:SM&Gmd[~>endstream
+GauHLD/\/e&H88.EA0)j.hY:8/D3W[[9ZsXkdn4m\du\4YS(fRO[P1ll?YhtqsI"gfTp?OBi"qh,i8(ZGXjsl0FVdq@JXo0!^*$kj`:XMJb]B"`1"L>'jT)2r].#*;p-C_:leh`kKeMlp7H(k'3K,-B9iY&6e5-P5QC]E)W'uQQ7iD(WQLK*n=kdbnIs,2_Yb#!h4!\)E2)5aBD.X_24_u3f)ofGDOi4?-]CcJGk^2+e^nH%nNE:BrWH-g4PQ=T?O>MX]u>]55u(;)[q@ZR9QAhp*,cI?("g@HSq&[C#9Kuu,CRUeaXjZD\6q,:M%[%;KXU*B;6^uGC8D5PPq9<*"qFh.qNEAGVhr*Yk-p(NHcW;CQeQfm-Khsf[P"3$(9bt/MS+7\(gc-qpV#a-j_Sn;JC8oBgjp>(-+gMuZoifWMsZtHh+8u`:,&:Nl0eC(:\+]**%-Nt\h7jRLNNDsQD-A&c\%X(h:EP13W"Gq6:"JJ"V4Djp)>!`4i`J\&/V=)/7Gi#I4SoP,0R^T"L.421N",c>ODt+$KJNn8S"qP!B4Wh-L4lM)T+nA-7Fiu(NQ('#SMS:+A[5/$K,%i1,!.*nYF\e8f?JlBXO'e`&tlBK57oU<-IhOFhPnBG/:KrYn"Z'6BMS^3Dn[\]7645]#3&U:#V\oXVYk<Z:ll!/MA>IB*r4^f#K8X*j@Ei&i[tl"(($?_`:+IJN+%$.MC..&q''IDi/UHTtmpG6t.;Rm6iud`Ca0&"<#5PTuEOAW<=7Ve0klgnm![@fSFRH/AL-3a"tmp]bf./Z*"O3FW55P@9PTCo0kh;=:9>cAhpgLFt15T`,2:CcDYSL=r5kPe%QjoD%?d$=DKberV#oP+6^FOjRlU?a`R[@SrC&Ug5=\SSGD!>gPrf<NZYn)Yn_nrCNgh'g"X2gVFcgb"GZR@,u^_86bE4hdm/$B2B]dX0[0#'#g??O6CE67MRqT+3$7W&C7&pZA/r^q\0Q>!qq5nkhd=-f?b`qqW9jesV_Qml;[#RH0/"Oro@eG?fRFAQGT!Z-7V#N]<Je4]]=Bn>[lPO]2-3qN/Kmf4;8eAPjO?I*@us9CDKYpM\Ek9YH%H:(4e4<M[47(g9tfnX$Ft4dERO==KGG6l%$*.dkXSHA==RJ8LcJ=4PUaZg).ue2;P],`)d&k+Y-#DcWA&k:M\s@u3\/&S[5:Q+gklOZ`en6V9-k0daA!?bfU=alXas^W2_2j4]9jX,,1e7B`06(IGb,;G!.U27-js@<,nJab3UWnN5d!Kue0fej<%8Ti)e8'D7Tug.L*k%[obu5(,toBFM8UplRf%in;Fd<bSL?_o:&/uYFPh%"enbaFW,G/A,d<-t]2QacY7ZfPh@SoD/*ZsGHueeq)^UR_+gF=lI_uo8A&"C_K3+aL7iKURO6LiX?^kk^OkFcM/(bo^EF$]C0FH6#jf?W@afe=tBEL;oQ17hHAFuqR*hE$_F>6Y3*g#KhM!:"aD&@]@LZ=rCBVX*doIiAdbJ6NbUU[&&?#Rf%@7U^Is(p7P6WXlZ7QL<\Do.j3n*R;!f-?[kV(lO(NSQ<KP"ScS6b#K9iFf8QYW=8UbD8!%2*-nMG,P6oB.s9$_-VSNk,Wq1Z?,HB(rj\P^,]%bZ_[>*?/4q&:2?I,1m5\XktKl`e#t(#h>S)HNl8&2D)KBm]jptHKVe$C&HRJ2CVD5_Ie\_niWMY0%NB*K"Ap`&qG5./LiQ^QEkah(*J>fHj6Zbrs-C@YG,9EOZ?+eg)ok+SDcgBh?sCkJ#MBlEoY&lmJMn']'gr4u>Y@>HWPYqblCUVbE=+s9>%,UmcCMc\6@H9Vn-f=hVTA_Z%<b/AVefL<0OMfP/bO)!O^'aj5e$?F:FRUAOCE"PNYY6a+>^AKQDqqt&A%HX1""5^iu=X42^MO:O*Y()oUb^>8M8D8@GGT.`pJho(c7,/#g",WJ3"Ohj!O,0X4LLHD>&BBr>OS#kUk+A'[!>Q$VL(kd((YL`Uj92&&]_sl2hQ-_O!1,D2+0]Q$Au<AfAAsV^ki;jrk\EK/c//R56u+'iT97V""9d.Ic_O,DGI>M94[U<];kRO#ejSc*4^`D)O^7Bi7Q/NPG]*6u%$PNqQYgB!,KRe*B]e?5l%(n&)Lk#_]CZnZ,[Da0/Z#LgRmNC_Jf*+#PM.bQ~>endstream
 endobj
 53 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1380
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2327
 >>
 stream
-GauHJD/\/g%0#[%5o;SS2^GCD^Er9FDI&#=Jj\/P4q7C^fQ<k=Q<[!q)[uW4#K\W=)Wt-0`?@M+Lu^p\Hq;]k%m9@KG?P&q>eoTh&,l\I3VXa(@53P`$g5oO,RK<dB\&];+H!(:!3^n6ar&X<5/]XQ5VOp+-(J6=F8$PiB_jtq#T"Gn()">t=GD=BiZ8jW$uXBN$7@*XGNOA(dj)tV3XHuQ8N_t[$'6G)r?R-P0+J<Ig#9@-0I1WD,t*kcVTljWm[UK+UU(bI1c9JP9BX\GZfXldE99lFb^s@<7HS4;k_C=7di"!NC`XlhrkU<S??:=[7aIrOdNu0kPsB/Ur,Er9(UBi?@s13cFboM^Ze1&b^\dh#^n1a?C=7*J'u6'`jmnD'P94Xf:&s'RI,$E4-$$-C1\gYGh!<0I"4n7'*J+*sclYsjBF]IM&^Q0'ha`*R\Y.VEY#-*fg2LEXC89-(h+/k<dp)PTI*Wa2g#:_gWPj`H,Y]@O_hKDG?%CfBjd/rq.or=V>u(aaC($SN'U!eh\D+IrE(,JDC*pGOY4F2TOnHXUl1aWAB9/*2U&K([\:4T>CDrHIOj(-TV)e:];fD-+[\uu*q.ol2p<t70@YgSn26dZ<5t#<Bja.^5+RfiTr4k/egsUIKp\o/mf"F4I'rENp.9'$*$^m]!Hj(IC$>d:ghSocgj>DE*L!JZ!kdZTue:7S]fl<dU:^:#(k2I7)<;edMKqE%`5m;t8)'G1J6[@Np:;Ja8CX?i"78*!++f@a09:A%p(6DsY4@>]XlX\ZCoGW"A,F4J;hrRTph51?*TFsP"-)ANh(q8o?Z"d]tnL%0r@CD)/c[?b^.5rF(#fn'&%p36g'ttJ7Y&hCFWaI:)OAS`m3@bZ&CWW$WPtWXH=!Oq&#8=`7JiEGIR8j$eTOb#)5H#f/pa/XNI\dU%<2Z7,^k/]@ZKPUT-Up4KIm8a]@EphgZbs?u?mcMQj:8E^Rce,sBRn^$*V>gq5#G#^Z2+nGlBi%B=dthnALdHg9#UoTf47",+&c%Fi^.*t5*493Sdni)Ajdq"7k$0FV<q:pHB#3\gm`(j&V!7CE:SH&n3SSR@mdl5i5KlkOf@<q9-k8R^+cD.5eNqpOFipXE,Zs.ADW9#Q]`;j=c&fYOR3/hS9>p-3h1@6pMJ5J>VW'P.aoUL+W!RZr_Wh:PF-)h&\;e,k#.GP_+KhI)FA=M\M`2/2haH);GgsY(F^ruiYb?8V3%8*MX!&QAbo8'HH\@EU9(;*93/D5e-pm?E1nj%2p5)r%q9$sp5?Kd6!`)p4YMWO[c7>#kJ^$)k/GIB^?((=D_66%450Ta9AGOZonrIBGORfn:7QFl8t<P&gZar/00>/$E7YDjBj5b"rWO#XB<D~>endstream
+GauHL>Ar9+&q801(^)g#DilH6/`5:$!kkBu(+G\10(r_Y%u`p2C+)tQ;G"P,qqo^.WLG+YFp"7'd7>U>1S!2Y1C@QHs$HH=c2c]PiTtsui<Y`"#brMojX$EMO8_0iG@n[E[MItN0V1u$dkNt4l89Rf9CC7_(r:GbgbK_Zs*B)'="M'sCC[NU]29J1'PYF6L?1?r^*(.l_ik?::7L9PfV/acoD*&^JRF4A7l,N^@5sanQOcSWIX`WVlmN4<&S*S`%"ij$9>L5JB2ktHj9u?m1X\;/]Y\)o*BZ)#l/A#$QY;72b_%@4+p`t_@N'E]H49s/'6dTbgqm95!3$!agJg`kJB7p,^1)f##-<E>\n4-Nh)Tu9Tt.U*gC@KhfA&]-HeH+nJF.X>jmP-5K&(B:;Ic,R3M?,BdMW__h`QHO-43KtAt58Uj2supXRb"o:)^jl\?nI<=>:7uU&[B&Sq^hLp'E.hBfB+m[#c$B6=G+?Q%&,4l?"WBXA<jOrm=Mtkd*ZY5hDm:C;!osC]9=6k\!fb1eBS(^aQ.(1a`iMAIR:o[IcE0l;V`5[Mpn\PIT\*VDLNW;IL"]%k1D7.r>Rk>gQ*1cTO!)KtT2_c5suQXk?W-s0^1)9n[W%Yeg\*8SXMSAI]0r!)?H"2U*C8S"qup#LLZ*Z:(%aP%*/K/H=")gOq-l9!3`q-I[[UBbPrW0l+<XHYbX/pY2j/(C/X]GB[2L\dN+K]V"+t(2mW`=h]HWfm&,j[i:'ZE5=,?KaJFR%5[p(9aQL9j',>=0%`qq,MLP45k@ZX`gSN)e94uh7./OXp_:9<D!>m""i8/>j&4\\Z77]bfNlNp"n:ZjrM3&I@:9Kicq?^)gKLCDDik2-K#Q@joP(sHGQb^2:<PRi()b_<9G1\uU6(R7gTMD9O[%u0&T<3Y1JQ4O-Q#O24s?F_f=R"5A;(`QR,,D(n*LfVOoBCB]JR4)RV^6-LQ+ptI6fV-q&nADEHPu!LJP-&/*J0\$qL(0cUO*)'iIWq@0k8.J_iJb=3QQPMkctUj\)_Vg-\rL7s3(ZABeLS6N2&&q2,ds,<NG&RiX^6MsYJT_1KfVL9hC6h].:pB(4^3Fo]QHWfCFQHPP/50^J)`Sr3^+puD-lph"XGkK-)C1*Jg*g[VnSO+uT0&Y)YR:QPP2g&IuCX*O_Xa(Jq`hsgZT"$-eXNNDaW]i-F)S[#3FiQg/]79/_>4TDrFEh^[c-Z\!;3!pEa^bZJB:T)*<\/7`g2D+BI'SE>`2*gN`F&J]@=aW=ma%X(W6\8F<f[8It<r9>n<8C209UJX&@g@Uk6Kaj*9DNTf$p46*!]Ph84>\<8"qA@JiRChCb!m$+P*?9t=gI_I#cWJ1//;?nKPTp7"C8@P,Zg76Sr8h0"-nHY5bp):V:o<1@L8F&dSLO@b@I>nD%@>>B8^**4gW^GqXRJ"ega*RF)JgPW.*ZkKb3'4M-=W!!Odks?+F$?,ZPGUSZ$Le/86)m`a!Pt/^7t5Ie1Qs(d9@^cgQncj->B,(1Aai>uTm1PA=%R$LdDZ;CUCgQhtS^oX=2'mV"GZ]W_WaUSroQI/UN_2]Ref_Hgg&++rCtGn)W[VrMEV9]J6YmFTZJ]'MQVKFWLPF(K\a=/;!tboo3`@*nPMaB3o5DRd=<+2-DNRCR`Vf4(Pe7(uQN5=4D[I#G+58aua4$rPLSHP@Ju(i$'G@>LYu$c=B_pVaMp),C#idV$?'p3mQ'H,hd"?g%qt25EHm/$:VnS1.sP#6MK4AZQn=Rph05K([Mhn`ohbr4D>/A)T[0['':;>-mT[BFgk.%0*t;i(C%-!ihrCPoq*Zm^ag5fU2NO#!j,Vh"!$+gP@Z<f[<)Vcb/4=l8&.R5>j_2%=[u2_"c$Ya!dsR\e8mGC??mtD>7$bCT_4a5+DY[!)WfC<+N_S)rAIim7reISsJ2Y^ZZP$%71BO\b7RN%>5b9/^FPZGU(`g/Ig*e[e@`^10`ES6(7Sj<+RMDKsHNcA$Q-k[RGVD.O^dsYA%mIV'MG1Yri,)LBMJrBsK+8B45^k17:?OGd#:d)`V:USFpp2's;=sZl*E,ZC,dUE6S>-^Ud@!UcPo9T6u^*mr5+NqmaDtKoAH_n-bWu`kg1KP5Wf"n'=2/.s:_iAN<d?fn2]ce]Y+E4K!Y<1X1ErWlXqhYTEoc#-[JLTUt4qE6.;8#S,hT7mFW%UMKKQL7Q9HZoFUT4RY,rD0[4+rgkoMkant9Y(od^edf8[dX8hb4$dEZ=Dj5eQ?+TMOs%>!JRHCZ:XRhQ5",=uA5PEcW09VC_ed.G;(I%-UQhW)+87T*Jr;+=I8W5P,<5NAQ![cu~>endstream
 endobj
 54 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1876
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2520
 >>
 stream
-Gau0DgMYb*&:O:Sbf^'*;:E,"$5O"+D4GIjh)^ORh$3ra,LJCgMH!.sM>QrR;AVE7&g^cD-$"5JSiN;KB3]Dk!S@=q$@q._9]n%<*\:CN"t5#`-TG7hIZ0_`(klQOBuZ8W7^L0k]3i*,)euo96n\&GpPcH\`q-Cs-a:D>-!h70>Nq-/E*CYZ]Ro6h=M?\6pGReXLOs3Kh2V-ZTm/Ker")[Ebp"eF'F1c[8+>V^KEAY)nbVSp5Z%LbKV=$1c$p/I7q\S=UCLgn4G]OF"csIo+!VKNU6#W$Xaf3YaoMl`3qpFL%4Rla=;ejer/+$>j;uUQ_kWr/KTbIGf5["qKtH4Ic>t/.Do)+kpCiKMY?!KTQpE@pH@gE+ae^C/CQZD)875tfZRpR@PY$FI+sFuF6QpK(qOfl,eAI^$H`dtsF$lGKkRgrLhMZ0p"O;A0pr4k?iGBa[77EW!$d,`M6iiSVb3FRU[37O9%XLM#Pj1K6$i!%*_29WhNTEd62ai8S?k-B"m#pEpc$HBTP#<:mW8Rq<F0/pi@'e/;bY%%`Of7D[S@W]f9DhQ[bhEpt!([&cSr7@fjG"Y*n_HcLi/$0Ma0c>>fun*_#p7"sK[fdK&QilB7WA,o93ddj_Mu9N_/^_s\c(3ZZVqh,iCr%;r#r'Uar\-L[=[pQ`^$s:aljH?XPnA]CqS0,<(GF%Rd*UiJML(rkEE*5o?#,8A3-n.Gu(RK'4jJ>5*_ilVlcb@ru^p3-Rse#J$1c5bn89&kZI$XBH^LFKNN#[)'@AFqHtK;<aSD<(>3ft_[Jt'n@0&*jQ^kDgmpA.NS!Eq2kU9nCggEZV5O-<e@Dtg&gc0F;([H,342&IAS6sii+kc&@TV7TAesI3'p[<<<h*+&mc2cW+,I4rP7/7=cRPAh_H5:J\O#5`@J6%)otA:Z^jHN!ALLFZ"P<D'8E4AV@5pYXER11`D+QVd(8MMQ-cuXuqf;5)'0\\Z_/4LaU='1AF\8o>^TqjW8'`l:5s8H2".6qMH6/FUqFSjO[Jf.ieS^'OWV/eP%TBmo:o0T-s+2rU>VQN[^I[kl(F5[h4sUG:.AA2d\bKO\gkfB7o2bW/hQ8251XZp*nbi"9p$6rn=\g16PN7;XKKjgH?ZqAlFuN2&]aRt)gR*)m+X#Kr_kt$u1\RV(5DfYl].]X1TVrWH$^`@DP\7)?)i1tc!R1`Pgm9_mi;$@j8ns;*d2b^RS=*Q%=4:0GaL<0g1_Y:6*icf!GJL6EfK<.^?\9NojPQ0A6$^Rke^n&`i`XsiRt^UHJgp3&aQm4[9e.Co'#t*=potWi"r.@J4<K/XJg-S,5"GaUf=/VMD14G[V:W+=g66!%bRqTA,ZtFV@'*#7^_/koM&8?3gK@/)@]<Q9V77jMD+lFHSD94-dT#^i?o6WTn[?A._.6:Y!L0J4VUEu.0R)[ONSG(E.MjER\C-bL`O>S^kNQC(q)EERq\+9'QEHr*bk#\p`/Hb5TQ=nmY-/)akrZN'm_.2UZ)PX/ecc87(Kf;XEn+f7?MF(4+9pn+l039TAp7k8fO2+PEUADVC4RC[q'I=b"`(.&RL;]-83JU1-8NftG&jKlU,:_q:<?O9&dk.G-mo99>na'sg_N4VBdt]=e90<jS`WO?#'%P"BO]PG'8\Tg9oB*'[@]XM=:86!3-@LD;e#VfYm<Op@*^>4_jF#Io52MOD'nj5[W]kK#>n<GGkaX4Id=cj-N.m;h`BU\:0+l6F`k,c]%<*[><qqmSEiWH]%jom1d0Fn(MTnn#FD8ZdnCI0i+]c<J>VR<,$0gM98768Hna)(eua_hJgfPD"1b*t^B(?YF<04_bNV/#Z\f]AQM='E_DPR+H"g0&:*n$+o;K\FP4#.IU]1=Yb1GG~>endstream
+Gau0DCN%tK(&dQ-EFGMB-*S4`Dn-B$h2N4'G#N%U78_S50Hs$8`$C,/Tr_oDrpN!oL865]M4L;.*g/LdHd=kLhD5RSJ3Tb)5>$e3\th8d+b`9eXsk=q@p8k"n!7Vd3@dU3_1[RZjmuk:REh]THMV>6]HAbLT8(1D7RQ#aV;Bb+\*rNM7/(.8l0YY+C-t5R<%MD(nfo_no=g4'P;*hJO3>FL@pUjYc\J8%"Z%,[SDeN/L9i?-o&CUbn'<b=p37QNa->"_1'm%(YCpf>5/=GWa;H="kHeOs,eV$'NQrs5ZbmB%s-!OoiIM9O6+E;:X\Z9sh@DA6KMgEWSAfEL7PkXQ]W.;;]eRr=V)'(#dGCMnLPl&n?ck8!8Ng5Z.$9XLWS!)[6t2sJ%jX@g>?J`UZc`]@9"O?Y<;B+]Gp4tGdRmV5OYBZOC7JQQfecFk\#lFo?;W>4BIg2L]!2F<N:KA)nra]gYVI]\.Df5P9!aX7l)`7WMF9UlVOVO3$TLJ!9bBK;!*Ef6:Z,J&P!gYL70^-S.SKQKeU%pnMO[QbIqL31M6mG`=>F9I4"\o.'a];ldp-F=def\'Se(5`:Sn6`VB,\u1SRHk)Qte+i2'<="Ypal6sd_,*>Z:>D@9m12?OR.Bm+i/:+`FFYS$FspAIH8aTlMijOh7(C-YRF[hS(CXZ"f[ju?C<!E3BS>l[o8[':+dNCY@Wf))OCkF:M706>+cE]6D+3aT%u/Y;A]gg_P;Nn\LL123NTVEGT'm]-c?D9]ctTh:O^/`PJQS=V"7.ktpQ;0qo\K8_YY^FuN>4*gS#4(Y7E[Nr2r*%o>/7.;%5!-2d)K'MhYZc!2]M9'/e;R5_/V)XpmF1KR2KdU">UWe:u<_N_9csl*/ImOUC4c2+O10klpNSJ4\!Af`5A%gC^!h7'*eY*?WQ)R(NVF(YX8%gmZ.[q#a@o+"U0>L-g!oL<j5'8IKK3\P5ffe\b(1;,B.s^&""S?":Vd03NM`BFbR5o(el#:!Bah],AM2ZG33=s?=&'-7IP8JjE'"tbr"]jIq>h![[74Sk,Q)R%=NU.sXBOM<32:<4/>LkuB>k"+eI:OboH7cH%I]h]%9?3mLXqL*DWM9mr!1,jQ`pI)M$G*(@hob;Qmqa;F.pQub*?glV#:$csF':YuO-PEWMMm47OR_EgF`S2l\p6'j>46E-<RbDRMM/rn0c8n[1`K1:X;*L^5K)XY!a,*j.p'+0B*5W.<te>r%%K!hf!;)4CIV5dj:=1=1'jU>9&6._S:/+82_4e74,8n%W:<%q?3#\,:@Ioq9qq4`G)0.>k]G1[7PTpDeFAn2\r%h1V=U;iIJ9eWjSUG%ERB%1:LPa,d,RQAn#@]2m=HJ=09>c#AEN.Fk-*h>`tK4BqL?DtO"ZT'5/(_K@K+RK.s(2]:Br8n#)ud9ps\mX]!s^@G&`X77eja!]0d-)^-UYiX_Z%u+Sd<B&YjQ>D+>[o=as4k[W%KM2.)QgF"%M6F`,?5(r,D'9rImg4a[&K<5O]&eg6rir\[>jFT8)3Z*H#elUmltf58+laQ9Z3)n@o-E0X@s_Nh:u@qhSYj0F*e@g>Nc6?Cf@0n4-chs2;?2E*A"Omf>.k'XB@fe[A^1`ZG^D?IB)M)L$#r6du;O_s.l7bKXE5mK88NeXBS&:)c-J_$:Pd(SY1.^n,;A'#'D'OFse9WTDQJq2Wn%.t7[MF@F*]+m"9&-5u=&6nj7\*\%%>G"rN>h57*ep\o!XZ\;h/Dn+E^:)`e`);Op`8K)Wl!/t]=K*RF.)bkG/]>O:O.aHmM1ETZ5ig\T^!$lX37E;H6]Q%PFE!C;8c&odL9kl4:&-,r1itR5jQdH"SSs4aKK^)T+]LT1o>keif<$U8W"l)%R)AYu1p/p)&aKT:+lp[5IcdY,DUbJOV>C\,!?uV[3`XsT00GdL^85FWegZ=1hPY)TP4Ai=cR@BpF8+;_A?UTs\C-2gF_Oa?93_N<?FATKM(ceE!Mp%u^NbICIYq=pJEJmH)-:t@Ab#pTa@hTjLl+1*jj#"0Y2!l)-4O%d=<[iGBO63$;6IEAi6luNK6n!aY;8_WB/CPG[V'LNC5:-+f<9Rjdd(T0e9B'l>r\=]`.4I:+#Z(X$4)/bXhU_\+R#=9GLu&Q`oCFh.s%qV@K-i(DAB2Wj`D=;RDS2ESqi7(UZ^U1>@`+K4fBPGf0RFTU.&>u6\$W%@*hZ'c\dn*\o@3[@V$p'NJ-oNf5a$EGpkc=DFAT-@^\j6mmu7l$C+"kOY#%u&JQR>XS?Cq*6JZP]p.`E2+c.4Z4,cpc2>lT0o<tbgUL;)W^(dtQg-4K&WXF[j>YWdJ%3qM9f-kY]rKY),l-]*^9)`>i*MhgUTI5b/m.677<]:3>@,@c;rK@`dAnEJ\STl2i8/3j]W5qQg8GHqDURD<I9iB"_hQb`*PB)H(VS"$Zn2+-2-dfK,2p'"erulBPVS@VLcOAl9NDD(G?eohDd#"iZo0tA#E_;/n66L8(+\=F\E?%S5f;Qn\nKIDIfV>+SZV~>endstream
 endobj
 55 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2694
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1800
 >>
 stream
-Gb!l!D/\/g')q<+1$IS8cD"?-]rPEQ\BQmh?)65AV"\G#*#OO@fgqo2;0BOmO$A_jA35r]iY[SX>Q`KaL7B+kLVr9uKtmm3OT%Hr!.MM1o1K5-JX\)2cgp#V$JsWu^5X%&B_b772pX)-&#-jna.Hh<3Z,O9!b==L3_ETWj3,d#DrCdnn*l:O5AN:B!e.:d7aBrS/):&qoWE?14id,F<Hf.[[Bm^uEa0]f0SfcX"=s*U$3U(qo>pK10k//2k?3?@"o,fK7Er"UY"'R(haX0#U#eOqPaSlqI2c>17WEt:n`T&]CiEBB$95eB!')Ae-rAk??gsf*/;#Iqf#RK(^oXY)SJI\-j`qE2cCqb)EU:ZQ"'4cCNpeKJ(tdcVi'jmc^r14Y&=EGN;JPR<?TkHuG0]@7['^T7TM5:^K-4)F$7mLF5%&pPN'R`0'q#oK&6U?(O:FReP]P,8Eh6?(19E(tT9Q\N6qAN'EX=BO?7!\u/E]TF_is/=b](.@a0QR9RIFAuq6_KX8<QSni3KGI,iqJ2=d"0L1`%-E6mTl9SlMdpRM3n'_Q=%=lNk>Y"4BUCZ=lSh\2m:4;nIBiD`lM9c%B'pW;"?+#nK@H@)DY/4TBN6WMX.Q9Ec\OlaO>^E,kPDEje&,rA_5pj27`;V!K4@n#FK^5agBpW@7u$7@Oc'3RtQ<VT-X-1#1>:cRP#t!faG5]J5(jSs3ZgI&4G]r!g6=K4Ncd[-:+W=)nLV?5kPdVP7;Aj6nt*)4"M-A\]0t9skIXXe%F3j2CJ?a$r*52#>:ur<4X\OAOAgjHL5ahL6h]frCm=_3D6aZ5M!r"CW/[,_H8cF20K+pQIUK&uL6sC;AXZ;_2q6B0_>YP%>n;U[<X6M;s8nQt,rQ$5S6"fh5GkQTuk\C*K[ETIM+qa/R:L0]rh*>Zh.YXaMX2S!<6h7R%15AGdt/`f*P[,`%o*A5Wd6Q)#%=CB>iHs4]$fqb=I9O9F=$_Jp&Y$J0'W_Y*p#Ud4@VXOnrF5>kP5ZEc%I%K(,+qT"PP2db(<43B=o[H%jMf9/8S3huTR<u$j$Y,>BO]>ZOrJ*E7SXT/0G11>RY(*25DP(KQ#LDcX4Bbet9_q0dPLB<CGN%`fcc?%h*>>9tPnr.+"'fIk3iHb_S;qL5Q1,X[BA4#.]A3ssf`'sALR2k+B_2@V>Z9>E924@O!Yu-ub.'iatT+Is9V?r.0%c!qOh))CraED'YS71?0#cu[3WU8cMFkWj@Q-*l:p1["qIa)m-FN%[q?Z0>]/Ne-Z_o$d2?F)hg.!QYX;O+&/:CU8gb$DDKhj8(.h7@[$d'K7+)LP%/UMRBhU(8YKjK+Ee)PsR5"2S,=D7$ur7L^gc^Y(PT58`n*&BT&2clk$SY@Uj0&=gqq5]Ac>JnH[JWdlkHql"Jdj)L6LcURhmB9ta,aCZYimCjUHC,K2a0/CLh/ml#=?ajYoM<`W/fic)eXsnEf4(W_2BSNJ"+#msb0:n]4W0aHL>bhKVPRYO^5#J1r8HsRBGH=A*,Y?Mng)1nF+6f'Fo4eR$$q-ht\9g+Db2,pibd!$."*.0fW=X8,>DG!E\B4ZJ:=5UUZL+EbDCA$o.I7Gj1Mld6j[Ke4c0Ekf#B0iK/TQ[s,=9k6((Lr$A->L"N6sj\#3hZ?f`>N=S.inU%5.%)eBqn*@Cj1JjZ8/i``+Dh`u3Yb+Ys9O3SP:%5Z,JKKu'G#4V;pnc$g*#]c-kO$agpSJFeZ9'[p<nF2au=0tF1pSE0#_0J;=">tH/*E)H"[Nd&W,gq`'L&l/m\=<VjX+WpWWS7j$l^U>EJ/mFt_PfZNpnOdE+QEU0#8jWHjP4O.?Q59*3lT&,S\lpcQrQO9(-ta37FC?2+ZJW(Rn%T&SkQ58:C<(s#h&$tbcL\ag4b*lW\X`-2UXLhN9s+,"bpf"3F^:;b<#(Wc9JVK<N)u1>:#oWMKE9Bh,uf"a?pVomWbT&9Dn)D#J;%%205P<o@72\k1VXWPgI2u#^HI+OdHV.V7Y_sLFKKk%&8V6R3ON=+S]ouQXcZ`Y]mHo-<[Z;0>$2hgJiN+gC')pLf0<G1Y];a+ND>\2Q,?mS'Z?<47qo]FUE!gbY.]es4&PY"@qQ8ELCP]hWlgk&N)Ymt07JHd1RP/JcIGP<)ueP\=-4+'/4mQLc<fm%.<NFObL&>-K#;h\HiVt4O'p`A!G'qJJo!ZD'Sj_=s#s#fi#B.M6e1Itp@a\Zs)\slhD6qeFPPid:/b/Hos+Af6.hCm"j*EL\SBaN_)C6)Tkr4?-'plDU@eq)rGCk0<B_*4,h]>/[OCGEK63+TF@W1G)Yc0t(6UBg:RHEK`A<TL]33$#nP%m>M,<>UV+r+SXH#auiG).!]u.+3hF5#HI2sVM7ji)s*lF0N%=OSSrM=qFJ$]i4Ke_BPadAbX4U;s&fNc5b-%:&W^3L?ih]H"9.IKI<Y2oW,EdC54`VZlcUYt64mt<"$,F(G\Ch-9g1L-U<pX*)Ef3r\Q"\p@Opk+lEoee*ZE/OmN?a&AeVJ\i-ZLEZ\,\M(sY)9gF@EN2/mQH]AmCiXq'q0FAMZ?hCeb="mju='(;?oJVDV%(TI>CZ($88qdYK55f^t!GN;Ve$"jr>/HiMQ#4%p"a4d[^%3<^\2ZHU)!RDgSf;q!5[sj-hoBcMK9G1e2i\ik33MIP1GAY&B:I"j\MBJ1pobY('mP?d36s63~>endstream
+GauHJ>Ar7S'Roe[3&!$/.r7Y=jBMJFDG?E?.FQ.]*b^D8fL_l3;TZSFs*][P`>>e90jmAq8f#1ZF8sN/&E4dOs/.0YLF&Ht&KhZ:T7A1Q!m=gC\/]l:1afV;@ZM;LpE6&$kL19.T5&3H89=Zm";/S7]rcsoX5=s__ECWnTPFauQ-#kSl\]?A7p(4kjZ@hXT("!k_<F^b`-]"%2P3M0"G.MkNFqrZ#anEGiHg%DQ[u)X-V6!dTS1E4%-Gg<!ZhT=dBNcu'='m6[)DFLU2an0/A_Z7nLU,&XChV)EO^O0^'LSi[]bS)e%7p0Y,Zno@16EYUFqA)Xr0p8Ors*,H]kD)`j"g$.QRi+8/>,*a3VYJc6/S%d1Hf-q,IjpTM?<.HHuM-_fH#9PT-KuiDSmu"mhl>RAlE)FB,RE)4m.Zg>q"H%ckGKC*PUFf@s4@reZ\)3.g*)?gRA;Hq"eE2X3pbRdnO8-54_)Y#ZEik.7gf9KebpX_GA[ad=d[M)0jqiLR<$fbs0U/1ZkEZI42gXE$[d_Q&Umiq9Q3QX]>k1+)V]JVp0*OiWG8$Cft>M7(G;P^%Rl[FmU7/*l+L'tbsY`VK>TO%0TJ\;J^.A?X1*'U`=V3Uip&U)<TWIG)V><j_?2>$XVQ>\_O-@5:jQ1)B1q=+Xq8q2JZ/SupZp=4Be@/ZBFRaeE0X\_YoN%@9s.3bMUB<KmuBTd&fOrmZd`TEY3GkJCUWVRBVK]$d5EK6QtLnFupch>=ZE6ED'l=8_gS"ELShXDF9J^0=VPNb7"KiPE!B&(R6nbC=\bHd"NlbXuV^m@D0e*%YjMh;c!V-B@"TCa[MF6Zc7"FPeH;3,8lG7Dr*nU7PG!^bs2mNBSoq\9S-ngo$<>mN$it8m'O\9[9<1G3J2q$nF7?2%229d+mIqFQTQXSct,)2HSom^gtZd3([K89[FDPVj00G">'09\kYPh9JEjXC.hbiAu:HZ,oS25-k7:u@DS;SA!Q/B?0V&6)F5N\<dTcd;$gQcI;aAa=rBBelCa/&8`LLhJ]>M%#[Y$_h<3@V?0%q1_3'Wpc8h?UblqrBqK<tSTdPrF]\=1p^gI]_)QB^W?tC(bYa)7u48t+,>#OkNmS4,bJ`ZNlbGq0li0\^h>##[q<p@?.bt)f!IhUUB@JQEm#RBbND[-o$gOZlbCVM%(.pm&t<s52LgA91j?>g\(DL'nLk(2hEh:aj^AAUO[j>[q+Goo-:K*-@_=<[A4L:*bF>hdgk8J/*u:^P+J;*;hC"oO@>RBg'5RB6MUDH@h'4'`YpCRko,1A1!+O;dKWU103a$Bo6oKeD/hoL=_4"mNJ6P8:S<P'U9s4DD-HQlk^)Nr13nMqPL/.a&9!OqcqSB!A-IG$`9!c)@<PDqI+34M5HR>nYIZgN?)N[(EJhrP*P^'#c6c\h<ZI4h$F<.pK0j^a3D^<T`1Zh%'-MB'dM==s7ktL;^Q0imQol7m=.8>IPgeSU(g^A_R8M;5N?sn\4['0*jJrm=;\7D_DAXeFA.;Sp2%S&r5@I&8'D":(LPYq,`75GQ?nX1-qOP>d41.K:So+=(uR8A=\WoMnYD.HQ9uF?OrA;$7BR]6a1/nF9]dp@O:+;=\bbQc9mn?WMp$gP]lJ</T):(/rI0/#i$3te7JD2X18S"b!VE'M2Mf.a"u_%f\5srO?_dP]_2Qj2=U(DICO37mK=RnpNtMnS]J)ao%kr51s:-]RE^,q\PMTr8(3]>m(c_?*E(oA;Gn<+>c4kgre@V$_9KD]:EB'>#\aj)(hAd<0+mOSA7[Za3?Anhp]j:YN;N~>endstream
 endobj
 56 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2074
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2570
 >>
 stream
-Gb!SmD/\/e&H;*)E@<NV.r&7`W4-1PYa;5#dB72Q@UB<RN'uDmA5T2%ABqA#84p0#>F(Jq5W8h%D8+f]F1aRu,V_::!&jl;28F,H0L*I*$!]"];afU(/\J``I%AbM!V1>6<4=+(o0_DhLS&Ud-WmnrI#J?@6q^b%o^)1IQZ170CUW<nCSb&u_Q,.\plBB6"W,Lmgs0Gk&k)]cF<#JDTcac#lN%@jcmJjeJ79MnnF>$3;7N1X<]?krVm$BOF&6!=b2Cb0_rU-Z2)7E"!ob=0nTq[bO'LH2Fb6iM,9Oh@chj@U^rBMmj1!,+%D2K./PIfu9S)8E--Pq8B,`7/QC"7F*#9_k\:fQtH@T,[koEPBj%C/+?nIOf5ktKLdK11u`lf16ncTT&(qf\:rm.H=X`t>b10(u'Ho;_).OkTor7#`HLHTka(IaD&92T6Y\e$(c*o)%We7u/)gqoG\75D2'juOK2(\nN,MC/KaGrd,kB2d[h]U+`B2r^9MI3.!`84ZY#A!Lnc]L9FrnY/Cr-`".-Wfn[%O[B+;DEp<[S!ns3`!%&KaG1XQ6#p'iT4frS%E5-<@n\7e1,bR&n?n,qc6Zg'\RnJ(jIAebUjE.c.,6GC9mUX2;f'rUj=Vi(Z?![X9)bZ1c55ds<,CJqs0=i#k;R8JRgFhM,8/RPA6o(c\0b!oX4&sfpY*i9gX(%,R/LI^b*hP'2q&f1d?3=UjoR091eW?bRHD\O6Qr77QPkR"j'c=N?DTT.+O7V*>FTfqbk&a'gAcPj).1npf#/Mo?]*)K.Q6127!X5%2nM40(p.\DN?aaZ.:*Jf%1,KTiCR4QDQuB@b.uh`'i*D3haQ0gmi_!V'rHIO;1MNqZ#JE8<(H9hdTd)d9rSqecB_Y&rDQbmJ4F;fooseAq#?+i5J4_f@H(/!Nj.=\MYG+s_os/>I]lbh&5(k>>].+U/RI[&DkkKPZ\P@#`8@9HXm&V?BG(.g=]$"sBLj50<P/B6mL"7fP4IRZ_t]V[THq/.ZK)=r8r5E(C!<l!@ngcR,UcSr7'9X\_n*ui>%HD880LE"`>h:kGBG-i@Q3=^Y,TZQMZaLM(9+dQ&W5Z4OtWgD7%mM@&!]_D8Pe.hiKj(*`1mp;aGE6=!Xa(k[n2R9[\1o]*$VT3C^g0D)2.OO+Xd[<2pu7]n7dCR75gY#8J)gU*72aLot4_DDX_n]B&rB]UJ%*^(fTKY/e7OMR7JIfY([g`DaL*U!,t18)-Q&_cLNf!p?M8mo(UY0>%/_RP?s#:dVL6["[<r;;d1L5pKn+Y+(k[>`eO4Gc(tuoS6D7AkE79c$l+Ys[4-"l'uGSGGk)KX4%hE"`>N;U@BifmJs/Ch,%E>4Q37.7/QJ5mTAZZZU=L<]b4U74IMLT`393I\)UX8jWTHmK;LH9@:Y(DI[%7RAF/sDc,`AkhAq.5#Eg_g_&:3W#)F=WmX--Eji;X"pI3)JsREoeQBrNjO^Z8O@U^IGGh#V*/eURanXL/SQ;*$40Hk!PB5<9:h-4&Wli0('a21YYi)L'#Im+`E.7'r#1Y!l6P:a$eSBduQ?D[XWM:Y"7WZWnO`5^5rfK::A,.ap(mrEW@n6cT5e2%pErC8[M-_l&+S\;(<Aq_Ij_f$^Lo_u+1o!nt'fp/8Ds7npVkdIaq7g[58M]pe5nMY.M7KDc&fA$,^<[<D"1L'2pk;?qO3p>gL0L`)XtaU?\6cnXZe\n(Msnh=K!:UjKiA*P^M]P=WU'.E-YJL+Ab[%0&J$I-bIQE-K+V<ft_XW>,E55cE*_9T=:%LPd/paB2kYOdH5=60H(C(T?[S.8CHI"Z8PI0LD^9IKS)"eR#f>J,Z:mmL8B9F/0jcg7G<k4ZEe\SaEaX#bGbh\tCW-rP-O:/Xq2ZA#[_QO3BZ>^rg3C3%U`Tgo[\4"#^<#TkA\[sR[>EddJ+bfWh06?nLZ'>[l`Xe"eN>W(HbF4%I(&Tb/\6#*#+e$XIEa;%sW$GgNLoI+6*<+E13?]CRd0cK!q5YeiKEH_L^Rt;a%(Aaq]f#Sm5fs3acRd+l0;c(4oS,uV6HN[%%nqtKaU9Vjb\->Y+"ZjnbR/~>endstream
+Gb!#]CN&5k(B'h3E=lU+C_8nm[kjZ16)U2]J7`7$#)fo3(l>OYPsgn5ijapGpH>;nYq7;GK*3S,'A4RTann-n>WSNArWV_.QkFh^Uu$lWJcRH5$:`h`/O.YobHjFYWf_">Ckq0'qsJDcR8&EXpf&cU+K2)3K'n/D""Pt"M[uEr5L9iIIqL9,h\B`T(&_6jM#Ws1?YT><Q+OAI4MntWj76Tb1Trm2bm)'?Ff3l80ZA)I"Od\5rcj1^S$T3OHSk"_7[2>Gh!`OgD[A#@5!cI9OAeiC6K^?[JbRun+3Z)5*Bs3tl]XDq29icj9e`s#O*'o_f%^h[,0CX]fcB$)=$-l$-DibN^:bk1PfQo%C.G*rm8HaA@q^KneP<@GbSo[:h;#nh:$aTBY?uqHFAMh0nC_2Nptnmc2KDD#EJhl0de>:+8]%WV]aZc&/`h_f,K`aDDl?nmr)K!1+j[[P691oaSomB!n@]L7@Wb)Zam]a^XG+EHN]An2.-OXtI??"9H68PAVCkL&HXG@@(r95@]jqG_Qe=OZb%!UV:#AeI>55/^cYV1L!;qDEH,@0c(5DQ-SkHC\=csb%F;VZaU:'Jl;)Bm^[uQb'n)uV/.I)T1YXGX?o'S"=9h.TAPT:0)Y\];XJLM=mmN![BQE&MkfR_;F256#jRT!<:@&G/JA4EAb,,&tqA4o?,EMX+`<g,W6Nj:`c<"1_^?!OgN=0[7te41qVbdNnr>/A\CGis;8B=$`XFL^H^C.$.P[G<M(33%_qlCLLf[j<81U'^KJ/kgg/P"92Mmlp3<nYcK)4`:a](\j_V!=Dt!1,hO38;]"P;V+g7AKcs.,%oSOUg&.D$q6*V&a8#l_Nd]\CXPY]-Dj?hOXTE`TorU6.bQ+<*S<MVTFRDu[Dl$;D2h(r5JejHIPcG7LfNU";WT]:d=&.XPk,JO.kJ6<,8maK:B^F1;_GJ^3k(CEqHQV0I+-o6TqdQV)"(N%+-68ps7So%Vj^C"7$q$aCd+<^#C$ZTKCRRq6>#DA7PpRYENG3!LsV!nh*WF-qYC[E"qBarpR9OKDXstM=BVYg)8i3gVV$_Z1kj-sGZOu8-+aR*%/mAL+jp,*esl7]g3nh0Q/c$M(eP1$YI@SUN*JB9p.WD(L[<V)]I[OA02+EVbi2e+6BS82r6hp!2jglFQ[3Qh5LmK_H.LLh@h2#k%s[_"l$Q\us0PSubHn@3SbBYjcGG3VqqlV44b!C2<F^Kps0!ehkq\:I.['.29;46*k5&qEmp1EU<]toArf]"tLU3Brk1p<c]s"jaU03\6c_6a7\1TnRa_moqN;hqJG%rPA'&'&dh,]mGZu5"%Hdkk-@Tn!'Lhk0@AX^dN0aKUOM9&fA:ILL]J4T(%iZA?hAG#;3B^um"`?J0d!W7d@QRa5E0\c<K;PB>oI":Z+e%E#=^5j$QA7ZCi0)lM6>7YL0jP3,5o1u-MQ3tmeR\N-h(kiNL7]0AiC!,GEaP:BNT5Sg#VrQi7!fnBOS&<(d>;eu)WLBb5);hl^A[].ijUp+<&pIoH,Ck^g+iq*8;CH.V8@FkL8OL?s_LSQu(lo>R0@c2"1@3?0r-8[-g'E2bAgc];'),Dp\8.QaEfFXAMbDb0ZR3U$\`n4VfBcgGL?+;8`5RB)i9b@.#_*:f!-C?#aD<_/aO-g3+C4iF\VI>VD:4HNSgS_n/3G^/<s.PB"=*5!;\&Mc,0c,cGWL+;"4tCs_8$=*&C0XnDs(jL%?b5\s'U1LqJU'9>52mc)f:T)."4Ud0XA$j]F9',;)PU:p[dYTo9ZE55>hGMqLSY+faA3bp=LI\PK*lbkF;S+=js]:nnL6Nc/Pael.C0e^0="_Suj\2(HgatJXEg>ATXBKcn:u#gE8?g'XX,Qk`?K;Li(=`2e_="ab?#s?slub$JRHIT@Z1lb>hSjl.T,`<[+8;7Rc>%'Jkshg:4/9[T14b"s%Q6,)h874`V/\:Tjn:FLsNl!fHLQk*gQ'j='3Y:3)u=\+<%7(g1Pk%rH;L?K'/`S;"2c.ATLFp<k,F$WQ8s%i[k(j'4g\[a29O@S7Y5H8(A!'u+Jp0:Q"SL*G%`RT(97V\>KiZHZ*L#A[W+.$e_MH/q%XarWrSUt:k=T&/7W)2M69;K3+dK%]&gWZF:ATLLTG#'+pIb(@LI.,1rSHN]j44am/3&AmgT%JtN[La;O[9Z.>i,8Qlp&bMuqpf"9GO6#aJ1?t6aIuf>i?(Bg+bW,>$GaUD=7\I)'=X9-S2%D!:ZS7Fd/AX`PX8HF"&nu8gOHlKq?Yj>-V4Hp73/F+=9Nu4YBu.ns?Fb;Spkjc0E8-`pM9"=]XT/$P3rNsC(+S>7&k<]e"A#>Sq$Q`=]l]eIrQ]\kpMe-_W\g1t<6X,n0;atDH]KN"mK@?F(f`hWkXb'dJs1N.dr%0+/>QAX9U@/PYS0jd6*\<WHYED/[KVuSD+)YJ199pL4^V2+[(SB!9^_.)TB%(4;T#&KX0f0![T$>.j_e)kfrQJpR$I&DB$3bG&M!V,mp*R/5g#'.Vu:mQFaIkS]9@nDe]s54([`7qp\4hM6mt`WlHcrkXfGA]q`gG>M>@~>endstream
 endobj
 57 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2392
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2405
 >>
 stream
-GauHMgN)=4&q/A5oV7Tg;Zs;`maG]]S5"0MB/We*X1%R#OY$lL&>0'N)ZBUM^l)m^3-OMMX"4km1qF295kcE&++,4!IpN3S["S5q!><1g%4(Kg=FPj_bLtpWQ)%`&79SC5KlOCh69+sE)`s_?9->Ba!+B9CQ#Lg=qu'%[6LtGn6$Qb+X]4e2bmO@LQ="(rUX_FC*(PPr-&:G))t`aM`?GRtnBtj0"=\S06qEc^Da2R\#^/#ObT0,Y&jZhDm!FZaNPk_]5I8C5De/,:OHR].+>8(cXg<p,#2@TkEmBHY@T((f+!aPc[LJKTJt_bUR7DXf,m96XO&\9.XW^i"3sk<C-b.i,-(*=u=A&h*cui>[AZu06J4m$=^i;a54lfN%=;h(]YS4d8D"2[tpW=lQ)jQRY"']!MSks,J"fs05=H%OhH]^2F-'H1Nh2;\cG$<>s+@0dii[hk5Qfo5_eY<Kb7i.,AUTc[,$fWQ:0CuN(++^o*HQ]aT$/;'`L_cDF^b&]60dq_JO#$k2YO.KU'2SLMftn9+!5'jWU6L1p27on0Pt#80j7kKX_fSSUCHq2B$r;(pq%!.l5J6j!"L@*"lPXqM\"3s\EGA&aMP$=H`p@GH>YL;M?81KBT5/Lb^)0ap7)*UtE\cBIdJO%-TO_mNI_GdZDcfY=T[G&+:MRj]J`(F*Jf4u3`Xs\"TOk7r`i=5Z.Fb;fR+SnY[hYoIGP3Hdg8I%k[6j<hDK.S&^%Y3:3'IG(E?%8\_YGcig/(XC/j&9sp;1)c\g^LDCJ[FuKT#R8W<CFR[q494KK6,qF(`d#$r(Jk"+f#,P<BUAB"!fEMIFn)ln[g@a99>$6"1NC)h\a02R:gt[79an\9(31S#K=NR.7Ja*@bshSYDD*<=TaV_>GqPFPP[%)W0:u?[;eZ;qq?dVdk/fC[$8t;OhjD#-kj-Vo&4YXD6=."OS[]r:nMbRbN2G8>'@pXJDS*h]A<VTKn-1riSt(gnWPsJ=Ii!=?p/_"6e>SJZgj_DDGHM!08+_h:*a_m>YG\GGKSjH1&'s3JcF`2IGZ;g1NLo[ekKRs/`=?dBn#dF5tT9e0Yf6HeKb+IIbam]9c8*VL<fYp8oqZkU3elNJ&RF(H@nQVp6WIk@ms3?Hfl29Di>3o^JJ>mK@oXWV_$rF<j)0(?o?iol>t=-n;HdKnc.X7qP"2lFquQZ_[l5@@Vs8/>/f5VAu1(Yr0_(@8d#?`9tQE'lR&boZA9%Gi#tm5iCA<fTo<KWQLZ.QCf4:X_>Z13-[f?467.N>:I*[W*MQ/i[PTG<PGm8eP]8<f@LYN`pYU,6bb_E'*Ne:*o,&i'k[U2EqL/g"'[5^542t>^S-j^nd1jtU8YIsQ5(eu.8Uj8q[1C!oV4?eZVs%R%-q0'b.rl@WYfKtFhS$Z:ZL+Y3:E&o<q-XCcZH7GeTGiJ/8bsW;b?Ohg4MA2mJIn%[psdm#soQ'Hq3oL8u0=9%t.L%1t88NFN)X[jVITG/d'87*o@kaE%)l:KkmY!EltqpT3,H,hD?TA(7,]Cf%&[k#iU\%YKM.Nmg#HMp("((khqB[/DlMU8#A@$SmRe0.r/HVcDfB2]mn&?j\cr-_jJdTB`W5`RW0$rn"ER`WZ%tZT_6bAkm-`M&+*@@..GR30h9_cqJsT1,Qg@[oZue3cZL,Sl]:=*?_K@r\+WT29I+t5eU!PKa^mJ%*DAQX^Q@0%k":J"dasf$iQ5na%5d5-X62U_C2L4#O4r)!8m5pWR)7Wr:F"i&O'RaHo.?8MY%hBIM6OiKI:?)[.qD6LqQfZ+-\W:HC)j,7KePA+GqS-!3:!%2Y5fo@-tc!CJ\c>H9Ge(11HsCVM;!#g^tDT4)f@fQJ@/HVj473IK.15FBu4j0aZ5N\"7(Xlb95X[ZnsntTK>Z4i&?;*?I<CV(9%d#Sn0e7a.IKkn%j9RMX@3cGh5<rWXTXT[7_@FoEer3Et65f%"#Y0#A-o;5_0Z-!_'i<<Ammt@sTkL8@M6C_I^S`37++OQO7H8fY]gqeCa\\/K]r?0kT.qn<EN[Bi5A]PT\ODTpC'gNoLGNF5&^!$'1(DecMM;E/b2nDV8T(\pZ^IpV4<El+UB;"(KfI)`K0U]s/QY0_io&E,O^G3>_%V."k3-c"oRjNAd:BhZ!<M:+g]FHu5i7/<N90bnI_6gY1\\C_,D%%^K6O"jG-4=rS%FO>>T"<l9>GTq^ag]sj\D:Z6C;D>up0p;?Eu@2E(,]Q.BF*!V%gCpSAEo*W;^V"T,/)VQt3[:HA`W=QpXqYaB0PHf=!S%!AuG1c8NOF=:lS7.2#^6c@=?5>_gL!O</1RWUU8`$-h*D3'"`4`gJdQMhtQIO/3<MaCf=ZuPR<iW.iqL(H,!p>8#)jLj[9BmS)UG2R0-OXOb~>endstream
+Gb!SlD/\/e&H88.EA0)^.h^D']@1W4(:6GaFE8Dqe(,&:7,)H&;'i3=hQ[$okGT3?Ods#[[\6D48]Tl]m^_M@oP&i*^AAor6pIg;kmO-]+g!Z`O1d9MDX$u^io<K'A`c_^e"V6YN@*-MF@6X0^#]QLWI=&Y6Q-D:>=/9)Dss:H;?S)[<mm&>h'l&_k><YBV:Bor4^l$`aceG+:(PhP8OLdmc0*!lKY/1g*R6@!I=F/O2a:Y7r;IllefKmcl'N*P9Es@dI#@1Vi\`Vp)``Q/F?]:3n3jNi^\5sokI(7#n,=)_(t%-.Z6MJ]i%LsVCXcSRh^]_&Ss?S9C6@nL.[I9f-^i'*Rc!#5?*Hs<KhM:g_Y:UGL?.O=fI5S(=r;Om'oA_i$"_IM`Lj+:V4mS=]mImt'W%N$lr=P\YBH$Orh!@F)Q?]SnXb]`KGIV:7]V2746di/R;H-I?IJd)$?d+s#u-.PH!cqNUbs4,26b'J#,-_h&aV$3RL?5=H:GAl@dG..6XdrV,ODTq+ubu-OZWEV_4ODu<D:(p$.Hk<0c4@:c%_DgUGZWY+cnHd^q)&q;o:ms/d>'NJS1;f".'qD3\dYBAi/U<^0,3-D(!2()(sn2Mpi5O@Vc7n5/7Jl'g=*Fd-#QJJ(5,WlFH]^Y,V40YIecY\_iJ/keTA?QQu5[%AQ2"$'Y2GOs]eJ]?@X]g2%=0?ClJ80ao\6\&UJFpa8;Th[_%S5JLtr*PVH"'O5hH0DKgB7Xc.^9?P'?hji>uo4mrAE:e%pOK-#ZSH$/.@ZtdJ`8$]q*9IqH4"K#"UGT2]O\<NO,0SsOH0'&rWM2slaWsfTbfJg<C<?l)]d0AoU`qTVAV"*X^8FeIB&\NL&0neSH8:s(0s$qLA]@:]`d8tK)ClCTq64t?*=@d+puPfd,."hGTqeO&^eC/Pl,?o56s:MEp5=$RVaNp%FOhsCH@o<fM=DY5m*T@naiXNqED4N_.j$!I^`4W#pCo$#13Hn4Eif_9RQScX[_0/agT8]:RgBaD&Eb1g(0e)V3f*+-/X`O"b;+_2E)(A40]FH(^!^k7>J,l=XVAk`n[<VD*BMi0F=Y+(4M3h(^Wfo"^VWc?H5s0D!jq,aagBb'ap)fJmB+)n_iC_5(^UlKSQ/g.Z:?RJW&;C;:e+=j7'Hcn_FVk#JS(1"=&bkjXl&.@^II<M?0.,"^UX3n<n1q6(42<NZjI\J$($"b87@fJXA*l1+U,@';Qu)=YZq=mq*g<-i9Ff)ib0"AX8k_gU^JYP]%g7WgEi:iTbM+)HOU%EE<Za09S%3L.#oi+QemN`U2p<'n-7E+ZN@C5P;Sk^:;qoNHrf^gOWc2h%)\i9&jgC/b\9gO9!CM!PKDc=XOil2kC=aQ.G>;:5k_8c6F5kpnE-.u"g$%@E*B\#8r<<O88<-NM?_5UV1_-34.>C!PlAHqfr85/cSn]@F/90SHWOlsA7H%<+D[f;0\78:c_DEaU*fLGYpU,&<C\i(*=Q,iY`1/N*^po87Gh:$5c%OtQ"+qqmjZ[&ecB'K7%?p1$DBGd\;+Tc'Q>[&:)RW#QEmsb5/J`okJI$LO0leM3TLA!<#<4.dB2_FkshM=gd('5`?HoB1[;-O6&r_ZkdP_[K8L!)hDgTOnXLfCY1U00IgnUp`I@_S)MBm0Jjq-24\miFD[HI6Xip-s>MD.6'DYp1=JTYPbU/mMkjY"liYLQ;Bu?UD^lHXQcmfG?h5p`RI$9'-/$-88.@EJc9Hrm>7&nZ`!$Fpb1s*2!_&=bA#Um?_V_6$&!l/:6\*W%4o8@3DpK)X$l%]ULWHn[rLjYOL5K6PMbU\fA\$omKEOFm?p4!&L@3(&c$Q3UH;$jb.26r1eMSIsFp+%LbNj8dgW&'RZJoba2:tB<.3Mg__XLm-sr@3>u31$ma-3m<6ZA_1Y7`fUGFmDOGREY[77W+[l];k2<TsAT%b=PE`ke#T#A-OQ!\5uG+2pqZ.(nr3Zr?$p59;LFe6fQJeA9Ha$n[auG^_B#7rNn:%:)h$Gh&=]&]]A'(*2/\'b0WpUr<ZZ.A8N"]Ks\)i<p7.g#7bh:(rnr\G<O5&N(h"r%8f`#N5i]/ASGA\&*.X%/edKmY"F;`#Qk9a<F;jFaR\.YD,r&D,*2,t7s$E;[^L?3.[:7]gCB+G$m!32\j8XNc<EB6EHScU8$pq<H&XcLmV2i!&-U:!aN-7h^6!>e6%&oXk4s7Ll?KtCRW+d3<H`JC6Qj`h+m0\p<il,\N:Dk],Ce[E\3695r`>FV>bubue2o_6oU>M:4_A"9H'R]3\#4kngS2s"j,9[=ioXKeG$T`tQ0fUJ+n`?']F9i00ZPZ($nF_=V1lYDorC(0J;]rBDr2O-n/5u?17ZKH&L$-E#KHmLUqs4=hk,cBs/i?$BanF\p]gqdVg\~>endstream
 endobj
 58 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 857
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2739
 >>
 stream
-Gau1+:NP5D&B4,;'^nRSM*T)5k*XF>\`D*ao[\r)(9Boi5a#RNp)X0a:e6AKP?b2oUj^tkPBJrU(kK0RU&r'R0YHH(0kLg_KI*!Ki-#m<UOFM!P@eO_ca3-ec-nCB8%3:93aIc1ZP_`4;6)C\qtY>ln"P%=9>XCD9'^G'.nO)%HcGDfUO*\;8Re!]YMo$8BHPFg4<@;6Z8>A;$nP%2cVcm^7kDJ71>UVT_U8Q%-Bf%bq`g(<kXW"?%S:7`7`H*"78Y)l2J2O_L1]W4`7tW4_kb0-(XKC^glBAFpfMna0g=UGPiHjJQ#804M+g#!I,'Yk(jNGF6Mj!-4*-T\o?VK!&H;_h`k"cUK[LH<DoE38X$TZM[')ibjV?oWLtWL`L!n6R8Ij13LTplo?EL:::]\F#^^";DE"Yek<b3q-!EC1j,-&?Oq@+Km#Y//!c4^<=jsi@LG0mT1`=BV$C)*E/;AE:n>G4c&GW/+;dRJ,iUt5M*iJ[dQ9%0UAPbt'DAM=#`&'.nUQ!(s/>J(@PiJ-&%[^&29#ck,[Gh>'%,meDn'"([SOqu3=TWG\W@[s^a?W"b:pQ=*D^RkXI)tDZ:C@bp$etAsiYS@LLXfNZZ&9]SpfTp%Z8l?.BCDps)H`H4S#M%@g1-PuG8]&&^U9J5s/s&K*&1tZ1T>@RUchRX_\8N=!/!IW^H!Ve,rZ>_Be+?@c,fg+daJ5b`J>5^bK8oG:XpN7@QV6Mm.r2:.2&bi7>B=+9_T;HS=7Ro,i<Fu_d><#\pL2;m#d*L&UKr`dSY)Y#_O`.))nj,$%S[m)&En$:^9k;6m?K`\4'7,58P'-Z/$D<8Xu8RGKK5<,UT@rQ2iHlY)-mn@~>endstream
+Gau0ED/\/g')nJ00aM`3D@nCb/^*k]E'UnAh%q?=gUPlO=C=Ef[*=7J[3V$U\(L_p1Xo'f8?&.&6'0/'al2`W[qD'>qY1a#^I\Y!_]2G.Kb+`%^4\0I,+,">O7Rug&#tb30VY7Tofa4Qi^l7cqbOPm"^r]?%YFcj#:(mRUN`?VItS\40%l-"S&2;8JY*:3npeRT!p8C&go\Pj#T(LibJSR??8.sE#/_#UA))5]`b-!?itsuYFF_iD%og)`'ErIZ)2q&`?rDE:E.79g&(W-h`ei`)M!L5*4E/rG'Dcc_&.[rMlCjT2:]t2kSAo"'Bi]1p`c@/W_5.<>jLI/YPVsDCi:r;4LR:]Mk+&>4.5Kji_9s(-!M&]q9/_lFFiB@#l)gmp%EsFEiT/f+-:(=o*$'bY31Kko=:I):*W\&+\jri@\sIHX'9^HWQpNfqnRGZ8W#rd/PW8qkXUCO`@6(hT#C_k0Oe?mKD'].1b6B'C0ZMR-$0.QgZ:+&Mao`VW/"`5!e,B=h_sq+k,1f[OIuJQ>9^uLRr+%c<^H:Y+6)A@B0C=*>*Afr`mkfcd[eSIun0Pp<n=VRLfYPJ6g,A[B7UpNR1j97D)%7[*F7`N9,JYH?naLljfFO%Phg:/m^g$JrN-]D/oDU:Jj2>nYB/nLD32%(Iquqj7pkYYS38EGI5!K"-cN3t"XSD[Q0aNM@nb6LRi:&F5(!u`<@R>>SlBhH2n+sMWlJ[)j5BaV*5ONIq)B#6D9Ik>>b;Od)9#EL2?&,3d[Z&m4$RoGg699'(.+u8=kh/;6Skp8J`\=)]o\orN*u97KY(S\pr-:+?Q3X@p+Dj5TZK&B'hC9G1.HBXdE'/#@W15[^C^Y^q"peDmT(+rXm,`S[n_f$aiJquQUVGTpC>mKHgB9<r1Rq\-MCg)LGFU/j?gq;tph],ng_&+BXOcTqP,hQ\'r8_7F3J&-4meC2kco,-QaeY*kA)U^F]8YT6921s6X_9Fn:]=\_MSc&`)9uKnQ"EmCS"r`ES@)M-oeK5YT-;qda#$u((s%ibBka]g*WY-3[HKbf/P!mJoBZ\:#aHu*BgZ<4!?Ut/@q!]:i23b&QkKZlGTg99Cr2Yo&\%:?b_%!W-G`Yn.MXDgbaCf65n*HDD3g8)dsai]Hn7,3@ETcZ?G</.#psL^P)&7_S;(PF,FlZSI0uU8t/NoXfSae9TM<6$^WZHO?8o(Omp*YSS]grJAiT2B'>Gk/a%o+Xqd;o\$^/b?#9hHa;eOseQV`(TPAUX')kYLZoZVU?jg0m.6!?(F@Aj`O$R)MnXe^&3H9a-kncQX1XQ9tjH8p@UDJTe(B+a3jTaCgE#h-!),/4(%,s#sj;+oM>bS2j-cj+R(bOf<?XYll-:DrLT2&_1)DaLMWetW/%5&E2#@rIB8CMN5l9+MhHpYR=GoB=+6[(eT0p+8=S,5#t-CocqqU894#0PDu3kXIBKOgImhH7sl4n2k<B-$rKI,#2+U]7bWp4X[j.Q=i5J2;nN]%%#\oN]3AWCFt.ROCou)XWb^Q?36l.MQ,iX]jJn#&J(^_QY.#[VC#V@;QkmA9V*eG6c`Y_TM+4HdirA(cGEB7h$DtV[q;Ji@'(i/K`Q?I":T]<QelZaZl'(*k^*bgDq2de&TMqTYFRL2R7Q#fm?.>g+'Y?!Hu#tFuI+NE[2uUg0NTZdh%\/PajqXD@u+MI`_+;fobP)`CDSTpqQp(;QNP]:j;mChqe"UWYsU!]geL:A:2@,JSsMuP?+$-pnV@Y2(Y=*-9B><g@R(+V"u"*:)M@in1o"#%_!?E:G?85h_Xj^ddNTD1jOZbFj>t2RggXkU\tY4fRPml_1`XTo$i/l(#QI<>@qJ:47+pd58=RDbU*nD3i3N2khMbQDp23moZsrjYnTg?p7gU@`0;e,<EhM]P0Dg2;t,^6+T^uWlF?/18AMWQe3!$'9?oFODE\i'[CZ#T^M^/GZurnF1TK)^b53i'cieteB0`>qnnQ;>X,`[$%/7\$kggmT:"M<#pNKF7]\O3PDlJNEpa`>0;V3SB0%3Z+@phs24Qot^"^q^dnd-(HF?.jE$:J/L?Fs3Q$Z_:))gHeSbCj/`3#oXP"_r]T!sQ9e7]&I@1tu@)+,,EFp`fe)7^4[*>9KWl!DaOs"eL,U<?qH&&lf7b2-'j$?C3%%N=M2qP(=&`[Z(u]8@dhojnhQi0(GuQMDE>"JP^4i8;Y<DRUX/ppapeM-R)K0p"*Ks?BY7cPW*)ih8NMO<erlkS0urc-cE6P9<Z/^$77le@$2^b)Ur8U?I@:ReIt%A/?kY=Mmf<=7B`Yf2Z[2k*m7:)(60^.nn4T[p.8CfZ$`_;jh8cBRIoc,@Jclg9_(lZ,lcd$GrfFo+tKsE[B^qZ4-j_I/=4G@]/+>kV9<YX[ouDOaX''qe.Pee<E58sZp8BmHb,fH[ser_mU+oanO3M=:2j)0:S>7q3;(l;N>[4/s6tJ=(_<C^hn8>J)B7AU6Q4-%G3HRh_t*IobH<gRQugbRA(JQMk"tXT$j<Q1<*8gFBc4iko<?kaoesP>n3=2Q&F:,!],=o,ImP[!0>d\U:AXbt5/U!S&\3?!dce'\aqF"%_Q::)KOt=)LBcQ)Q-q*b"GItJju5SO08ZKTlpU@#0$_UDV6Yk]@_9B-a\8k>'c;<[lnTWqR,cemT@5:RCtH`Z`?S+)7C:h6mHp?>T&D"UDmnoQ=\)Rnis]HS,\Lck<d%dF>#@XTl@REp7Bk_.+,7K/%f~>endstream
 endobj
 59 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2319
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2235
 >>
 stream
-Gau`UD/\/g')q<+1#LP``2Y9P`EFf&kk:2!%_^\9il,AXIUT%Wbsj$[P-U;KonO\:`JJE3krMoLLb+[Y)*T%c4<-,D_A&C7T5O^Y?GP;G"tYGH&m,i9YkSKjMp^-Rdujni2.b&,?kt-]A-UAPH:7qK>QtKB6C<HPD$/h!het.+'@6.B$K59-f1Nr9=qp`B=F>\=)j7fl30(iu8fibCCp.3-cKF.;L*04Q8XMi+7Z=/M>^mRo&aW!8l].\^M-pF*4:UGt>7!6`haUsCSWRUt697hn#kH7(lR7S&W$$bDq4CGq2$IX>gT(lf8t^ir:`3Ws>L\h&E*3IIoU`J*obAh<XAd3;/5$gBIm2K,g_u8`#+8g.2P]G*(baGG%c:ngJ2"dT==stf.Z$up\[/:;?<*iC\J7`R;JEYC79Ko,nkpsP8d873N@5A))I^TD#bT!gD.bc8W&5C^!j(P[*NV*$eec,5!@C<nqV_L!_QJGW.CKMYOEY*agd5#12&aQf>`ojGXTB!DQBFqOk+^@_(T>0C0g`ui!6f['A1n$@3el_1/XWrEN17g&25qr2$`m/?-uJb[C?Y`OW$24.?H@s*#<U/+Z;>OXI90iB@u9"!cpXVX:ScmbZBn>6c)C0]YaK(^k4gU;PGR9XJ2(!R\nE1s(9]k,O4siu)_@>>>Y3+m_u_F<P@&7d[['@=#.R.\f(+3J"]trLo//MfhHnH7*[E"[N/_V"PUG3E9omSMEJlS#kn`L:^Da'G$@b0$gN_"+^hpk3M=W>2;U9%fil"2Hrlig_M>0U"o5J(3F!u\-.@Aq-:Ou)A1h\hZhrg3*;a:9'5ITdnchO.31"cjn\PJsXJ"dj3+c0P<L0"*,"[a_LIK,9l7+j'ld0focJ5GBt@;(6X^Em]*eJZ4+"k!9V@%N)\8ie(0"M\1o-qd[ITqH0P02'[e[2'[=J9%:E\TO$=f<QJa%KP%;+Ti<;b%Qd[R^XBF"soDR;Bu/H_EssC-PD8<lmKbajuui2=pFJoW^4bt_0>:02'mElq+035B.]!@a0iniP&!Qt.I$7K00cDh1P$\`deK[*j_2MJL^MhA;-h<J=`81TH[",c^&bm!Q.VgI@<:S>.G"n;$AT)"q3pG71;@Nq8Tr&"UNR$8,P>@LD(JrDEkn,XA'NWC^@];@ogoI(SLZOqq6ef!9n"epSap,fR!s?eWfm;+EOr#)lrn>S!Y,#H:?2>VJd&D%@D&4tBFVM^iEL[TS%CQC8#k6fl;!Qi/;82+]lB(l`]s'2-rnPEmd\Aa4?hXD$495UQ->!hfkgXsg3(om(MiSF@FqF_\B$4lqUL(TgsZQo*Oiq)nZ-#97r*QmaU)TiM$%f*\>eg^]@%JtZ]Ck_S:)pc%(#uA6KufhV_B6fm3&nT519-_gRE_HoEVjE_9cV22OhH*@]f,U+SK-`/SYY8EQ.O)UQC=,V9!SJFT#GQ08.@#QHbOie[F5p'F4>,\@L4B)O;(QLGjD0D")l]9?oHa)iA],SReXP73BjE-&5\c:TJfgHIhHE?;!6gc^2"pV>R%ZSZ-joV_&7>o,Yg-6&sB.?G]b$cFJU$4b_&IkRbi^Q=_8(L2k,_H7^[qj=j^R7i;H_1n.8c#j,)bMTJ[drBi=kRV+nf'/gA1cj7fR,6melG%0f'QQVbnB3>L+Q6oJO+NSr@WYq%T_h-A$j`9C+=RI_g\Qmam5AEEs\16Lf/S!G`&A+)H0GXi^bM4?7B-MB>-=AU[363K<J>;GVdYO4bX;_*]p-Q]/X`ij*jqtDbCaq*7'iptFR-/[/A3Gp1a$B9L!Hn8CEsl$DYPs)P"e#fQ\D!U_oW'S;&N-=3VU=$0i1rbMcNVW(QC(SgEr_iITX9d,-`nlJZmo&5F-K]BaD7o+J^?BOn9BL9L,_76":J:ZrBSob!>)tLBcdDSDGoI0I<[(]S7af7aH`!==\e@IBR7s3T[cr)3.SeO:t`nIZG`juTiYP\&-Zbb8aD^K%D:dQH#;FkrL%7t]@/?Jd-;9+4GGOP)c#jIRF``LF[P,]qJMjPT\^:ZXgC<R_6(:mV$F/W?#S)I]]4)[nnlS7G]gYW'g&jE/k?K%7uh!JrEB)k]^PP"d8rB>2W9j;7q`-1XU\pOs,7eB3HRtaQX?`(r:55Ge)Y9?9t+H,0$V8C*U)-N2q5Og?tu0Shks8a[A3Z/[`;eoLCELY:tso7g6OS\^8Lu,Y2_M/GPBOobgPqV/:H#@I&0b80><,d=V*W0rNA_,$1C&nCek65Q78s/H-Qf4b<kmJ$032AZHG*HlrmEN"7TPG@pI962AP=)(TtutYp)hEc4$KJ!tjihZN~>endstream
+GauHKD/\/e&H88.EA0't.hY:6A]sL*[G<lc8@C'E[h%dY0G86/V+?lIm!6MJqsGk8Yq<LX[rr#i.CrU;bB(]06Mu]<hlHg&IL?rF,D]g=SO8VE$/Ak(\$maR:DuhDN/0<-^'DR'GVU>WiR9>K+DS9EUEG;"9\Kh5IJJ3_/R5XK*F!K-<k5%bn6I>\rY=5&L"duNG=QnBT]#TO4A'hmJoic)LEd(&1`N@f9VNpU_p*BQaM'i8[I#4G`X*>5)MQ#'q+nloj<m&llXYm3Bc*OK<j]oD_bSo>KV!DfE$</nGO/%gm^fj-HP5f4I_RNWq3Vp/%I&.pG)'aO9U:;ZN2GX6o/$h7?#(\V^h-hkZO*3+9P#'_=io0ogj23K!7Nu9VbjUAgk&aNBLKWRbea+GY#GnT!@pg"+%=!J\.[@"[/c-=/<iWe<S"&1FNob2WWe-?Uf$$_jdC`]PL@;gC'CM$3",YF;Mn.-ZDHnmRf^MJP_Rmp0\gERi\oGI>:1r]1^^+P.4_Og:RRK"Q'^itbFUgM_gSHepJEl7U6#J`Y[U3qae4c1c(//ug:GE^W>.l5C1FI`DV5c6DBnsU(tb#Cr)+6G%=6iFo4tkY\KUu(AAVji?bJ-qYttrXMu**f-#9RY'.<*H8:Dgc"nm_hUC2c59uSa(MYH7Hk&_9TI3fAMY<8/?j\Vin]-_"poSOT?Y_T6"YnD?$,VmI<4ChWb>U\`ZSQ];ZaE4tdcCC*=[8S)QB$P?r+P/Db\a,jQJHV"]J!%Nd=D-R.'Xl^+;E1-C2[k)m>N+!.G.7"d6_VFtn3;SK*q2_N(=,U-mGq-e0sfg+J@Wp'_nHi?0U"(I5rU)fB1uWI/"Ftdj5el*JK+"/&HOAUI\@YYp6?f@6'nC,aff-djB-p<"]X3#`/Z<IaY)G?[7BpH>j4,k#&^tS25@"-j#u8&R&m7)XlJ%6H4K^-,F1R)d:=0E(4b#WUt&kD&Z'=R<Q\?RW=AZ+:rcrK'ICmM*&"bCQ3:)+n#r&s.l)H?!o6\sN@r:Xb8UEbD\kd3_+Ihp6YnQ0hfFd4F?@:J_"461*WsR=#kBHX[$9?J.P$frf[S&,e7AnsT51=3\j%K7)NO?#%umqXNqqe0p_peIdnA7JAVa!Ha8g*m?1@+uMr;*2.:3,=%DuUe&K=cn*,DkE:hn5cjSp#OI;qha$aY08\X76pMI#!K%)4f^hL,"DYW,<ki9F4WF:2g'_q:T<*W+TeSGpa.aF2rUOWn>t]YoA[&Q!GaKJ[oT/AWp";;LfL2AFfr=P3lqFlo4MeLg%'G>Ge[QCfg4EBe21L8.'eOD:==1#O0f+[JWD0KIc2$Q:oe8RFB/g-`t?j:(XKd9Z;\7DGJnp]F!7aU@f==LVLSLQ\INNt(Do)q>e/0MPZi5,bZgY1btX-/7?+rNKMJ.+u&U@uVkV&phG-ZO0m9EknnfC)TU<GN@ujSg:)bP<B9/C>rs[qD`?[?diO(`qUCJnRt<C.cSM#A2;-d32]jE`;,T[K^j9#coW8W2nlDr'ZO\EMeb\n>qh]bf?CHh"t%;S,f-8d%^ftu[u>]JXt#&XqV9GGi1d>CJ6-KgK=A9,IJ#OK?O>k[jbFOUioHqV[(YN=^\T@'ZWZ2dZRFO#a0!YT\qLs]at=Eqns:ZJ:)s'+<:C:NmpS3R4cDi2-2TZMHq:Hm[6o9jhcU9MdgMD'HElXK3sE@=hm\ZV(=tuP1hAuAF<=OIBA9WKhR@HZCJ-mVs/E2Pj%8$)^n)07HKPuKd/V@\g+So.&VVXDnHehl$+GI9SRZOPp7O]2;cM9[iPFO=oE)90r0=878pn\1lS`H#,uUp\&O?Eiltpo.lKu\#S'_^T[k7&-"<;GBD*XYsFo25PJ688Rl]o'?mjit<R9$'ManqC99,o,$k,rnelJneK*+&or_]TqYit:;.)GV;iQ?:gEp%9Uhff'bpQ_JCg7GF?k*5dsW+6X6XpKVMu<e.%ebt5R(+Z@g&ELF^ldC-U1f_1\@F$,u6ml2t7DtRZB,u%*>R>d>O`f59EdGnnd"OY]G,69r!>!U-[ruKJHiA!UtCBpjD]9PC$$GZQDK3((I%&fg'B/'*H]B=WOUlSB'Kf"=pIllE8dFKcrW!2o5.)WuFD1jh"grL:c@5#g;T%ObNd6+r3,Gj'$Np(=#r3]19.uVJq+?_]O<eI`,Eo4r!j>iT3K,s5qmJGf@AHX:#4bP3)@n&`,eJSBZEdS#JT;LQ*j<$92m'?~>endstream
 endobj
 60 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2195
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2104
 >>
 stream
-Gb"/)?#SIU'Rf_Z\8Utn<#,).mA\jo!^k^RM7:4[KorNT2DjZ]PdUGdJWs]WQ#/Oa(1=oh+?"MeH[*V)MW`+bI.2]ss2>?'k8Cp[6\#:nRfeM[#\NP`oka2EdTTO%[\g^>pVJo3Oq>A,<"%HSnOjuJ?3"DA]rb]=k0Mf6E(u5q\j1L?RAEmP[ULP3&$o%cqn`-blPrEG(F?]]6*Std9=$/TA+7nl97dkj1a42>i9'FFMkHYt#!7^T,_?cLZ0u7@M8S`AO3-S,G*&[>5Y<S$Z'p'3Gf1tT6K%1U0<+aYg)4&0b;TH`TU?g`f]egL'J1A6-7.8j6iNjARcL0/57Q/fKjBeQKlk4W#LdHh49,O0-&9$o.kjV<V0f5FCdC<<eH7Ma//s?:=t8PAN%g0Y&b[bQ7^b+=#B>u\Qhu'j8)Rs%8Rac'!BpY#*Fb8p?32cNk/Eu)k!)NFfY=j,aUU2uo#qX9!5(EgU6L1p2lkbW8s1tm8(e';KDZ/(KKS(3*Xk,*USn!Kj'f]2HGN;-QMk,J&H"FGh8/'^?jsKa`c`.#a_\F6"aT%fh:B`]`-E\HR+knh1h9/rH,7RPf9KN4NCP^5+K7RDg+@=rbRhUK!D/oT4Z7sE;$.OZBO%W8R,d@1$m`90a!1FfDK(F"2ZWOXhr%[QAsdD[61$"h8TBW-(llW1<E[0D=UoJd)"PHTF'9\_&6Qh:dIkqipF3g%)KCI\O[>QMe),]/Vu3$kO1AH&O^0cL"PO%R$0HLg*plQ/7eXf?j=hQM.%8gQ*RLe!c&G0a%5[KG'a%FM!KnFUUeiaF<1GG2WW9A)Z<Ag*hU?I.hBT!t6<6GSIPKdN%;c<"@u1$p(]*1P:cs40gi8YQ$.p)H?o3>I,"FFWnRB-u:SO-0i7S\]Nqq0nW[fsFol<H@$kZ+/%2B%qX[<R,jgPPI:D5C!ParV@7s6(0FX""$%]f;TC;3tqG=ihZESIa\-!f-"A34"b^TI7FW9\aeF^9pC4q8$<-X*qo=5)B&ChJU1?+lFH>Dk"KD1q7,KP]tFd-(n@crne1>G!foGUjoJH<9;]@CiQOdli0W6aDEc6B^+3goN?iG-bZ0[4`cR<d=?jERp!,^&m_5Y79o##p0[UR,/T,:d)B4gCqn3=PH24K5U#umlt5hoRJ?M_YgCTJtoW"[T&&9CAJ4IAu8\aHalBRdK&*"`p#Y,/%EWO<Z9qO19MlS;*cX.]4SWXgC7\;dgE#X]>$t<b4`!i\K0`F*a8k6*\fO(8l9d0Que'lQAi9C^TUL"Mg?37EBaT9Unn:E1]\g%94iX)[c&!4H:p3LH0TaU'f2e>)7ZT`_n]f<8_Qo'.>$Wnd'!/t0X5T=*Y!F0j+m?Ks0J`to"`'.h72)3L6ephrRP!op1MAn'FSutGp.l=P3X1pjs/03"CD^V%tW24VZ/G1,A(a]eUQamCdnSU4eJ@pS"m!r)p7e/W]ULk;?<+A.Te*%M=T>Q*iI#NGYXt,%QDJFaP&i(-lAs"BOH[5Yr'cOmVZ*([O9h9BY.J/2^mH1^':@2BQ@,L\O>:i24U0T<T`,C<Q1rR&l;/J=os[3p--RVNB<lcZY@0$Cgf[GUX,n3Xsk%HMi5dM.)#me=))Vq]QmbW^0'G:co>Zp]Ml]3\B*ECpU/*>Di([RBFg!(JE05WmZH;-D#]5^gj@s,?W'*d;`)%qhW=92aZ8C+5akQ$r&Y?VAR<Y"kFdp&Z8,60)+U`F8pfm;$\Hl7]:!jAk>WDM#-=OS&e&djob,L^'i4pqZ\>VT?sq`&SDI>+QW@eQ-Yq?/;-$GKXlRL=:]ZhX8@9/7-!eVb(m&f(Wm#MA_G<3]e$gSuIKdBfY3\aHhUoFlpXZ?HlGUJ@6ApNURB(_$enX.SXJMEFS]Gj?V\N,/U6^\':f9Yh/eq2bYRLrtZ>`=0di0T;Ts.;s%<p:PGM!ope&C3-\1?dPH9A**I86QObdhc3Cl\8%n$euE^"G,.NgkccQBea)#D$Ql2"0]*?N(C'5+oCe'F#;<?#jc/Y,;uYDA\6dpVVu1ne/.KdTns`#>Q@<%8"(BrLH4JEtR`^MRl8_m#-oF\4qD)?Zt4e2#Y;gc?C&jq&U\"nDW1V^\5RoSKZc@@Nd\/T\rdb2J5_qSgL%@ruU^UpB\_;_Sm,D)dK$rK4r[s&cN66SaR/HI\[1u&ZW7H_7_C&mk+[*IfS3J@at~>endstream
+GauHLh/D%+&:aF]EA0)^/Rh0>\'q7ND2Jh>Q8\!FYkEX6.#4om\g3QZ)tLc4Nr#t#dBtnI6]jtfmuI/4]AoG+#k;9_rf;,NMd&0SN$'%SD$nZ=(r>SS]Y3][mo2Bt?qaerC-<Do-aUo+Sj2n2(nsY!,RO`0*0@NIHC(7AhSM..^Tf)?o>9?5%IXXdn/$'@'lIBAgb%[Y#T5!/p1Um'(JJJJ_/Kh!'TX8.nMuK$kla2alQH!j8![eK7_rU<3K2!e0WTY6E7=W5L,DRuO`3(F#'9E)BlMRHB,K%Ld?(HEEfQNRNX2@5RST[/;_Ld2qe!fWObsuVQ,Q?C>RS)q_JfV&QIF##b^p/ClWrN@Q"%kC(.ntHXpCHuHRJ]9c;VooLOmQX5LTd3Q0'[$!3XfRf<Eu[".e;\B3BeCB?1FMktH'pW]&/<K<TQ-ml2/Mo7e,\Q=[9c,-VCe^>^p,11$<mE;C`=Cj[LkTK2JcL,rY])4nZ$#L-=B>FpA,m^PqBCGE>@YHiN1CUDeU^/jMuP)<"e?jfjS4K')cLo-etMYARha&OHq@3K'Foi$umi6l@;fp3"U&0N@Y150g/NUgUe.^ZJJJ-HCVA1N\u`)g9FrMu3h-`,"S"J1IH=Cb/*ok<))s/T4M_G_V3'hZ'4!k8pY,]^$mFminAr.7&@Iaa*:RcQDQ'X@-LN\L?T&6?2O[Q.hDn$t?tfe:1Oa$188Z':VcaX`EN;bY(lS>iI7^=#.*)C<29ALf0fSSeLQFKD"N"(34s7mF0[Sf>RaT4$8P10\ZP1+(d>Y*;69571o"+F[iFdo]YtZBddO&7$2kUN@Z]^e?X%4]>?'Dma@kR!,lQYjZU-o-N[TdA7gK'iUADoSXSXK]]O^&RgUobZ(Xu-!7=5MF-Pb/Cp%+XN9`Y[u4.gWl?U-dY_21[F3=1.u%dH6i!Z][Z:_6WuMqp6=b3BV'9j[&sJNT+f'.EQ%bU8cORm92D4%$ZU;4^31AA0&*DD*4s/%e!Bu7e_0AZ*\O?;9'LoDhHF/`OLr/dq-Zjs_leZaoU$E[&:#Ad>1kc5Vn]S<e"R"!<n\/V(FnW^c)h3,'"Ku]2?l@M#6&FfmhVX;+!P0BKpAtGY@mN!.1\e:L!UY=rfqrKOb'aE)BQ7!1YI>:]1rN0O:+(+4`P8TH1a^M=H0%kMV1(fnC[8rYB._mMe_AE[5Bt'eKq>Ntc=f+P_L>GmnB\Llq0)&Q"eg.@l&(WRTpgZoZ/J=l"CRXk9,I1jht%JkS2uS)Aue#;+C2poTPKTm7Md72gsMC@0k=CTYqFO_J;]ZIRqmmoS/El8>D6QaLb,7,A[\`p<T`7PWX@R3?u%lHmI&aR5EI^sl"El@%'V<H.VT+)6(Kn*qL>Ef+Gu3%)lkKfDm/03$YX;n2tB;=mac%A/.jF71?h#B@m,K9MICI*/F>du&Kakp!o5`J%.O'/4[XHTBle$#fe-p^3"IN75GKoN9!s`^&]UG?4RN&q-D4R1pBP<"1V=fSemC5(oG:[V9CB:F=JkJ(kf!4kb/S4*(j.ufA#noA*r(O3N/=c:^dD#fg_;:(:s9C5>^=7T9ZA(6YH;/-5G]&lB%5@ih@CF?%Ft&b=RULXiF(kBB\J;TTssL,BlUf?q(uBrO#im;JF/(;BDNR5`MrpX>.Jh6Q-Q&Y\Tf=N(29ue`n$B<QNO*6)5(MqH_pt1G&K<4Tl5k.IRM8'>dL*O9&-BtUu^30n](!H8`Q&5raP\0#g'#mV\r^-!8c9I?cuQ,ki[8.O.Dni*Zh]1VnT(b0@`:AZF'*<9!@PE^Sib=oR)DR/7?l6K%`)rA2O)@m#\Jpfa)(piJU9UB3lR1!:PkR9DHCDh6.!BOj&AgNOQ:W/6UG'M>_I4I,X<1(au,@s-lX:9`3)PqVd)4Jq,=K2bNO6"p(6(YDg_MgUrG2-6Bc)rmYcMZDC7!J']Td1[piRW/40,Y\t\p1U@hASf?IpN):\h+aoZL.A"Y%J1D?ri4d8sO1!efe3s#P(LQHO2j<b"LeWOBDi[J',(26!I&E*mgoVh3-eMEB68RTtW-*(%/mTtdZ_6n`j$d_[<+3r`f!Nc%M6&ji\o7[4d*"jd1B9`(+4Q(B<W~>endstream
 endobj
 61 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1995
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 702
 >>
 stream
-Gau0D?#poC'Rf.GgddgLCN^L0h!&q#E?-F/0e)&Q,r6FDHXYH<V7!+Q\A,b![3&e/+a0@l@p@BHcFN])%t*S-(OYs5c2c_Hi:NQNIK6\XpcYecZYR(@[I.5Kb/!>ldTQ6m0C23H."oX5H:\?6]08Ws(I/h![1(dXDPrijOi:\\'&gL-WR>`cn-"5lftT4f6[#pKpNqJCM`/V.E,2()(_22&&)JEI7_o);6-o91&PT?2?4YU==l/!#Gu5)-kkD^GYkh#.[.SY/Y15XThuth(HeoXY=Tb#+%N?="BD3"J/k!WL#49b9@'K=4D<&NAg\BUBo+%*/P*KfBI2B\%8[@N'rNjT&q:&&N^ZRqNPZ=O,;l`9&p`'D=E,,bn'H@o0===Us=i085/8EG>Ub+S.QXEaF'utI"[!hHC?$a)Ef-:FE=G_c@\T6;J)ULi<*#4m:_XEepI-6+TGWLHH$FO:9LL1tmRp-u%p0@Y_S*kK6itTM^d4X7#+bYDdNcJklU)gKY&n[QlS>_DTX\i80)At5s5\6_$\@pLs<Qh4(j%QBaZ3RiCJQo>cXCa2M:IRuGRgHfn)+n\e(sn-dV??UQ)bZ4CN/N^C_4"NVYWue.NR_oYJ:Y]DC6UHi3opDd(G'_aUKRNF4$n5>IBK>\DeoHX*RfJ<XCL$KGf90`qH!/*WsiF1<<bAC3]Y<M[eF0+YBZ!1$CRP3Snh/<$%g2#a>c6sF_3bG82:)N2H?VG3c2>/F'L+f]I)E9c0'djNlcX;dOtoA^;?\[*])4TK=mQZDGj.N0D!mPWa';pVj@<9q@U+<'oA'Jn=$NlhJ/W5naLo%d@ecYhg9/-.DO,*KWU.U02.6-0]CR_QW?tN'iG[899p_<1kmLeCMm'N=;Q\212W)6fFR_SdhbW(Jp.CMQ/F,PL+r6D-V#Xi*l6R)F'HMCWFSN:*FN8/B:;tVs*,$t=r(&(OFU9*6^4=-)>)j>1mSG6qW;hm"V\lZ.2qmD81!EgAQ8q2EbTcMi8/g6^TN'J^QYh`GCsceK\:[09`KI\r.j%V+`nd.h+\5eOKfc.!D,>aWUOD+;I\gHAU@%=6(+)F8[ZuN<T(s"[qg);$]QLh[AWPJWa\Q^lj\%CC>7EC;IXGk/raH9R%Sdhs4IJ=4e;I@6h=2>gq\LL4IJ!Xafc198P*VuCMkT'<OaJ2B#Lq&)"$'s,:FkLr0L=#5B1#'i6-EDeGsO1I_3Z_TTM89k:fGhBfegs@87O;At/[-_2R=\?:eae0kQ4u5t(q"p0qNd)osGFg6>02nC8id)iPNB=,E`S8:4:NO=7o?C0d7pcs7$^ZV?*m;[6I'MD/q:+KL'3jQj&A`pIW-Cb@D%k2_&=d+?I()\4_qE.pX?<4rUo$72UMjhW=oHuVq>VXimIh>nkqE!oS.N!XK2(TsbNEOe19`db!s$\uXO.mY8HpV;(1oH/Na(nJ@Q"nrQ#hi6`!keF$3KeQEHkFgSebpuP@pSuTPBma:UDH@H6ij,d1^7:VL+>^Fe=,?3Yb!iIfQ"d+Ucq[NtD%lfe!/H2n!tGhCXt:_*L$u$aP@@=q5$\j,]eYf>\pJ3"G^O&@"Abt'ps!YhB.E^RFr'K&pC.F'/gSRK_uc>h7VgqsSCZO_>&2<b5\o&J5J[t`(-K$PUr4(BCl5f!Qj0WAij'LXXrC6Wd<Zl1ebHY\&j3op5;_Iq&`MdG`F%e0QXA$VBCEm)03>V)rj_U+U_t;Cqi6>-BWNIR@O*+/@7at&1r*hJ9/&l(TStn"ZK/!TMXf8FfF2ud#l7q29ldirrS[?`_ZU.LQlLBE)#h0dA/aL3OS>@;U2+?6]C?/IJ++,6f>\=O[F*eRV4'B_N1!V53PPDO*T)74?G+#mSU9&X8@5(c4LNqj*[.@$>(-f-Ru-?a_nhIT0u!I*3LO/JRR!5rqBCdWH#`eVm.<,/^P>\`_u@tLh&(VFe/./7l1g]tO%/:kInUg:/(_ePVR>auNW:+/l3mftrrG2FYU9~>endstream
+GasalgMWKG&:N^lNfYa<-sj78l!(1-;6*6mA,90d@0MRKCVX(lW[Q$)G8>-!DC\_#RD#,Yff=,>_krK=s0Mnm-^ZPH\:Z%3pR$`s(>"E5BFH73oCYsClnd6(U;4aY<?(>@LZebO%U;Lo.q($DYHP2FkteRH\2q(Q>2eUGAF^t.*KgdNGNA+;j;>PAo6>pu@2(`)%i/&H-RA"t*X9-h0aRd%W;>;@`rZbtI,AP`YhET(XJiAF,m,3O?WtlAMhdI)0=DlVDWpl0Y,p&rcJ_2H$S^%.-';OOFr.0^]qa!CBQW*%4QQn^kTh799'3N27GGt$.?lM'[s8s4SD,Kb+_"^^Yq]UqLfiOdY1$K+-[%&V]U+]"6HN,+D.A%3%o[Of5$X+&Mdn!HaLnI/[]$7=-`IgQU4\M7^rp7WNpF,SnnU_"MnG./*6c'cja5CP6J8MeH1%mNm8g"]P&3DVSA,.E[VP0NS4%ZDXWH?]Y9R'>D>cq6pE'b,Rop6ge8m4$WoNr_CJXZj&aFIem_A&$Oh="400AU`ouDn23@EdF)GQuRE$`#pm;45O\:9/2ed<s&FTXq84S0/$VBjPn4@t>Y6Ro+9DBYKK*$j8*)[mV+-)JUF1L-Vf<DdTu*ELK7.,M\;+js=28?Z<lU<9<I:=T#Q%.rY_1Ndf$dH)t@W\./U%Ad*Y6=0+:WS"#+.g*e0O2rUf~>endstream
 endobj
 62 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2455
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2119
 >>
 stream
-GauHMD/\Gm')q<+1#FUmE"kmpMq)`[]%PhI\(;rj'Eng`BPD:(6]h^I`UU\rL6Q6sG#mp_>:d"e2<&TME*f/)&4-YbqnK35I[n7)D$3]EZNW`gOML2r]Ut0)8"Cn9;A'`#o3d_ndqf)h5P:0TGeF]";%UVj->bVFh#?dA4oEIF#I[%1DXC&1psAR=rsc:f0RH<9pD0Yu*$j3TH(=67(Za%Z4@p^;ZY:3<&EHCsjVcj%(^15I8(-js,XI_]%;?^be*`QQqpB>Wa&-bc*lO.qH&t9oNugeWl;\!B"Hi`\nl-blK<B*%LiNPCNX1o.c[;^[j`1[:>1N*KQ`SuXB2t?__gac'4%kL)kk:%RW5p0-rV>/t8`VIZT^_[g:$D1I#I;?=YS%Dt'nYpugbCFg@MNXV<E50L`j5.YJD#f!=OKW'WLcp*W7;R'R07p"`Z9n/A!mntB,p)0QZ0OUgS8'0>Ku4AiMJJ5eRf4K8hO;bjmp-&)M'b<CW:=o2#O%N:#[Ob*+at::`?J?QgA&`5-otto,EfP?kq%fqOJPn67*P"29nsN20*#P*8$;[fVfRQ7PJKr->`hn()kGtLM+m!$DcC-?E;5-h7?40<#-`g"dT.,fFe:ra56\H5.mN455t-3s7`kc]@m(RK";j_@H^L3+A%LdA=)!k4bbBQcCVS1s1VqXDH:kk".l#pSO&=WEP2d50UthR$tefHffcRs[M:F+E2o::%T[cec5\UM;fGTs=)!Rm-g=W<N#hoCCF`fTOrNt>Ed>DdK18=Fp[/M,8l3;W=i"9_M^7^I:LG)O:@l)jGL*r3$)Na/\b0$cph\'?\K0/%Q>oK&6nrFYm4>Lj/`:]Fd28s89.+j:D9<UE$l[NV&`.9?Q)%ehg((VbRRDRQqaQ?3hMMI!%jf\nUN$nB_nb+]KcbBb8\WAq7@Y\."@ZEd_ZYQ?V=g(3P4X2q/t#Ck+G7jN)Pj#<(@O^)d(es@PN9e85qrfr71;JEB1X.1;##pQ>nj-QRZ%)c`AtWbXdXp`ZmNiM(c$;Rc(6M?C"V77X5fncZ+.!sI8P]36G[o0-VuG[;FBX=;:PD.(R:QW^?Gl"ScnSO\%]>q[K]o,&\;<l%X(VkMMglX2`fT8VHN]p=.iQ/&UqIomk7&K53(cag\`r6-+hCZ;W<99KEa:Ne`q1jXq[Tar9gUF[-BkJ9=TTHMAn&WY$d8V!9H@"K[!ZefL(G%'itk["/TaW<tUIf0oaLk_Q,R#Qn`9h$&UMWdGmLRL3YHBL9*7J)Ur-1,!F<^5:de`j*.=g"f=\EH8G8%TG1"m)+2Z;^@eInGq`_^NSkG)JBFf%SK4`65SB\$P)ln`NMY&`p<ADjF'E7eP%G+<=ad-O@D'@M$VLe=#aEFq%E^^*qc0[C[62sa(b?[CY3Dr_n0c^)BNE=c3lXAf_9\k^^)WUUC&6'0o]`uM\gu>'S]8sY9s&EH?0HU*I]<35Mb+]XcbgRF[]B>4m2O)g*&DE_$2"r*CF^q+?;T_];qL#FT=Z1L8[:!h5Pe[Z-.,I#AOR.lS,Kgec%PqUcLJ$aB9ME?m;sk4`m#"Cnnu1<iLRoO!6Vn9:.XWVk>_/E[67k**R!tcPij^,mrV@cIGJh#=M(O^rg'PK>0jb09Q._2RQ&fW<l)WA"P<NLOX4,RMDs[:(^_`9%[RR2j<\c+,P)pK2\qBYT\C9H=NR@<G!?"",FCpXf"`8,m"m55^decJVRoeNO?I`Fa.,fbL(d%QAmdB_K[\C'/+[-Zhptj(it7>6nZ)#A&>$:,jT?6Y;Urq\V[gP+3F^#K)1:tb`5ZsP;2#B1\P'10aM^OFpEA!95<2EtK.t"%9?G-1EO(T<q&?'6f6s6hS?4X-jdL&%XLToa?0-DF;EYWDOa;GE12TC3!(B3`bYW@(/#Fh!C=]J4NFOY*:%`7K]3pYh-"itrA&Tk5@/$nQC+caaH(`Pe0k*VNb8e*FZqF`'8E/u87sUTH,/WM4F3@3'i3!eS?uMF)8u')aUd',+:q(I81&2EEU6cKscX$@$*?SMb_uqe]bjJRWbNkjd(1fY^F+cD7Oa$\"fp-3-%BR)O@.f8o$FQ0]UX]2LQ52HbSTGi\4I9`TC)au^b1s.V*Uc/LH]>8X4$i=go9KcYWD.>6AZcfN_4XbJ+a@^^7#*//%,`olXk7m@eSs9S7b\m(/QF'?"tl5DTiT0"WTr3FTji#`]md&k0&IVW?D3$u9DB%R8!G"<%c;CNZRt=@B`o/2X$"YqLC"dj#/q7ETVDb=@VJ!1\Zh)k5JV>1kT@"cWh2c;=S5Npe>;2]O)*sXbUlWY(faqTkGkqM':k>b.1$_J&+0U%/%OG4[Kc%XS[_2e@`BJ9W?kQI2PT?62.GUp,I^JoP6UAWo`,SB9N)*`Q'16*0GWj*g<!-J\\GbdK9AIq9T9c8.5mEkR@AH`W$t'AmL9rV&AL:Y[cnGpIf]4AnK\~>endstream
+Gau0D>Ar7S'RnB33%kBh,*mAXA7n8aAr3i0`L8V9[Kcm<D:(7G8lSA3M>QU_86p&P:6ZG&MH2@5kOS.)(CsdKj4Sop.DXURH6Wq_+3&Bk677HV8%9BXrA^fh@]+.AL=NdIoV4\d^r*?\QjmAEHK7(M"MQlJL!Jo*blq@7fls`pn?1,2+lT_7$%2p9D_QWUcJ@..%rl*dhX7upl^W2Rn:Nna0ja1dp^KA>No9Nj&MCg[b0%?6d"t([U#1'b61mGP2b2Ju=<h@8$Y)-8IBsX.SUPhuN]LMBF'C.2X?aI]%pj(2id8ZpS\IR99;SM+6dG#RX&*2:=C(%!hD"NYiV/K34;aAjn,i4#.mM;ACrQa97$:!*A4\_B,)9;Q$-^f:S1_m!"eQ+];NM#O';>f/,#M*nW1dF"AP8W11BQ*)C^BaE6I7^rH^QTm[CUEsj:E29SQ&P45on<FVEbN?\d>AZ'=q3Pc9HbWJ;VT>6;'2o4jK4l=`Fe3cGUo:5A:0@DEe$JZRX:t8-(S\pGAj,n)Pc=O'u4Z/(0r-gbbj#Em*s8ZqqZ:9*rcAD`@od.8@<T@hoa&VMm=El7Re=3/I,BfqoH"-8_Xq:T!rf\P?%gk+&;.8eVHD.#MZO0@)b8$:Dl'8QJXJ:LJ6GM#rL/:h6Sf[*<AP=F+h.`f1n$58/@o`td8*$@S&UhRU/>39'1:@JYWO?td<<FBUB$@EL>L)5>"#,VQ$bW?n!>A;D-2QV@Eb9]7ehPUKe$)nqF;V^0Q_&%+flj*I#V.$HJ(-S9($K@4ct*?)`u%8FEWm6a=:dWV1<(WTb#Y7D`MRti*$7fO[t`16sU:J\b[DRZ;c#KL#Tm/*ubAUX=sO<C>G;bl:dKl85hT.D@8?7K4E3t`O4cH0-P>BC@-&tlim_1)(cIt@OSEK2`R!6NnG"esrd.p6MaFfnJc]`lm.@d5):oL@Xih4*h$pS'Sr'KrA'P`+<n`haA<hQ'F%pRdbD(01]rnQp(F\FeYd'fm"SC$E0UKLBT21N-(tqZ[K;<`6f1;mC\"=GeZAj)k%hm2j\'MohGu:]bgKE2'>[]k!=L[e<=n"M^e5(1A3d/SR$E9Xr.Z$I]KsasJEH6.1jr/@(4GMcP1NO0EF;"c$U@l[mBqRjcZ.%H]Rd"(CjBEsW7t.hHc3,4qPLoH'&m%rEkV%@pY5a!V.5@q7s2+GJ/o/0"HafAiLcn,r.jWKSfZNg`;<$n2tbF3?WsHFh!qe?_@:!)Ro,cQ+u)8A\0'*=RSP;nG'fOD8;)Q(ccQQmHE`oUf#,o$YK(bPN#!`:5>r+c[(hEJ5s">$&-dBlmK<bV;J&;%b[RrBW=)pRgKC`hH8>knsWB8WdFd;O3&*>qK4-DrO+ld0K)I0=CdW&QEeO;H/:J44H!tj-\%W9(K,SZU.ZOi'`<r`GH?_etZ@-20B/%lOq9ZFKNV2,&IfleJB/bi0KX%8OEeb,NGo9a\:s9k008i-r\OSKiV4YHCo70M,Y4)-.Z;3/r`\4^&/n<[\[1AGYJL2P4')uRd1^D8PIh,Q<H4OX5[i-Ma.-Un6d(T=2@H_/`[6Ea390I1L;=AA@@U%%"D__CC+L"1jj;fK,^nNNT1opD3EGUQr1OWVLr7-a@1C.7!U>qon36:KmZ!U3AUsUZ@rJ/`IA[U6@">rWKAXo?]npomU/iIAsu0F@%ADKX1$S5*4e=_K%TPdNDpdupB([5KFr=r(FG+4[p-4V)elI?dVmiQoh@//k)/'#Q:8HaQoELTMFd;39>oaMK/HQLG$WdMb/GBd=9mm`lX&Aq=eV8)XorCYh.Nc.!<h5@TbqDtZ'^tRCu2dYdoRe"-W_A=HuZQ/LgqgtI)*MST$`>"k"7.ViD7pObH*VpTY!)DXr#X;%sD=KF/rA4^>54R#onUO0Vc$V;_9]p_XPM]J"-TRbWgD,Xl_dm4(Q<CT(Ypn@g1Tr-rl#?'OXe](7C7d)GYY_#T#;8e#N;<Ob5&dRJmZH?kS+1CrnHt^fAk;.;`Db^iEBRfi#-_/Iu#K/J06L*83"QRScXMq[^@AL"_J,>V&:rH/,[]F/XN9Xq&+:_oAH."t!Sak[+!"S+bpJ/SIj[<2:@gG:nC3O`+P#^lWO-5I``cEW~>endstream
 endobj
 63 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2549
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2751
 >>
 stream
-Gb!;eD/\/g')q<+0j*?6mil@4]rUmA\!o!rf65ouGPu"/^dtiO7NtiqEpA.()!](8Psf>L"n#3[NqbNMLVoNmL(lc>J@bdP)W8(^]Qd/%qQSfX%7pik[rB&fHsQA-$&Pl:le=uB`G$=-pV2$0'=r<8`0C$.ppaK:bLcdjF:KBpI`6IMIVir$2#PaYK)Z8F0<kEZf0,NAKg#h'j)dLH)+TiHon*N@&uW",!(fLLP8GqO=HF)s(UB5FL*R8&L+)U`g4*,lC%635FYPA6&0DOB@e+j8F[;rrZ^AW(^GiXa6%Fd@nD^hdeF1bX0uC8E-[(q]Td5#k]J1dKJ%S4UQZSB<4`MB(745:jaW9K+')7IJ=3rk0(#%=;Q&=UTA=_p'lar@R:<HdR(0N$GDZ*s'Lcq\;K40+EJB=P_jO+C[_(#!8FT<kIEOk0m<HPI9aB6;[<<^unagXl`Yc>r@+a:`__;ZO>etk&C%+p_qZ+PXBX/=laY!h<'C;/0PP.AidDY)>K+<=j8qMFtMhT.jH<p9]kQcpX!:pN6V;:#8N;g$-(!p+BQbI>>JYo5++A,-.?<HQ8kPdZBX%745%[a^hb:91fX05'qKr!oO=F.gHnoI)]IRqNX_0J,4?8T$)/>Wh[T(Vei]rJ)6Pn'!PriMiYjQ<L\^Rkl`YQWtWX5ffZW<XW_SD'@CH0OqVHL?2KKo.t315=*3rLKqqaf5l*NV=@mte@>90!;.emU9So/27^DrW2f*t9'o#q';n0J<-EfXmuWku^Okd7gQH>[J.Z9;R2(&Yr+dhVXQ%Y0s!E[^F6Ft-?\n-SpbSRiTrJIUR'A-U\clGo9=5Pb(/1kL%fBPV)qu7h*!gQQ.t49AaIY'O"9`%RVsBjnET>3tXgUINngD&Z%nao<G].2-=Va!?b7gf*`tf(,*"'r6.jg0STiD3?'?p6aL^(>A%*(W=d8ENdF/:G34<I*0,^pHd:*b)B#8!aMM.,KNTK-h<\RD7nSU#*crlE=g8I<<`ibonqL;oZbbDQm)ZNm4kJ5=T'5J4oT#G_hmZIu`\fH2<hKR^TOT2:Gq/1>mk!%2j"XS[GBJYQ],lA^e[NA``0CDaXtS,Mlcdg4FZI&9's&)6fKL@qHf<^kl;YMn$d2eR)8MS'q1XG`g"<f)E2DEp`hP!d.2>l5"?n!9I-CanSIir>o.D-OnZ4Zr5_X-]=##A20(B!!t\\*bTW;oMP:>+rEHrLYWRok%_'LGb(ECiWP-8o?O'9N53#K'UYcaWaLGe-4D.TDrI)om8Kbp<`"HJRseJpB?l5lB9i5S;*7A'-.p7:T`1@-5!VXABkLoDQ=+DK/nnlVE()$qM"s^qXa[#cS*l4(SiZq@Su?#GML@!aAnfQEC'^CS/!Cmhd@e.H)("*ee:H\F!g18h]GU@cM(Qc`i)fqU55f;Na";6H&fJ=3aKiDUZD(:d&fE<Ea;A9P%!3<99oZX244eTQ_U<_*^aRH0k8.&E79M;UKX3MU`Co3bY^<'1'pDm>H86a@C/=X,OCBX$c5*rSFk10[iY0iIM?BZ1+u;6&4h\FH1ZMA9F'`N;\JckNro;"LA8:#koc.c?BCj>:#[k#5dJ[2%+?Vq><29sZZ$Q&XW']i=Z8l`Ohg\TQj3kS#\XeIfZhC^gu$oDH79jYC27ljhjsbp,Xb:M7Z!`lm1pIPcD6#nd[1I#.6dl+6P;O[H8(IF\q[a95=$ci8:AMs",5)aa1H&NF6!J\.p#-TL>nf3,(_@p2?5RPR*`2:J$d/Yk2/^"abD5,nr[^"?n8t]K"u#qD$^V#V68,%ZF-pSoUf.6!Ob>cqf#+\8j!nFNTPu]r@Bd$&3:!XTBO+FFJ3a]<f"T"YU+=q/[>B48h4WdQb6jUJN)`*Jm&:Sp2$B9]]$0S1-_isQ368$kL%/Ei-\T%auDHCl?#?2bGr]n-!AJ#3,3XZ*$MVQk5qHERN#8OS&l>>:6G;d1uE>u&W0i$<T/fpQQ-3@\se?6]J*/<fs1tL(DHX/@!qtl@52VO/8,fc7gkl^ia+QsZq.-\F<72Rgc0+rFhj<[&:!ZfV8$Y+?+U=Y,b<88%+e\I),)))D[OXf,6?[W;5&pH]rUss;Db%'BO2]E+Vqp':?OMlq@#"A1,e+oTuZ4Gl'&T:fF8^#pOu2kI>OR<%?n^%3&OAOOS^%gI@pG.cG*#OJPqLkP`G-k7h-R-A*?M$Ys%@.Z:9:&[(DBm-V28N+?@S5Xu?^-O048X)=cNH]"`uJgmZ41TsQ]EM>M>G_i8?NZ#6PJX?8g45DioP?c2Fjdo+8X)2cJ9[Amh>jR1/6OTRL204Ed:X",f.@B]/!/i2kl<#>.][jC\9\DUbNSeE\,m((-sB.hf4FKF!I9O$a+njk<'<m$d3B&3r'[hon@%@2Z!mkulpfhT<;]fs.M=:Q*9g5:`7RQ1"He*M#!WYV3f)Qe1O)anGno'(ODGWILGh!qdadVQIc^(Hl$/$Gb[Q=-.R8<3FN?%1bCKp'QPin>B-o^=>u37j.Q=RW_S`kAtAZ]ofo)"Z0K+W3JcbT7!0l7K780@g)IcN~>endstream
+Gb!l!D/\/g')nJ01"aD&S40OE>unQcE19K:?"CEYPMVX)EF:?O;'Lp)MJDEDIf'X(M39+:P#GkA_mO1N_VoGnS@<-A$V^J6WW2-3J=gc<eN4-i)f?F!\V:JNQZ-qco#F<Z&f@2[$ENoUj7tLgJ`g+KPS:-U]5JQF34@nVK#tXNf,&BpjptuoiU;K1@iTqHP*hiXbrsk[./C:uHS/(cS*@B3U,.DSb]Z*&!aO:dnEO1Xi5;I":6>DD,V.Ji?,Lkp"eK?FZg&unl][C>0eHpdKE:L$6quTd__S@@\)@()HYXrVWMF:G;DjabYEps=Glod,O<PD^mO6:^p6BYa3BZk#cl<18h:fukXtY=gi?f$J#,PD\3&!/d/TK'C8("`;A/.PD]TDeIO.nX=X]Q?-T1G,c7UjN8kVj:?"-NgoXer6Rl4mMafe#B]hCh\g7)4DN\2qP:<Kf-<oNRK:1Isp/02PQS2E.V#)HS/0`<d6HA>_7kE)&4M_tZT^/KmkKSI<Fr`kX5*YhWf6`3g(4';ZCg1,aG[ALW(R0R*^GMr?G5k^YpYdj'r2E8NFY5[ic3Tc9FY?C\h)4=O'\oX4ki/4Al"nW$OMr-2[#7]!c?q+W0*X^/\J.0*^-n^f9d(Q>PR5eUM::.FLk!#qJ)>A"g_/>[sk#,=G<-d5Jqa[M?@Iqs6_ef4BM)XeCQG>WJ"U?IamaaA_Qq?'EhX:XLgGiP+=js_V0QFc0IJ&Qp3,GL&njJl*(hTB5hWI<>Nc)l2%6W=R\S,KVd^eK0B"n!B#JqHGCDVLCG0s-H;U5AF;`=8>E^5l%`)ldP+Fl_7_aP%+8g6)+5#am?)o@b20e"l<q[mcJ"\T7C=LhL_#B4d;=^3QiXT)YW%Un^M:e$^A>?I:4'e"W)$,3@OP-XTH6_uuhF,T3g[kCZrG\!'$#g[h$jU'ICO7pe<Ldl#%nf?'JY(jHJ!5\W,6gB>30O^t^*QV!4U176K,*YWMu"Ga]cmh-&.$dMdn_g7en,"TkB5ZbEONc>9k<\"7r)nkJJU]'(jN9VruT&J-f`cr4mG^]iP'%1]/0%(3aYt#])EA]!Z#hGSaQ6t4?NG]Ts2#9ER)e13M.Y&<Q7]eO\pR&RcitFEGIiB[[7JH#h&V$-EGkO+lE89.qnF"U\$?Xl?<j<C,InI"h+`bIShSR%MZi18hS@;kd':(a8O@$0!NW\p1'QM">LcSd`G>#mPmYc6tB`Gp-N(rVWUW@MmPIXN!jh>7Zb?7H0mW4[WXU'E4fjj_DdSphW;']+gq$o3$>\sb,42Qq5d;q*agc]91]"?/lbJ!legR^9FQgM=,RZA?39G`YUgeAGd<+;s\adV1:BhN,&@+@YGfGL)\&K&U6$)Lc/^)N`EKVb.&.D@mbeb+6T*o`-fc\:'3)[;'R%;*L]nBIC'eNR$dI_MR?eO/.cBR<S/ACk54emQ\$dd)[r9VFO(QA%2bIH2](6YFD\]lQp'@aKn`.[DraO[WCfA^kH.N&B_AgS#YbHH05FPb!Q;&Cq[A4qn(Y*cT-;)k^_j#:gSAKiO/07iu:.Q['34jg?#H"Sb^mdOcY1k$;7keJo%n7u?gpSo:fF7$4!^hEe01@,I*Wa#l,B$E=QXqiQZr*XF.#O]ibMIE2,Q@KF$Bg-83(,a6bL$uDX.e24$(CE2u=]p`rb(H[],OfP\6l-Vo*k5OrhA\F`"3[IZC=kW,&[<BSoq^i:[C&)>dA?VFUfH!aZW_OC/P'QQ5eF)4,0fPV3IA*08<B3<bZlep[5nLJD""M?C?`u]l?JAJ_?pk0<b2sY04Wdtg8<^sV"I93l2&RG:ehK]0;Zn4g:;n*,,fL"9Rir^H8i>d[b+9VPf<(c_5iXM([]Af]LLf5\JC+M))$3(9^")Mok]EF0I-7GW=k9#D)Yf=M]/o_"Zi*D2APP[88oqqE#`t9.8LtWOctN[9dHR'6=5F`RROREYmkk]$<;[RNc`?';MWft`(`1P9]2&Y"77't-IlB\_'5]>*k*V$+"#h#NL9<Jk3%'8EQcZ9\@1=j#`9N:\YIO0$jrc#&`I(GPHr6^4(o5T\P>!!1'i$8$J"oc-`ik7N0@l;T``pnKgTnl4X2I9+cUs.rX-o`"9e1r'Plo'L/Hs<%Cuq%EFcFQ)GRC[PHl=ACR5)p3o1Jmu8i+:[PAVKr<d;t_J%2V"UK?GC'[j3(a;@m<;.?LCouVOeqt<<MgT+No$E<:(K6eH`\7j94H5BdJq?3j]S:9q9hCJAu8(<_D_bK>,]W^4Jc0MTZX2%g8?9Qd_INtrOm*'4n>7J:-LT#;TV7^U;f8H\HCY*25g[l$U^pWKDgP(U+15"a,HHtEc*6Y@Ym#O%WVi$(,Em*^9E$S"6dHSHE332HjG"55M>R)Akd/XIK_#+3)p%m)7(165.;#U87F`:$!Hd:WE3p<O.%DuoKV6Hm;Mp6gDH)"3o.+D+*_QjpV[C=XWfcqiV,"j4f-b4)ZA7H:>HVCYU%;>&h(@*<Lo-SjL<PcCdg;a9qp5=g<(R[[li%5==N1d8MXP%mij_(8.A(ltXN`jX%m[mV&I*Q<l6L!dSoh!M@qr!"i,]"8EiOISegg-@bETi:Uo1T&=CKDTQ;e7r)_,Wk4[qH&\>p$e'_gT.N&<u(V&,bt>k:B=KW58O9c#40=%fM89a91!6ZM@U^fm9`9dH'+DWm4UAR!o^=bQSRQ&#+"(HW=\aD@'o\e_*3`6KAIlH^'I$?/<Ya9DWuj]%t`Z>4aHQi8hWoJd'*~>endstream
 endobj
 64 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2037
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2079
 >>
 stream
-Gatm<?'F$O'n+];3%pi$R5J'Ap`VOkCF>Tk`bsD:g.l;OJgE'=GX4S!5Ul''mf9.3m7OCaA%bE#J,mmn^cgj9`!eGTrjQQk[nGN5LBo+U.thmRA,-/?/19=%_b:gkDCQaJK6`V4dQ(Y5l]k]$mi*G[K*_(imFGZks3E@5i.2V=CdkjLD65XDD0\^&`UYOF5Iu7R(+4)9`9D_rPTIIRA;`l5:Cq($,)n>\=WE0!MU0%4Jf*7!m*C^P+H=bk8S5eJGS9d,q)%n*)*qk#KZr1U1m;jA+In.2)WKlYF44`g4-)5.]oN`MHLHODD:9cGB55qN?u(@e'e;=]8/n_-3ABIA0oe*:K)BaN]Q[V:nc=CKp&WWlaJ)1$.(LL<WPj,P4u_C4CV^@hJaTcmNKP7S.%\7UR]j53,/@DoCD9H7Aar<!L#j6\/sqjBY;I^"R<I;YA$66Y9%)YKOJnhJkeJZ@)RL[DTk'I_;'e9RU0sG**`ZuQ1P81AH/KSf9,AgZE@UL*'P21,cFR`-3c(4kYR2n77oh`X1-Je4VB=..PLhkWI'0:HhFh@H&1D6eZ6WRl\r^JpmOjbpnGJ[#S[*>25m5Kn`:VmL6EOEa],WW*1js.2>1!f+THomZAGnT%O5/=9J/N$0iqXNX/%Bu].fD3DJn`cX&e#4.L<J,OiirS!SG<cb"3"+-WZk0c6F)>p!j@=dTf!S`+eV'0Z/u7<!5iXRJ(F#c*/bq^p.oV-ekk98l@"$;S10-G@DoXWR>!;;XKX8iU-n#R?V$PpOnM($Sk8+s.o'5tJ%7E)>Qn67L+]-Ve#O4Z%uU1eZ*h>`78:bMh_#m5+6qgk).2+hBEXV3,a?@F/4,HEZRABb0'V:>L_k>ui_>q.'<3-%DO]=0gXG$'j,?IUgRXQPF[uAk5uXV%_lT^*JSFg*I?>\1K155=QV0KRL>Eer7VQ$VD9(/j#CTH"?OR]B<e;.b4S'&(:k+sfq"c?TdCZ+jS.R-?#i4]\*1T/2oC)DU]BL-45Fi-a]GPD_nP#*OOU^0kJm"].@><kZdlS7qQpehnRTZd=9Wb`-s!=dDYuXuePKlCR^'q6I8O=iu"D3(!fIAHW!YDBq[rV6?#&C>ARZ(`rCq/Gb>]AHRm,Bbk38>C;Zt<R;@HP\IZ&[Skem,?dXK)j1^o^Y?<(Un/B>DmW!k)>>?h=\;Mu#cfLm.=uZ_R?jYY6l548$_l5l/_q<T<Ji?K.814NDg?r///]R;pW<s8Rj1:Td62bEp'jkj,l.<Z:<JrEr*keW=?KKp:@iNp%J1'V[0"9c_W?gVQt4#L/Or[QC4P1##I*\oZ$WG_scDZU_]OQ&UeaX]!jl$)L;C>cqsPeG'#<_VYf$o<n,ZM@&I#%V.,;'\q2;3m"514`M9A)06srk@&fp@(T&#b)d'qnYGtJ$qhb(bs1O#@F9F98Ja7J.lt@pEpDETV.LYbb0j$fqP;e"/If-G(F')ZD,$SMj,D0>DAk@Jd7feNY,<&L=RAf#]@L*7>e'XX?7UF'?+\k7^n"*d2-mDer9RIjopR_Ggt'Nn\o/&R?!P^$6FE(X#c=SC-2;0DHWd?+X&8G$?%A"6%k^_!5pNah#\qnmC1$Ll2Jq59X,`l1jALi(k,/;a41l"MUUd8Aa]S/qY++m$4HWU3Xo*ia[O1AGAP[Mf#@$XqCKi;T0_TPM'#h15'g)h1:#P25l^a2=lO<a?Y1LO[B5icUV=>YXCA>M0Eg"BFM&J!9<7e&c5J(Z9-u#5VL[^`4GHuiM1geurV</_[GbgdF\8.QK):-t7EdLr9d!'iM0Q=WSWkLXK14qnI@sl%:Wi3DTZtm-aR!t?QQQ1$@'SO)qoGRbC'3qgb$pLsS5-"/T-MKC\8pu@Sn3he#?O)tbqG-YeA`#Z9<hB(!""'7;).(&T8>>1AcPkd?>cSXc(>i&<T<#,E4)MQ.pe3?@b\:%7r+_eVGTte=A@=A;$f+uE0[K0VU"e&lUMm1C]<4;OZo<L2H^JA7X\JiD,!+BR$J%3Tk?2=3F$8YRcfdk;"dAreK:[('~>endstream
+Gb!SmD/\/e&H88.E@<NV.qVqKW4-1PY\m1_U0Z5+`P)a/(l=:'b+_?s9q>Y+,:1K)A6Ep;!,W=dVC@[Pp[DK1;?Uh6,Pj3&"$AT!`@1iI_"eTK[4%Q[KW!u\s.-Mm!m=N'U:/s"4[8RE\G\!4eHF='mM!bEf28TN@<VMHh,?:CnL&M%iK(QR#mnrC1uU[:q+!DoXOcc5p*`].\'l@q2pMcIcuD4Q!Yjr'pe;&$I!GPT"G^?TjGdtJ/YBlu4O:IQp/_Ie:>VXPSWX!`%#>N0YHct/2Mle_\%cjMAqR,q=X,m9_UbAIHj.j_AX_4X?id/L9=TX&XGU*K9&),mbtnX0EinOZ*GD2KJZ)R6.toIC,.<ILfO4MEj;b='!j5X3Pu%dC7K/^u$CL,(3%Q"S=Tp"1q6(I#L:#A#`Y/NcO.XFHW-+)U7^dqVDW#c21*O^.NXI\&/0F$,OspA#M6.S/9[q@$CQk:6'of!hHmRdM1WbtMY$"cpjGZZR8([l^cl"ZZ/qd9cnjLArCsX\R(BG.O\QIE/s3LhdV,_>>5/5I6q.NX0C:1"Y,3,"@hTXRqR5Y[@\cJ@"q??kJ]S"7>:t@3LfMmm"CRn1tIA>-F%Pj)`c$m!?o/q6;k347RJ#EI4^dQ#c#L?K89p3Q)/CVp-gHZX_*1_#uGoQ1C)B^[(oU7/S?jVX#4.uKTY1!H<Bu[F"ncTS+0mN6Vp"uV[=3KPpVA1`nn2!pC7:"k!::[VM*#eIlmlSkcDjWWS&dt!#rbVN]frpSU#"M;fY9g"?BCUiQ1%5#XOqb1)ZHWME?4`,"]B=H(B!?buYYl)54\*(RK98_!>^EX;O+t2qM`T)q/1"kr?XbT9KWNf02U4.r^gt*p$o$dUNn<JOoJ:huSA0D8doa!f[Oj*RMTn#igUHTJ1nm)*83[FJUZF(53+BuI-M7\CU$*W>9ArHG<rHQWC=9ojKGLq)4[TV%l9.e\<JB+5;A>eCoe`1u/(IjIL?TbY*Aa[$/:/\NeFcbkq%TPo\9FitC.CKT\t@j:D_^`t16Tf9JF<%m_orU4^ZUkj#UOHfg@P[iVX_lL1JQ,3P;;NTqjb-l5CKH;i#g'u6IS4pqOjpP@^C*b&>#T<g[d;_A*@KhA14->2-F2koUIaM=gi$Dlt@YB+f7u8=IR.=cDn7e8u2WcO<UZ6%dL8TODQEsL(W$X9r1%V@I9+-fCP#'G2JX6=_Ak7.M_bYRWPMnP./iN\$acVBS=3<8"iYn$C/eY5ts%lg8H>AlHmI,7PYN2,Z;\@i>;rhF!Hqr!hT[1C=EAb4"Ht&lQU*<=P""Zf%'`:0mCoC*^p!9]BP^:j)h\a(p^;'Ec`6,L:MA!H*93NOfjZNoH6sJA=-KQ29eJ$(tk6Wk&ZIqpe?[921aVkJ"JFjY$-q!B^rZj<[gG5&"f1Nk7VJu1)98TfArn#5ki&UO9[d56=Mie5*%MTV[80l?2=ML!57J_`\7S%*;C=\6g,]f!3&\M/Ie\#or3tE@LN3"!3'hDr$W,*8epk^g#MgF%?=d=QOMrH$Ag`WYmW*WnY_'nP>-$K1">q@i&JccT@HL_-LALVe1p8j6KX3,(&CeI(Df3WmV'=]eG\!#Fq^b1?fKH+\%O:FF3Qa4V3!I>4:79LbFisQV"lp!Fs5Da;m2miBRiO[bVX"$WNO9r?0WMh?gcs]Nn7$+e_\MLm:fb9*Hdk'p?1mFWMKWm5G2;c0)_YSs"I6Q]UO@dRU0:>42G>aT(inLUi^?T7]2efgMo^9dc_>WKu\Okd$1MM5Go_lFL2_U;hg7c>Xfu8ZnH,GGr<PlM/P=rS+f<ch6;6UeE9_64oE=jftSd<"t-Td;!@Nf5K`6iH+k!Da)V^4C+Q+O!A1&%`S4JO'W>N!:ra'Vj1+[4;AYd+F)N%%g:MEr4IE&4`3$T1:c[J:6KK1,;5=+2M^%8"&T#dEl;YjIP#pJE1M0Ob;&:0Z]jT25]F0QHotDU44INe%-g$EJK4&cqlcMAAYq=+>ajoM?*O\0&+3lpRp&c2AT%LSmm++9Yih\ZdpdQ8pRoa(`>$mc^'jRQ""jckB1EhrJ!eup=!G40*Hi~>endstream
 endobj
 65 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 932
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2444
 >>
 stream
-Gau1-?#SIU'Sc)L/)JINfJlg\QS6h=on!?eB.N@DJUik2M2b%U,[K%%I\<d@DMlXG@,I?[&,GcYk=_P:?io&3((tk]j3J5M1dkZ$7O1<LNHlR-#(n3JYrBp^s2d)mZ=JjUX/Z&K]e2`?8Vh*EeKcb2gofi8aGL4'F'NTfUC@tX;=`V+Ims@VlQ.%+UQ@mcO5jYpY`GS_(/AA$1s(n7"\Bq2dfc^?5U("H[D+e\8.n34N[H(kI^N8_rreD!k[[:PUbj8O'QV.bYh9it^N8rSDM#gI7,m269b2Y6'[OW`n]-1,$(W@Vce%@.4gK9B[Z<M@qXkaCH,F'KL.d8>gfU6bMMA+!>Omsc^CV`um!OJ]p^%3Z;/#W^)oiBrn!Gd2@>W-?M(LMUW;7%,g)Z[f;db=6YSLiGS<+_UpjOb2=a7qo4Gf[Yh(>g5YsUHlcB_UL\ro'[6Mh=ZHE15o8mWR6:46Ugnl:u(fj"G?9^fU6#slI[-g>?J.]g&=Xq@\R6?A(27]ZBAf9=<l_`=PH`H0##dtVA12[9#XGh@-5&r%i?_]4?K[U8p8Pr8bj_\EkA7W76(Nm?kcQ:q"GpXKL!<8I+"4nh%&_Qs&>quF>GN#',ogKqthAEU>d2g69T`r6IF8lVPH@(u3>ES(WMo\9+'dJ*NGWjLH+Xjq[nGTh-g(!Y-`Lbnn]m(Q`)X6&a'lhUC\jYFT^=V+_&ZHbXb=s#=l;@6GTD4N(OBIQ)cO28ST/JH;':%F\/C&C<2`_h&nH<p'l\(M@#_D;\Q;>^P'o$?4*GKZIOo2Rt]q>BlM?Z"NjVib2'_c=O6:t%3qcr']De;JV?bOKJ@?`rtqq[m$\lWEJb'`ErHE0du`ImZ`4jF#>%PP>HWs1VWb^:CjZYA`UiOn_6<R5I*$KQ>kP_YJa<bVXYL54bRucQW'"mFQQ%~>endstream
+Gau0EgN)>a&UjCToV8a(;nQ&Q4unnu-6$l82tg:P;L*gb8A^_q3$;pro(>!C09WFFUBsr'),VO'kWW[%T5Jr8im4t2B5=5+4jiWQ,L<9c"aQdTdaJ;HHFis!e\+PEaLk-WE@6S%GoY2O:VARm]M<e>3BdV\Og_.QqqiJ[dB>*J@7s@>9taGnIVM9rs$0@ekii<sG@tn0@UZoTmKYiFS7FhXK8?$#g\M4?6dJD7qSuB5R/V7TgV(MOM*kHF'Y2N%qc;)(eSd-X:bol*"?*/C@PHCN4!.jLmG.HU\J,uVT\7)n,h^R^=8:S.(&mmKnQ[`,4o4sL;7&46.$D$KH\)!?T^/-"4KEa&AHubZ.J^U#pM>c:q;lE3KMQ"1P"VsG0lA-A?B&'@m4W*P073i%eFOKH(hK_0opAHnHpO6Ji=jl9`j?G#=j[:p\<0ciQ:dX!_q.4TeV4FFAD%/fbD_d_G2mmTcL,$6"EnjgQ**Y/N+&np=$fJ^0R.@s@\F*?7Yu3CfJn8Ei^&LEm+t5\mrXVmk)[ClrDf0.k^g86&Z$[ZdA*-+;4*N1]'7uZadJVh*#Y:mk,2hkE1T*Fh0O-)CJKd0+O'b+F-?%.$jY44e;)g)%MRK`[NW@h'1Lr%KB.EjG38e(?/Mt+d^>bE6[g$''dY1sSon9baE5H[a1b$If6Q(;H[g]/XJ9Fi-)!m`;ssOnWDDmu;0:r+)YWaqp3P0.@5K42R[V^OO.ZH4GZ*V4<[/AUW5E8iaV'f-e]d.r._2EK2*,Mq\tN$nMX+=H4?ML;'5hYpdup_72d+sMm[V'DFMI^+p,.;P*mepD1ak55fVBE&bc7,RS/&&ZYGWTQc'E,tlVhctra`&,7H"YeoX5B4%8^[/b_s=f1Zh%<.U`?c9eOoq_jdT+a:Y76^hqt28ok?)@)<TRQRG?`<"$R-H[bflj$&q@;_)<Vo/.-je!oc#hb[*SDn>"D+6sZ.PSK][/8WHr!<%k+?`ootAbaX+n[;smZ"2ahP'%STPEt7$.M;TW>@t3@^X.Ea9;T&*+*QP$\\$>e#mVdCX#/n@Ib]D:h]Q_-j*9o\D(b+om?dO+(T2f#Cu%8a>Q8jpTgs!%K'^/Wj7?E.GDmX"<>D]UbpBl"ZImsZ>p1Jg2(NT\\Dn#i<f>QfAD@_?#[CeD)Z#,;Re-OT<5alHV5e`RQ;*'u"9*o)K1c^#l(-p>BsGTG`V]Of)/X=*m1QQB\tc\.#$:-cBg7*l2@+!u@QWHm;-0CjR9E5Q+7%D;D8BS)@70IeZ,mnKg:;]^GX1b$Yu^r9XSJ;n;c)MjeZH6RU<G"eU>0,aBiW[<0XKf5Tfo8dIY<i;JNFlHr0pZ(Orc0.^XJ^4n3l'1agh!WT]jeOA1ENFE?3Fme5UG_6siRe1fegu,rr271YL^QYu3,@"qOZ'O/MXT%r<u47):S`s*DKOhV9+SN[%'GSXZ@t=uQTu);1!^pH]mMYIdj\p*T;5mHoU'?uN$p&o>`tpcVQ0KP+gG-C5_%;-&TR9X1ueFt[NQI.kN@lMQWhYrAj9&MX$^lP[Lf]GNR_$nl:)G]nBM2,_N.!H6iIi"$#@CYQfH1Xht'd*,hk"?p(%>*Lm-,9^cP\5bE>MHI:TcV@d\h;BFN)B<pM@[THAJE*Iro"1Nch9,;O5!SD+iBR4b:TeMcB#P_D<3uj\ZcT:EW59gpVIIjTG6jmjZ^nCcdnTU,ZDU$g(M$=[12[c$.CI)jKjM6NS`_4Xd\"S#5`!_R;BF/H^Mj!T\+cD\ifAOgKuc.sl@m^+Mtb?!>,eA!QRWgrk@4%c,DTF0\RC3pE<bF-TF-?Ff#<AaXidrgH48NC4$l/pD1"=r&+ZG^9pp3B)_X2+K,O"1phmhpE"C&bpYV$fN(5,tqsVjE'RA[3et*-D22Iu:jo:Q,rdoJ*T/fcjHN*ZjQ,2=+"+qZ$nc.875]6uGXD7l[][Kh7#^ZVAJ[mijEjqCZ<Z+oG!puWE7b2%nLLT1@c0r3liIit<6+J_;d^)ecIh"RNdl%]Dg^IbSHtA!KMCdLc"*mhp%eHl`^lsUIgX[=Bc4KI!MTAb&D0Z8r:8+%K#@c<M)auJ&:co"`05h*$;iG/*fikI,H8-Hg%Zk)t%H6(fcYB*_r@@L*bKu##h&lOcbb?g0C=X+kDb@e"$p[%P$I';4RT'c@`OZ7ReOLFQ%6rOm$`?(:S<mLC>\9I0D>[r"TnCH-\iU8oVr=R^/I&Sj(1dJ\`<VcCbVVFo>9:CVJ%unVg%QR`&/`?;ks0&1gfP<ODEK@ip+C!DM&:I%;ujPZ*0hEr1#69G[[2<\gOHR4b5Uf/\*)jL#@)>LRcUQG0]-X2c(,f_6,B&tZ>Z^-HOS="hWA6>4GG1ed!+1BV\Z!M2T*rkq9U\JNdU1.I[p;?fm$2iT(3;.r9]qpV\Q`_NOP\QFu7j3#4@VN@]s:r;l$Jo!_<_EK)~>endstream
 endobj
 66 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2645
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1475
 >>
 stream
-GauHM968iI'#*[5oPHat1/1YoLtT\3j)VH^9'28W1RD>hZ6^\A!<n#?BR]n\K-2J0P%ZqG/QZ(#5bK'U7ecX7!q=$]_#DYqJ@@>EGS`UV_JB6=j@(d"!8"R)[uouJ]pQAdfBuAmA=?3Ml*":=J7dX<P/%H6'%1SRS@uQ5Hk!iqr/N?@0%Ztb$Jqt3JNq!;/'NI>H$9J5;<UHjG'H"&q9DX2dr5qPQR:0,9YjAs+@m1@oR>jin1YK7lmVFf#\o0*hj_3d$9jN"++5)N8u>o#WLnJKjRq`kaGZOe]F_`KH$m7S+07dFmm7:X1.iCF<R*3s??1\/=f^@)rSEm,Um"PWi!3Bt^sh2=+p5FX,W1+Rfo'6)^Ecp3<#gU#L._OTW?@PE-pCuWWUq-S.%(*HGmPuI^LD)2lS4Xp!>qonL+L_c==@<>_=\gf@3h3Q6*5k!@L5\.iu".3g81?'Pc2rXUQO(FQpP_!h=8G,?FK:cd%]Dh"nOUT$IEJ;X"e9Un@X[[?[nJl\p8Wa]D:R%<u44B7;8Mo^F.*/WiK.E3C`5^9rtY82.kGBb4n9g(4@./$fA5.@D1T87b],f[Ijg=WjpHl.OgZ+"[^JD!;;uL2dfW0Q//6KKgZBIj;N&A+:,p&DDF5f^Q1#jcJiF:rLT76nZ/eV4)<QSFS;<VGcl=CnE!?:M5Fdm(#3W`T5a\tj-QABPY@5B8k.4Z4gQi&1@R%`S,*_A;i3=bkpYcmOL@*:AmPQ%_:4B/+Y8'`"[IS)7t/s:1@a0*?8hI(=U8?"-;b\3QSmaF%8!=g8`P'!i.6/$l(G?3hZ&=hj1Ckeq8'Pp&9ca#$e>ma'VSj?_kEF)4$<0K4*0=T[lZ8KG;;]600HM`:U3#$[pte;YEUm.8YSm<YdF&A.r2G6'.fa_UhETJ!k?W[/NieN=eXTsYK+FZX,>YAO#9$+r!u\*`>IZgYl.l&=)25hNGs53=b/>gQ5)_=l^EYs*tGq<`2>JhG?o/4eUU(mU&/G>Vq\K4Z/BpQc7'Y5>.G\Z<k>OR$DTLbP.eG@16dMH@@.*TYZb+n"tnW.gT>,S&j%S5*OB0B1%D&?r4qdkXl@;4#;#ZQUAM+hl\\RSX+3:,QE48?>Zc?=d[Vhh,V*8?2=oaIa]BCJ-=8*tKYR<IR%;+`ZrWWh2UA\WWs/67eG<AujdijTc6d()'e%@CV@>"/W""tb$.MJk*i7DN)ak4hiq5Y8`qW<>*^]>-?*a1>6%B[dU4Fd$TtlQ3;)*^RAtLs[3ssp35,_6[,..QJal'SMMY'Tdi>D(jj*%*7#Mi5R7Y@\dn(R_1D=+:!Xo2`/*;^Fkpn;P"\#gE%[-dR`m?sbUq]t"C:AMYoSmIkW+N_:ClI7q5FX!m[dF9F&!3IL'JaRIR3R5gAY!t*=/^a1mX7_K*ZF1klk*WJ4%3oW+F[M;T<&I4P9l?f7/iG5"!t)H;mb9BCkC$gP;N_c:r&-'Apf!M%>L3d`BZ$ib$rSqkMgFq,o/eMKpEbHLcS#tbFC/m=$WJNp"K"'-F.9QZ8e`DD';f37:no]He0jg>"8alGVa!Lrp42gi63l'Dht)U7qBQL\BGUHnB-QtY&5!2T%[MPr64\\H!;t6gfflo/"T>79o-XI[kD^m+\l&1sjhO(&rnjsZKG"MTI5!ZAN4P0Bb!0cp_;=\E!;m5@W+GfO;cjULa(c#D0<o,!\7ZO0Ce]_c,Drgbs5dR&^/Xfg^qV:*M6]UG[^ktqj17#D]SWZb5ZmuO44$.K$<k;OR^+(I)CX$3h1=1Y$L>,uFUY,Mrnjq7iZ=B$+enHNUAJok""m`jBakpPqS.]'o$i+o-eOl%DACc6Z%d#C]6eVCMUV'51>u6P#HZR84osI`&+;O:@]f15Z&IrEhjb(O2K,,Mb\PJl:(Y-_]Y]q57hTeMaiX)Joll$\Yj,Aep]nb3Qi#Gi;,EAeiUWRh3J.D+SWTt=.N]nBnT,[^nf3GLkj3d;51K=fMu=(>P*ob9N_X4C&dUtLMMpT&B\VR(j4E%@o$e.pgGR<e<MX9"*M^>nlsn*.DY\@@A!ie56*7pSJ*rCIPoO,V&hT.1pl^&P5#\i?;f8PGS/Pdlh,cb"\24,G;HjRao`_sUfp34^>=N;BBu_d6N6jo>[QW;YC4U!ODI3l-aR2*,%grXuG6-1]M6jni,a7.@H[OLLk`MuskXUJqC8'FK5_08?kAt0kg'Z%aj^t1&K*QmJTZ[D;#)bbnQTQWr$+rN3Gg<=(6\W>3MJ@4Oehjh'$WR;U>V!BAjPoD6NPu?4^d5pK.Qb2SQm5'kf/R7OP5)/rXglDZN)mq,'T+PuQt$]>lcX`QkUqB\EG>-EXlN=LVfU&D'uC^A85Td6\4OlTqpeUZ(bWeIPdJtumSL#0&)<Ci]r0XnMZ_R?a[P*\+D1c<#\tnt;=P!O2oe10JL_E<MVQ`'lt'K>?dBE=\Ya[o0#aRE\S8]m%')6c^mJPkOQ4Pb3bkW'eQ;Jm^qD,3HJkLcG<toiTV7iVs0PkcRq@S;>j(gs(.4m<eXE?tP;=AXE<f+R4Y"2(=MVR0/St[fEFIDJ<,E?Tg%Ib#r)3SG$BjO&:R<2ob!?Oa;B_3<rj:o)^F'(nV9m4d+0mhm[a<8-<*WgP9sE47-90YO:TXntrrM_<,c1~>endstream
+Gau0C8TWWE'Y`m7]N`o[9bH16>M=oiP=_6)<c5T9,UC2Q!<rP+dD+!02pn@:=WViF2FZQ+hciOb`=H\^B-k?#93>F4+<E)c5QW<`j]D5aSGet#2mF%MX0as4r%L_e+-)t.@i7fb4X,mk^1X:-0YdU,q[*7sffe.FpfO#f<:IH\3Vsh_GHh!Qjc5_G!#_O6],-FiS2a)&56N?'[9eg<J<2aBn"45`^70s[G7Z`2!%!;llQk:j!OoBSFDNWd7`#GQ"%34:S^\%"'V*ZI'/on=YmNh`R6^TsL*0'Y#d-^MO=1>!%k,SL3f:_EG;R%g;)fuI:Hap\7mTi<g"P9PO:ff0Y1o>r@bQLUD8P<B_&9J/d-Ib\/kI9eE:eMt(`,:^[AY^\4\/DM'h`A!^V]nQD),7SUN5r30G4VHfEE#h_l2L&o;oe?Hlkr;VTtg4X+d^W8h.aL'0^_TqUcQYfu3/XCQn^%(a]ZXJel<HElg-DBqVd;ba(Q22Dj1+MJ_S[Qcak**\,arQaJ^okTMj*bFrLL1<^P@0VBVF9T"d/`d%m:$c:#MP3N13Dq?oOno#ruR*l6aX=="9_\sJNfi!Il<jcWqYdhd.fN5bOFceUBY8A+q-jC`kL0E&+_4H8C$i\u,S?VB0BYQnEm3QZ(93::f=1-;2m49nJ-84^fZ&/+3psl[0"M3VL[lG;$Mm9jMM"]Ai)V%LG$'$i;W(E6-k1SV"0-ct-R#;r*\HC"tnE),Hg5[+uD9&4(p^'FiXE5>[/oAWCnbZjrQ,8Ct(ESP#J!%&pk-*#7bR=C4ZYA257aflKIO85uaY56ch>1M_A1bXfofn;n8)b&r'5oH"!a]ZV5tCSSDd<;_^$15X^`+FsM.&2E`Rr_$mQp<OagOI('`nW\+'@/5XYkb"fFX:C3E+Dhb)J!!$JJm?TIP_VU=H[cp+fTU'#,MfKCGL/i6d02_W?&*@8>@1)b&;k+!WgF]J<=)%F8FaA-n5EUHUkcntP=X#9EDJR[cpA0IH7E8k^k'5Y;dqV?o^uB(q4BW^S(N_i][<0W<]Z<82DdE>aIB:t%Jg'!OH:_/7pd"[t]1Q?<ZOT)1PoHJ)rt+`WG2;de,7?HA[f%!N"O#K3=!_R<"AY7QEDQ3fW9\H8S4W)9["\\`KC\+RZC<`!5f/rj4aO>R-n%TOaY^+=`NIW?"WiHt\shg]5dKPpEmQ1V5N=X\HmWYEnj=!`rD2#EP\@6n;bY&,G,Q8,MnFb(*3iafr910rW%)6;I3A]9A*cNgWKat@KtB$EsuC0E/XisBm,h#jYj6X4pWJ(*oKp=m>,n.4Xqqr`1<#0\2`qilC0VGH%Kjc>P;(hglCM]/3&.k)9eVtbCdnH#qr(+n]E9//lkY&pjT0(TCM"!8[:n-?r]-&;F2K8H!IGAZX)_Ter]\6-qR6(Oc1H0iBS#6_X-N42R$Y]s"!QKL74nVNk[F&h7@;R43kIhY,7r;p0:iB[~>endstream
 endobj
 67 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2055
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2334
 >>
 stream
-Gatm<hfIL2&:WfGf]gT,:?l3h#4A)2[->e?R&2=GHg-Hm(9A]QXsAelhqtMH9W1[UVKiI]lc60Bh>R&265[K<_X_W.!PDXPq,I]/"H+"JUL44_C\Y-trTI6+P@.'OZg)lk*66NQ#XA?X2(e=pL(K,+"N-%=bFj@XoudTM@EF8+&M=EWC',Oc_=9B6^;Jq>mJC;]GSC=VpollL4d[$ZVUK3<L0tWij(JM1A/'c^(iDS3Je;gGb1dtsJp7D9N5pQY>5]i-9CHrj8$@)V&k"F1VSNP$XCWY&#El1_UDJT9E#+5uoC)4C#;@F)1-!%++H/F#@8+K0(Fd5/AmD8lgkZrH:_-A%\S47!%>1'-Iq5=m,V1NQ_thgoVEmn1:Aa5WE*eqcX\rP>hSDCO>&k"=[LVp:>UjR:iS&D5?#,J=UV5.&_/)qV<[M6>%,eh'M7u?`lYn6ZpRsY)4+%N?KuNf1Yps1C>rVn'bN-Z0otB4oJ'3L%RW11IF3SQCh+AV7CEiL"lsJ"38hY-0P]/si.j7\M6FcYh6?*Ac`TC3>JlQ56phmKSnO6!U+I!T\!EkS;<Z&4@o77diUGP<dP!r&ag1m\5#$f:jA;,/fZ91V\93c1`V139HeZ%G5UU.16#)%"8XCK6bGt7^jVcCi&4itR_50I]%pK>oD3hQF\!>Sg2jH-1)CmOo=KS<AUD3.,B#2rc#9n;Uu#%-P78=0I:#Y]5/R0>4EhaCSfR+WTHHt%ubLDJ/:B9$!M1P;@-"+uPV*kgR/k/_f@4)B%EGu4Rn\7Whm'!:TK=Abp?Bue)1.pG0K!kj#^_opI3f9UL8qDO\W!DAB[/X71NViBbsF_<9^DiA!A[.R#&k$RC)f*[eL:RZ`0E1rm\oC'+C4kl`]2"cb_6EP0n92]T;na/1n_j$G1T`s]@\^Dg7NX?g_bd?&o.!6%bq,2+fK`48$\$*Kpat]U:bf)^[pFWP%F_ru#R:G\o:A2hnb5=T1Qnd\jdaaXQe*'l&cXXVl8;3m4-I/nJ6`PhCF&t'[8WHe\N[`8L<oja^Wb9-<>RIKX#?!>f:1RH>J"j9>3O'8r\/cFK;Dc=YFb04,UNqu`;XjUW("(+"lh$D96rP.dCF/NJe1_<h?R>qhe<\62)>m>;K3;IfVd588--\U\c_--*k.VuB#HsR6AdW[T2c:S)0"&OXU-$,`2CD+-Y5.JDkdP65]PA`@j%!j#qAaQU**"2=r"\r4U(+$5.=2QD^/\4\=`98G7_%8QfOVbZ@b&JjB;P9bMr'^^]<S@d&&V?*E&`21EB"<`,0shU0H;/+kf[Vo_>^\h1kH""fA_eBf'+siUprc9&'7U<^;K@H_ii7ac+6o]B5#k0M;XR,X:<A%3k^]@.2o7Hik;RV;Q?8=&\d3XHtgMkS/0V3=OLNJX_C=!pJ'\qeJ[,'Z4n&_Q3s#of0a.%AXd[k8]V8%RHku/qC<n'@B^-,W)>V"O[8V[Gs)YqdoN0IWQ7_;'!524,[K1D9qk/<p3$uUB$h_>_IED4+J*K."M3P-[])gG=s#,TM/<2h0>D#Vc<u8djKRFI#Q'[Mr$*\"EC;gkf]r=AjS,O)G%lAg(sohiAY0_XHj_6HI6=\c.r\^g--?*;?"4clS<qj,j1,#?8?Rs<Ot4q!p4@==iZ#pX4=P8pW*M/(7M%J1-)O$!o&D6SGA*p0!o#4YUC66<1NYq9CDdW3jR/C'jhU+<;H^[7;b6g"QJ/0!*63&t23ZtS0N=d>3>)g.Y--aaDTf9Nl1Cc=iH4S;$qQWNXg`7VOq_'X7688^$^^&c:\9G-;<!HJdWLmeNoo`C+BPqg##M-cc$k`8\521/^947bh:KJWB'K;pW,ZsQ4.88Dh:g^qk[+%*+g6a#4Imf]\M)s^fd[ER[e.\:h)o/`N$3U=a*\/f6!Hkb<ms,:<36847S@t#)HB9jM<h9q65fFPm.m[qTrJ2R8&F-ro$PjCjEn7CXl-XL#AMo[ctrW\0+6k\Ac&%@@!,1A?5hdN/fEJ7X67MY*Mq=+$\^&]?+,FWh*'.*QcsV1l=oo&o!o"=rrJ!Kr@@~>endstream
+Gau`UlYkN9&HA?:ikEYf&lk1hY_ljSgEjgnY)gLi0q_kfM71sUU.3OMZG1j4Uo688A]:X$,-CM\H&pi'mm/[InW2qlF:%GK$89^B0Ft$:@(t[=oKA^>O8_:W7Ns4QTt#C:N.Z'^NoAqsc=m;pW/&Ue@-eK5-&g-`>b&[/,eZh4*+#hu6:c@1ats#I9Y\L;"ju..*;I#t]Nae-)tTS51@`?b3"`Ih,/!c273S2942U7JUXJZ*I4+Yq#smK1PNJipMkeUs==[p8'-fHQFm0Or4+SQ/D]NG-mq_$:(?jkJ#:q&q4@Z9.:2^i5AQ$<XQ7F+;V#B([(e3PO+`gd+13e%laH^HY/@@KI@h(Do/+T8a3,![]#Q]2[$.LFRZ_S-YLQ'hd8lUmO<KX29b!cUmS9MNdM_$OEL.Z$Y<.e;P)D)(!l-GP>LMrb#=j9FW8g\h/$qfL\R*2:/*!>b`3oqZS\&Y_ueH.$FnnX7MjV:Zc'ND,ZJ^i.;;A,>/<!"Gh<EYIjk=JuNO^q]`c0H9:F9]Mh`_O/gR!p-?Ik%B5Gu\W;Y.5hO,[n\CN^'?iDF)K'+A7hW5fi-MM$AaER$Rl>9VaFBnV-$-:MN(hL`[L'\g&c_=2hFe(\CY0d5'34rZTj(JH-2dj"fqp?0EhG)\D_d"euH3bYD&5.WcJu6,hs-`s["#1+U`NM<'aHQ)"d-6W`2j#?nX(B4I;g+d!l:`jH8u-eC#?)6El`M_^r(PC_$(@u[@Qo2iQ3%49:!C]b_US@!joeT2g!*#aW'hcLTK,C`42ib]<X#UR3u#A1%(/hh!t3d.9j2J?dtUYj9!rRTd%DD!;PFO?T)GQ,dd!>r]3).BbfIhiG0JQ=^j"N$4l&I:W#\NkuId4dCCTKD.%gN@a-Gb?1j)%>g-iI[4&L/`+US5(M+W-h0&(XlPbi1BsmPtR.2(a6[WUib\;=ks@h"fP0))2QXgm-bmKL[t.Eet=:/16\6CJm:Sg\4Iql7gq;=@\^JjQ)LV`s+hE04NpKFC7D:RZ.$U;b._e)T$?"nCIB<0EF(.f\nfI3[n'"j!^eA(_7nGmDo->u'p8e8W_L$#Y*PE!X5.2/q`=3bk,;$h@FO5iPcJg,8cm1(V$k_0BKf%b0^`q&he2g9gRif<E`jnP?^1`A\FJ/*COKpCrUi`iM5=LO6-\%cC,bsbmd?=S794W]lV&#RJ%DLm7_O!;Jh*L*h`Nj]mOG<%cpme+qcUa89eKa"ka64l\R'6#=),18]$>;^cd2o1BW3"@YCGK`:^F.8q*lB=MoUV-6f?N>m\3C1$F924n$9"Gd;c@bf-5BC%b)]_a>MOuNni(rh]92>a8"0i^*]=f2*'WSECs+k#/71gXgRfkJG+QoN7qLq#LNGp`['"dmD=A\D%4<UDB`q1Zb:=689_=m$\k+lnTaV`Lfr^B5jYU$0to/_cf[lGgC%/uX9A>.mW4hp@sE_g5/l[-[$940[bI>3^da*K)BK`nAe]$92RjRtFBi;k*_c#1MK?I+ZBdL_@BE%0Ek%oo)O2;*T".!UbF<a393P;kHkl4P7e-7kM7i=sXnZ[&1#pHQJEr`/[7f`5PDSphR`M;c76M2S]tj*A0D"UHQl)a?i5BLqEIDdQFJ]b6TI%kW82),A5mSiSK(kY/AhT5arRjc$D40B+]lEB^jTo(;KHN1n<R%8j)^ZR#qpQ"+@CkK4J%Br<GL^;QdAMf'2P\lq+gsme#a:=mp2U\ioL.c+9u(;@EKEuW!PS2>O\]RQ.*&Mj]hm[n&F6ooEr^3)0UAWhmU0>Tcct\LA<*b/EI&FWYVm2^h_FVP_R@B@@MuA1Z+?AWEI6-)4mYg8NJ;=JWu^+dd/bh>_$^qfbIdk'IXl,KTheQcQt(.t+e>$a(/*D(-)EUEXL1m;s*u\O@*^73"+mL9I=4V`Y6,n0R;!H=c0hCcfA)$l!^_6gp&[q)V(p/r?/iJO$jKVRntJ?3)$GD=AJ]tt<8S[h=,&_3$.;cueh>c6E*KNA/+mppHCFY%GIOg;\@m&/j`q*Kl"s=oX!66iKu-+JA=d)"?;pZ(8^ia:V7=oC%ggfM$WK8bgR>;'agJ88P,eOu.aZ_gTci$/515)*e%'WfH/%a!.UT/rD8IZK*MFLLUtD!hrke]m[sb-JO'e%Kpgr`QAWs1ZT"]O<qIo!pG+l'^g84Y&(7/2Nqqf$\cFl0_cIbm%Rp^(bA-_aZ*Js^fIH7kUFcBnglN]M'Q&U3Q[k6LZVHT1,4ptkROJFaXGLCrs<_kL*'m)rNmkO"!O6ROqPaUb/$032!A!_8NF_Xob)G3mVl<9hUd&*P-V8H:rcrS)YXdS/3Ittp3[f~>endstream
 endobj
 68 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2160
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2226
 >>
 stream
-Gau0D>Bf'd&q9"FeD&DmLr&5BfdE48h:\"8%$9;3SC9u!Krp1`\P$rKqs3uI2@bS-OI].]?pIUq^A@+=LX:YpK`70J!2!?>4UWEl@'tQ)&.Drh!V9=W8#of2#=GtB>5]Q8LSMti&'pj^]*"nb&4U(>5sKD<12*<9/EcL-j**%DQkhU-"CDNcn.Vo&K%4d7m_Rl@+:8=Ja5d-T_7j;>R7-us"QRm?'TF7Q&&N9JK#Q>B0S""5Q+@3Q?o3BBL;R=OWIC\JD#N&`dAi0G#8)p.cTH"ABE_ft4<9.Fr;"jM*qUHs)0F1K#^[jYTnfauDKO#PJk[MIPFRck_1p(=TL2f\Cg&P3pO^lBMPmI@Vs0unK]-;u4GD<$6EgC*a6'bYrjq(8^/bMTdW_W4Y9K&C`e)VS3&-VI9b7qSC]L)!1BH@\mTCVY_8o2dF(T\!\*`tna4s:hDEh-JC(&`<Po#["-DZMBB/Td)5Uq]7SRErQ1br+&4VBp@9m`@#mWWQ4*R(BhY91>_pqY?FTR[L9bY)Q*V7ZaOJO'Zs\N\\=JH<ubFWDUcRKTj^8S+tf;>Jst42cNM[2j%^io!?eqVrC0&c-%Z%Ur80oMuCG$A3gf1Da_8.T(2%!m'ppQ"[hlL1LWg+9S\')l$*-SV*.SBRU1eIKc2plfi!92KsW5TIZ-i!DJ@(CNClp*(@ogID[U/K4^dgS&/Q0l"O=g8n/=3[7rn&QKnt(;&mIda6$!4Z:F]Qdr'`I-JJQp]mIlMb4:-i_dW=LHj>;enU4K!q>*RJ1J*VIb_!4;R0(8aR-pt#(Cs;HZ3Ke>BkJ*G.[V+_i's+YGAATL-C-#e&sf<W5UMJ1q[uAZnJ%@c&u`<^>GSiCW>&`\VG,#\g7R@cbI'ZJJJj*ng2egJ;TNVuAeQH1-3Zl9W,0$I6/(iTJ5oKWg#cJo,?^glQotP%Vp$!gOdrs5LYI!YHrR"3P>U-_#>;/T\N)#o8GDT.?":<)+oG3M>>(XqND<h]ZNo[XJNB+c;Lh0()EVk%\SSFl5u(<tRA[PJ[<f/NV*_CiVap;s3#KAmLVkP:\30[5=ff!8OrI6Ck(>/][Xj)$l2TRnI;:qFCnJ*%.;TkN7t-Zc+r.8D.P!Hi6[M(U%d4nSo<naIr>0M?s)mS4OdMI$#Hj?>WI&4p;o8<P-g@4be:jmNK.rV2P"RKVON)n"AW::u(o3?Vj)WT6'Jj)?ed.QY8)\5CQlNZ[VV4_AXKl[nD5%CGm%=]eM`=0e')o_W?_Z:[)%;",qM?]_7qEPjPa*-'''W`nWe7s!<<)U_m?+:_:+!mKduigAmIk-PmoIGM0B<?5Ni+OPgdJ'79!HIt10dd,&-_ka-=se:"d3"Qiqs8f2b8T'$qH#Y"3.IU0?Nj._QcYMU]SCj]9=`4JAhat&42,>VB+_YQ$`gj&kJU2f'Ps.s'AAP4&Dlm\8H3,_2"p>X#R^7QXhG0GFg0>/J@<f"+_55\T,qtWZjjpSELTgV%SjGY;)0i:41-FA;874[#kAZkggi85'2*kiB10\@`D<^*HJ@&P*7fdKGW4*X\Wp^A`,J(`fTIFp?3IfbHA/eWKf*S8.ZSrK^$:sjX!IZo'J,oD;<IO^oSim0)TqZ&fa2UIC71=<BP;tNM_X`mUC!(o&Gg3o7(hXs&0*tBnkK7^MQFs)=Pbb$T\%Wib"<2N+;Sp<Uh01K\eV^[k?`*'r<sJ*NT-4Q(]\c[_9&l(1l<-C$ioG[PkUerqTI\IAV-f;R`X2/Cm@gelP?"hjW`n/oWH]/=9,eS]OYq%2kH!=a=I[nYU"nc&MErpra?*COln^1;N1ih6?#<5h0!11/!M:'2/EV905'Ybc\.8f,+&IZg5fXl.),3OGP2EN$dL6SK]!G5Hn(Z]-`F\[e'eNoCjm^S:F30K#6pA20=jNSaG0N4FSLR;>;Ct'`NQ*#-Z8j6-u0.?`b+,T5Rcn='pSRPi;,5p-IY@4Vj$I1e2V_4%A2i(HT;IrW1<j^RVL1(Z2-KfsgS'I($Uhb\I2T8?8`$pQnU1Oh5u8X3D4VHI4AK?n_HRrU4Zh\KL)SSm]Q3f@?J]s&r`9I:(:6bqGt\p;6arO`<6K0^B?W\ae"[%7W=V3pNmKUDEh0Cfnn7k0rF#&gVe80CL6MokTprr#@erI//?ErrB`aIZX~>endstream
+Gb"/)968iG&AJ$Cm&`n"@0jU#T(8Jp,cP:Sc,CKTKI"POTn8pSs8+FaLLcS]-(2kKB0%*g,d>o3qZ*iB,Q]=l&H+Ok!PG#@bP)-q"k,ICa)GG_$/SB0rjetSI)Ari@GPhRXqu=@4T6uLC&k6@Hc3/([Zn389]#elo+%p:F@R,U?57M&"ah_]Qp$)dGF1QqH?TS*%M&->__#dscL?J%Z<]/3KXH4*mh"K*E;e_s`QO1@_KHp:F'o0SCDoM;QGUnc=#@"LUlU*k;)$B)gC7VTcm/&Ts$P7/Ya%^ZkSsud<dBIFautrf5U0^[H(+1qq.ges$Z.+N%FqF3$%t13Sd'dQ-&>,Y+tCe??\)H;rALG1;S?U;EcD=UVL(3-/(\#s@pk%B;pDPqirl1N=D56?#Y&K^Ja%[sW0"N(l5@`KVOF4mKSB^b8:]$<_>H<.;a7Z$$2R$ue7XOPCA'g28#M#?[$s@QGD'QU3(("e*hf!`dkup3Y[ZKM?*EQ(la?[I4;%5N20CBJaf.3/;^\?jDB%sm7La+b8P*f.cIGQ<5[^FVe7l'de_ZN:^4Vh60&T_Qei[Sl1!r8D*"D:iV(@cs#+c8p]&ou/,NCN%JS$XtCp@H;gqRd$\LncI]q>+4^Mdn/T)dM$pmPVN':J?)+3_.1na2FW[QU(mYMpD5n9E=BZQXZ^SC35Pd?(UG(4r]U3o5YY`<'G[#f#>$G!o(i!OHS48$7l_P1Q+--?=qQW0@+/je4W)fnC9em'GZ^(2Gn:0rhm732(bM`;%&B,eOc;J>l=pll)oIdF:QP77m_[&`Hn/]N?_G?IS>!Fk<<3W=Tq#L(aE#_#4XE%KPP*D2oIsDtcWpqujP.<gEtu?*LEXm!FY),DSrT)mA]U>2eFaFN3$ET"9mCKc%,gI)N1m2'Tt1/np&kIDeL!VXb=K^L%gq`U%P-#2,/%?^&-[33;BH<BVjUGDI5BDEY4u--ag%9b#CT2,1^YTZqj,f1>Q"kaU4j['W!mXmJKYde;U?gTKd3gS<Z[5%GgR%mDr>RV4MuqPEHHS[R?ug/^ojRWeYXoH8!ag@9/uhsQ_\<h=OZL.Z`fHJ3],CELB7r0hkSHeb8;a'Ao)csE!m2&"i=Uf^Yf/7[[G-eSuTT"nNH1-+Dq5Od?M>_i+T.<b(IeB<HW[!fM"N4gY(4lf_A6q^O8j"e_9So>X;Ui_p.9:2u?(-."_C_<2W9L-g!</K_U=tLl)RT;]$(0k3$'ldOF2/3A5ZM2>SF@Wt^@7&=Os#-bemD'YmnpdfF"uY\JA\-\38C=%ia@ZR\#8S]X&#]Y9ON@sNc$FU5&%%QFOVeW\9P-,m)fW6FJ":!Ma`4:cUhcB/$[p]\iErV_U##OZ(.Gt(RCK8V42TT+:5Z\7XZ0eA1K(Gn+a]G`2(AdTlLt=/i)9#>50I\"J]"rjs52IfG[iNZs#]A_AlQQioD'QD3@`4i%Jdfqd-*#V_Z:R`BpEoI/<KI6nLl,5.@$(`hn+@>dJLj?/B*UN<9G,3*\%q!_NH4'je2[88FC@rSC]jW0B%(5I#^DA]D*;?TNQD=Fm)/0<0HuN$subh9(Qq`'p<g`@UOfNLFLT+AFBmJ?FV5#4a$-nV(HM^8E__fH<44P8/Nhh`b0Z6/s<rZiplSgc2*Uu30Mn2EK25gLPXE.P.)t9R,n4TaObUD^#[?\iLWj>88.[^i5Dfkq\+n;D\P3fk51_/nOi:rP-Q-D7PgA0Q:"WmQRIu**CF=C819fQYLlRNWnpqfK9'SfP&(#;RU[@u6HH+0QBr!bQ:ls<!fL-QBsPh0,r!J#ff5B78K'+RV,#T2pmr:jM66PB_;Nri_\qMtdung,8$<%Z#=aDP%M\i:@5Qd]n)TO[GM/6aZRc!"rT&T?YuHp<UPK\jm3ABR'\BADHX`s;]Hp_Wo4`;YqP*$pN?P0^_Ao+B@?GBqpe,n.[n+b&iWK@\:50a+-adj(fkr-p+!%jakXp!.IudQSN)5l'>j?$(g\^BE2AIRj>74TV2O-]k08-oWa;@i%c"FVZnK4-uG:^?/9M?e;]tPIjeFCIcH8Q+BRJu3c3;4&1@-PO\VNB5Q-AEpR=FX,>q7;A[(:7Enfd._EE3IEiaY!&]#MQYu")CF$#hK)a5.u6r9i&HXUah04hr*4L;OZdj4GaQ?e($BIJtH\c5Mck%he]R<mL@(&q?TGOlfT/Noq+/*(lCfm'73D)<?KG0S9/KX\G-kV=^p%~>endstream
+endobj
+69 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2011
+>>
+stream
+Gau0DgJ['$&:N^lqU%kPTo1Ll<%:m!@G+@_+h$(:C_\h9`qBO@bXf%+I!nbNAD+%;_E_k:J@.3sF&)Hih.)4Vr,^*.;+1%b5URWoEa0NAa_=m0)I1\/i99^0I+#:Rr91Nch"'0JfD"LLhg3-IS2.\E=>"kO7uO>9nZI@-[pntP-Bc[FCmo%KbZ,d8U;9&NpmL0F/T/&%csJAK4)=:fSSm'Pg15?1XkU\\QK*(7l<PIiou0d5m+lDZIZ#Cb[r&0Mr\()Hd9clS*O:;642?4N-7ZM6[Th-eRs1KWZcQiTE3aCWBDlZ4_7T,]nAj_X%5,]]-s,'OV:1$,bH[U:hq@e,-e.pe_D%O<Ou,@;\YqgO>S(>8"f,_.jL@ckE3,lA<'6jJC+WE/YKS9NO)-:[Y2j&Xkj7!u2sISqDug(H4Rp$in`94R2k]>eGQjd7Kjtq'*0Yuo:&gZ"k#-uoC&^d'G.$YBcq^KpI3@>fAN#tiG2K*BQ6R&b1QufCdo'f0@RbpiK]/H#*T^JJ3$WtWOGEug@oOC+[`6RTaX!+M$'>p`/\4T;Ymer,dpaR_Vr<epL'Z<TNj)Mee:::^O>][Z=)#[28(PST3Pe%T#\YbXQ>9X;/Q*4;2jQES+tofCPV`ceaOCWAHa%65GO7a2^!+J7n7?&I+-Oi%D@R(QLWT:Bf23/P)XAXM2+e+o1SM-&8u8,[&]!II+:[j5;mM3.`2>=Si&H6-V&#Utjlca6,\^gN%J,C1&nti^"-BD10K744p^)<+%tmu)kc3EE7][\_)An2YS`7Jen?k<WN4!P%9=sN)74iCKU2MHm_HH,U<l%2l5>N4_:Cl3f[4?.teEbi.i!.,q"@>tP.RrZsbjm`*3[Y!.9P'Zm,c68^6Lr?"@@A@=2'fWDm<8=uM>-(@Y&l,&;N;g2h`#T:VI_K`2*0>89MlF=BGb1\3n,P<7fTJ+M(B;b/e]!S[_X/rBIQhndH;@F_iXPNU=qRm&*d^p97:iO"R1u:Pn&noP8(-`b^""!Z^nf-*S[7-[G<GE(2IGA0-Tq*jO,/-).'20'dtJ^6&#dnBPq#4/ZONX\\u'R:J>=>UsD`Be6CVa339M*ZmWmbluY%TQH.bqdj7jL6Z&4c8K>oN`c[->A9EKA[@DjQeCs;<XJ'&G+-k7k:4,/lN<I!5lmsHu?"fMF_R(1>qdRJP)iaB7.rI\^7,rbqmeFgL.pRHX20sd&X1$p,B2->)8\cU1V@l38U/B:!3rf^jqi=&EiJpneR5N"29":+rM9'/==G6dIL`JCCMAXFs.g&Nm66Ns$D:+Kq\:bI;&CX7W.)RrgYHcO'Wko=T/@&kj@JFA9A4ti2q&8V"8p`qF@Mm7\0$18CW&O0fa]4'!)Ts+'S8n:8FE8<MmTLBS7E691EK;QT3IETt3'D5<37/=3j([2Vb"dVfF^U_F".Rp0^0_8ZXj0:HbFsFc_*%biocpuQDuQm`^Vg!*([,i-iGYmThXhO-_5AR1Rl8"*],RS7CJs;'VL:<XmTsLkOl)k<YLnb,%kDI.=eX*?_.Qd8f)bS+Y6XF]"mgA<;@5)BFhN/q[lt\mkimebDPhdJ(@^@I3MuS%kCm9f$Oo)Gk@1`1r3l!U:jJ`ihE&M-&_GFq3j5Hh[?jp<qag5q>)O8H#>5IDK710s9'@2'3M>8pL5G>_jJ-0&8^0)D)Q^&'a4oR5mbn9E^0=?>9"I/Is7>UJir8:^nEHfoIsLeapBrJYWXGUVhiY-s!]JrS=@-\t'>>7%B]"3\$RBV_!I=tHERF??))pT`qdFWX95Dnd?$dCap;&>"GAl]e&;;1TSAfi-l.(2,;[%XUhqODb1WjN0@h!JA%IR;Ugj,"_<k@%`e.buQ8>IV\kICPeJ+Md9J,\]lq@)S3HokoHBNAs[Zo+Z3Dt'o5;XD<!pg)uha>gs1o(A_9\EHqH0GOFR'$KnEl>n]EBtjQ68*tEQru^MUpcG,Qi;Ut9"2DQ6qso*K_EBhfX;P3"\Y'.GVmCIf3r0AN!jF0~>endstream
+endobj
+70 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2597
+>>
+stream
+GauHMD0+Gi')q<+Z/8=.EG1K/.-^RW:#_[):+rm&l#`dY2_YP0Le0o65canYI273m@S)mI;*1@;&jS!kT7(($eAkq[s%a#sT;H^M),_=!F@K[Y`&,0)&(@k'B?e^M)"Q7R=Ut_SA=O(ll)0s@JZti>KL&"YLoD-=]DV?q"+:sL]pMH=>IfGGoW_;^r&7?bde!dA]5`'4j']/V*fW+M$V'/r1`0+E_R7bsT5b^.'"[m`L<!A.AUSbB#>%Sm%>Xmih#,=Zp?W.il^/[N_,5]8F(p3u?s&W0C(Ss'^R(rrStV(cLr'aV&qu9:mus1ZiD_h89;;m+Q?/0PdO1U=%E?/!hjk0'_5+V'm"^cMUo0h\)&S#a#9cfV]n?Le]P]tmEg_hb>&k!BH-OBh:q=stPD0F8A^%#o:e!_!KsEOJ78U!+Up51&JbMT)nkWi18?0VWGtriW5auKLT%80;>4:#[;*qPV.dM1bcfpuQB9gHhgM4:CAKa^%eOq=hG?l*CIZUChALc"4Mf3Z:MLSe*,aOBlI1`eQ:(p:Nh6a7Xa9DlWNKRd[%DA%q#52e$O1HND,['@o-In7^c&B#f%\Ar+$S$9,3fo*?HnNlMG#V)%5q;q_#n[6MQ(@UB5(8koYC?<Bs4cemS*>_&6'31PY[:&5[54=@8"3I.3ikAWA5Bl!^Fb,6G73!i!D=KRCG.`.-)[u`KshJW=Y/N:GId@sG?nGD19]hj*gR.4@=L0O%f1amC#a_cUP;H%!>SHT$Z-r;g@gKWU%"PB%\PMa[h;b*88iYS?,6];>9grebW#^`)(\h`&8(0%VP:AZPbY)&=iHEq+E@Y&8sc-Ye6cnb-[ZT?_(+k&[l3JU4L4!)<jE:H*,O-F*(g).\-YI]!k9/-i)//eWB4KB_e=.n?,ZX4j38b_`[JpONr#@MGDG3AeiJW=>YUr$4J?02T8`Y%"_3S\6Y<@jrY\TrScfA5!AQ,uRf*4ir7=+fAE2Kp-igrs"<i1K8n*kg-?\<]Nt(*$Pf)Hq-r3<f#`lu@\qC"*W5cHpI*_5*-b"L7I'$qOnbZXl;4$a`oF!(2j%P/::(ot6\<cB6NNk=^&-hN`#PK'.3/V,TVnDfU$!1908e)Z,Bk6OI#X%&?s14];Xdc3m:.c=5FG6+SoBlR,3@+;iYA[m?b`H,R-C"<c3)^e^J;-K2:(M:J:r4FZ`\TaU=.9hYXH<H%R(,EZ6<rV[[Qh#RfUS%]%:hkl.I@_PYg'#-flK^Vq^9n>PBr(=79T.9/5F@.<F*-XVe$2QcK1*O2TDJ-;\!^,e!KPbUiCK3-@Kl)Kil'/C7Y>6!Hg^5p7[.k[H=Scc72o`&[>AIFnP.th(1:(!&Zm%cal?qc00*"j;HWMQ7*WrlS"Lb#QZ>6!8tH:&b[8=Fp[jQ,+/l=Nl^i$,gcoA\LKE1(mc]7<-KoF\+A,f^,[X"$WL\(R1:3L?JpTkIi=PMhY5^e3B@s`P$/\ZA)U)29]jKaS'-Mi#7]^cK&C;>qmrgckD"KI)ud;>/"3K9rl*^mF2NTCfH*MEeK)VQ5$3->gXZ:IC]06jgAP=?pG(3!S__R6?Ea6(ZeP#bg-*rLm0:;5X1j=)fDUbR-f3X82g<-`ST)7U-5-C'da[/XBtir6l3DsT<IH\d[MaJ,f>oeS1q-!1F?I:5jbQA8F6sNsM2o4,en-MHd?->XE:8j,2#<73Ref"tV#G449AB$_7;4!lIMf$XCO':P'tQhTV\"8!T1t;K3g<2!#*h)hB=@n:O/<<<[YQ?pcmgh2lSeP:oekab>bsa8aJ&lFEr0#aI<D5Y(%#sPF'@XOm^Jgl:cV`*]t;=E,%/%_p<>-ll1ue'W=MdcWj8D6p?E^?E`9*AAi;FeFm?+H5Br9Aj@OY%ao.;.$'Z=q,X!t!M3@(IV'dqHGnTMoH2J#7hrm2+a)F)QkL>/'6M'!k]UfuH5H1tnH9WeQB.@=.FnM3FR4=I4i.mDNPJ7]tpul^%2b&5\m^Hq;MYs,,@5Da]7\$FW124UCP-o?tGbh@;$R=c&Q%0gUPY2g5>H@)3C,;^R_Hl2Im%+AQD_>><9ULe$7P#>r7FX0Mh!mt.h5a%GCi%l7,-eIuXr!Eohn`$,KA[W57(nJi3G9C16%<86hnKhbqkooXEX7&*@/[(Gl))VboDF>7oZE]2D5?Xd=e2OBA;bfjla-=8B@d`rNkb-hV&fb01D4#`A4=<T66QlTbS@od1/7NV>Pq()76ULV[,SWn6aC^#3;[ekl+=,I$;'d_R`44tp)H5&<hWkk3P5&!q0Z[<D3W`-X>`0b]W5#Wmi?40NV*h9)R+E?6_4SafF3Pj%e")NV?hU%]<?O8DO%8M)1ULNc?[CPJ8<MU(!YgLn3q4YH_Y?Pcq%[;*HS98/?*=?i#EZJ:Ncqt=/f]`68"Q(N8N=P3YBu7MYDGdrZH'A`\ZkP)XEB#k560]/ND?8BS%e][kgQ*hOZN)-#6lV3R$3*m`$cq*g?Hp"Zm%[,b?;uhjL_6<l/hUE<lMp)Gs;7O[<iOZM4:43g)dqo,=.CcQS0-7P1:4\<id<PO`Ef)Pnql>Odgj`_f9k7c[U]"..p-E4a!tWQTD,&*`F6*$Ad4~>endstream
+endobj
+71 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2642
+>>
+stream
+Gb!;eCNJ7=')h6*Z.#+&=7&C,hiIJ0l8kKC:?'o@qh6gHR"Qa',f,#(*W>lI!$@@t8X+&IR<p:l;8cr\#E,p$+U_!AA*O#W*8m/$r:nP=bD+[i/D"iLFq%NZMm!q6943"E.;I`ZNou23"4'3N64L0QfmV&J_6MO,3DA<.H$9EN,^CL?$?'^jj8se2=\?Gafb^%ST]Y&Im(#+&?OsW@NIF>.L:6,n&YN8g^e`Rf!Zu<0]>3i1(I_igFUd5^*'DP(_Y.1<G8Hlk@D.j*Fpr?7&L)ep%El+&hh($`gIj=gH_mBl)JCZlI9shPRZisN$b5A?$*8`Y/k[fB9n=,6$:k=';OXk;.Ysm^n7%uo7"V5"1cEq[H&%l$fXNqTnO)ot"_`D9&o?@tFq)/l_$@D6f,-1!:=?F/m#rN9qg@u$fD&mb53Z1>=9e\TYlf+TF!`@sifrJ5*,*g=:$Zt;A+TEk#F!I"MUqnZnjma&MmW:P$crMTmECX[*!d!\9fMm`e#IiLgR,dHB.4R7:Zi]&8R<c;'e#k[8bHK,Cl.\6J)uh[L!W1YH(!X_""UcV5o5-57>^K#c/OL1B$eBbqAlgMG[EQW!aMhbBh>+P"I9>?@J@FujA=Z^elX5fS]L#H,V-qJG`>[V7o&$1"%*Uh8Pfa%_<\E'BuId%C-_'_:K\*Q8i1\Jk8sI/9U"*9K!":hPDAkojG*id4shs:3PmEp]>k1KM'RE;_l/J@\8!:U2c(g-TORQu+\Cul$Dq2(oL.u/EVTM#e&V61Li&qf`37StV<j./S`a2$[[mPiD'"I92to,XXIt.C7,WO51RlH7.k4,r9OkO>2H!OS6A`at$)tBO.hH5hJn,b$3fppee=kuU/[/0N8#\V+EQ@Ca;E(TYfWB2BNhYNG83%AhJuB&bEbe($4;DAYgYV2I+!%ZCjC\bO]0rl$mL@YHNuD_u%6J0L_341&D)#i-q\bPC7Flok;J[,9E#&)q!gD=_"o>W=O!I*T!r<?4U`)VPN;eb!G*AO!h-6I^.\Th)-P&<.<H')r!1tJNn.LlYQ;H?HIIK`mYkB?-r@MmuShJnZ#.0&]O2a*:m<.1VXg9=C)ign.qcj274\Cn!7f$i*]Lq>MV'([FElU!O]EHKs,MC-)7+51p(:/0+.7Vh0m`:A])aBk.p,oaG6BS8MDA_==Rc4tfNVO)h0rfrAWE3^+1;C.0J?MZElUE:bOqW\/iJ%VY,^KLD.'tj\l4>o9KVd'Pi`I;>bF[2H2``o9^Z3'^8'$%jb.M"-4t9Q>BICBXk12V8h5P1=2Z!$jh6="Eimot_NpXN2oh"AG1-T$hi:?aC)rrT*1"A`rPC/Ir(re[q:KCjH5r$8V@nOatU)bU[(M,n9O8g;3BjOk_g;3sL?2bPY2af:YGfJe=>+\1si8;@mWn:(U@j+5133La9.Ea3$';"C"LuV^V14^_j'lg<c],K81$`$K\s2+m&pu*:bFZfDc`7!i&6]#A8]dGR<%TCM>Lj$1&>NB1PfokE`Fc(hjn?,6[`(O*9i`kc1iN.:_T?C"Ps15e4?/6EE3g,C@G@)6SXL64:1QH7d/LBWcj&`6-(0'P[_]IO*]i4&TedDi3/$utSF&(G)b6:>m#Eifgl*U!1pepWk\93[.NYn:aK;#f3G\5HRL4FA=8oLZ_Z:=#K"HuF[;^P]#.]<^i*a1,H&pn%fjRV1i(@oeeRJeFS`V#0a2b6K5`8Ee4*9A2dTLJ;dSnqAY/V6H)Zr^=mDSpO*BPY&Aq3)3nR*DmjC(rpe<G8*gBMBe/<h=>g-_k-CCh>1o.\K`JNQDdt[KC0g\[F31Hg8%&2aYYFUX4,!#Se0Ke8;a)a5'dPCM;?>q&6?KMldaRlt#%%:8F%=i4B"ZA(8k12[jDFAELs^ai&`l2Qu;WA6pW#73^MIn'S\k_aEg]7Qa<+[D^OK]Oc5;TU(t:p>;WIJZC!RN#)FopGZ3&k*-uAX&H=`oj7O*>0FmI0=1'TXS:L.[c1@j[0BYrOKrU-%*tg33Y*+tOmCa]occOq'mUAdB*/-jMkD;)l[Q1YiSr`2>#BH7>*i/`"LjtNUT"9D,EFI>.5T6khS;;&oKq@S+igdj90j*I&d2hUNDa/00-3WWH%jWh3.E=\7q&-48saB0##@oFQ)'p#&L2$)4?5=H-$a%d`#Q@VotWXdQlH)PV'X);=sPWBN*klq,3QqbLYuQR4B,M/kmQCnl`Yp$-k"V_*J20dcPRsNJRQF%nM#6BeKGQD0h]`iTS:\gFd>?E4$%#C/!kic<5:LCC6Cl(dLQ@ggLl29^YKpHji']EW9E.7=<U[-^^JC(.7]Z!Y\Dq0?ssd*XU^]kS@*\7!&2\9",70!`<[eD[l4HOEa:oR[<OUffB15]>-_$TBgE=Z?>+"uJ\&b:[K,uhJeQrsXEEnJ['aNkm(*8(q5.oJ6ZoHsFb<ONp-\@q]Q@HRH="4$No0#!-Rnp.I.#j,*SE=603q6/p?r*mJ#i6NpKi@6>#5<En+!Zl)fE5$pAHR-6>4n1R\t$D4,\($o(Rt50KSliW;B.ra$%i"`'Lip@:VME%22U39W>V(Dc06"'?Ll8ifoI-(HUh?`I#G+&CT0nD=b*F[\9ZIj`eI:.Y:GS$9M1U7\,?f<:)K?eD]CO\!G[E~>endstream
+endobj
+72 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2127
+>>
+stream
+Gatm<gN)%,&:O:Slq=6o`hn"n.4KO_0$^8VZqd]GVDEXO84Z,W!X\p2@DBOgi'k(#=]+M,,`5,tG0fTJ4f\iTr"JmUo*XFK$ne\,Lgl`'+;tD.R!jX3Z]f;Th4&DGd]7*V4@mn:OsTVmdk#3#e=E1"5n$=YVc@\^ouG<=\7YOg>B76T?)\:GY=69WJ_=+l]qBH8D,*U21#$M?_L(U#nRN7[.0O.n2BLoA.#Q"^I!L3nbL\,A]mDRCZ4U&tVI;1C^.Ggpq2C=C7ZMIs2Al`u7&"f`)UM&"\iWO*qi;eSBa[<?L!_`8[Q_qK:1kjXWNC#f)9seCOu]JJFeBP2.o;`P:bbs+$$Y0\KufYq>.k'\QRm&_ThSN[-?AT.?X+m2#r9*c[!U=d+3Za!4!n`\cX:>VdVs!l]H49Rqh9(Gj<[_t4u5mc"ZLVjYVW6.XjUtgFsVk%J<A:OY<7#Z3t$ml2G8]QC?nOq\ZSt:ETOtn.l%9pK$B9W\_`Lu\PUKUDM*;@r4FO";&bP_2sI+KeG^"AMBR7FTn>'f@I%@_oD:?Ri!Za\*QJ`]*dinPJS,Kq8D/9Y*M_2C!TlSH:4H>jCI,*<hX3'Z<aD+!Mtk.]ZCIP<Bl1gs'Z./dHsjB@@Ys$c!+'GB6I(hD%d"a5m_g,1"F)mhet$L0j1=X*2QBZ]Jf>9HEk)1P,SgV#K)puR2c)3KYXAh3FH*^J1jcB@8iMYl@*NM\Tr`"0#/C'VA+ATN+i,YZ^m\+1C055<,E<"7:KlAZhP?A)=A\_S=r+mYAK?sI$GPN"i$uc6GhTS_ae"QZh@'r6KU2?mAmo-C[i4QJA($g#nH!5RGCGP-=H3Ean-rtR;V-O9D`(A*XgP\[@_qOT4:D<BOH7nsgG-aq9>UN>i<.%QTbkd<`#X_8r"Y#V<tN@_ld-rn^C0@h<^^SZE5=Fs?7]j7"+S]VYCWJ_#5cuibJ#K8N?B*3@U?G:5f0<g\;-U&E;Y+E1_/G>9(RcS@#:gED:N;<4W>Pm`+#RIZ'DN$]]AnUb6-?liZ2%[HZ1_]%%DET@60j30n(D.3).LI7HUCjaqWl\NrMHN=M-U"rB[RA?Cuo-c?N/5rCpeCk_c"8%As]X*2`Nh1[G@O(dgDPJ`,L[>\[hHjM>Lcb4(ZSRm,CeoV>MMHAG8&O<SlZ9:JWR(&ra]!U8U;W&cX%^SFtr\$UW%5'Ri\(A4jQmJaaSAFXaPnVtD\S(eV4i&hFbl#[i'@CCp>9?8Dl$9;O/]]oN%lEu=q\C%Ng[<0tISc:l])$#ODKj@+(!Z!A-"&b-F)M$>>JF`C35Q\cmY[T5\E6VN-O3lWIG@:G*%'-F<p=>C/o*;l?RAj,%rkc(j6raR597tE\blq2W,U"?p]K@hXO@D"Mp4/]EPQ0*CiXY>!-gNWKkF\u<rheMFhNDFHqHbq'`kM2$+\]WG5Aa.XIE#;HHRq:2QKPMk'c&\SrG2_8<H6'l$7Q+c*8+/`a^naSS(_U5F9Jl0[1Oh">dH#UGDYd;f-Ml<*NGTLEpm#3M:qZI:W'*e8Q:6(&R'Mc<Y&QaAa+!JQ==F=]OI%3BRjS3SR]X'W!H4?R:apXF+`MrJW,UDIs)!sB7_?qek*lPmWUB:Utc");`d/k)HudIXaBRZ[L^:(c4a#%TlMMS96S?7)Uq\iY>0N*XdN$%etm%KHUCsXRHG."l$/9;Lm-6X.?,9Za@1?+F.BBCcpkCi)*@,J\:0*jD*f4hA-Q:Vo]2\8qI9)jC,#g6LCn:A*u(9)VAkt\nicP%J5>/dDHe7W[U4_S^fASK@8A$>ho^_3G!!AXr/+Ef#[>!R-ZQcK5a!%&Y=R*q>:Md#oD#2g0Pou\@$[$:!oZMs[QZagpU3uC9g0^7#H*r&P3ucM-p,#.mnX[g+].6mR5aeR-,"X@0&R*,s%CrJr/@<Pc8GpgC6ZXue*'$%a'3"jN3+=,],5&=03-L"!c_N`bS,]J,aPI'&R&[&;"sZPl6Yl3);K"_Y0RctqGC[\P><fN[d^Wd/qU9l79hZ\iE!Z4$=LMB+@Q0YqA]OKPX7*@H_4-hUJQ3hVFbq^am:#ske8)-5u&,s`9M6oW]e80po'Q`mJ'N_HP]:/.uMB^QY:O*(QQTk[)'l!Z0-k2~>endstream
+endobj
+73 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 995
+>>
+stream
+Gau1-hf%4&&BE](/+0[3[LD=XHYYR_W_K]a]"V.D9O],[@V<,*b(%0I&d%Gg,:!g5#(3tnce\D4#k[XUWqSIX\;K4n2$%/RZiK)h/jqp3)"mn#R[q7bbgrH_h/YVBoGr1ib,'B61u<Xig#1N&>7MJ$GI&IjV"#+(1:Sn.8k9eaBu8^moGaP!`p_d%Sr4-U]>kqtB4hBVBKI8;!J[ua>[9Yt+/YeSR]h(NNpXEDmm7MUf=/WZ>6_Fj/V:B%#&"hb'.2#pGDl+8^aJVtI>QM[a&F>)in.AA\iRbgjghm.0b0=r.>nB0bG<ufr:^0CrkPcCa2N5fa92]Ai$oTQh1c%>78rJ/VXq>CKtsh\\(rr;_fcC`Q0ml_r42kE%jVEe\DK:Wm=".Fi/:VEW]=fJR06bo.QG?sb*Pe)*Md"d7aeF1'9T;>`H$8UTkg9_coq5q*$i2PCSG>C9k?\Z^d<nuel;4)00]f8D*SK%*,)EHRXm$#:3-VtoXV">[XZ;+Cn72sh&0GFGdBK@<'aY4<+A4I.8_;?4;0P[8Ja5jC.1-l`sW-mWmG/X]NN$Dj@lb]IkVL/_7^P1q0(>\HaHO-jKK1F/L5t.-md*BU1F?92Vo-o75^kJ<RInua+]Tj6q4ODPu=^2L-[!%4C^C=U0#eK$=P^@[V*=*,ZSrXV)to>AeQ,=':Mp]e0Zh*NjCGm$:^lgJ>8&ZSt\#U-=<ENY>`-7bj.&^SbH_(e#Tej]T(bPUfp\rM6;^)D"hIa9Ji<q?2YVc^.fs%c$3d\$08Hi>>Sn2AOquK0"Fe>N=dYd%<I6>Sr8Q)>T'<L.rQ%AQreLY5M`tI=_<]IgUXi1)25J@IY%cl$hEi2AGg4&NJ:B\T5*p5AX:#kg]`n#a/jpI4/7D9c;-\g)Fe<Y+(rtI@Xi7"ERH\gbUK[o3M]i`Cs`:Np<O#XFaaDUn)MOgq!hrS],T%!i[8V#X1:r&Nm5Rjdg/R@BrV9l+kndX]mnb)k&g~>endstream
+endobj
+74 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2667
+>>
+stream
+Gau0E>Beg[&q9SYR($)-'$^;"qln-2EDlNVD3N&sQb6-?,U);=,q(kCYO;lb;Nsb1P+k*'#t5E@$jM?Pmi*+:j.@LpO&CM;F1?[3J76<B$&5S80`M,so;fX/W\9t+d&3OOf.=u8>mjt'M\Q[TWnCZF1Vkh\[M1(W*kpFG+(=dYXr,r1bB7.,q^ml^:GDeQo:KaRemQP<JaREcA[_GLT'r/7".G!S9b3l)@<aDPIXd(-T<C!rgU8ukL(kUtfDOncJM1)sE++`h*d70t&'%*f[VLnl$<oATrS1bF%T9"dG:".J)9"GR.[->G>4[nGjgJhUku1ZPlWK3(6T5(uJCi-!+q;'`WSECsm=eurP6>N[(S#&J=RnS,-/(6!Za/MID4)4"%6Ui3&m-!Q@8l7E:da/M$L@U-6J,6VZ=9Y\AW`l%F7BMu.s!,j%#SnfnSAB00P+/gZaa>qjE\uW-Mn&aV?4VdBd;qe/1ihuh=f3ihr-%$>Frb]^"dM&pgBb/f=/Np2ZJ1)p0iFMgNtN3a#((bV,?uF&Y,l%<GrI1L0:MA8nJ$!Aeu]7kXOqT>oV9$DqST%0:9st>Ol;T4[NrtNk65W3GrB!0h=['627"GDb--aj_E48S25`.aosh'bTLCHQCCPXnDD+kDurN]T_l\a:\FLk2>,+\1+Z/VUF%dJJHNV]103-.'HT#9^;.MBiT%t^5E.)U\cYRYp<Gf'e$0#%!^6$q)`41]N'fX<eDI(h[J`@3@:o<0)\9gVB:Ot\l:s=Al=0!X#7Y=P!XpW2LRs9:%oi>(L3WFEUlNnSG[t.()cbJXSQD0?;*-#oK.aXLCpHDAXRQrmW0;DW6u,jcm%[sWfr.YiF^PDtddV(t]WfW+GqpAK*Ulj`#)sn/,De27aO7_b=/N:3$C7k!;D^r9(bc<$A?!D#4H)]LqCr_<)iP@!fWu8u"od\t8E))Zc^F^fKR`o+ns$u.4_4f>3#HQN51:5'`GjaX0MYm&PhKEe1!tt_Zkh@SF$3gPG)(\8I5[j6#Y`Cki$K&YAse4/QR9i2hQ%&2i2_]iOdE<*-AfOn>"@C\4Zf!DWA$>C6X)e0o`qSnJNpEK"cla&Va+DU#=NcAoCi]jW%^N<.&3r_A-r'0g2igOZ[sLeXg!nUC%,]Y2jh_jq(arVr670UlsuQO[F1S%ngH#Z/\#Skg>CJ,r[9&+P6j6F@[>9e:m;Am:bT1]OYLkFlrfZu)`#JgYYhhg?YJ%.h^R/eL[T9*6A#UHCj;6pW.MQ1AdMhK+tQmfdV"PHn_^f>W)!Q5P6=3`n?g>qoUD5c+lZokog"?ER\B;3#%qt)Fh>B>VXO2YHh>Y3Vc\Wpl=Otd.PX<H/mmlsL^WKkr7T<^\!?]Wre;AbTh$R(CT#XZ5+H1gp&MJ.F\h<2`\kds*U4!m+^op9VAiX6G;PGi#.^sG;7NH27#_cD8r?$78g2;;\ZKr;@OM<4(acbj\d.?0cQQ'k$r1pB?8bLIV^=^\TG\uD.)R=H**ObF7:2cHM]Q"`lUqHG]@R3jMQY[cMXI$($mVEQksB!!,[qX%GpNmj3bjP?BS?67a>Wnha7B-MTftVII9Ec]XQ*B1%&$ms3M;e>qaViPG8*XgFpgqbMpMp.++Wh)*;%)71$IL*_"Zu6p!`*3NSV8<pZ]KM4r:>l%I5YqE<Oc1f#;(ID18/U;_?A[%=]+C57riHVN6QUF!!_rL1*PZCe;Mn4G=*&APIu\,6c->^T5tNY6t)(aI3U?=Iq:dY"d--I,$%pT;eb=#/]YTWWV&XY(1bAOdBiP*X#<8V7Hb)2[N.C9%>)P@d*iINQIboJQQWN<F-<qIUK31HDq?eGJ8Pa*VZu?RZAS,VNFh_OMqpa8DAK4aGTtN_/Ei#gOtViYnh`g\j[[sEPNmse4a#Bm/#UkB4:?$VD;G&Y5,+3`6KB1YYAFD8Al"J(WYQ[hf4.-:`Vu^ImAC*\R.r;,ueDcE:ZIn*[2.3O(H&)WU_3!lQ"q=ehIZ`d+Mb?+6r^CF[#tpA7jW+mE=1A"@AO>$-uXBdC0"1Sb)59H)a<ig?+gSMKJ461?utkpDm1Zi5[NAe%ME,8qB)'g`TNF3LnD.m5D^WDoXY&\&IE5q\YXOo]gD6f(^DbFr7[`B!f;V4%:(R(noPnKV%)dn*\-+4&%$JXP;j[!/#*jj*FgX&Hi1e^i4n^HP4NSB9/s]Kauf4Qe4s<<"%fn":A+iROqWD:g;-f::V7@n=[Ui%Hrtj8msFoZ/QA#9&MG@+!)RII%`l7]:u=.fMl@O\QGO*>1Lcq1K;?B(6(b7MAQm;NZI3Anm[Ur+^O,%OWP4N7;m+_m=R-eW,Q#2jVW%q*,FI:`A!i)\`VS[2#EoHjA>EFEuQ_E#.J\!758K:-7uHJ*TYEG_bKi&Y%apE\jMa?4S*TaDgTV9Z8cfiXa&E>.#>_KG7:oZ^nTg'Mr,KUkqUqs%,E50C(KkjYDKHHJuuPUH8E.T1>u*0]PIqE/QKU'1>G6Wo;^6$k*U/ZjZin64UKO=L\eJGFaMKfc)Z<H/+@;3b'Y/1lhbEH\>X/%.aOddnJG418cU?dQQ1;"6CjFR!khrCX_OlAMSm<eKeiHOT(+ceBpIfE&qj1Dk]tFO&4na/g@PMR(($(e;V',ED_Par)`Ium5?$/:>Hq2E5n8<[7C`1!:0Aj9~>endstream
+endobj
+75 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2051
+>>
+stream
+Gatm<9lo&K%))O>@!YtbP:DmZceVNg2P&MqVQ&nL?@&:kg1Dq!.S7VL^L*(eA@n#!-?V+C-Pf!u&+9OlHl1e&DuYkrJ9MC2]^`fK@'Kc_kRCs?$Qg.t+2-[U`#G+7Zf6<b*0$lV&:XVCCLc9=]8q@nJ1r[hV9m!QqW.h7PA!V?'WuJi&J@:i/>fUZnJrB`be?TeUELP9&*@;F[*G.7Va39DDh;kZ$%<A4IklcS`uZkjosjTV*.$WgUbE\r]P6n;!ag8GnR,@Y'3mL'VJ$dB%8Zo;4o*Lsr..'Oqsa4?l(J=n)QZhi/O2QADZ88gf3`>Bg^4ZM^4q!#d=h&MdsnO4+4!8lk1lU(YaG4:dk,kQ@Hri3U\5O1!\OlTeuMC/bQZXSNC[L^WDFMO$M9'%Y9UF=`._6A1*2`I^BCl/JXIfmhtQ%l;iu<tEo.I*i0UE(h:mDc=Lk0pM'`C7:I@)BDF]klK&ZZBn,Ai]6mC8_?J^N@ea6DYJ#eFM\PRe+2mH6,(#qtD_/EH(*f.Y/O"2rA)JN7,lA`9ic+NL;n:k%aB*F5EPTs!;D*W(*295<>aCKd9:Y*<*_IKq&:<5$,5r>At1291^N,i#u4>aJ9X[u\n^V?XL_2:dB5RUDW8=aB6oG^N&cP<<A.9T\?>dC+(p$V5Y"dG3^6=Yg01tjS$,;=hgi#$PE)iC>=$aA?H11bu:&.oD0;S\LV3>KJ+\P:F/-$"pY<F=^RlHfsc*$`?.n-SO.Ka(+?gj/ObV-8jJZeq`_VofB0\><sRm3*)^.Ap96SbBks;.I"[Yl^JGUVgjdJo9T'\%]utVL_-5W!4Pors>+327nd$Q1n1X,urJe]@L>I1de*Y?.X;LnuFlbig3^Fh'CI-')e#j?aRb'ISVe`[N<Gtf:XGK.No^%QFM=:$<*[Yi$"qrOS]fm48;N$G5F>m7so3_`O'?2>u'7]7jIF^>r/=Hb,D?\AV?KAB-ig(6^1\F\7ST>>8j4qT%SL_WXB2NKLX(\Agsfa7LKgQFA<HMj@Jf7A$@4E1)+IhWa5[k]n@9ZCIk[=JnDNF.JsbjLM4,,8DH@!Jm1cE0.VVH1F_<G16[<j%t^9+ZL'^OADGUtLSO?d9f_k(?]m)o?`4[.-:r^J9[^;r6@4MSo12eli<<co)m!gGhBAm[_dq%sHD>2lW+AQd7LsB(+^64DY31S8c`%Q!6W9,1mR`+,5Gm'FA'-$.ME`:u#pNnrG[l)\aaN2O@Es0P)6V>/+Z35_dcP;p<'N%;pK"&5[V+3n\p3GJ%>Wp/N5OW$K.E0ga']`*k0`cVmbn+e.`CCU@cM3J;f9*"r(GZE28pes>=Q?EmL+l8`Z:?1`gK!/#O"RF7Bi('gJmg&Ya2BTO]2+4L"B/DY3SVc)#EDbbi5u`Xb]BiqJ;t$0eJm7PL_29;L<7HWS%U29O,W'eW+KE1G%<qY$L-M$oIntni`>H$^b>O`p:IIqbB5V7im'3@FnHtQ<@IsVlULHFk,&N&j2Sk[f^P&$O/m&Mqq$hf\X=OkS!>*]+)Zt?-^Jf6<IE?.@/k*Ub?+KpXg+FqrVEr)j>agY7GFj"tck0P2"_&)DbWm1,.nVgHNkkE%TS(f;En:?%CZ`>+0G\B<Ets%5.$jl81.Y+d*/2]>g*YS=OY)1&2jM^PTqgG]lZXW<c1oGR<+I](X<KS>&hR@ml-1a\.Lr]??/DTTlcV%&V-T1W1UF>2Y)DAb?B^'Da(-L#0=]SE?N6R985R6eJ-6!2XZn?&_"7gU*4,Zo&tU3]M<e1aUt'DlA(]Pc)&2dLC#["<8"f97J?r9&,LjdG9u0W-heVEb.oY.`kP_Wd[``>dhUVYc,(8,;"^,pK)5N<sQ=SaY0Amq0NJ).sEUVBmEI#3aqN:SVV&o.kn>Il'"KHI`.%5abl<&_hcb]q?&%fHP.`1#K-\1iZ5a"<L]QoM]ISC9Br6#lW5H#IZ#=rs0i4.dl3HYWFBWQF4>2"CRL0Rqds9hI]&@9\0c2S)UZS6b6P4W5?^)p6>RA\QRd.1_PaiS7j=g'U:M99FB6+"J_pDG./bL~>endstream
+endobj
+76 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2170
+>>
+stream
+Gau0DgN)%,&:O:Sls#a89Sq9Ll'%hiM*#n98ojggR1)JM,%?^C!Re:MofW:.[S5@pRUe/e8\eeZEH_*C_Cg!$caEfM1"!TZF[!=rHF-q@gNWM$]V*sKjI_WVBB0KFelfQOoEN5'YX_JRe]&SJ9C5*unYkUgD)&F^>VB^]#P2leL=7Eo6E00Y/cu$,Q="A%X3ph.n=Yhp_h[9crZaF91`h"W!BDBlog\`C]C'?'o8b71hju*Im=*q1p*llTT^.Q[?P+kbrkucj-V"^fffT'cefD6cSdetOqRM*`0(fVs0u3>#m2"oq(:Mf)Q4_;"AYDr:C!'D`UGW]^Xr^sCc__Mr;:dfY]\#1))G?u6a*%93!Fi8Zf:'IYYrO>95OUS>XqFJ[-#\&qBc2I]f,5ki,@</G_HBX-e<r\mP[jet:HKYE1j4UCHcp&i+4<l!G45#Z'/I+D;p*T2Zq)HC;$7=Pft^W(P0d=VG[et&L]X`u->?OPFNnZ+gJIZGEZ=F[3cVdA14Jb?5KX'Lcs"QDC1^;Iqj/h]4<qgDH+HEK3A`VM[B\^a'bK+ROl1QJ7![ZJh/])f<a-LLs-t=mk`$(,_]9JcIu$CMdRu=iODFiNEH;Tm,/Fqb2Z[H'MCi[.f.?';gG-hrI:=[laj*0:LKqS?<d]THbA;K=,A,6i%!2XcJ;tpAI;=6]dZauR)tu55=QD:@h-%WmVmOqF0G6Fq[$$6HbVNVG>T^r4/T>OoFN5-5hd:PJA:r%Y'M*SaE1^8Cpb`nu#NH2`GS8n8eX5GWUa-Vrj>!AQ:g>P;*7l/r.CMo4CuQq;aR?XmJL42C49F_gS`i0nHO/CrYr!^HZBXZ5`Bn>b(GbXpc[_oU$'7`qLkt,P73WkFZ33COU$<?/Pfa+d85*e?YAB59aqD#2'M9*OKku@Y,(_4J%[8gGim9H^Z#'4kJ_M&D^Z[-LaH)uqX9D,r<=Y=.dRSR4BP(5AR=bZDY7s_Hf3I.F;S'kaGH1F&q5^XY$-^KSYaGigr<%0n?Y+a<,um>'k)HA&RLW4A&FD=6("LJ"3YGip9ZlQi*=hpuBBjHoGsAGAh[?kacq/no.5="N@c<Xom#TH+\I6$'(H#T#dC(C/AL]FVY="^JJRMIKT_7`X5?M`c9Y%HSMm'1bgs>>e.A+$+;3CgUTENY$T5ffAD>0$e4/R\TF^6&GDnqIW'H"U*2q#"iBL^o[F]qjOWoPYhZ)*6k:f>NXWo7nr0_\:!eSZ:8V/KRhaXN"V7kCme2]Jo[KYKb:($IQ"O;Qk0rHKXZ_h*VaTT#g&:m/]YqIQRNB4ilY4C*.n*fTe_T%CAScuGt*VK3p3gu%qTJW:\l-n#J)oXG0naqG,&A]L0omIgeugLeBLMd^4WZ:3EQcP(7X0g?=q75F7+38dG`T`g%\@^f1fVMsDF(^VYRZ,Fa`7`+%[%W50&gG0uaeUPgkQYifKHNHjtL:'=WELF.KAVs0Zig0$jqbW[M+Q+-C`X5`aX3(\sDD'=f7fkdFm8lCaV'NfGBg=MkUsQ&j,O*bu%Y*^7AAWV`i3E>0pTnV%4qL@o8Zbee4NiW5LI"QZRVk5M'I(*@=S)Whff#BYO"t-1%,<d%g+1aW0/#Vq?VBHp89m)i+p1[$X5&0MAAQ2gb;QUVaTKnlV#jW1M(usIj,eDU+m<8$]*N_t6Ee^BG/G8[.QTOcPQ*:R8H1RBX`MUJr,8Btgbtq:b!f<f,!"JHXL9o"nh8$SZ,g%5(VI@JZ\'B)l'jWH*U:=6XA4]'D43#sR]F<j1SaHCc#\"D\.ah`(r"7aa\G55*Mr.;EFMi.:",Fi2d2E\5+Ykf"TVr',??Ie@E\@qZE[@iM\J)t^elL`YR24[HM)Q'FYWbK]t1kHI"&hLio!?KH=Q];:>lY.5Hn(*o1TXSpsSIER:#n9_C-8QJ"Z"/fr$``L!A2.3u[LcIo&?&*\2a=Fo'G/)iiAJd`_I^]BeSSkDqm=#`$Z>)\b!R")4G*K5?Tj8'`4U`65dMr:kU3o!A)RbH(H*aaEsLHo[ZKYNN51!$6qiWq+tQ1a/a?gVZ3lNW@H!INebtn*p5CJ']10YOPqZRI1p[q==FBlLU@]o[E/I![*p7@Z`C8'AsU3A-PMYQbdX]_k.0'Xo&E7_gHV^Rk,Ts5q'2W^$ALj8+&AU=7ej-rrERCI['~>endstream
 endobj
 xref
-0 69
+0 77
 0000000000 65535 f 
 0000000061 00000 n 
 0000000123 00000 n 
@@ -577,10 +646,10 @@ xref
 0000003186 00000 n 
 0000003382 00000 n 
 0000003578 00000 n 
-0000003656 00000 n 
-0000003852 00000 n 
-0000004048 00000 n 
-0000004244 00000 n 
+0000003774 00000 n 
+0000003970 00000 n 
+0000004166 00000 n 
+0000004362 00000 n 
 0000004440 00000 n 
 0000004636 00000 n 
 0000004832 00000 n 
@@ -592,48 +661,56 @@ xref
 0000006008 00000 n 
 0000006204 00000 n 
 0000006400 00000 n 
-0000006470 00000 n 
-0000006763 00000 n 
-0000007029 00000 n 
-0000007726 00000 n 
-0000009582 00000 n 
-0000011266 00000 n 
-0000011848 00000 n 
-0000014515 00000 n 
-0000016931 00000 n 
-0000019528 00000 n 
-0000021392 00000 n 
-0000023773 00000 n 
-0000025549 00000 n 
-0000027631 00000 n 
-0000030387 00000 n 
-0000032891 00000 n 
-0000035189 00000 n 
-0000036661 00000 n 
-0000038629 00000 n 
-0000041415 00000 n 
-0000043581 00000 n 
-0000046065 00000 n 
-0000047013 00000 n 
-0000049424 00000 n 
-0000051711 00000 n 
-0000053798 00000 n 
-0000056345 00000 n 
-0000058986 00000 n 
-0000061115 00000 n 
-0000062138 00000 n 
-0000064875 00000 n 
-0000067022 00000 n 
+0000006596 00000 n 
+0000006792 00000 n 
+0000006988 00000 n 
+0000007184 00000 n 
+0000007254 00000 n 
+0000007547 00000 n 
+0000007844 00000 n 
+0000008541 00000 n 
+0000010764 00000 n 
+0000012493 00000 n 
+0000014829 00000 n 
+0000015699 00000 n 
+0000018061 00000 n 
+0000019833 00000 n 
+0000022079 00000 n 
+0000024623 00000 n 
+0000026879 00000 n 
+0000029298 00000 n 
+0000031910 00000 n 
+0000033802 00000 n 
+0000036464 00000 n 
+0000038961 00000 n 
+0000041792 00000 n 
+0000044119 00000 n 
+0000046315 00000 n 
+0000047108 00000 n 
+0000049319 00000 n 
+0000052162 00000 n 
+0000054333 00000 n 
+0000056869 00000 n 
+0000058436 00000 n 
+0000060862 00000 n 
+0000063180 00000 n 
+0000065283 00000 n 
+0000067972 00000 n 
+0000070706 00000 n 
+0000072925 00000 n 
+0000074011 00000 n 
+0000076770 00000 n 
+0000078913 00000 n 
 trailer
 <<
 /ID 
-[<4b8c189b74aa4a0eceed86605b340f65><4b8c189b74aa4a0eceed86605b340f65>]
+[<6bcb2540622874bb493a7cb90e90f921><6bcb2540622874bb493a7cb90e90f921>]
 % ReportLab generated PDF document -- digest (opensource)
 
-/Info 37 0 R
-/Root 36 0 R
-/Size 69
+/Info 41 0 R
+/Root 40 0 R
+/Size 77
 >>
 startxref
-69274
+81175
 %%EOF

--- a/docs/pdf/FUSE-User-Manual.pdf
+++ b/docs/pdf/FUSE-User-Manual.pdf
@@ -2,7 +2,7 @@
 %“Œ‹ž ReportLab Generated PDF document (opensource)
 1 0 obj
 <<
-/F1 2 0 R /F2 3 0 R /F3 5 0 R /F4 17 0 R
+/F1 2 0 R /F2 3 0 R /F3 5 0 R /F4 7 0 R /F5 18 0 R
 >>
 endobj
 2 0 obj
@@ -17,7 +17,7 @@ endobj
 endobj
 4 0 obj
 <<
-/Contents 36 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 43 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -32,7 +32,7 @@ endobj
 endobj
 6 0 obj
 <<
-/Contents 37 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 44 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -42,17 +42,12 @@ endobj
 endobj
 7 0 obj
 <<
-/Contents 38 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
+/BaseFont /Symbol /Name /F4 /Subtype /Type1 /Type /Font
 >>
 endobj
 8 0 obj
 <<
-/Contents 39 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 45 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -62,7 +57,7 @@ endobj
 endobj
 9 0 obj
 <<
-/Contents 40 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 46 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -72,7 +67,7 @@ endobj
 endobj
 10 0 obj
 <<
-/Contents 41 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 47 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -82,7 +77,7 @@ endobj
 endobj
 11 0 obj
 <<
-/Contents 42 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 48 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -92,7 +87,7 @@ endobj
 endobj
 12 0 obj
 <<
-/Contents 43 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 49 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -102,7 +97,7 @@ endobj
 endobj
 13 0 obj
 <<
-/Contents 44 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 50 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -112,7 +107,7 @@ endobj
 endobj
 14 0 obj
 <<
-/Contents 45 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 51 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -122,7 +117,7 @@ endobj
 endobj
 15 0 obj
 <<
-/Contents 46 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 52 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -132,7 +127,7 @@ endobj
 endobj
 16 0 obj
 <<
-/Contents 47 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 53 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -142,12 +137,7 @@ endobj
 endobj
 17 0 obj
 <<
-/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
->>
-endobj
-18 0 obj
-<<
-/Contents 48 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 54 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -155,9 +145,14 @@ endobj
   /Type /Page
 >>
 endobj
+18 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
 19 0 obj
 <<
-/Contents 49 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 55 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -167,7 +162,7 @@ endobj
 endobj
 20 0 obj
 <<
-/Contents 50 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 56 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -177,7 +172,7 @@ endobj
 endobj
 21 0 obj
 <<
-/Contents 51 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 57 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -187,7 +182,7 @@ endobj
 endobj
 22 0 obj
 <<
-/Contents 52 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 58 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -197,7 +192,7 @@ endobj
 endobj
 23 0 obj
 <<
-/Contents 53 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 59 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -207,7 +202,7 @@ endobj
 endobj
 24 0 obj
 <<
-/Contents 54 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 60 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -217,7 +212,7 @@ endobj
 endobj
 25 0 obj
 <<
-/Contents 55 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 61 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -227,7 +222,7 @@ endobj
 endobj
 26 0 obj
 <<
-/Contents 56 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 62 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -237,7 +232,7 @@ endobj
 endobj
 27 0 obj
 <<
-/Contents 57 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 63 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -247,7 +242,7 @@ endobj
 endobj
 28 0 obj
 <<
-/Contents 58 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 64 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -257,7 +252,7 @@ endobj
 endobj
 29 0 obj
 <<
-/Contents 59 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 65 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -267,7 +262,7 @@ endobj
 endobj
 30 0 obj
 <<
-/Contents 60 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 66 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -277,7 +272,7 @@ endobj
 endobj
 31 0 obj
 <<
-/Contents 61 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 67 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -287,7 +282,7 @@ endobj
 endobj
 32 0 obj
 <<
-/Contents 62 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Contents 68 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -297,286 +292,412 @@ endobj
 endobj
 33 0 obj
 <<
-/PageMode /UseNone /Pages 35 0 R /Type /Catalog
+/Contents 69 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 34 0 obj
 <<
-/Author (Hunter Rogers) /CreationDate (D:20260816011326-04'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260816011326-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
-  /Subject (\(unspecified\)) /Title (FUSE User Manual) /Trapped /False
+/Contents 70 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 35 0 obj
 <<
-/Count 27 /Kids [ 4 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 
-  15 0 R 16 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 
-  26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R ] /Type /Pages
+/Contents 71 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 36 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 679
+/Contents 72 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
-stream
-Gatn#c#VMl'SZ:1MR0*a./LDUVG(CGL':s+^r:ngg<q+5amf!Efks-."'KkYa]I'(T?b,*!sJjDSspAfOlC9$^c9aoQm<=/'->Tc&9TKX;.41o`JIDPd/kC[^C(ua>mAOZLYtJ#`+Z_g4^_P5O*P>u=n)sc1Xb_XmVIrIRV;6"Mk,8ci[!JLJ]'Us49gWgA$O$o((lCiaL2t_,[-pq;NrH_>Cfe]L^qf_>"gn4e_$+QE>:G&6UXnCJ8c(N:>_\*U7o5hEc<$-&i;RimAu5;I!XSoTgZrk-+dMm?43_OR!Yq%^-5unnplqkN(<.'HuF3WZBOh23fdj\0>,JKj);_j9A&16iiIhC1"r<Y/@8jE?0e$T#?1]kEWs.K&]8[^mE8YN#]"0K_%MuoadD9GD+iVR8fOL_\;^IBas\3EL6(@b>=E6)[`XQ<(SS0YibWIJ?!Xp5.c)M"VlGA]X7KrPk=?FEd\Ic>h(UX-*@eV"1LHXL#)U\oORQS>WAfU-Z#t''IJ)4Q=<(%8n"%.'&#Vc[M-d.VIcn&WTW*,]T$/hA1frWO'U;$Na^1oG>I+Z0ZSgUlNO]NDP%4h8eI+0Q[W7)<`0FnGo.Mo=K/C"(AP0Wtr[pn;a15U-%2(Nh;ocQs^T;deGc[p?\^<,u%ar?g0?0chlDuBdIa3cK!CXK0o)~>endstream
 endobj
 37 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2252
+/Contents 73 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
-stream
-Gb!;eD/\Go%fW&,_(U_g%Q^cM@OI)O/\8:UTSI,cg2mi5/20n;-IKbo>Y/f\oBQpOCaX)J\F!jY].\;DfbF7DHq5smpu"MIs(4oSh^3;i(-iGJA-tWh`A"iQdn0#:=0JFVJ<i[tF"\FW_^'iS=#H``SD4+-^^D:m8_OgRB@g4_E33!RR#-\85JuP$9\trBNGf#@i[*"KX)R)V0-(P?BE2A-%$N@K09(T,:#PS0c\pbr-es`%lm4A;@5.2a@=;4m<UWTL[b%OFH6K)5lG\i:Hac.Vi'_i6G_,bdTe/H1I?)W?#Z?6u$j_dj#;h0n)-e&V%-AM_IbER3)(+4=hD"GO;%g\)lP$l70QJ3?,._)GIkp1*AeiW($sTBZQ)nAnj:W;?"Yp+FN#,*l*#3Fd%4_c>&fBCs[31a:6St73KR7V!^n>5kK$=i6qC;5#N#>#:2(#P9[+h0,T.+BGZpp/J<Xf41!>Eo*;*fahQE<CkQ7[Q>94U&AcTb[+9[5kNr-EP^C&IY`oY\fJ5J:V<;m*KY^VVZ.1ImPLb*k4XojrueTbJE2bSX<JhG`'<G+:V"[o\1/9*)<;f23:6J0Ynjhf(%[_On,SU",j$+1OjZdZl'egGGcdrN4<X[sA"W+AEr6?OIs1S&0)fKP'7/18/mUe&Fb),:;fDa(Gtm]nAT8LOM5P!q1KLd)tZ9O)+qnho2a,C5.Ju`\eH8TEh**R,"C`f!.ml#\cP*ALT&m4.JAL%fSX3>N#h&nQKn<K!EOV9\Bj)2FLKC2CRL^i;h)QM7b!_/j,<EhhXcIquCu3^^\I&<=*\<7&WAW44H=nk<uCZ.<@1aAg!R!0ghH)"A"Za:[VqB/I6AJ;</ig-Xcoem'(+K$4k/rk;C^eJomr+lhi8])sh]`,C.%6KBG5fGBkj?%Tjefbb-lKbX'7_]<dRqs)=<n!o2$bh8T9-b8kk;b7,6.F;$B)@MY#ZYK&3LLKQ/'!19=+2i;/N\,e05E"qgG'=e=U"26Wc*04[6O5&=?`2O-4@JG.ZU:nW)Oq5nrfi#DtMHr[tam4qDpDVRQ5(HN!kEmh@U"Q`maqC,j^]eP>M)X/-!nYGX!NlG,].#ck@m#"9m>7U,fPYmlHgBU,,AplXg0Cd`%$cV*EB@_f-6T5-k1Z-3Q)oFc>fi-qT$4La9nrZ*V$2I6@)eN-7`,\a#ZFl&%mo`b8cUdk>TpPh+XusSr8Z>gjPo1kdT^mh'?3h@'9/0mPP]"EVsF:R7HrbZ`<K@k4E,/&6]f/4Vl$#CD-laU&rDOrRG@V[,:_FHQk`NC1nAro9&+)2VB+NM#".R+K3,Wbnc9m4>d+V;=Z5/ljm<^X2@$ZOS6pn^(NsfSS/f3$[?;%cJPBT-Yl^d[)N0Pill(fshH!mTG"4kF/(:Y8W-$"9@^YXqW)-Ab?pKUP,@M;;3I^JOf1J5/m;%O);P.g-(bAhCARSD6ajs'DC(H)TQibp9<iA[8N/$Zgpe=tc+JUuA,JRI*-Vlsarp0+,<X+QI_6pMN'/_McUprcQr].G0[62d8SBE-=@;)Ej,hbNa/=B[T.OdC0:'E98PGaX8Y("gh;mC.ImrE"W9R23TPNT8A.:F,7N(2Yc>FjaG]S%aX(O#TF@VXjSM])l#KD6d3>S:am2#R%FViQ=t?;@(j.`5fd7&^TioPgYt%odqfJo_%oQ>4f)Qj\Q?./I<6fgVB07tdB4=e][s\9MXb09\`G_PNp*`%PE-q)`VX#+`SL4hhueK@j$`njDn9;&ToKUpL+D_?f/[a@kGs(]i1T[gu$ONdcCl7+_uuS"3GJBT&KH/"0#^8Ql%\.J?H.;@'t0K8O-`%@Gu8oQXPRoG#_aAr?fleI1<i1FBie\7KM`(th2.4n[Qbre"kWIJ9C;Ie<<">tt[R3^C,T#2p^3n-%mp$8Z$LEd$Y[pjl&SPZ<Fb7he2:JnO_ZUFiWkL&)'eMO!f,Nl&sf-M.uekQNWI#Eq0roMj5bf1;cCi;7gQmkld"m,gdr*G7d,odQ?,.MT[eU=[W$k=3;27iH^Yh'fAH>V05ks.Bm6R;o(8<2`Z]Nbf'>H>:-a9n%GLq>\\d=)S#hZY<B/a,]$kp)YO;q-FU9K4+nHq\Kc3mSL#i#5YT84V6.b=VWsPTKO.D'2hks"ioDNPE!#$;6n$$CJ=u`Fp[n:K>9QJe0\_s%Me-74>pO88_^sr7qr?2aQnjN,&d?%3o?"=S,,"rCI],,>NM`f&in`H#,[@.LIOJM&a9/u[LV(e~>endstream
 endobj
 38 0 obj
+<<
+/Contents 74 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+39 0 obj
+<<
+/Contents 75 0 R /MediaBox [ 0 0 612 792 ] /Parent 42 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+40 0 obj
+<<
+/PageMode /UseNone /Pages 42 0 R /Type /Catalog
+>>
+endobj
+41 0 obj
+<<
+/Author (Hunter Rogers) /CreationDate (D:20260820234331-04'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260820234331-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (FUSE User Manual) /Trapped /False
+>>
+endobj
+42 0 obj
+<<
+/Count 33 /Kids [ 4 0 R 6 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 
+  16 0 R 17 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 
+  27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 36 0 R 
+  37 0 R 38 0 R 39 0 R ] /Type /Pages
+>>
+endobj
+43 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 712
+>>
+stream
+Gatn$c#T:-&BF6%`?(3a'I4rTO%q%IUlB#%)a=<[13Eq%/b!<Kp6>c#r1P#N(^;6$C%nP*mLC(#F(+fJ<</(/4A7G:!pLUW7240/GYWm.d!^`_Z_'^X*CYo74G*0%(NooK]Q9#;7)XDPi,5i*4N"H?)Q&qXA`Z(NmuW")mZ-upb)p[cfS,BPTf>V7_uRb'(l?L.0oe9<?NRS1,EQb18eIst!Fm9F]!i:f_9<n^J/4W.4QPYsQZa-+q_g^@%:EuX\'re>L>XI%-3OU`!_&e_kh90PSp5YDk?q0-EKf/_QpW(.K,MR)DON^^<Glf^_I-@ncSr.[1>A;-[F-bT2PjGW/p%V?F9u__B*>]JTsM1@N[8cuUar"rq>b,Y]3*YAGB:OrA2bsW#eM(GSVbH@9h'rnBq&9JBo'I.deHaA*9%RNE'Bl:)BngBAPCfIkbNW)Z4XCAY=h>&B`jrOjjn)1k=_]P,FMRt0$G?+$nn>hCaKrmVAkZlO@4I%'&k4*BX-A229J(@lTZSKfhU&A7`di>82p`OjFs%?$Cs2.-<aF=-AlX$>+lHVUdICE0@Z`@=UfGW(0\eE\.0/uaUg/M$hI;1e,NE[-t'\kM8,%>VD`Y(kQ-SHWGLu+1X/q#;S\Kr$se=g=DX';O1e5d<kD_8W.-=?K0"+9_G7`h5G\.;n64G@aa,Y^+Jh3k@_Bjpaia26Y5uI(_Md;V~>endstream
+endobj
+44 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2414
+>>
+stream
+Gau0ECN%tI')h6*0jfg<JPD&u-q_/h/_nhc>hF>S8hUMc#hJ'/@SCbV/nnPgp%QZ_8]fP9[\G$c8F\DrHfiPrfqh>Ir,^-_d>[:u&KRLSjE`X$PM:/)1qK@/dD<;El;$OGHtuhiGPn*ukkk#EQr!J\\$Fk7*KPT/Xj*ecpA+QL5&6S8V8u8kr^<Nb1j[(%<o+./I0YLq\%J!HS8^1Or.(:KK6\W#4kC/?FS5&%:Z!7)G/R_5l1\j\6-s`YeZY4?%mFD_NGB[Y%(d\>Me9Ke"P+9i3j(Vo4I7Z<Iu_i;E^PSuEuBn]4'<7h2PKG'jFrOo]`#3$+P_-peUVPh*VNcbHJC9U91'X!fB4@_*_d;BP;7t@(#i8/>,[V(\XJYR.$Z!O/!6X<&hsqn10o\mV*a//]uk9HAJ5V,MfMSe8MS2T\VP.B6rM0G`D4Te!ro*\E=Imccf['OjMF/r-Ge!*ep3OEaAan5BdtJS=qE"oh>U#J;T*[&rpK&^FT17tQa<_'QX;@?hjqFYbF-=+:3'Xeh]@T*G@AJC)V:2<W4Csi<MjIWMF-HoT?Cg#[!SL;pA,eRpejBT)@s'pWrVB'3.@'$PtUr]5rI/,EN8>.-J.M)Q3L&%GKmHi#OgE`4+FkNprNB]pqU)krbV`plhKuaWfV+j4EX[aBne`6oAO>S?gDrB05t1ZTt8Y(lT!F[L,9po?/RK#"c!PdO=$B;k_#SN*J.u,.f^`k6b8f6($B4&E.^IGn);n9hZJn2Z_U^MV2DgN,%^@gLqoXJ&o^t)!#[#NijoE&iR&bHMg3akpOL9jh4Q$dP,U/P_OS!CPBm=N:9k&J!*_/m"[u@P9r,mX"sf1t/,+F<Bo$4YQU"8VXakQ'</2K<d-UI,2pSHrcO&%ZWp0,YN30]JYdNTKJT[Ruf\b5-`dPY@-l%G(9jaq@4P?JkF1LmLH`0PerUGe/3<(8q%=)F:NC:t>2.O((ef,**O.!HbZc;PW0KX\2EY0%NT^XB4*&BcIg7oj0J8\R:N_r[GEPn>ISD'&BGcsWWhhb$DGn6Xk[*k5>fJ]^Xs7MT@m@7-mGn6*b4-e3q/SM"5MYUKaW0np+[5RQM[Tl@b7be3p3+XFSdal^r$b"0K?FS=5O8\HK+I;)*(q5F9-C:b_L&f=#\Xp)=e8;:'hrcnQ6N&^b9>gNDWEBo'+SeKrLR]`.[0.=:;47J_=G--'(D@L3<fk*LQ]6N++AkumDF.DPKgY#,h2*tF\P/F(Ru!Iprd8uo2r@!OVDOuDQ#lQL+m"l`$0!)%BqrJOS-u8oR4\t0:<f02/7aEh;`QJ[h,4hd;Yg'F$Z4Z1.5E!2;\<$4.!2p3%Cpss+3i!187o/nrbt=HW@V=SX\NKUU)=\e'(?S^9.c.2>"n#@P^mW%Lj)6V5(Hpd^,"Kk%B=2[<uVWT951@$jo#)MkiCa_oEp2`Kn0/A)Zfp:*d)\_5<mjekSC)oE$P,CL!C&6pNp:mB;%=2d)O"qVFj4dR]9B,Y$q^;3BWi\cLeQ>^7I_:<S>=OMQ%LcTk-9.k_(_O72,TfP-MlS/>f=A7(e[n0!#NJCht0Z+U13;VX/ee[.o]mYkJ'A2HJ+)?$5SU%KhVk7O^`RD"rl6?4*;Y"]0KWi"Tu6QhqfjH`,q=/FT9\J)mE5j^8Oh2d>dRK2_mL)FCf>fDU^6^JjtcQM8`6lgtpRq1?eN6,ls@)P^Pd/!Csk0ma#5.LWf2W)At,J$B^cXI**/(>K!q0_,G*Tbhm0TZ6QZ6r;^29Ni<f/SHKnD)2U0<FO2a?g=?RDKF3),_TiKRN3m:O,ZoN&e/mE7Qm-acZ+ENI;ZMF&@@Z3"H[oaF=)lEL6fBU9@ko758Ih#W5]6MV&0>l$LhG7e_JN.T/'V>!%\AcTG-<Q>ORZ!G&K\r>J7SiYoLMA1c=T<\c7muPKR6hB5P8+mcKi,RS*2&!b0QVPQ\%U,VpBn0<RKq9sbgO<h!IHNQj7bp\_KBhZ%kI20r$DpKVnMgYBW'2]oO'r'+c<m/sZYIk&3MgVe73_;8)[U<1#>Ik"Eg8mi[-li`VXV)Csifm[i//Z?h1UH?+;meVCmos!/W+81Fp%gP>kJq0E;n@[po`AL'!O)P;4No)t!>NR_-f1a%s4qc?iL",9/Ie]<%m\ST:NB]bM4qjlV4D/&q@a<Yf&U'ZBGRV"==K/r6-i_!>f4TIO0U%u+e&*Va'ZeMNou6?oCYe)>p$F,FJ(b_B0A$g=^9_))mpjE9KVhYC`RLpfAf^E&bS?++R21nNT[+Hj)*YJ$/((rh<<r0mI+nL-G+hH<HAhp*Dm?6\BET)cDA?9T'FG;RWEabLmPQMCEH@>e]0rkcXYsF/"-32XRClXp[;I^RK0=Yr61XN(PC-t$n!69X9GUK6Hi"eR"d6,:Qg.SiVZT!T5B>r6mJ~>endstream
+endobj
+45 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2540
+>>
+stream
+Gb!#]>ArQ1&q801R$Yd3MiFIC/G*X0a^SJPRjJU\"oL^1[&$/'<DlHSIt)(/M]L!GikQ'nOHi.i1\8k^ZPJr'A*JK<%,g^k0!6b0CmZikEX`h^'=aR(rH$QV"GTEN@C'i2Sj2ohfR:mW*O$II^1GsTfL.<DdFJ3O-/:"'iL8jC97MNW"&+1jEa*0=f/JdfGKSV8bQu3ug[W&bOI7-Ie$Z9mLYH`[q"=5]??:3o_fm7+cSLQ#o2c9CB7D(p(SV)1LZbB?f8[!8'"XcNj221>cQbP4IW%=+N^L^>F*s/kQG9#ZRS\uFX3T4pZTH.6S-&2:`J5DSQU5;c/G\:[8Tn]JVA8qCloneA0E<%XTI):o*#KX&JLoe9\l`!j)l[3Q^=^k3%J+fAI<^Ca1q9W<LTdMP>k;hLbnk0Xk+d*HkO`-XB1pbU9'qC"Xm5nGla0.6Jo-\,4MlMa)O=lY@gAmW?obSRd2EO2Q[E(u0Y2YkEX`21*ncFg>#^UEWaohd(SG57V$iZ38/$\8!LDba;5=M*)"=Ld<Q;+n6p[+eQ/jHO3BFr3;il'r%Z<_D!ah&)bdN/T%OOb/MIIVi2AA!1,R=9:D+pS_+5O4JQ"3:.E@hs+g$eEiZsZ"/F-7FJgg=E,bL]@i@*,F5?:hZ'W:8<L,-E,$\88OHD=ao98Ff*gZHkLC)-84Mn!K4c8lRR_(e@R(>9D*J7<hWQmupK:.'47U=d?:Mb)1:BYVK7Jr9nhorbP"DV'9A[,'!`1+VT[<.UsWen\X8^:?B.RDJ%P?r0mc7"K-F]M^ob,]*;^>3Wc4X)P,H^H!VMWa9t]e4H?ULF6tg93raqO&rE,`JkT.$!p31..!T&;/]l=?BL0^9\,h#'JQ6K^:%uSEgm*HXA@I]IYOsZ>=[CEX5P7NVH^jeJK[]0[7,)X:ke!"CeXdVOf[HM8f2W-A'qt?<+mAXpGj(1Z<pVF2*UJgZ%e*C?dR2Z:bTD(/_Y7:Mp_<9D/3%snK'1PXJgn[^7O@>0)n6pGd3O"sn24XT>c9E7qKtJYMKhl&FcHUbN6+ScK-Au<lYVoR#s-k>W/fQaW1WFd[`h][6Flm69"'N"X,"3L/EnOH]dMrBK%^)1_\Cm]1Af%@?+^`RS<@'4GrQGU\jJoTPoQKaFjQso"eq#57#t+Fb>Q,X/<d^ZPtKZ,.Oif1lG_'p?\i>`gR*inO>g?OSL/YED@jP(PMT7UDafAcEk'GZEXhs(L_mJ@-j)s`_fVEmP8#t%<u$q+L:62AU$Yd0W3Ej@n`r2tp<\!9m3Sp'mJ4A,]$6g8H=er51Z')d!ch.]p6i,+q(p"=-`ea7HfR4)l:cb_"j9r3a./u;]`&AE3pCLhcAGM1)K8X2l4CL.8QNdn$2FYILRD+L'Lg,qG7:*RNYEbC-CUm;1[Xa4UB_4oH=:"_%OK$%=`GhGR+.]WFOrmq-l%mUQ=La5^?Ba9(G+XtfLE%;F<4)^3NA$OLjTc&m2oQlXIu\tr@3$3b>MOeMHR[1*heOhW)bW:W?&mN"pK;u[Qe:ID!iu(T6!ir0ksPML8C&/jBC%s<5jFrKE6:EA'hj2l1FkFhsQG>0aQ0S,s7aF4r4(^IDo"<AEkq2+;B3dr30GOfR61@gY)3\U$]B6hJLJUCq=#5kt9=YE@f^/)4G?$29,CeU4ZMdYe#n"dPRRUB(LS)e.=dk%=C*"\7'g;BT@cE'/)oQ7oOM]5r$E,TtL3Hk+NT[GjHi"P5Q>@2N_QRN@Y%I)o/KYZiV'2FD?R.JBK&t"T:Mj<f^<d'Sc[W7g#gt&_V?5lF;:.Y.$@!5H_^r/jIQlT8J63M:l]s2hlDuSnGBJM.FdULC'GoOZo1\RE[W+Y1`/1mb=qGn`a"QQePqS"oh"kh5"l3jaaYLdjaU$b33\#+&J@%?W7m<enin]0Y5HsIa-QDdi=>Z[Mt\ZmCf!3?Zk,u]4o96^s9R`>p&Ug.P%H9bm63#[RE'<DbnKG$?_(^'A/t5V+C-]7u1b2kLG2EPf0da1V'0Ha\eUGa(k6AF1"BA4POW^l71X2eUJ$hoX;NhSa*naYtqU$b.#RQB%>e?qO:JtZg)@-Fe.qkO#rr!+/4ohT)*:Kce^s_NHK@CjMs1Q%iX1DoZ61lL8g@1S*?\g#OLN1IBt]qD(ko@;B`UK+%Gp4+h:KsdXsUlkkA?a;C,Y1=)gh+)`cEL>H\NI8^/WPOPNjM:"KVBL'&'69lL!%)3f8W#h)X7_4BmJVGt2seFsEkkfQIW8,jH,;UUq?BZ,8F.H?,al]a,72og?]QL'6-C+5c_6@$b4PXY7>>PEnppT!c"F&L#(,NmCGa#$/F0cRbEZ?$Rt9DKipcXg+;@P_%S0faY-EkI=Z*BI?gS]uaOmtkMF0mKEcXN9.3mZ91tqu+ZV%k>K(:DP7#-'LA#JY#-mWRCe)_nlA((sk_8^,G$_Nm1se"qc?(?L1ci%p.b:Uk!S0.m[UZB7Z)FihU6XnqsYESoU_'7o07Zp8H"dBQmQNOnHH*0=pRtoS@nf,X7EnPGm3E#/.sa>0Xk9rrLhT=pk~>endstream
+endobj
+46 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1140
+>>
+stream
+Gau0B?$"^Z'Rf.Ggdeg%1!#ukD_rasZUniG9OBiE;2kQo/;Zo<#lhV?2Kib)n0VQk1[uUP?JT[EFKPmknW+Ca'+XLXL<_d[i^19Xi]B?BQS=A&pT<7Fj90Y+^DhC0+RFe'4TDFX%3W:L+`UcV>ap^?qg::B_Fu`h=&e6;q[;D5+oZ$$mDT3Wk[:,Gb26Fc7(o2X"lMeYR2b,:-R9%-12>e59hU^4qS!X>^``up:2fkWK5'WUiRF\m\1f+MQ\=D/6b9'8&pXES'2TK-b6(7,>U6B2KS5YUp.V8K)k(?;=RO^eF1?)>pRJtR[c5kMl.);JMm^ki%a0jdjH&(lR="@Nk5Pq40B!K+n'DaS&^Tr$2)(_<VBh]gjYUA&UA&/<O(,+EhnN!4<UCiXf7?;9_ROu$+;N+!9n-^_[PCo\Cu78IYi*m*BRb'(=EhZ*ju0;TE^uHi<tT=5[7HQ@#6@PpTj6JLRWk"'.eE[,g&YPV1?i&c\aI,O?5"3*n:!.jUL[>l:N.g29H0sS\lgQWONLf1QZH9M%.S,+@LehN@D>Viq&7Zb#fc"ChLseR^E7rE'RuDD"SemL.Ka;%?qE@/^a;sPqKXgj5Xh,Q[%'P''JsB;8Wta!3@8s3ThI9KWAn)C[ZM5$)YDu^2`_hRZ,2+q:6!*]q\tdM4.8,C%;W:B;=X=ua%;^,KS1_SX5WpAKet;!\Npi8UeUWq]5)^H'1?b^o%.*p`<)p"Za.$%`57!Pg!li"T=hQ5&lg6j-CdeF<Y/'HZS.Z_l*p1B^:54EHk&AHD!0Gh3*g=H>J<"YCG<%*<?aH468L-,J3C%k499;3\-(oH)]PEB6Rc:AC0+81^jV5%2O-Tf*(Af:Dh/E\k)U5jW0F\h`\L<:-m\X9rsYktZ@)Y'K3GB;R9UfCk3'Xih_Vj_LA^W-Osmtj\QS)"jPhl-ZcG"Fb50u[dK'Y]\WM?EGIkiE21%/62/KCUQfEiC0[648MN7LESbs293K1)kVmY/9<m56<OAJeXkV?5@!H%=WLLVR_i,inXZgm^1Ho\i&)dck[Y.m/o?K>dYeU:J7_%[PS'5Ht<:Wl5WhWamXpVGNIK@0130T3]*-b#l(`ReOXSC9Rc"[teC)c:gD#41!RGLm:-^B*Uh3&:~>endstream
+endobj
+47 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1914
+>>
+stream
+Gatm<gMYb*&:Ml+bZhag=0_0OqQTId9bF$Ig;ZEU?sdT(ZIR<tQDEO8mrq;pMGma,HIjQA=lShmbaC9)pb9O6^AU:N!;sBXbA/3t!#>b5OVbjn'7<ner-ctOUg@klB$GNQN0@rg_QQbG1(4"lpVce-#QqEf#"I5=G9>aL;$j^bf7a),Mk@6Kh/'R0-B8]L2sOG_HdfWL3XrqC]G(ka;LCsJT-j'pis!`b?>t*t'R<7Q)i3O22f7Cggg,:rF#mt`:/!#aY0/`uh2C)ipsnulc^2(6^uDo;%_tl".g"W'@WX3dh_jMam9m(<BF\BbWcT]"g&q?If\$p^p;':_"s#1Cim/5ZIXV2&/Mtjh^]c>gIU_8aUn#RD^-7,p8^]dR;=o@B9H#IJ:8@8nU7kOoM"&INLuN,plFD_X3S9*iF0<K6-dUbCQ[/nG+ueR-.jX(CjE\jK^rR#C$6e@I.@CkqVp^2:%1I_IY`KMmTH`%kY#OmlJD??_eeI>3VHfO&O+A]JF_fRLbVgR/]G/`*BSfMe8Q)Z6>8*$dNF==_b<]\d:qJH<$KItP*I/-['Iub?3Q&\;V`,i]APP=YNH-JJ[j?f'Cb"4L=YaKnZ&I'Fa`c6#Ado`t*J-QWE)eD?2L*l>i'jcp,Bn910tKYGj4A'OrBo)_$pRWr;P$_nX?1RM8l"4koP8%:gUbKGMQl!U\N$1PPB1<DhMWpI;X&QX0Tr7:L"6U1L\M_^hTTChe:a-"Hd(d\%\q"3Jj&Ml3eXK!R/*Lb'#^C14Z*>t7O(1m;U<aPM3YoY3[5n-fE'GnBd.\*!J^V^DmS$4[0M$hKd_nNd>&sF1:)%Uke2Kci"W$ZR@fj?Ybd9fKI*&k8&O>am^*WPo3!o17_^^A=b:nfXleCE`DYnWCae6LoN$JEWdmWt0m]WB$DPcT\':40S@i-+DO=Ih*;+tm1)=&$"C'@K6hTdH05'Vo@,o/_m]F"X5A?u`hbq\Zf2l`;SLPZ9@"9e*Re2[fMSo%Jjebo96;hP=NI&]4TgE=4Lb.NL25RLLr%Q9!F2Lt:l2:)C4j8h98c_Z&KeN+^Po4s!;:lV;a3^<#E/1)Nh->C'N!VKI[SIs>8U.uCi.e"G0P9N37q[9b[/4u^iG@5#/PP2G8iO`=b/JG\?&=+DLKHV:KhQ^gIn^?CCW7Zd20C1<#SVT^YQR$[U+fMHGc_Xan1lL*'HMNoQ9DS>e2.QnTI8"$@!97@]-84`3A2+M1<d'_"L'KN)B0d>.APV$VAuV+_<b]7Xa9^eT'LoASujGb;^ea2gk5=''67*H-7ZO?]mXBW@I2+P/mX>^gDgg>lg/[I1UF^m-::i_g;pjO-nAAN>q]j)frhD)fjMu:beft("mP)qZ2;8l@@,6rB\5EdAjd^#2&*-bPK9)Gq>[.W@bj-lr?_0)e?^GK5NG#`'NS"6e9G-S!^#pMBoErG=Oa@UM_(c.64H:<;bM*EM-u2!BVFg!_d58ohH+Du95bd'Q7mu$\$m-EgTs>ETHH,0T49[]2=CUi!\?&r$9S@PBE85TlJ9&c)Dg;^Ze*ju]>VLjmq[Md`L?$$)BrP8=&AhJ)>ie]RU.arZ,5"j8t&Tg7=2^&Y1o2`gbK)lqT8@X'3f<u4$d\hl#[,fmA\%:=#KP^LU,K=EE>*b@b^>DdFM&S659n`.KhYUk,r.]HB+aGe*\JS$E##CX11'BJt!%oee8^,bGYk,IBq!QjJQ[;WcI_i2;!_SCr6W0$CeCb7T(m:6q#/!g:naSAg?H1l$Dj!fXT;t[`dZ(8;S\G'ke)S$oUh^rRb6`=k6[=I/f.jm_-.9&m.crJ;n)Tgeq%%Qr."0H>P429F^Z]rooDFD^`h(ADX"oZ5eQfR1+,F4sN9d7B1&#%L]#,N0qps^SE]0pK%+qHp-fprW<u:!0G/F8H~>endstream
+endobj
+48 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1967
+>>
+stream
+Gatm;D/\/e&H88.ESomnWG;5lfS:X7Ot8t`U9TVc^jq$&BUau,C*XPGs*i:V[d:q(KWIXnaH@tBGgFPR@qt$WpA^>Hk\NR-/n0]"1mq4rMg@4jVXqpW^IRTK_l1nb:=dadDLX>YFQr&?bkZm94o6@^3n3QdCcSmU^5UD&Mj9$76rAg-=.4N7aZH)3kF6p=&7M=0X23)cBK-oQ\p]Hj=KF<s[26m$!Sq$&@J',h#V5Upd@`uip&",i[(a^sI.S<2WC%V6i%X:nOrVfC\/h1M@X<?K]V.6+3=e,JdQt0*:>u:%V0+BQ,$E<Q:@1ftT:]8o4UeCZ]bucT58-h>*KLH/ohcEF7A_O_?]iW3aq<=qYD5%"[A/os^uJF(?6o6&?$ec*KXG+rP?N/sA_1+]!;s%jVcucI'0Z[o&6bfd#AIF2GDOTtA<)./=7ZUQCu4/MVl;L6XV+3WI.SL5\ho9K]R9$N`2m-,Y+o`/.?]$4Qh4&Y1pKqr[b\O*]"C+q>^a3^G&d9@k1fS)jlsh#UHFP"e6;,7LR(>jdV5Qc`%0"):1\H%UEroB-aJ\/ARsf+'hr6`.P&X442Zegr*.g211[GkeC[Ge=l@@pRp7rMgLcqTR"lA,FTnF[JQWX2L#Y>Zb%=PI4@\J0>LClTZBQ\NJ.aD[%a'#5)"U3Na,*Zi$h1]\E+BcbgrCX3ZYU_C9[?^*WMW"o/b$5I@FKt')kCQQ60iW5IuNoScF$R]o%6<l#ieuM-M\mK#X_RjdWLjS3E(WP8f'C9_#.(jkI`N@ECeO7S,RB68`(\faP:*c^i+$`o9=4!IKOm#bTR*sn+9k*L)NJ7mu7g6oW8V'@B;^n>X?r"b"Sl\3n%t48L@F)[phcY8Pd)g#c,nAS!C,^EDp&+R7[U#c5FI&WZnRH1J.^>9K]FV`jE038@qRl0S?5H,\Vp8SD>QXOUNr9#V*+(0Ror>T!CG8o3)c_N)H(CWAH0+c)g!%D5'S9f6N2sn]B`<nqRE:$H^DA*9<P*,\HCo<=/-4rYgU>)ne8)%7bRs]:hm`Y)Zu%OMql;?LsGFKdc'lW2Dua',193`6O-g9u%Fq1r120e1)5j6W:cME=-VrlA'#oNaaoDY+1d1N0]"EB1Aa-)"pGT(GP4Kq`f_list"Eb+)q38CJ,G^\q%mS`(_P-.dm]eE.hCUO4"h".-V!UD8Vm@aZ!Xqn*&eV^bUn@5)ceV&>!^;N?tNa0(;q`YkRlZ@KmdK+(-rUuSRFFH._!>%m5RO(J_$$$?hE[cLT\\''Bh#s6dc>*SL:5'U?"@Icnp%hi282JhFI,n'+`6DVXQ!eZ':YV,"6%C#LFor;8r)@5"bFa:\)m"1<(CB;1jTgj=hFsWf!]uMs<hg'8OYPH7MP@P33GQ$QmbSO`W_=feNABMJ[p$3c[!iuAm*,j9N]bH)+EsH/P,`?O9EMEloKE06nGm$/UK**@&i-l-3?#aQh<;jdj<[uY=0BfEh9,7u0F9ZXnlSVK[bH?qJZs-cR3U,`eI73:Uleeu`))kWroKmt&[L*igdO!LGk_C7Q\^SNEQ=gY"ptBaALb(*2.FqcXSDHNNhXkg"ng[trFT?_X9=ul'%A7mQ(&@$R0;gcgQs`%l0QcI0iPO2#DGEN:rZjQBbRT5JaDJ6$$,b0M\L-JJ,ecdKr^<W,WlIUof2pi).48W?q*C4Kf6]SXah<fK>rh>/oP@"G'ge>qX@&:L<U.CFNZQ99*\YG6X7(LQAD72k6t7Z[Hp3s'h-Q-;\C:Z"9*I6q*O+I^&[J63Gf<e/Ug(MR<'5K+lGic)<o'r-)f)Ll&al5dhj3;=d!$HOYi)*mL%?\7WW]\Bj6M:#eK*6NV=1Y$[TJLPgs%&cAcpuD@8NoS9,uQla'`6me"&93/.RE36_bJtlehb)-g,HE9ge/&1=m&LWi29V65*cr,Irud[YmQP'jb3N9CW*e>oZK>,NErQETu[O[q?\<~>endstream
+endobj
+49 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2236
+>>
+stream
+Gatm<CNJ7O&cAe=1#L2[M%IK^F-i\I1*uOdZ[F$&8ZG[b=of"?,J:YsR)f.$oIM&\%['[i<%_B3J_f^]l04e)9-a@SmD"*:oWq%(="_$nnj7ApcBPs\g3@8&cfukcB?$!5p%QaB2IF`WoZ*SMcO8NSpUTUKBeni,&fP#'g26&;Od^_6Bdr%+OnTsgIc0Tgf$("4#91(O(+6:GMretAR?=hk@H.N?:0i&uVq^Mn]R;b4WtVC0B0N/FB![W+XT'*cmd)lcdm@9s`J'<$:[l'XNni1?V*Fs,*70KgS;.4r)3[.^EoPe`%5((A>LG:K^.>Q7`hJRkD^Y=0lU$sl>6p;8E>R.kY!)9oemMLKpH2Cnr(@r`DCZ.9XOLcV^UT`Zd[B^d_%.#cX1rQH*)J9c#I0VM6D[Cr:.6GW.L];o)2IlD>+-Yap#`fN?W:&E9!Z6o8-:UK#N'$l13]2&#9S&<U*l[#3Xkt6N63"el$DB8g\9<D4)]Q5D;I<Fi:Q)FZ)hurI57;*?6Ro+&$_;q4dT=u1+bmfI[25bclg2%p=7Z8S^eB2S[a(,E9)u5V<]bU4.MPEXjFQ"HP)Q53a.D'O,r*8EWnK-Dq<RP4g>4=L7+n?0;ru2pX%=nJb8K&d]C5kSKJ#[/<15=S.uX-o:AolUs"u4ObtFk'KC%%1?-pjb#"Ub5R(2bYr%2,".nI=#NTh0%"9#L3Sd>8n6oK1D:FM!;8LUe6^=M/U[8+j(\]C[s(*1cPk&&&70!N0WGI\+/A8SaYXI6%\^l+i8-3,sbSA]njTTS+;NdOWS-'=X864NTC#e9A>l#pL^51fZRmSbfDEs6cqEt#)H8M\ddWmTP//f_GK\#1PeoOLMO&Ca<ag=h7ZZp)?nT/rPX8`FNj#3sF"Uu2Z#H!YYfu;QXR%gs>d?D83]6^d9?7;IQWDc.>3t0r@i]`Z0)UNZ<HB<'1fV]VPm@.ulfl6X!o%So/QY]nqKJndp32jgGO!Mg"3JoWQ@"!6+DU_$!$KS<8ZiM),cClh>c$_!o.H*W*/ca#Q8oYT;#5AO9PnhX2^(U4bnBa\!qOQlOclY=ToWAhj?,&-jQh0Yl7T5qCpmP(ihId!>$ZT?J'T2.*('F&YK)S/G9N(^am6ZeR$,7m*+8Q7T0E4_"k2nUCcabamfL)N:ef]!Mr_sf#VU1hJ/;DN@U,ilT[#3<K4((;7i3VMQk]^0Ec#pWO<QpaIRuC85"tNC2'IZXRi1RAga;r/=k%0]S*jJCi^Ocd%a#cs*fnOH<1Y2&V=S.X_MYN;MroHkCV6\qW9p^BTPZI,WA0HA'$3_o`8f/b7eh^7"0E`@NrP7^?(uLtk%V_DPf]phl"u56^O`CTL_bsKUNX"L%BPaqjj@DpEV?+$PM?CIi&Le_/F/\krK/GX5'N,&DD*F:9kF/kM*e[:CA^33*a3lGaXA[/Ur4!.Vk8+USU$QsJiI`];7!brK1?@a0DZoHr@J/p;mf%NKUqkF4=-2jSN+"*hLOS?r!gPqZ!OY<^@Bctr4OZ_0jX.%MpU8iK\R)nR.$/om>n0)oJJ@[#07cl)L_'p;$p+^JR"bCT7;2)c1,%uaYB%?@grmYmc8(e`?dDku;-([;L2k0(7Fl:g0DAM'O^t[Nm2=k0POHN_D*`6a@fp+)HE9Kh-ugr"`P%5F!XuFqe:U9A.De!0!]quNas+uM1ToEhp=9=`39$6QLch@^$n3UlbGUP/:]087F-RZ'?>h/n2fX3ac$8p:KJ[RYQ.Os=47G>Q^md_Sn/tjQ9+P%BZh]g]5CJ+\ms$1]AFJRTo'bo1c/&5[p[5rdh=[]5gC9+OSfFj(@!kKJ5qtG77.nW+Yk[)RZMX.jDKknooBR;6F>U[d$"I57T>#DUWd)3Mf@F]4'jQoQJtVh5h-GI'l/1c&mS9-E)Mjb4&3#K%,0OaMA0R;VN=Fd!fucRD6Y^7tp,9PYVmj3b^V785]\RlUDL#j"/J#saiA*d/XgTtMD:p.$<`M*^>:=h9qN[Vr1m6Wm*d?^0;]^.sI(f*XX\k(Zag#OiLAh@J&bM?(4RK`ocWB_WMsnS""-4!X=WE&>$apf%#Cl-$0t9ooe1+\*=0ejo"cj4<G-]`N-:Sd(*&<6-9+3#UqHX><$GL/AG"d1/qh=I\C1>#t*S5,kF=MnbqH40)0=j+rDmn1)fS!m/f[-EtAoGMELMt&':pD#j0L#%E=M[.uAe6u1#+.M[YQ1j^Q-4"dfA+pkkj3e_?$L&~>endstream
+endobj
+50 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 964
+>>
+stream
+Gau0Ba_oie&A@rkk,9&p,&6kOB[J(7O9/RTp<j=#;)2(,F==/gs1Uj;na6Uh@6fLV]UAM+L-l"Pr^cWT8q>5$356_(>aT%eI+sFu%9uRrc_GA(Z3.EimcJ@>#ij9aohji5!9qit@_:R/#-A$oo'tZ?*\4,G)\k4^hSJ7Z-LVE!d[@l]D$1bP`CntP.#qRd!'<MWDM4c\8//r>eHgB6N'qI/p[-=_&q[p(j6g7T&#24^1Un4Z`eYH^8W!$sEQC*bYWf3&EkjIlPUMBH@^VYdd"l/eZaj&(M]?W"S//3-Q9;q:@bcfDiu9LWm/N,N:?PXk6gMdOC8baM/lK1`/s;r()3-sj>3DOsY<VH!28nt937K=._2j?sELOT,/qpE#ekZoI/+Bb#Z+CGD]R%9u5A>r0TN)L3L;rY!8_Olb$^isIN2P]:$O`n(Tpm'aXP8=ZQl6J$jr]Zuo'aEho,kL/j$/qdOL:\3)J$:upH5K,B"&q=Vb2gK[(YCN[!V9eKY?JI8=Hi+1\<=V-=BT4?SlClBrW&8<,8?@'PL%W-`#XP+,t^n798nG=$%*5eq#=%eU8gsD@%<OKG*q88!!_mrPjA..6b,_llj%Q?NZdQb:RFm8Hg$uMe3i":q8cdp+$uu-bMJFn:,?jIbQ1R?G4Y86_YD2fI0FFTLoSp.q!j?U7mfc1Y()R_(0qaFYqt&gO`gH\LW,kW9*s.$a3UJZs5%<_toq'WN=aMq7Kh:c1qarPS[O2ABHU;9i3=,eql\o.t"'*$fEHIRV/-j:%T`$?_i\'knE1[]PrkT<<MV'YptJ7Ko4h(;pMe!5Uh*KlqkjtNqj#ia=ihR"R*"<I]2N.j#>`]K=EMJY.4I7:Z8mbC0'$Dpo6;;Ql7FD=]0:V93OSbQ:mKd#$?I6Vd*3"2mQ$?&qbfU$C9.O!=AqF9ULQ:oG@q_9T>Z1c8<`[Q\t+JH>I!](TFsD_>~>endstream
+endobj
+51 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2594
+>>
+stream
+GauHMD0+Gi')q<+Z/<jYEG1K/.-^RW:#_[):9Upfl#`dY2\69eLe0o65canYI273m@S)mI;*1@;&jS!kT7(($eAGYWs%a#sT-eZ*'iGmrA4BuI`&,#u&!O><B?e^U)"?+d=V(@]A<c`Nl)0s@JZti>KL&$)LoD,2IeDgj"+@H&cmM[k,6'Sr^=)'I-F[u,&17JaFf34uNs3GK.-_<k(uhi7LsJ$hLC)dc4N#XKZa.;"Ne8USJd-j60PZ'uFEdEricM72n_gW1`4<7jH8)9h@5S>VYM[OO,L=]t<CGf-Tnl%Tir#"/)rXaVV^nMM\rh&r511gLfaYqcDr7)o`kf0q47%[],c%?1:DrAO2$Y:aCMe`Qrk)s<20,+C<*F;M8U8S$X\cRU+p7%_c8'"\3g&8(1g)5"o1ESW;Z._t`<-X`01qCW.dKN$-(`D'qBH'q9IokE/m?ZJn!k!O>gg7,3aLAGHDeqhAT@FH=tXl!aO4Mi8fRV4=,+1+A>s+-apZ)GgK^$'?PXE^ABa=sQlU49=K:ed-+F_3BnHMl7`hp>L>K@_"+*2+7pV62P,raHPA3[@Ak(KC#L?#Q"dQY&*CrP05*ot74"@)NTG7I@KEqV78_M5Yn\\mXrQE7]hbDta:-Q<$MX7!h]ir:TS\[9Hg8%p"@F\4"Hf?@OD'9n4>Hi8]=RmS@HdQOY3J@npZurUs@L;4dk0dJk9l8"q]UAqK==R.$rRkF8kQ_<iN<@Ug)D^7S<()Ek[!<'pgG</k_JaTYJATsq8mM$3^"F!>"W)],N<BnKis^TRYZOc5Knd'1AL]/[8NBrmSQ5$$%jG'tXE<]P9DsR1J&4.\)m!LP\[>#lifP7bZ''gVj^=iIk"+M3a%ZgX(VnR/"HU^F8_jE*)+;APm3:Db+)_po0Le?7G1?O3\2t\tZ.=B:k%YkFi\:VshK[P..2[&H+#$WipWnr\d5X\\%>\Fqdd.4cikP2L!?:M$6NQED`sCqi@1n2d0Wl'ZH`S;2U`9kN6[:dV7!L[pe*Zm97Q'%Fk'M8A41Xa(i+jY94Q#a&NOg[uAR@]j*+p`@F.*Xq_R3&rClG2^L+m:r4L!F6_I3k"39A,'::SGE<H>V%9I!bc6f:/Ks4?'HDV[E0E)O7mUFX9YTC;dRb9=,dH@6IeA;9GS2PJ@8_3s9_!]2IVE-d$jJ.`n@0V77f^Y4o;A;0sE^r.PY(ZHnLZi,`W_<-DUC`jt&9PKQDKl&H-baq1rf/o[TT%$CY/BWj:@<#1/Y3X463A"1NE%ZY<Yq[#*RrWHuT>$!1!KEh;1$OT`.`Cn;;sX("#cJClYR`#oX>Op5E`T_kO,11fX/g0bmq.E]"/s%uI+DTVDFT-)-I9c1Z:)fR;1G8r7gMB%!<C`:Nj/7[Z:hEO&BUaJG=8<@+Gii!a`X#fa1+gRTXnoI\XfqLnBFO%>bW\]b&lQ$o)_/Cs3mX2o"JIjStgAs-)lSa1D[](c"*u)\[brNHdFJG.0tCB^TY7QF)Lc.^>X!G^S7]Rl<i?65;t-L#45h5=kur&kC]UD]3XfP\(9;YWnlQTINML*e_0?^j7Tu:27jn/X5--+fl#_`]BX1QG2<13GN-l<G]P7fg^2Ro@58&&/5?)FQ0.\@WkRBJ>Lc5rA"1<tH]:]D965Hu9ul9e>)m:K0\;>fR-:IfBl2G<)]`YA$(q50%Yrrh?W/%8S(,4?C2$o/\L;=5fae1UIjshZ]gB2AV@(]Uo%DNkV*g)mDGY%GGBOq`SC;!lgD1C_**QnXBAEd,^UZYCS#\AZ)HkS*95\*0UouE#WM1EYCefn9ci*RhCK/Rp8T4I8;$:_0hnGLI.p`0#5P="";,qehf3Wk8ZJ8D0X-q5V8"I4A`Xa,d+F0-A6#o2c63:_Q4%TrW7A;%g?KoR)Fe1u_FWS:ajgR:slS4o)ml<8!L<r&,\>X$E_GBI`QJO8crg?BG7U<]>Ei)Ij"8F$MioG#G-9cb2er<P!])/%eQQeXB:=r70NY*Z(]hFm!Rq1oV&0@h9ahgUEAgQA)/*535gt(b:ZJ%ud]5ZAH*kQ'9d[Nmr1(u"0\Im"R7hIUQ2g9YtB:meN.Q03Q"d.Hj44fB`USi'0g`Uir,uLl*D@RS?<7'A9rV,c6UYb6IP8jY])-DA<Ek8Anq)lE#'"p%JD&_a:H<+Z.+PGa\p\O6ib1UpUWoL;\<iH>?d>Wb1-<X2bLJZ%o0QREeP"ZP'`"mjNDGcJo/Zj9#l&]_O-I+dq;gS9T73O*$?aD^S_OdOcb:<,l.;'H(,%#.;W/WQ:S+T6`K[WQTr8,6oe6%48XT?a$B?2k0!1Vr/gYj0tfG(#TE;*AYd&h>R0B4](bW2kO)/p&]Y+h=((V[u8B5^aD*u\ie^12&gO<kY/)k99Jp[QPen1&QS>0+YqJFP]?>pnXC;t40)hB/P1dWd)Z<+EVhc('8NZ3BFf"\k*?q/usV`S5Ir\n(3o4bm1PceWi*fOIhZ^0i;hT#@sgm5kt^h+AOP5GmolW"J\*)_&.[.=9AOX<SU)3Np9@r#DGu126ha`4beRR?ULJdO8C(fSY`k0TJJo1a9EW*Ou#*LYEhm86r)sIRn+$!KJ40'E~>endstream
+endobj
+52 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2632
+>>
+stream
+Gb!;eBli;m')h6*d?U`6<Dk&rpQ9hq*7*1]T$(.m?W`SF8P$^c+ufR9O8f)9^dF86M6a7cg9!A'&P"c$)R!L8%bUQs1&kl:J6usYj')a.(M7`-I*7;u2-eBY^0\/uOVR)WUj[0,5o>@u4T,s%4htcE%irgscdfA(@.O$;gFN%t;??5X=d.ilR!jP=%skgh0nGDa_p'UMhWe`BEU7uP=:n_X,Q.0S-OShp?PhAnnY0hnqS!^@Y_""%Xgn=1_!T*R>YjfmKH2:BC4ZHDHcr[b,]qu/kO+4D0OAH]Op2N=e">5G\`P/MjT=k[=osm1l`/r2d2[C6XFWnbOOJg;;*bnMN0j-fAI9-:b1^%Zk<3_:ET?2S-&h6S0#77_Qf-kH[qc8o$Jr)m]#Jt$[u+5W\5-NI*:bOt?fR@+qIDp3i`P\#amPk*@*XF),>NM-`doj-gpCss[PmTYIk^-2Y'DTaOp?j`=Q[k0=t1jI(h\;FlTo?@HFh4FT$-h=Ddrii?K;srGBD,MOQ(Dke:Bs/[F,R$ba')!pfB$r8;&$6b,YT9moa4\$G$dj/4r7TDAGHQZ(hepfC+N2_7T7=&`@+-O%Z3(,d9[eNk6)QcOSLCB8oL5lpO,U,[8.nJN$+k4E;@\'eo7kT*2!p&A51,:F#j-:'4D7GhQW^1SJ[^54pUG@%*ld'^\T/R65Z%-U/Z>mO<^4aUruqfH!FP:)#F@+%BNs_,V_j]E+GJP)AoOKI!at'$S#Tl&!nMj7)s5`t.G/OLdu`Ln?L4V<s40?/Rfh[QXpSf00YODXJmN3DfnU1P,E4cYTJUXH\SVKu%XKCd^mqTYfaHK[_XY.hQ;iJRSeJ*D#!CqTs9!(>,T?UWA&P\E!6kBc;-NlW-#[7oAe4j;^dp5h%)6[54OGSr,8hh;J+]T,b/mjC\bOgJ"hD*=UEuO'6g+$p,5P_6Vl6D)#i-q\c[c7Flom;J[,9E&I@<&sM#O"o>W=&#;JQ!r<?47#msV-iZVW]?/BLmL:fVSPZ-Ag&2t>2-`ZU^un5l]L!mXAJDVk*;iYFS-)@EE/PgWk=[b*"YJ]$UTmI:#Mo)@kA89&'?=(XHS,?**[TK[/,chX?70gd;NSj3\RV'9?@h(oOmM+PU1pOELfq3J'J!nJG2amXM]Z9d#(^)PWCbVB5>L\N:%8OD`r(U_(cD0H2CiiqFl->Z+Ohb;nO[DVZ6BVh_^?YLM<ICdU<kgnksO6*&WT0'8lKd:07-Hhhrs!/r/UfkS07:F.Tc!unPQ@`dQ#Xf[!1B[Rnd8\PL6#smY:$I&@]CPm+=K==<E6R.dP"&$nea@]g:La(fP:929?(0Mdai)pgbZd&em-\*)eV!P3b2sVA>)9IJj*^9Cl?8BaYH!GPP1+INiNpVDFg@fB+?Q!<3P+;pBK_*=Eaj8lM]R86*bgc1l%mb;?mUX:SL>;3@_Z[d.@]]0M85Im$'10Kqb9?JqH==Sc9L/?qmHG=6#c@7o2[dB47"M]Bqq4-CSi:74rehUX*?GbqH6I#IqXS2DttIJNEN^TVNe=#\\[+3?sCJ#EeL2Ho58)995EL6?qBnYNCF"k@qp\;+tgmZmU>o7@&9$8&IYS<N^$E^:<4JRmJZ3c.!e^.;Q?[n`.0$%l=T?mon:Sf)sK+X#[)dTc"FWmS@I_3ENdP_g/6$$E5b_hdDX@5#i^>lA`i6N/#cF1A$3gs"DmK8c$u%,Oi`TtDWE[-SgNPDs=]7F:=Yp?HD@D>;6lg7%D>riA?dAok&I)?h7g$I)6LUT"ANb#9n^A4WT:B!DQB!\1>!Ql;Z92t@HKCBm5>Vf"H_';TG+M/=?9=E@>8h2WS$h!N%iL5*C(YJKJ8\9`/4:);.<,ruo3Tc[]"-4S4B_iTUCAkq-J9H<k<o*3$(k4PHG,iZN/St,*J4Oi6ZLe$dDQ?_,FGFVD>e-a[RiHl7dnoZ4JdGeO0rW]FL'd^rEqNS(,IF(0\f(!b@bH-$mlTM_:XnWW3SUo>cUlm<\iRq2cj<4mpE,utr?fX_WU&^AGC]GSt&ThQ"r@bT=>l;4^.*=/6Rr[eVi7>5Q1q2BrjO#8/A\n3@)n88(?Kf!GjS1TU.HrQlU?IQ0;$efB`PX)\Y:r!?k7>hq-qn_Xl*@G2i/t"8QBZGB@RQ3-B8$e:8KO6_0un0D!skJI9TFXddu%TQ/[I<H`io%AOn3&B6Z=_9m\Nd%k/)?>qPtklPQ`#pNks]/B8i"b`%^/hGaQ.\l4AeZ0MBWhTV]d-Fcf$A4$%#C/!lDs<5:$U>8K+Dr>75kHU_-6gYEHH?>O_>MYVOYPtKX1]JPS0F&Y^LS(8Sg(+,/X9t7RnXOWe1JFUo%0N8<17PK+u]ceejS,-Q2`3TW^2-6)aaXXEg"\#)/BqX\ol5gJj!]4Qt:3=s*2RR2Iet.l*lO(_qS$!oqeZE`9%7]=/&&m`%dWO%)C$iJprfC'LV!M=T\U/7:ACk5'F=iX4^Q8<lXjMp[Hh4(L5n2J[a2d%S]^8VPpNOIWU"/IBT"9(2/]&MU4<W58jLLUFh+nr9mYRf!%W[1%,O5qUR"uAdMX7L[8ZhcF.$g87Vfgdld*]TWh?f3rOL^ZnS"J3<%8A]/^\a!g'7@5gf\+8$l9lVfCS*nh%N#-Gs!?34~>endstream
+endobj
+53 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2121
+>>
+stream
+Gatm<gN"6%&:O:SoF$AHSBYBI.g_de+;@cV\Ho46iaoJ88JBFqLmaNnjm+oiH]`/:('[hi;7&EOmaL!i:Fi+UJ!0;>=V8?9dEC,J,q7*)P`2=Kc/-eXZ\uRN\i8Xtk?$.#H'IF0Ur_cYVd&\GUcZ7\U6MsJ:TN^Moktq%T\mD(oN%?]csP2e'@"8Rj6l9U7p'-bG9tA%FjYFh8[Fq]0lBY)p`(U%\=a?s?=<Ts_R*C)7Stn7MXili-J^UT+"uKgT>@rj()E*R1^*l]T?.(*QLN^%`_O8Tr_HbuUEiU37<7n^<cg?+9@DDgL4kc-;nWr(<S#c4QaJY\Ug-_2>c1fje5DR+<n;Xc>-:9Hd*fL?X+`#P\GYo?7['e/CG3;$h=JIQ9=bja/,^3"S6\/>4jNB`]";=;>.S`+bY$0N0RbIA5</"e[cYT^SKYbqb"/gum/3%uCVnAN`h*,AAJSKW]7rp^D6/ksVRkHb.9K3VFD=bKQ<__#&Pbn>h217jA)Tu4E#cU6-[hX_LYtH,frGGiVNf$$LIk&&b<2L0ZEgqP+d,"`L^8XrcWJ9Aq(t0&XVCr^I9'YQC<G+ZdMgnI,<IfX]FcYcaoc#)BMlo&EilGL`^4r*fD!Lt:9=N!Np)b1f2N)eCe\tBU9)nI49p*nIB#BN\B"9hUI/"g'ak_gWkHnTZ::TK:^i@04DngUC4R"#:h-u=h8/Hgh/^)Ppjegd6c3'W<Xle@RA0J]B1T7!1pdpdK9fQ(k.pMglWNQM_4,fb58BF3\Q2,jPOZ'-RMKogbsIj3L%)ThGud$L/U]QCkQ%aOF3N+]ahP9_>K!<p%IkV#]r]*i^UG0`XmcO_#jT"1id4=gD`d9&L0+`:K>S7&"[4]BDT<`jf1L]D.Ki?dTpK.2jpiUcq(8RW<tNY3lgQ2G5:^)n<`E^jWhVq1I(A$Y)23tYH&XYQ0\EjE?4P3c2$,Pabe11T9Z#jnI"ImZGl2sM1lgdD:@j2X?j0LN[q[`oSrJigTNF3j@M>cD>g)^#RkrYldN_a+H>kb`%%DDa@60js.6b%WRceLR@<6IZ1.<0ii.#-bjjt;g32j5HaHAO8R1>se^M-@F?h))s-b2U%)JT1G3:SZ,(fNJI5R;=J0"'sl$"1+XjlFFmI335H##\YfGR10MC/rjZ9:JZS)1OmL$gA:sW&cX%?WJ^)=P>uumlcU'Mu)$9G/$6[Z?1DEpdXe;S(f1Di'eX)e*/\,dqhO@f2QK6$oh\WK'FMo[Q@9794qrf[^u/Ul,*/qbD7:@%(_8.+VZML"/n\5%7&ZK5_]'K-\:J^Gr8Z,e]h)9O#Ye.GG+sqJa07g^[Wl+_SPm`bg`W#E8f)FVCI5<dU3s#\Ni4[&n9;,jlQ=IBk5]P"P?j3q*/.3mD(>@ZG)Oj`ET^s?Yk.n[q*IW^6ahNZ1!)PJ13>Ta3@2Rce.Mp%u!O'niZd"_UIA;0E%QN.Tq\&65GG_Nc)ASP^9t"2KdAYp]tKRG>:GKe]je@4sn#@?.Z0*Ni6j@acff>@V1gZ4Uk2>P>Hf!#hE=E\&0#lX@$k"[G(BuYCpL))Nnd/F&^@%M?&g_2>bC!3fG_)1-.l'*",lp"A]G/-Q.uVho0Q.ob#Olg[UKdTuEVWH4o[Tq_0QA4TRSMb+17mMd*aDTRkgCFW(m2-_0_6>H:f32lu,W4Qdj4a![*@RZ3n7Bmd!&]1CgfNjI7Rg.:ouj%,^rf8n;2-Hr_jb^f#mSfBRn?]6.-/S68G&YXCGJ`me1h=+*;SrgDn]iC]0D$fQW^C!9BWn$rp:LNl\aG5XsfCgonQ/pFk^A@P``9gS=95<*cZ)%%O>^Bi@#u,!q`%&DbQE2eBiLssi+.j*jgY1q@4opPI;bSsg:U#+B4LplP:)1ta&32H9j*%cV_*(RIkr%u1_epKK)8dlH2J;)cP,1[tkWcAnpWVEKD9];.0h16-:"0%BnRCI=-O.I68lbBeD35:_]gIndM0ik>&)*`Co1ZAs<7kXM.5b^q0RFicpoX)%`Gu_8jNG(6VPaP`dLW;&&\r1aN'Q-E$Z-EJn@22Vii+2EEhqXjNl20mW9Q7?]4n>>$?6ALEEdMF7iCqO827:`%t?7;k1hU0P@8."Mgk_3>D$Y~>endstream
+endobj
+54 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 990
+>>
+stream
+Gau1-hf%4&&BE](/+/No>DDa=]sSejeM^5q=C3OX-?1/D@V9j$jhK\5$%[8o&J>?U"2<RHkO/7*":"WFeU*M_>_hh5L&`qO9RtcM%H.g7KtT^aB#c\I]esVT2_<#B>mjuBEiC-'NH^^+-<R/=Q:([a*fOL0R"V)rYA*\?_VYp=fBs-?EGW"+pJ2Cm^s;Fshm=@W4H*lu\CuU\0$M<u1uIqM*R_A*f7k7bB41MZ[g[lF*V-SJH"cCR*@Ar!GCp=FcmA1-I7Z6q9,AemR[@3Z\gYMI<U&DE(l(r'N(&?uA[4Ehr9jU;ma*_DVo?+1a975li$oTQh1c%>"c],;P/.@Oq:q*aB@lpj->TN.g\a?Kq`5%m/jTGfGhri&Hfr+gkkkj:iJKoY4q/ja&2#FI*24209;[XX;THNpl-B*m86*$+3B`YS2D7U7T6sCo&mcS8;6keNZ6>/MOWoPiPs"0OO+M"K-j<EW1b)?U5d#C#jp[FF\Z6REHbj1XS=ce:)-bO&]0Ec(_7GG:M$4L&7'YD69[K0G?.?fn($1)h`ugnQ6H9i12M"-SXB]36?n@[sHR\a\mAq?*A=]sGE?S;XO:8R,/Ra2F>o3!<i_<:QBF1Y)<RbgW0bMia:l@60;Mkq;0IW`!A1RskoP44f+\]o0p+3W`Vi!+4F:Zr@2R.6]TipJJD=aL?ERr,u_5L<TE0P@^;fkM%j9q4<9j4\LoD2-[kIoQco]iL]DkjcBBj">5M6;\S9`&XM9K8NeYCDL_DprEF3uJu_$oooh%TM\-Bp(HP9.j237L5:BR^p:CcUC<%Y-_'_PrJ5obc<lHS8V_H/CVZ+m9FJrK#65&5=:(q"o7q)3r(Y%Kqk((:Gqsi3m1i#DSd[Z&aQ*5/uYGFo.s4(8"h!E`ur#]m&r!!:0L4FI7igT%V_nEQ?5CHK*t$7S=]iYqdb";H+XT<q']p5T=EIRju,dk2B2*Z/LZUUW=F02m*6UCrW0HOj$W~>endstream
+endobj
+55 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2320
+>>
+stream
+Gb!#\9lo&I&A@sBluXRQ[:@Z0.I*Zk[>E@(8!t^4dp.!G85On*!\==TU]1,X!Ycq`P%h<fF?I!B&g+`(hnEA=KKfBgmVc81r-An*mm@@*\Bc<<"9Z0+_Ti%u?PgtV;39/*8b5'#PMpa'_p_DpTF#&5qCi=%La-**K\lSZG;o$1E"*nWXBG&qgcrUQO0m]fS7I01LYGs?]JD/WNQ4nd5VU(2U(Mha_Jh>bgYXW&q!(3B/I-o93.MX)U`YPbrsH9Jpl,3Z[Z,7aW'A.EBo1/g`%Qg?K@#,(GGYnrT^2=aKHn>X$42[J*Of(jKn3I"F3S:=G7=Iu\E@fF[sNl.E&%j\l0$NT6\g-T!\s4r#\3_$2Q/6rJS5+^0dV@2b#kSL[cZ:ojGsSXj?*OF+C-b5i5"Cl<"=)n9://(-%:K*kH$;;!N*DS@-Xaig@B(?;_M-+(Q2HQ/!R]bAMQ3KA.M9?]33V@e<R6eIWK:9Jh88%,Z6Hb'aAXV&rj21%-3r3>&t@!!&n_GFnd;TS-s&D5np(3238:gTO6)!%W,1Ciit#,;*UG<\,5)_1tujZ%TPW3aL*K0--\IFBO1aQkn4\b</V1*3r#!$0^#u5bD#no_qok+dFtBS=YO_l^@0'*[<Up*l@jS#Dc[uM].<o(`8-E6"F9&$Bt0i1CFom?-"P1j\+'r?4\sg3Q'EbZg-R!o.2r=$R1*+h/jUu!,`Ht6N3%7RE^>qC7on-PK5aC;4s-`5@9,%-%]OX9-V2585#a9)2sc.]K?R?b@$EbS&J:gaeZRLZm;S)S5Od/HSqiMIR4,FO);!I^<G&B?md&?V#B3HWZ4p;m!Qd&i:^D^E&e5hN5h5_APnoOY7`']#%@;6*J*n]IX?c$;Zh,1CRD=O=:KZT[Bru,@;-6qd@Alh-$n^^aA.=]eS>P=AmEWRl;1Yaq^Wi2A=XIrcIYF;3`RUIeX<YVK9\Z:]1k_4"6<Udb8dHF@6HH22+mA2da^s:^*%&VbW+m]YRkO7nI#7%)Z[15M:RIE/`_#9cgX!.uK12@qP"p+5BbH.jC6ImK`bgG8PGUp?$mpC=0.-3;8eRkV`:6]`@jbs?'n/OKc@=WEPAAA<Y"1rt;mt@n"@Lo&bpQ6>?SW$hp5*MW_Ep)2#l>iJM?k'Vr;!MX%>OWNe*S7G5>6"Pb\"UheN7BrCc59B/#I&=S,FZjbB".l2M^Phm;03GLY7X=0q01]CGuQKa5;XgZucePZ2k9H;C<i_#FgMI]k@<2TZudMZTfN>j^?k.d9[6c]pQGtXC&oq\(#jeKkn(+bIabj9:&t%>.M:5$49F8Kmf,,PeI9q:ud(=pnC0\gOqDkIe9Fi;Ir[+)7+2CdW5e0N\+[s6dEi/[n:*6).'Bth6pkb)%3t:<%<,,7a*S73Kf->Mq<GGVLRWA=Q(Z/B[3pV^,.e:q-m]MV?ml:(XA7#`(ujTTc`o^7q95H_9\)6L\r^%K\9BVNTEoC\\mW4%,ntngaEko)^/9sKlE?\i9_?#[YmXM!:'NlA_"9G]<%+(,0N(lE??]5!IHtY#@R'MISIVJNt(bfh62`G^$19XedpBH3G]2`FY+`1FGMP]J?e<I?+DM\j`)8k:1%.@QZRmHVm5^A4B4G;/nKa)dfSZ6RT_heU/fih1h7r+)(]a$6k_;*h6>kqj(0t%Wm-#Xb^=Gd#2!_b:>6J:k8pBn*b;2l,IoRg++`(1AZ%o?&Tk!Q%XFDuFBCE=qEh0">t;^j9MT8D1l9NN+UJA-)E@@*+O5`]aY:VM,[-].D!KL10#b/aI,;MLPT7r)J()l[o?$pZ+jmEpq(j&+P/VaF`";aL&N@Lr='5dF&[nNKZLGD/MVCkeELLe\$Is>0TX1ShHj@[-M@H%\;N`Xdf2:HAR/"ZM*.tWL)NP#&`psJ__K0$??<JII>sU'E.%EhWh\*V(.:]PPiLgeu08--rKG8%?%A$=0/I<FK-n<O^'dX5h91?l1IkT47._WYm<1PX5MOYL>mOg3RiJD*+_Y@B':X\nV8lf44r(g`tT<N'/X]BHl8mse:5Fd[=m1=<,Y_]LI\4[-lr[YE\8m8?cOB,UnV:[nTFJ+<m9HgWO%H&bm(Ea/>4\+=,GD^L!<3gG48BAG/D4F8Q`%.*:P)UugV8)*FM*\?+UjsZ^V:OD+0gPU6+2+)e2%OS1<<_2`i;[l":o3U_@Cm0+kVaXnam(n\m@dPI[a+@^;ek"%f5NE'_:K5k`,"o9(@t^pipWdurBoFACt0]6@6aR;0Qru!g>uZLM",\:(s;<lL']G/r5BFDQ6DL:V:/*]*G`$_X!isBeIgfgA.rC]p]m7k5:Z~>endstream
+endobj
+56 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2599
+>>
+stream
+Gb!#\9lo&K'#"0DFQKgNQHY0]<cZ@DA!1"WR>L:T`>=>`,`G<F"+Z[p^OBMlPUp$Z1sYm#Q#^Dn5i\R8p$6LmeA8mVr1B6B^Kf-dO"$o2\sQFM:\o0Q7NX6Xr]FndN043+RP`nL]tnYMm*W^H]AO-4@ss^k?0ZRc>"PiWQdZIel(k.sTkdN<Ul.J$innQiB@!63ou"CIBn'c$1)c4c]`BE(SCS_>Z_++i+as7\"Nsjo3ZcuC-c8-51`1=tEV!6te!&[/T.RJ`(6673ZSLAnh)_CQ[k6PE^@&%_4W5\8^4)5gd`F3!qm6`GI1nY#jaWQ5e_V17/$Fmq=$"-Hos%/(-i1&9YGh8;C\X%JicaMU^[L2):.E@d!<1of1u.(AS3;^!rs8XO3>Zhsh<TK.SRf7D`FO#r!8_(N-Cs;2FM"hQ=Wtp[k2[!IV'IS`6;m!HgI8K0>]A=[GenLO6tgqfo^CT*!iNY&X>FF;^XZ\Cr>ZEWWHJ8UFKq^n;X2;SV#HMfiq-5Hg$%;;8NE/2Ll]fUHhhp"\T8-2(f>";a,uXP:22FoKqqCE7s2c\Ru>K0]0;eGnWMl9AZ`cMp15B`,$WMi0#`f*QE!9Q-(]t18s-;KhGuE'a1OMO7ka<qkm]QMJ)%7%6SjOT]ApAf7]kq'XNgn&F-F5^qQ_Z5^e,sZZh#9CqZ+1iU2]\D5R+"O;n^ONUD((Hf\ep[,b8gsK&9YZHCO(''tL_A/A93io),#Z=j\4_PW.$n2Z_3X(K?7X=tigSg3]Y4b^bk@k&(-=Zma-l'];nbKlTANs2`?HWVe32YXPh-Aqs/p,a5UQ8-,QM(/%8n1F/n5cKNj\bt8]%9Jtd];4:]fP%/;f$Ca:S;)2X>@Kq'0+kCq30uu*[1f,FO<MXDA<@R;2*f_!qMaP='V&cmbF6D\smKe.E_r2j,*V@?INa("uT\&!HEl10"b6ftcoPQ+alQ^q+]uL,H#!>sJIF'M[&_5b=eXmg6FjHONhUY2;WS`%*8,oJ$rMq:.L%TT=%`BUN5hBA.s&@==>-=/@>LLq6H)+gp[*]5.-#hL&]fD4DPnFId-D]`1T?Za-><R0rSbH^PaoWG*+h#IR41_jacQW=MINr-f'XSqhaS?;GVmF6Nf6jq`8::4O?XrK&=!abr5c15-0jZGM4dDb9_MB22?dpd'ks`K[E?eH!Y[/G:p"&r@Q1@T#b`RXmO_0[`=DWp#=031Zfa=]>oto<8;%rfmE?ndV!MKl9V&cSLJ.YfBZ)XL,KiR_2//C"U4-qJ\`e2ZI>Q8)@B(T?];W^K4\i4qIRK+uD[%8"/fcXg;^;\V6_(ia9o[slH6IE74cWXd0lEO@;+]]&oZHUhP\&jIGa>'J*U3dg&Z;A<hHD;XXPHs^]La_R?FBWu&A0"3o?IPg1Mr1D$,@S.fD2"amW@`PtNC9A5"b==9CJ]Z)\RH%.7!WhtMu'qBRe26<Jm7<<6@`ln137:G9uIi%!'Wmu$WE=(5FN-j[2PYWC'Ha)R_5\fjK;M5U_q8e_4#t2f1l:O+X1$7rBUCBdN54XoL7VgLS7\dhbgr"TqXeZQC2J.Jbr/j)c#"MEq1'8qWU:$rG39Q>L"EfKDD&'QLgs\(DjJ<V;O\sLf38j:c(fWnsr.MV-b*e]a8lS:`6.)I>>S+UG#@,OR<YX*_;TbZ=M!8YDONqaD=4G_q.3/Copik(p&rV8@>iFE#4][5)8#mLBUMF"s_1$g)EG`mQ]rp2ZE^=FnZl@7`Dh0#bFfc&NnmsjJdAF/\CJfl-)rNPKPV8oSn6Z[bWE1?nD(-^@&6&gr%iA<T%tH\?-g2Ij,]cju;'N68-*[n-=(e=W=osE@36+P<Q?oPR#f+"Ktuj175>4EO@R0Vmj>8$o0!ne]W,P)6jo6$<>">?'S&Ek[&mjjP'sYBhf!`kGD_:!nA*AXJm#Z?uU[G[HUK]]SDWp$^=LMh6iV4N:FUHO!I&a*^jhJ^[A!eG3c.Gp#N4\%Tm^4]tk?XK1>KTTG1E\FGO8m>M/3LTnPK9hcoq&ChY`8aBYiP/F0NsR^-J%=&nd`a[YE637oA/@8'"T`JclW1Q."cl[7u5Lmc\@+@IW2prSE?]Z@Y3@EN_KS!=`D_kR4sKAs?%m-HfZW>Uq)M9;M'YU[gTpGrnH/LtEp>%Qe(,r==09Y7Rm#TXWI*TRX:eNo/VYbnbo\AM#T<kL,p=piN.!S^s$dAjR'3;;F"p-d2%AJ!939To/F&VbN91QP'(7l)68OXi8!cHQ6$kR<p$1(St!,MJ9q0j?-+Egien8\[`D,S\rN</5b4I@Je#S9_XX$Z-kb,3^j[8QmlJ89(]89;Ffq.[:BbV0g\(0f[77)hB9me;hoaT&6,tS)qeDGu@a^]$^8Gi5?gb/3:Jb-Fbo"4kmdE$hpu7N;`splkG_/KgGun2n$fbm\\6;W0>X/a"*!Ts/?`Me*J'!-d`:TD0.j5-;25sDt"+4A7Z_`OD(>G$.?]4LlNYf.kC<5\dj1Ck'!3-Y9;&*IJ;UAnF1q6l!]r6j]rE?+decD\L#be>1,@R26de$GqoJ^pd1e0!+JBo`qP@!+6SJj74n>K_d2RF)I6`si)2W3+$Ho@rr~>endstream
+endobj
+57 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1829
+>>
+stream
+Gb!Sl9lCt0&A@sBbcPVWD7&1uDCQX8"^Em@Q1iW6[EFi&E(PcE>4KAr%/1ue,[".t"@6J3Jp,8pbaUP0L'h@@J"cmLe,[67i5JCr@0DJq_B_Z[E=8rc=!+WW2gLM5X',0ZLsp1/`UMue=j_u.Z^uk:"E?i\C)Gd>]6a_M/3!&';[npT_W!^0INihpHdW&KB:jC%l-?j_T2).@KcnFbU)ZC]0[)=tqs+tLhd3;Ua<V(t"DUKV8MKPG8[uBYKCKAajg["6k.qH,^un!C$"mBH?[b2!BEE0ED@n/#(6UAKceC(d;KE4<40T6qJ.4"mYSDp[/'!p]T^OU_\)s?ngM6<\KE<dqJUq!k4Ffk1PY`l8,B1$lr6N/>,74[VL7&Z(D0eT>#UUIs\=,G1l:.(IR($[PeQ@iYCLM#@MD[&\O91uG`<ml7+<6W9r!_MDF1@XQ$#4B#[UeiJ4A;$XO[FZ[%E#D0`DAMAM2c$Vg]T_7H?0A_Y_@K)9cBXp%"b(V&Ku;/FC[QQ[sGG+*9X>T[sXs1ZR>ZCVT8UldW>@Z>OoM<M.%<5D,#;brXd(_o=M$p6GN55Tq`tTS'96J5Q9%Jre-kjKL!Suj$(?DRTBnRob.1b478(X-8"\X%b)Q95>da@MppW>V&tmr4LT%1fc[ct$rW&#H`P]GdA;,30Y/rV;`gQRP:3$!0eBapd>#u([KYE3,6)&uj%>@Y^ZQ6*?@`fJdmL%lSJ(>k=6p+<VC7O3NZLK=!3iaC:10?]NP3#IlG9"lM."k)X>6qT)N<X<3?ftjl/A(-^`ul>EKABG>;;hQK-djO]OE`'/5o9>5"=N#!U7U@)FpNq'aH+$:*H2Wa#'Eqq!Yshniel0RJ),MZdb;e2]MS><oZ&]9ZRl)RDtH)o"GG'O#iHJcL)?/JIcm\=._B!WR_m4"uFo@M:.%)QPLgQ:risG[P81r@EDBC3P@5[C^T/3UL%@Jme*'cZ<;<SZ%f$$ODcnu5<6XX_]"H8(s`d?p'+A#hR]PaMQ;mKlfEJRc"Dr?$5l=hLgrLsLVp(k:67#p*Rjp3RpK3$kLO\J)?I5RIB*`&DtWgWGA6\D"noGNiU#?WH\uCJr0>,71j>Tb1BPTm-(XU(WdBtl3O2&\K/nfe]g54n$L+rgZr7"nD)R\j$b<`^MW&dG#m8:!h&o!e)@M2$9[-+M$hbRG?iYrs.A!F"icBK4\/&nWZur*n57nkLq@d<PVsu(>1N0Lh%#n:iM--m/>&d_=M[>IX+*o82CVa3Pfe6;Mm(+BCCCe"LZ*M<dii4<FTs!t_?T*Y?Fh#n&[P%]n$Q;XT[X_Z24@!J^Z(+?\gp`"92c4V#L2j]RgNe(j<5Hc830S7YXG.<_o'`>^7+:D2=<u5W(4IU6\S?(e=aODP]R>N+TQ)/i1$d?f6nY6KF<m2MH?eZ?lD`%V%OOsP8\&(C'T-\cGunf&W*#@LI\;"lO7_J7GDO.P]\]/$6%h2<Db5QD%*[NJ:Y8=bbn8e>%L(NYcC(Hu22XZB0Lp)kP1488.mCm)FC)K.J'8(r5:.U705Zb_BRdX2Q=G^%29EO(i<b-5.F($7GHO1mCg0"%SU)E><i8JPM2r&eiUlVaq6_K_/%@n`rApD9DXNeYl+k.eq<fki([$(2,j,Yn7tl%Nrj4?]s4E-S-?80r8Y^?&YDmAFF_:q&*Hu#aB9JjZ>8SIZ*?bhEpH&F2k&5*IH-;LYg0M--oka>OrZ*0*/ifF6;efnb;V@f4'l-&6$8pZQjrchNUd`!>[l5QH6J>Isqt<q^5q&2FLb]a$1Pq!c'je7^k/a^?r;6A])#DqLjD^Uu[ro4W([`'&Ac~>endstream
+endobj
+58 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2176
+>>
+stream
+GauHLbBDVu&Dd46AuYLV/Dh/j<LZKSgE^WF-/EYFPG!_b"B5H0Wk\!25gi88M0>o[pfJa1RePSF"lSEJ?pBPbi9(jQn03B*KN/1Am)?2T$-uZhs',sgR?u9"5)ahcOtP2h56('%Zlp8]:BN8'.&><q=M/m&r>a[.hSC]hHe*QLWt2H2SrVR[PJjsp^"X9tHgA=\\I>59]F:Wj)1KUlOJVI?QO@'4]oZ!"*.)B./L62A/Vge>XtSY)4d0b$0$LDr7>p24i!4NG^usUI>3&%=NbHff+U#N#8mo??pe,a(#qss@Dr>g_9>.7uRsS]C9.0UE-HWScX#s)8*5((QQ[TA"P0?Zl.7riX!9.SXV/R/#;4!;1of\m8J&@F3`::`&*Zc-Z+Wd/MEJE',cCr.Y/=np^8\X9@.%<<MNZYFoXaaS,CngdWn_o_0;u/bN4t`M%Q]D/QU/X03TX\H!YIQASY)gRWaC5S0)$N4a($cf[<+#bF(#kR:M[m\YN3rtmYA:PZ0"BuuDT:J<C1+WET<L5q^T+D3)^Y=M13N;^;26$)A,kl6p/bDjg2pfTgp8Ib@rN96/TXu6.mC[JjfH"*<2!c\5%SU'oqH6H^#nXH9/C5N3Rp*$no+='iPJ5-3hoM)\-)$?!qcOfmEk4e$XrZVL_#\X.fnP;PFcK`ZjMkhr[24ThPtSp^A[f,1a(d;T#K0W7DX!!^5Ok(FQ5>ENh[B;-Gdl>I?<UT,gsdtNB4b`O#SE.UVm084ERW",&!BD&@nGGI--I!*7"Ue]Z/M.CpW*%"!PM1*-<e%]`];D]l[BS.P'V/cq4d(PCS@2RKFkPV!paX&_Yr)^a:M*AW%9Q\`)Ap7q>t'3\8gsO@#2E&N@@4L,V2%HIoSFRpkj*g1BQ0djHreH;gk>6a)WFimKEB`ZCf6-"mH^K.]D]5l4%"(+mu>=fpNf;q1"W[FMc&-.K<-f=^Af&1Fgu<e3oretV+up/[l-;KEtWEM$Z$:fZVn:LJ>b;6U7.[Xjl]:q%j,9k$uK?8Jt<;"]I:DKcCD^a6U,S<aLXDJYqq%D1`U"gUCGV$DKd%*$jH)JnrC'XseV%'R3pSa(b@`f<`%--$^m%<JdCI[f5aVX`)aCt/2^G;quR[5%]FGEqGs-4:=0"C"NqN@8DKGFTu"FA'KklB\rLb'nh^(P:fa#6(?,/\g.uO8Ru%7Ho$t3*"#X6gAohPYVdip,$)97JuASpS/im?Crn$)Tr^H27ZF8DA*p<ndlZ3&^qC2fbt+#)!+_d=Aa=J_AlT\%p$*b+R#2Y1Ym8F0Fs+?%:C4W1K`6frB>(*B[[nOcq>o%6fQ&!n99]8+q0\CA^YOUd]mt=Y%B1gd4!6(`2eb3k-GC1<.8p/l=X43Au[!mmrX=@fq\#/7l0Qcf2e[(?HqP7P[k<@N;o;]JaX[g_^-!+CC*hA!tDT#Qpp4KN7-dYI<1ti+,q]sEq[ZMr%q+:._FCqJ8s7Gp'<!38I$2gl6RS_V55O5H[%nH34G=0WIA+dm%D%JVYF-\`^"CgJhT^_0Sq9:(D&o-\Q(M'^"uCmhs-lG;FoC+S0D$(TJf[Sc"HqeB$5Oj8ecXR4!7&KT[BTg=,mEV.km.M&1ZrcJrQb#Dml2j(3e+?\#ei)"]D>hZc>4*@&7XVJG9=PX[VK9Z")DmT")(u8i\/p?G`U(d,[W#"k?)[<qY)r)RZGUfN@>ZJ__Gl+sP^%=B%Ya?2pR<`r^,smJ;IiK(+*lGY2;a^?*EP;".n2^LjY[En"6LaM.(E8_.+)*B=F[\K8@&f***BKr^$_5__d48JpW'CF'J'L7\U?p'pPK#6S'FL#8Q&49316i6_N?T0t@"*!1ic#Y)04)Z'MHbWA>e/9;_rD%rimdcZAM)O%(.U9WD0R.X^[rF;K4/C+S?<4YlQ"QY]$biO2QWE2V;:[8dlhZ>_X&E4fnB>8ZIE&>,8o?#P[[m.R[MeXJo*AtHtFlepXM/.7BpJ;Z'<8Unrb"0gsRMZKs%8/`!?oKp.bBMJ$Y]3F/VW4.@Q$krTL&K4%^#:i\'pq'2%_38=kd1EQc6NqSIW'a+iu]/6[uTTQa/fRJD`Fal:21\X8#.mAS8(!a'6k0Y%6"LER<R:%#s5NkAX..K>%iQ%(HIsJHgiVu963.]+EVX#62)6gi&e=5cLc2F17tL/>l4gPbrIT~>endstream
+endobj
+59 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1769
+>>
+stream
+Gau`T?$"^h'Rf_Z\8S2aUEH6`ns271lPU+f_<jm-3fCA<NMTp'G@a*jIIF<aJdkhDV!V^43%OCp3;;3T/p:ZRs'5FW.0/5MiRN8k>S#siE.,c^q&$9t(Oo^I:Eh/?O%.C)1CV,[*5_;C\M=uV`d6i0*Xk2AXao:*qq3j^.k9MDn;?9k_u)=7Ikg)/mK>_f++Cob7Q^'!;&jr#!1X>.GnGN%XrE(6pZi!s^:rO59Aaq[*sr:*JJ1!Bb@,Sa&bF\q(?(169f4Bhgi3Se.!4GDkL5@o&Cb^5H9[)8$#@$Z.(sCk(-.osboZ,:P)#GPahqAHKW:RO54/XfNZr+8#P#`rp#?Mkn72+R_5ONQnOTAJN\3ngldoNMmKD3IP$HCp5XN3pjA[s@bDX58U^=5a\,f"64_K*4P6,Wql'"4G$2uD6j9QDIK+ho+PQUN9.LJRA.&F]meR,Ws%sSHR91cZ\':5?p4A]45c=d5f\SUm&<?+.O+Gk*'D]m/X@XJ?TnSVVn@&YQRdK4n8/!((60ud*H+e]J2Eh-&;9EU^t,ZRSEG!TAC\,Ttu3#C+R$`\t&fq987Qm)`t'pS#3rGs*S?kiX^@SW7_=DT+^q.8m.Knba]N<MRp<E5>OC77I5pl_a/Bl!'cV1GUsi"R$Z"uHC"%T8`LAU*^d_d6Xd)H8#!6mY-]a":G@9.#ql^crZ]8+7&+dCDMao_<;9Y)1@]Z\3AqJ`pp)+<[FQ;B=^#_fkPI^HEZ`K6&Eu9/L>`^ogiP7JeT5:f%?;Ul*G3:kKQ<m!W]M93=!@+djJ@.uLu25pNP,dLKLoD@!\DfVa.4EDN99.DGQ[hk&a4c3GagC"R"@d^4o`mF^<CifDk:/-p;@<tsCu:8K4phsa.!Zde]gb<bues.@HN:-![RO^ZbR*,L[16*PHC?E/sL-!"R&i!j$#kHjHtcAU!PHKZD[h1S<Jf(C.=EKKod=X)%2%65&7;6_+O-#a'VF*p\<,>D2D:b6Q)1$>9'15`/D>\QgYHE]!%4@`=<VIIfpi7g"_;StBthLK&ccB^")>[%F+%?6M*r"9d12Pe?<LWi3_Z7<5S$)pba$DJSVc2pi^Sn(`<;5nqQ,n@m!`GqZ3_P%BHaBR7*M6Hu=gEq""7KXD^=7m]T>YUYFpbmVsB_2o20.pW]KLW5aGh5>L6:tP*cG&g3mmu=E8,g>MegO\'?FtOW&mK!J)gtO:6,)/oZP1.@48CcC]n6?o_sD/+\Yh8`]r&;j=X$7o's7"<&e*:$O0!,m;F.XQTWS;eds>Y@b-RF/S,.S(MT'4sBVWE!bZ*@q'\1deQ4t8%;lqfjfeOKmWd=V!/m]M>S2*D.'U<Nk0;3F0YRdS0aBX,6abIsC=RDr*\Y&S0UU%eY//)g*Da1m%^9=D)F:;UX@Z/:sX0[t.UZVGR39&KR^YHKg\,5H[oT>f6V5MB3LQHdB-4?9C1]6[rg'Q_BDdMP8fH#M-:s@8Rhse!N>-^NI4.Y,P9lO&2k0#Ql1/$DZZ/=O((Bs]*rlu5C`>*8@bYWB'OY?$a(g<DRG5mkVa'J7Imr$/SpYo\@Z59&0p$_YlPrkERH0U2s(tM'br?HqL&9%UD0X1"0pDMOGH_9(AH=HlSED1Amq!%&<`tjW7l!u[m?iPC/]tJhMGrKf%[/SK_7Vs?,!fLR?%ho1E2ki(jAPN]P3`'Kkn:(UqoCr-W.*V.WpM\+(ZeqY/q9A!P/I:[$,oNM;X>hh>/2?EjDsXuGaQBb]'VuR6#8F>qOqTJI!OTAq6N~>endstream
+endobj
+60 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2517
+>>
+stream
+Gau0E?#Sa_&q&$/kdS_UCr__#YC0Lq1Red_Qbd5H&+4"9(l>\HO[Oo!ilh>tX/8)I9u^3R3#KGS7$44D];hnl!=eQPn=O\ioOU<)f)Z$u/X@)=K8::%FL=)T3ibcJK/!n]lg'2NGVYbIkk2DfnV!QAI1crT)MPh-7d&Afm]Yi0Q%m#2]G0VfC%5P6r.C?jR59kBs("2AR-iZfR*K=&BM=%-Seb)k*<j9$6?h>4E;ScKY9"QMK1SHKNQ8rQXSs`Hqm52M54.4(\8aR"@U>S`qI!P[Kr]j!qYAa0)3Wn(`H=_fPd(Jr#35V^R\_p1aC@f.E@_L\IkIO>.UVRZrqEnJT8_rcH2[YK(sF?.^&EJoM,@+:,+s2rP$l5cfEe,r[oSe%ULT^V7M7UK%""$N.[>+@.&Te#7%ValldW(K6H.7LN@_GVG!Q(LA7ZpCE7.Xa7FJZMOYWho2NPQ6V9ZJ?<%cB&X[FLo<4qkE3[7(J2t)n$O/o/QB4?'3l!mlj6LoU7Q.!2hX%DK;Ss<:dfOZ3u]F!F>f8bNlC6`:u:1LkOT=cm>?W!\a5o7D5$K8H=iV7*Q)<j0c_A`B0a8Uu"L'[WZdTr8bCoL";L0D78XJO_!hu!8tPNpQY_-bdMXum)9=+:0"7JjCT%f)#Jd@F+55luSF@d3B]EX\`m,0U(](kGZnnq;J(\O#BUVL@7Ng@YoQ"L:Yh&E_r,.J''Bq@p?G,C&85ZjP288;0DA<-S\IG2`/t'hk+TrsYqF9VASu5C2s]5OL/=1D@,-.rb'UO?H4#AV,GA<i75kI_uHu/r8/BbQZEZ@;M6;.nH&JBpgZ(WSU1pQ[.$AIjX0_!bjQ.OOD3L$?/INjTkG:Puh.b>p)YDj3t7;H#sVYB&TY[,MBlAKBW;Bd.rr^L\qgRJb>8-XP?IhC2<'8\i.nZ\hDPX;Gr?OXs(`gXlm*Q3Zl_`Ub&I0YXC[>.i,0BTi=.qeGAt(B5%o997"-bd4b)*faEIeCMmes?V99ZHHVg-"8R%Eq"mt`5rj`2#,#,p"EI<R(J0q/[Gi&A*TO%0jCP(.jZ7I2g#8DB.TPQ'8io<<:<nXl"FL/>1d@[uhoVco)=[,Z"s],Up@*g3q/G6"-:b,\m^@lC[X9Elh`uhYOpe`2nKV<T7JbH;Z-gVBo8d9?4d9.;g8>P0HXCMQ-I/&RTN#GW072Q$phQi_/(mG'mp#&Ar8Y.VWbR`KKQT0C3EbK>V8R\<Ul0B`N(u[cQG9h8G+"+6%$!i^Tk5[*c/MM`U#;'e=;RV3RDBUC[3fKgJfW$&6%X0S8'WKBJ]t)M6$YeCit`=<Vk1k&6..1M2=`5LrEC2226o<\lVC^;*Me#S<`_@:*KE>re)A\@YZL@t@=3Gt6*s07?Y@i?>ep`?rj(H^C"L\-W;LfH/kSp.EW@e&.gskZgb%s$5sBM.2O`7Km[0,NFKGK1f:ORl@KBNH&Ybp"#hG_'jU6JA;`j[o73?[i>nM#,5)m[o<ja6#POGf*s&ado)HK.kXBuaaLoa.DPK=an&6uO5buEM$e`<_k+q%K(B9S/Ld86nc?an>X7_.okR$0ILV1%Jl)C6$<4t<@-64Y`7k7F"]#e04oU1&"g+@`,MP-80i'[?!Z$i!o/kWi51kSIJ$9pL3fH%&!gEj\.C)7Pp,NX:omRlDIh/BE"1"fmd33)pM\(-Okgef*in80R,/OB(!U)5ok1/jiC1GBe9U$N*mm-q,4n.iF=>`%b2?<Xc03@p=Ke2Hc[h^^G8f/Y%9_#ecEbmFnHej-Nag]IcmcX?(Tc89-#cpmY]RSEV_`^5KAT.pCl'-ao%3_lG)V[NqL@e6uWq_ii8mT8t;,8>=INd7^lr['Z,CFmGAH9IHSuRX&9d)P0\uO`@3Pg^/J2:JU-1Pn("TZ125sBi<ZfI54S')H6me2Zt'oREA1C$us!u7:F/#@[)(T7[L/5$=mF(qZu:>m"pkap&(B3fF^2*[loj?:[I$-=Dfd,2i)q,=)adu:h$2`17"2OBVSDETuiQdGN;IP)h&\AgU0gUaY%WuCOkm3^6lc%_Jg.<7&s,91+3in<3:1)>SECWF!BY];Xr!--Ft[9[75WBMFKUK!\o'PA\"XG+q(l_[I6i[>iL%<AQJ_a$f(+ff)&S((lU[U]&&AC3-_?VB]&"bni>l@L9)rNcTHcaC]]07_Il/Gl@'o<q#9("LHuJFbEOCl.*/).>ro$Jmd)P*AskWm8ell`WIo%1n5q@n:H7^MhQpO59?NQS6YWU:5=d994.m]'pGB>a7Y9Y2[J($icFNW,S^-Ai`m!,`mrM#9lZ9/P>,URtd@RJ!8EB3$PIE[D#:`<mk/.(%r2Fhi6T)i2$&[Q]+0VGA(iGTHHoQW;=g"RlL83"JmGPEe7e_i/Y3Y$Do*Wb'Uikf(AYNr='58PZ/t2fa@/,iGSiGJ'm(2n`OsmgrJF!L4<Td"d1?P9m>V4U,A".RgHV[5tla4fmEa*.U[]d'_.<qTIP0GGO1DjJXrC$\`)"-lNdWG24L&`%C~>endstream
+endobj
+61 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1366
+>>
+stream
+Gau0C9lo&I&A@C2lr!/+'L+u`C/.?8B;X^d+-piY5idej9EI$N9%LcG!gFDPNe^XcO(V-*";Z6#hdRZp#j<XX^[hZfdh8P0+bUFYf+?7*)(]^aC,pSWmGDH'@UC_\j*mMoo/)3b:K?*PiBDQ+q@UZ.NRko?qX4%amPHEgSV`BW5Jcn0/:Y+e:=^[HR\,%9'eW8Dq:U-:`<l;Wm1s:*S:tC;_V\]i1jqFurKadXT?a*\,RODErkB@h7t2,Bj4Q2VQj"Y8bF9_KMfF26+1SjW0a/*lmU6'J=a"hme(F9U2"ni.%teh`L@G-:4EBXfDVS))4lKgcT/Y[3ILsOC/@R=IAK(b!$;aht<e*K4(`.('K-_FJ\.g$X'7%PbM$4U;0PELa5Y(uHnZnrI0FCW)[[f[;9UQVNj)#Mi#V24uf<Uos<!S51gKNP?Q(a!Ce+`hTpb0]_(QlJ:"J#'1?1`'l:0N&'/:oS.PNEK;?:nAd$B'IF-LpmM8Gc*d7;r\7G!**4'JR7I7$VhQ+9_h3d>$fiCR4R\S)&`eC<R,7BlH@qkYj]sRYuNRPi9$GOIW;,PDM1qYnErdjdkSBPnS)+Cke)k`I3?pTjj%e03'`8'[2cn$24X@d?k97A.;C8&E^Br)DFu4UVa722I(@"I^UU&^aaa;"g5DoQ5E_D;.q%8K%Wal@kK?o3=>D#c31(\B<&sOg!cCp-)[u@$6A+aaNiuBbt:)$^OQq]4)N@cd-@T?5W_gT,AXHNK-iSf/$uCoQCCKi#.BJF7Hp2K\S0V?Dn:\#)96mEFor^1Ma^uLkIep^^55W=Q"Z4BmAk3D$PZQcT/o7^)E;RH?&\E:`j!,PARNFN*A=a/n:r)*q/FXDF\EaOG2LmppL_4=(?>*MJNJ$Ig5d:"NW188TK4]M*C!g8mt^oSquYQYl?@u=>&S7-\s9mZS,RF\E7L61b39:_]D^b?i+":&d0&&$Mj\iHp?un]J*29lmPObI/LL7iV0F/8a\)g0Mlbgh2tX$>J#JfbNP1WmSe'4-Rj[Yph_Fn[Uk=^Z2pfVI=s_e5`b@d\I#ZXs//&as`Khqu.2g.k+lqnI*K_Fq?N>@HBtX2!oONj]%&\P[p8s+$Y,n)YjXa\afl52;<'RL$4`W_C6@pG;CYOn.X<&]7Gf?H'U>YB]'#"S7=6V8]?;!%s$sHVPGfh<iR(Pb+iLEe<QCPOdOptirMo&#jC?33RB>$@,ah%7d7kTM0"LQQW&r*J1ojai^8aTZ1TQ\MX*I$LnHE=`eX_j--H<Mh>7340UNmTm&cVt6S0nG)i4$/1V<4hC]ch:/^p%:cgdq9X<V0tj5ps=$WUi?7\[gDl1@t,K)4NH#T@*^nsN;a"D#Eln~>endstream
+endobj
+62 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2367
+>>
+stream
+GauHN968iG&AJ$Cm%mW>A((S<S=\0YDOX3:^X?G/JL+-%9T^k+qXO$d!(f]k,uUHs*KM`_$h!$WYZU7LJ;o%Hs.?CnI^t5l.g!Y?qZM^fH#Wci0(2U84_Z=<jXX6aoNSI?7"Ga'J+JA?JMc-a@QE@-MVAJ5YJ/dt_AC$Jr(6L;Aj=-12n4@8fPS:]HT42k^ZF)ej/aql*7kEG6toDPh]<qL!4T_6i:,on]GBaW<oCe$I,DB,jsbqpP8gmLkSE0ncjoTZfa@U.^Li25(9*dANNkc"FE-CB#o+3c;.,oC-ur0q$pGB+(!Yo\b7_ft5%>OXhfM9lIVd!2kVkh5U8/?%iVc>8+4nkD`$TIh3o>>45g.h)'p<P;W>%%eeIh;@asGik1ueb11]AV^oCE,k0cZoF\);>LEf`rCEsD3CA5/+sEsDEC2<_F.9F//P;4%NR:Q3&sj%p%bnQ^TT0+nG*ErB-*BI4Ns/jra5bW;:rX7BQFCQ(E1KW`bi'kep$Giku9![o<C!\Ff)BLS'^g+K.*;IoQ9%A<.m>L=gESKEgjq^bqR:,rDB'<N[dEd1n?XXP`)67O*VlHWTR*+L^MRB]Y5JP`etk5s:/a`tC+\YL+[4=`=08#]CIA/ius,hRe`9=eM`Gh=kp*Jtq#/Q01mphgDi)![[Oe7Oe-n!0@lSNXh3q4,.jlf1Ll%Xh0Jfs7mCHSJX-*CmOC<ht+pYLL[Z(/]aj]dUmCG"u!Uk9YD/gsf[m.($GlZ&kRsUEbT4^^JQ:\99gu90V$]Zg3Y0N37AdZP*S!F*>E>&'fVdK!T+Y_:`ftE44S2c6V+%A:QHBJiu)?d0S#m]E`(9%d+fn_i-tOE5''$cScYl`:iS2lci\H$lsB@g-7PDi%T]^8lbJ4OR#cXWc:2Hq*IX>a\SDtH)KOCTr4WM8S)40]I_"h8-!N!a%CD7dOp\T0T39Ci,Zo_d:,[;lmF9Y3o&$2aTf.tpj0NQ&8imUI(]@Sf@QYk0Q;ZlR.!A85%TLG3(!*M*9r0iUpEQRE.s1:J<jc4ZM?pUX%X^781JtQ",S?/U+5>S+r_XoMs\CN2b'HSO^HUi[Dc,T#&!,*-(@'kf^HcKj@]NkcQl.r;@J(pN9i/*[htfY[2t4g*"c>N-,s\&Q7?]oCOug[A7GG.BU8(k#0%&-B)K2sHrWGc84Pn+i2=Y!]0Z9I#b9"<_1L-V3<[/1Ek<ILF#4T<>S%Vk55_h7B$Zt%ih@n-(]A$P>@tRk-!jD52MUs`7uJC;nlZ`ETl*E<U=D@H3WtL@TPOL3/K2;B?>hg`(JhQm+4;^*G`1t>#,/9=M1O#pJ?cmWQ"ED(i-=Kl'Wqd,;jZ=9_CKW4&6Q2H'(;hfg@uL@7[#K^!jBjJp3PO5L1>mTNs<N?V"qY9P,A`C3[Wh<:hQM#kR:Fr7+-jLokbBUg(Rsonm\;53;]@(>'LjIla9h+Ct<!U0T6RQ!bflb<+e)2,o-B?kUZG8TMQfa@$#>di%?.eVF'Hc0MKjAp"9Un#-6@'f:CW8<b8i1MARqX$c%*o"A]Gt$_CdG]T3P9]M=V`]HO5lcudY*,:%JMs./^\OlKoSA[cjeF_)2HBj(.7?[RZ^M%NQufR75)d=St1r1h]OFbZ9Laos3Jdm]_S%/Nuo6)V&d7tB27bW\93Tg9b7[,)C++lp1/lOP/t+./VT$O;qG@2U*>&>Nh*69ra3h@O:e\gOF,A*k+PLF`HZ&[VcISV<RTLlIU=!/i'9kZ\Rc?4@hYkKnNoSB2F:atrG!]<oEHQ?#U8]4JL7,3u;,>]*M%9Kf1'(Vs0CjVZ[]<XKciSZAuAcB:"[qr9d\`[CM(UEf8K4.'Dijo/WVkZhB0M\XH7n^sXEG0T&;r-[7"!EF9m:tJ_5;TYq1kc2'@W:nbO*P[#"a49<PrM3cF2%FK<rMIni1Thb'S]<Y-en#aed8,LO0oVf6g[seFhGEiC92fu"QD3*1?_7IUU7Vi'4f"cZg[o9"@4:uocu:KQ$FW[D/r(:$IVNSs$IVgOg[seuLS<oZ6h@$0"l#n]QS8h:58b@_CC7N)IU/IW$2U?lKV%E=4k$Hi%W/t0=O6-LA8^&/WR?+d8J'p&<V'S,egocm>?R(V9tgQ<MB?%-k"'Y35k!uSk^2*Ff1hjH^CX"bDjOc_3E.Zho"K<[hYrdm=t9%P/I-Xi+kMscgY2Mgh6M8@oc^5*#Wg](e.Ip,;aZ67`BobXX#hTgZ78-Ul=Kh]^tDXY,ngBWDIWKI9$?L4,LO*N*B-2uM7qPB'eVFeHrF0k9P##E#?J6!d.-]<f:4,j?Vr9*r0hZ;-^l3M):<a?l_!L)r]/d'n:NrtdDd%?j6km(c(ONrF@4]l%ms:OLQh`<X+tXl~>endstream
+endobj
+63 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 2186
 >>
 stream
-Gb!#]>Ar7U(4Q"]3%op+'Ib9lY2-"aP8;tK\"1IR?i[qqd]oW:+uLX29`G!BeAY0n>B.X`"p'mSQc&EC4?PQ$E52KhJ#=$sa#TZ<VEeFS07iu<L\V+DcY%aQ\s\?WAh*&bM&1hbkeZl*Eb./9E[c[+\DXne=p6:GYHQ71>+pUfN&Rj9"m39JIqQ]:lj<TOK\h$A\$:l[EU7uPO=6&T2ZaWfPXZg$I[Lci*bN&JdJ$5r6Nod6OLY0e_U\"^fq5T:[>;=(;4f+q<\;OEaoQiEoaKmhM`tk&'C*piUnb\F"XgCSbK#*"RU^XK<p-g8*lK<\)_H52MH)Si83DI"OJ$ZJR\b4EKhu<qGQr<9'Trpl^MQj*M-KXC1L]YB^io&A'XL54_:`H;W7rdl6\GDLSg2n"qhDc:Y>H.*CHL`bbOl&a4mhQFMc=XD\7J6i)K(oF;'T.cUu:]CX?rkI2\URm^>#sAgU&so*c0Z6F@Q+\/MAIZ)F[H?YD($bVXXPmjM&QuXu+Ue)V`EOFX%:*A/^_f;QpQTejAXNkgXB$jq-aZo.oC?lt=D=obe!eT*nNa_uBVs(/kZL\Z.C76CpMu2=_0$qKU#E6@G.7CrM+V7B/Cpe1%=13Qak%6([3RPBZ<A^9l(<l_;6;iQ6jS(P4/>S;^eE-!J=OP,3A8^G=&'C7`;f9dh;<prdj91e!hK-^NmSVIK)=e7C_4>8tfi$/Ko-YAne-Dp\*p,_Es6g`)CcZ,T0>^&i.(Pea1a4X40GPgCg'6guO;(^0B&Y,=5*D;OF_[8C6rRPV[p%!4*jZcYSsKsJu.C6Y_p)RP#bd7=fZ*)s[i=d3T&:lW+@mL^q25uVFYi=`Z;[Cok:cf\[8pZ793fd+M]]8gN/'=*\[msiY\,$=SDPc3Mm`!O+j\3ho&>0!>T%K$?"iZteh",T_T%ua]IXS2f0J0--aK_I;M!D%n*],:eDdk>a:IYm60$V1ml?K)#XU<nrLOJGS[\h2$K`tOTo_%OFp;GAr2?F/m+D6Du&cJ9Ym)DWG.SjS+IY1!NGmQ.tH7;6DW^ZS;Z]KdD2`'*sJ\Ar+]T[\DO=`ebObn,3qYm6qC0YfRSXu;j$E9^6N=6Go70#)o8H?&r5@e$.p9f,s'/k!k)$h:H'Hmp=F/eK_gc1'.7/j:j&Q`MU3?l@,+ied-Yc;f6SWigW@+()f`oM;:J8')fL:6621O/tR)8+4.e"C_9oe[?6O*W`fOK(!-n4W\\%7&JZNVQFO/fR*;=A*PuB)`@<h2W=+,Ljs9A)H'F4#.8,dh+[Y!A"IQ>Fi=[tC\4hFAVP5`'*"@s\=JbTXdb.TKW[u3aHk1iS?9@.B)X`so=iZ-%Jl&BM@WqY-aVLM3Q&AuA?=\=NqFp2bLi[o(ZkPQA3Cj68&P"u[iY4nUGbjXU<SI:L5$"SXZl-%COHVdj*W5M4#1a#gYQZ^(J-8P^4.i5EL]]Ej?):fcPU<Q"kNh$s/J^8;?!YIAXPr_C^$sFgbr.q3$>%D.os2=24C%-eie4YkJD;#fX\LMq6h^oN&07mOW/MTokSjUFC0;U83TAbooZ(pd*upGU"DN:T%8?a)_$p8/`l&4_e6t<Sdf3mlU)PV0l_,L(quRfG:uV&j<Jc,0!R$3MRH_so0ZH'[J8[Rd&)Obi:m;\basD+33S,(m=j=g4ppBFZ>!NR("6l7N'8!S*i5j0MkutI%gWIkc*:_sDi.Z5q_EAQ%*sDd)?*qtHHA[%-!-O,l\E9!#0dP/d?Zq"2@<%1+rWV$.5'C`LC^.OkM;0IMYJi6rTsN"Hc=dJa@p5GBrhVg'KQJa(NnUd<<g.T&t-U8:]`JcZON<B.p,D@NE1UB6[jH(LKN:PCE\$\;6=t8g'LKbB'=IdoT/4nH,5bXAQeNYAO1[E+23ka+!_re'qbM+k`%E:MIb%Y,A0,05";"Q.rgWij(*jQ2^Po[C@i4tOmR.fY9Nf`6P'!'=\*])X/38sH4+p\8:D6#?5M->a@P;Lo&dXDUI7#:L$Yn<Q?Zbm7VtQc2?P_F&DXM^Y,P.&j+uBaPPR?Y?a((>3oTtjkdQ7$_3]jlIJ5nb79Qp>;TP0"&m$W4"JnhuBYJgi^kJjl=[#T/U$1n?54Nlcb'.RJY_m.S;Z.!!Z1L4KLPOZlc%dZ"d2'/:g.]!UL:"^>0!rlE*f@8131lsug&D(\JP_.~>endstream
+Gb!;dgMYb8&:O:SbY&PEY\Dr?2*h4$E*O4)buPmC\d6mJ8m7_>ATjD@gop1jnmXVB/3EMlJfpc(^!5Z/3O9.0a$5.P2_+oXT>:Gq!.kb/;[?hcL<0`A:3OA<Zm.pkTqQK'hM[P=PXb00;pT,Cd-dJ0?3jD!]9P'poBGTQ4rLN^/X&%BT#9V%-GRuP95B\-kGPei_I.)L2]Rgo-in7BVhIKc`^):PiUgdgV_<4(F(?8;Bac:5M=6GXrtTL]o+CrcD&_KQTc`4(XDIeCqOdu:h%G<qSgQ,lj!Fh6i!8:!=F'0L$pH@T^mVh7-A%AHdXo<3;6kW'mkTEmdSR5c/gT?'SE9+3i1OgheTM`EF-4^5(pJ&k(Yi1&)D3GS.]A`>*/)8&$ngf_BO3-)EE^@sK-M.P`=5@L]>tEsRT4kC>$]=1=oR/R9L#\7,oqb8=RM,EACGYU"j@ppW?9/j5K$&K%$Q>U+E;iI5s-&q"SV>OjtQaVa*/I[#]X8D*SA4MC>DHK8Ekq;5%m\d1NYk]^bjg!*;eji%3`ZkA+l?:1lr42Pem>5,NQ65lgrQDJLpR0s'@khB?nE#oauZd]VI?VHg0F5kMK&"L;-miEG[&N?qhuVN'sF)7h5ro%nT-s-.E.h;SWXYEh73cN;r*?4-hJgU*JHbn+fNn:tc[=3"a.Ki7D5k5[t23@T'JtMTn+3KLN?-'NS4fi;*A:eHLO/N('st0UX/N=uK*/2AS&JQ;$GZ-_pn9ND!e\]AGEn\a$fe1F4W>Q?F[10ga/nW`A;l>:<e<E#p2oqXlh`/9Ef2[AF[Lg'nrGMLp:uV@Cb[k.?WGc88^UABC'*(VT_+SW$%ppi5ha2["JHcl:_bcrCW6=B/0jbmUs:DOLQ%0$q)0QA1BqX!>a]Ys)tiC0fq7k8&DrFD]EdK't,`Vll=BcpB!L9!uP`K%1,QGMPg8/^Gho66[Ze!CkU#j)@1A')%C_Jnjm=rj=ZIcZaqZM1ENe)DNQ6!hZt0oqASPQk%E?eg'7ZR4)aqSL!/dA68OA'?&-8Z8p76JB\oO%*`5!#;h_c65qG6Jc_!$K#gsZ,$0m*ZW6rJ/!Y55dA1!G&MdFGB*QYCHaQ/XbkO)HpqmP]'9D.F?Z+G&ncr-_GaNBqP;l/qQMuBJ*4166!L<;->!i!)S97XeF1!,q,If#L*@QTRHI379LdsaN`]9E90p>6$]HIs+6C"g-8=$$,'WNX^S6sd?kXB?-5%khG8cmKdcX3sDr-@%BRASgS',nIT`KR*OqE/1*cE6G\.*:^L%NqrhmAg0j]0@bp8tp^W'H/E+[HS-5[8dK9O\q7f[]UN!?Jm([&"V(P@_lqU1Lu<O3Hsq_EZ*0]lu4^?IWonrQ.qNN%`]ORH0hG)>gH8nVhN3n\_j2rpumA!Bg17"6h;0ZZ/t2/BVLb8h@*Ct`0jo0>><<K-;#i[LercQ>[Y`<Fg*R$`8:LQ&iBYWm_OGW?<.i2)*FR/9_s.^3@jIoVCg/!EY6:<'0;.Z=5ZUJ-us1NleZJf'`#S[<fN's4U$DUahP7h+Hl74bKt,HjGnH6O^[SfZF9)Opm5/hZ\%Dm;T?\q@beW.:"L7lo'Ptpl+uHUrO^Bo:>`hbHuaIRnG9?U!0*`3#(T0f[=)5/U,-8*b7TaUII;OY4N/g\h3<K!fk@J&;U\4NP*glR/s\GCD9L`-G*JF&HW"UX[8tq8\rMDWC0jTkNqS!&dj^V9a&BgZfqmA>+XT/*VX<=r=d'6Ap+QgMR/F>FhPD<#Q7>,E?iB1<+3*gTC4sEBXic.VVi\<,pX6_m\55%I?`e#norKe#l^"DoJNEeITb7_@IGJj/gWE]XA#_An+`LpmJ/>r[VXB>32BaAa.'S%'fA.L&KFth(c!8GO@ZIIJ9f4*N#c^n']M7L3o'WMY`="Vuj4fHp.lZX&-b#0a(m!8):u^q7`$*=d/h.QmSccdZI&QnrZ21*CPUO4W1)14"1O6!X67q\_MjsFWNC@=n8o?%C9h4o-_@`mJ#3A>&pp"0EU99gAlEDk;WMAuO@o\1,c)URTH]mnGH_U.h^UME.@#k9N6gms<ZPpBI`P9%t'p`!Bc/B@>TF&FQS4TY-$7/%"NU5RL%pL'Y/qc6W$7RMad)Mia]T/u6ohIi?ND-aPB6jd1;%fS,DtqOR5#X>dq*rnOYH\N^^>C4?G5_T"bM2C~>endstream
 endobj
-39 0 obj
+64 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 775
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2084
 >>
 stream
-Gau0@_/c#!'YO#PHZV=e).=*OkTng&e1jP1P=oLCPR-"Q65W*2s*[DW3)88Ym52AhTVo8;G?Kd>KF,58-3?/dclH"\$W.7G'-#=9IUk!hD8df]0(l^>UusFmp$hZ\c?)F+9>N$]d'GQt5\E%cI7u.ti[W7>3;\<k#GSC?DQh*c).C4F/phLUEBVY53?TsGR,rq02Pi%DmDpD.<^tq>Zu*Zr#WRi9]^8dTd'tfr`f?K\/@_!9CaA"!'rpFE_H7_0R^CBhhS*>i2:9k_$$:q<W7ACHRC9/;R3IlIX8*s3@3g,P]2Idt4^g:)%%(],.g,(F'I`f^"rgTQF@$_/$EJlL,J">]Vdhs(#_M8\1*Y]ipQjoMTci?h6F@S_P+mPk:ihXb$5)H^;"Ie?58RJ8a=CO."N/'8mSDn>?<42$:>7(9/8JRkL!2&f6nU8e^QJCcdj>4"MEPD:H\0Q!SED;G+\SXPO&;/4HcF#2(3u(nNuT)kh-gg8@2a!H9p3W\TBqR%S/gt1cJg]7hq?g&`?B"se-[rom-gfo`C[u9!9';>Nnr?0=KttDi;Y0J_OhQ0`Ja!e*HQRXg06mRkb[F-co]L)Z)eht\YlV-$N:4aZhD68?BP2(r;B0!4kta>V8Ks323Kph,4fn2X%WG)[8,WU4LI9?%o@Tg9Yt3(5F_mY=+eWjMs@[pZJBdYH-/dO-c]2ulk<C.i#eWgH>rRp0_-:ie*&!cI2G[3ci'DT&O5Nl?nL[WEg<DUPG`ZFO6#&(DL:/HquS[;Y!)~>endstream
+Gau0DhiHJN&:WfG(f`U;XWU8'69t:pPM3%74nZinh93O"`.6U\:2OXsm9b?!FqUH!c(`rk[11cKB0>'1hi%kMK)\13IoZXK\V.#m+bUFYf+>qf%*NF2ZQ+?71c&j-d+"d-&#RHb5+BF8:VEG<_IiOF(dp';BX\V/Dnk)?JM2anpm]Bo'ea"k'pc%:]7Y<j(t[+-Dai'i\fdQiUM0cqMUnL9T5b^F1\glcJBN-=ktT0;0T2WX,aef,k$%jFK26``cF4K(VXCBcM;pl]#oBoZIXW?1BEF%blg!jOk/#8sMh3^s>1\K6)m/DJ*4Yq2eEUl,=ZtJ"F?qN&SC7#_`I6_*Ibm.'?416PfI[>69.NUE<jV-3GZQ"(-<#+no,O!:b?/Aq*QNG+D$,#Qb<Y+mDMQO+K;/lMe-pJk$qIO&)YcHGX+K6C"K&`aFY*rYf\Wm-k$7rsp[S>?HrG'"9u-%!fTY.=\VsTLh%RYImR)4[P9eH_kp%7ApF?Z)`F[VuTf:iITS7mjRd:ob]GWe%&]3*:#K!#cQq*g[bRn1k`\P`r2T!Z\6o%c.9]f^t/n*Ga]sHI6farho46?ghMY::B7giGL(8S6?+ZCO*7%3Kgn],1/EuDc?MgJJs>;Lj<9foY?@&nI$2BVXADAc>HWm8_K)sOH3_ks[e3H3)@"j]\hh@dAPoRn4c*G/T]NPSO!4ATV.8P<)<;&V^"Ri3ABMP=L,4ISYZYG2u`O<dCZ,SuH]/`O_p_T+KmP(\@M\3<Y1ShH0aA,M#JY$VVbDBf\!PLYN-2<mT;[?SOe9`4T]F2Xqdf(/_`e*MqP8Kisgi&^:PoaZ>Zqrf;mW,J8:]2FA*`KX-h(]Ji2Ji^MWPtep\,Di^JLM6u@7q7b]U3?C2[m*$1C(`0@6.O4J;2a^\8FP!kSi2V>A"k;*G#M>h)EgJp5PX;)M%/BcSl8+Lkj2_cO6#eRLfn]&I!g.Lo'2?Kj)b*lDY'%0"`nnCi!b=$HfZ:UBe3n!1tIZdVFESnJfCmIr4_/.^816\WjWY>0BrXlF^:Xci<\no]jrn3<2no!;Yc`1YD#Ht(f[N8$e3#J(Uu\;7Ce+P%u$uL<2;3P>Z`E:TFdZUTaER@1r`Wtoi7Z0Oe/O;EVeHbKp1gfo2RB"]Z7.fCn4&`6?^,1=Nj3oYr'7Y8Y)m]DBQiCJg"Ij*s0tWX#6oiP@p^J#D8ef#pYdYOq4Usa;f!tfnSfk+ue]OMa(7r$_r*`dOr"2j$_?aERug+\8"S;0?d0nX>UOl/;8rg,??,5DEPrIfPji295cL]e/A]0(0P/fQK*S+O`DU#<!b!`RWJ?5\1T1l.V7tV'M)CX0Ti0R3K4@AAmB/[Z>Rrqq/)fK$G0L1[r9,Z,Egqgf1d.C3rj(%0M2#8QYdT$Gl,'!$#ir8T[HY"lH=`mgP%d2K2uY-7q(;]ZoQes'[6X^7D>U0m_V<i[h=uUCk93Wa%<^/QnVk4mb!feG='iWGSoI9_?as9^dH=?]:hJb.k)'s_k,%1.t5ebe(CBO&3K_MTWpB59gbF*b2'c;7V>\2)IKQidl+QFp)6YAB.gJ3;!'o`7ds9U%4\3jD^0Lda8JNm5#n"G(['Q^B?r,PWq5o85"5($/cU]U2nlm%BM&@29$"Y'Q3psmq18<D@?W1?n"k0*!KI=XE#j@A/M4B7R&?QlC9E8/f3-/1SOO&*(J9+Nr1uQ5i]FNAFsFLtRGSNo)qP;'k'P_pbpR.3MN[V"@B0#Xl2rNIf_,u03q*/@MEM0Hb]ALmn-5#F(W&ai[:SJ+(3^^,GdDB9M+U%6#b:-G*69rp#81:^FD,csl2jDO.+GC1Rj^CO9t7]87=27I`c0[b8iW=?5<hKE]9r0i._92o<C'c.pcAU)6]UOP7f9&LTW8W.h,kB\e(11+g.9Q[-H[WCMO9Y1iK0N@Bf<E[,uFD#7*[]Uh)1&"pM7eXr=X\uk^mPt/b?,_(i4?L_FeUK:E_O(c'm1:m6Ne'S^[58Q-ndlD5+25Ve';H^\RfjDVKg"r/B_+hGF`56Z;lK@>4M8hQW/%.t!r!2SFqt1\A#.gB>-QXiUB3Ar%2"\_P$Z?Y_'SA,~>endstream
 endobj
-40 0 obj
+65 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1885
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2086
 >>
 stream
-Gatm<?#S^^'Rf.GS@;p.9M.Va5l7eNG1mO+4.>Dh7O.;Y8M8r?fW"8&o']Y'5"^UYCj5_R8fZUKhK+)42'I\k,4pAk%Iht$:+ekd&T/BjiulA/--gFUpUtl`*$fE8>!ENe8NKF5q"[iAh1TP!&8;tL(e&>M%Jglb2s7\,UiF@aai&,-r<KgH]B/bK,]O`uUSh8:hJ9rP15SI,JoNhCUG7@?*/<Jff:RCUN,;?k42u9%`n2D*L;B\b-?.H2f":CYd)JA)nSfJda>Ua/?BA,Z"VH?jqY,7d6[1^@(D4Nh919Q+>kB[+h3TChf\t>].EAo\N9*[#4lG4(g3ZrhI5$hEUD?ih%&[fqT0Ig[2KJ06i1c+.0_Op!P9g)Xf.UN'dlJ"p,B<W3=GA[K0;ngD'slg&:'c?`N[U<Shn!_G2]IO>f)'bEQft($:3*taQ-,ZmfTJ'L.aPY16EhJE/<n.3j$G8^P7B:Q&;oQa=QI[]'J*Ip,oQV$7:U"2=opijP/aai!&K@G'3=#(m2hQR=+7.e^hT1;Z.,jW+^6\3,W!5:Bp$;DNi:b6WZ]R!IKj188"nI2PAtqK0`:A3a90bfeQG,gWqaX]1:8Quj`<%ZbUtY:9:"smJ1`>""5I#G!8sq8<c-%\B1adK_r^Hd/.+Z^P1C%\Teq4s;S1lmP+6&P*a$&?WSiqf0XtSGcYo#ETSqduLusk2nt)<1fkQRN4HQ^dWQ9ToR'J-)[U"3<_dHYV3qS(pAp_Z^%NPH%'uB?^E\YEV8DX1ABG`$](d-@Om6Z4,/h*`0.+H[R2Jj"o*-O"DA!sc:!A4o7G&mbZQ3V2L;)CnFTFXQ0W(G%5;tNXi#"b'JknD9K91!aI&l2[NcSc/Z\U$%f?W<S09ncuC(J')B;G(R9F(JG*&<d<AX1UTW2IMsrp]EMl<-(+#A[Y9*KC+Pl;qciHgjh];_Q!jh9kaE'4_5bWKfBd!dYIJ_c'_-r\oO)QkB@IYO4,>,a3!QD#bTYM]$Ni/=fNSNUIq(S(ZD-uf7d^'iJ2L3;ED5=(#ebN4.Io=U_W0hM6H#Gn-kXG,A@DoUL4qsL'X-PZh#h/k?[<l*OE8#3-r=P5Ej)B+e1qrAWEt%s1XM11p'LGE+GKOVu;c*jQ`^h/l`.qUL`q&XL?[ZCBs^XpJ7qkD@Xt0!)+fO1d%[.P2$rgMkEWc(/"?h:,7=H=p$_LXiG7Be?3pR&l%9PR%5sg)00WI>S,Wg"^>kGWjKi=OEIS^?.CTs^)9u3^del@e]!b.>>_hPk/cXmMq4?%.4DM,G?7if*#1)t*.I0X4o,A<a^#im`L2(bm85Vc@ApVHZfX\V7]V!^4nG5pJr@p_-(<CSGW7H"^)qRV=$(@G5?M`n!co^7jg'fGW3s_0Rt^m;,$pThM#Lp^)@Cl6aUbe?fu!W#K:3`MAKeRgPe/-]KG[\48pVWI'UlRY8@]Cc(If\YlgG5\b/!,DCAHTRp=)!HE=0=ho'iY:)ajl<<XMLq^^Y,9G?)d*o?q*a\=77K=Aan1+)bhq+PCA13T!VhKB9kOR%Z"RC83EO7E5a-f\$"HM!l&LOpcb";Ao_:N1^s2'ud"e_i;8WFMJ@7(=\9!n8T:u_s(\e`U3B$_RqZN'4M3t@&^;95/k6I4!n23g'^f`auKU5rk@=ZCR%@lAuhK8-n5J\<Q4VN.d7eG-5/`_9>;X=*kcW;jXG'thCgfFT9MQW>G]qZg?Y,1b]bHLQeq,%$.4>JkH=+oC$QHoh6s4@;d*+#jV@F/NOol_nT3G&fs+-cL@87/5.S9F_d'6"aYpZ>-FSZ8R%7Nna@Vc%r\AkJ@s4(DGFLR/dF>),'\9c-<8H?"rR;R]T_o=b;NkMVESE,abD#H:hi[5=q\p#krrPo3';P~>endstream
+Gau0D968iG&AJ$Cm%mXWA'q)CO]$KuA%0^YD;lt-9.hn)8Vfri"[FU'YO=)/;NrJqG2c1BVG/\IO)H*^&:fiA!rFc*!+%88i[TId!fJ?-OVbjn/R0pRr]P&2,i4bLc("H63/qQj#kss+714]ZpGhXh&5HoJ!_-655?u&qbn^/qb*qEF@.=C9^X./;2:Dimj5$_,fTYoifk_9r_+RVZ,f++-"A'$R^Rq4pk,`YSUWA?<-t#+/]ijr.%Nj!QUHb;d#mr$1e[3-d?Jl([3.UnPI?/cC3kI#I6C<&'$PrtXFKqo)pF9e'2:k!\h]JkX'Ao9D9l1_,XT?Wd&j]&aeGE9[UVX#lr4u>Ub:Qg8+O->*>_<JIX/]Fo%&<rQ/#nJ>kHGP1%1JOrjL+!?37G0d-&QYrlPhjnRg5R]1@*MnOXS\kc:#2E;$'+U2t[N%W)*ao@0U)ranuY!ZVmN7$4;V>26Pu<F)Puq2.f4iKn?WD(I0InAM-kj/aQGO=`C\oPs!ZgoTIP2AE6b1PrB9G3-$`<r"@"F7Y>/GE(mKH)E_Je`p:47i&=dQXNZF)^lP(e2b7,k#C/#s4[6lZ^cs_2\g.D;8f0kphL,+]DchmeK98',"iKh8,Oc&XLYs^p:(`-_VCo?@\.!F&B55D8"_J21LFWbd@>D5p`@STVH.dN0>72pX%=s5*Kd'%s09%"QBf_lW!,7lqT,Oe^9$IpHQ"&9i^ndo-Hk_Grr]NeI)[N37%ML>7T/EFG10Al@=;rlqVX5-DWPhDn9p=r24mKps'MEA\3^L84ZCSV9j,Vlb``CC^Jjk-ul/r@r;p#NX):K]:n?:JJGh,mQ%EIVHpDXIj^+IJN@)Mdh@"Th.h]mYOF_O7[++pcc[j,9V8bDE.;B/hS`#V(\[?B7&.>!<l4:9?QZ%p+7J0Mk&`uP)uKRPM=93:9XHc?C3M`0IVM8I5-)f20@A[#TIMMC75o+@aTF(.K=L>hVmDqU"8MS3ZQ92g!YCL]<.&KM9Mi50L/-(I+S3M=Tl_8(%I5AX=ZO,eB(7g$IW/SS0n`Ti\SI%9?)jH+B":)G-gmZs7M>$<G1XdTHChFQ+c?L-'3g%oe7+,TVe5M<+uP(h^W[p(p]'\A?t1]qKf,j*TN/TOK>CjScc;:/47mu"#"o[,j*X4/$>AKM660\!XB"a;#08kEtE,Jr-5+V_p\@L,t+Y0_YMA3"%"p`i7jAPpsXH?K^>Tq:Ifbg-m'40Ak$-"f'p1pT?;g/L.XKo'Y3el@Kaglu(.[A_B-H8(QrAQETA"KeNeXGG54W?[0UZ5V^8iT/M0$2rfX#iFaq$N2N[@T`V#i\u_WcV47g+N,K7d4WJtbXT2.D<X0WCoJ8jO9u5DfikPf[3Q7h3eeE,]3O@aW^&eKS8DQUm85!m/#&.FVTOYA+\,L2C$7NWp-/)c%Z[NZfolGGm]p@G,!-/2*1?a4Nu[@4<>agOc:mRf7"6(0hhjlsdgPISRBD:HXDMtuB)?h3!DN<OT!k:8[&Rh.iI9GY`!o3lb[7+(0sRK*L8mo7I\SJ_2K$B`"L,hP3:(NN0)d'td9%>uc0i(HYD<h@PoGST"r[t@(b4JS?tM+&reWt/prW%TdmQ?>1%3!L:s<30_nm_ORs8AHp`76lnQr&>IdsYe6'=??M2\UJ*@3l*9o&A<+NBGb\k]ao&T`%AgX:$R)3%&.k^jV6Wom.[RD^s^4LbP$G$MOEIAp`XRF&Da>W:iB[G5."idnYD#\RYbV[&k'ia\a?Xuq;TGF4mZG;Ac'mSE<a-Bm\Yi`-W"&O`rci]5$90U%g;SG@=Q(JfAcjP/Te\iZQc;Z\\Qq!"?D/1g9maKp(aYt&8f&0S=83-:K]6#Rb:dt\"7pD3VEfS53@H\;@54Q:8"3aX`3L[Id5['m@qrOmFS:8n,=DtX"&+ALi/p%H0;5CE/s`$),TG?85d5%c%ud"+&eG63Q0XJfQ:!PG3lN"&nlVpX!,HfP_uB8Yt.D^tH#1Y,,U1)d_BUMikl2o<0?_-W[VI$?2lR_^dgVdk(DE46qARqYgU+uZN=Y;-H`7!_LiUU%@-FOFQWB2ZNbMVbOE3;Xe)"f<g~>endstream
 endobj
-41 0 obj
+66 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1954
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 884
 >>
 stream
-Gau0D?#SK-&q0MX3,e,paJtPBbOO%Mg*X?2Oq`nh-l,pXTV\p4%7R9BA_6s20pJcLF^8pi^+XIWMO^k+k6rA@J-"[!2_0HgF1f&?&LWr!&W`Xuk4cBWpV-:RPt<gpV.ofh)NN:iFGTBMm><hZkJg'Q.)@Urdn97NI\0p+G=NDZ6J"R&#P5\as-8Z"gG9nI;*'*XQ0u=$9eJ)_i>Brf]hFUrU<+gD-RkX)HdN+gSo-*>7Su35M=Gg%?+/W)B"a8=0>5Z=8X*TqZ^%WYIHa2j+J,Gb^An*hTE0e;LD"NC'#[A*P;q["o^?K?Z7R+kme0obp]IRL8RqF$-+t;s)h/'o5G<?#G=(="[alk90IfS,EqeI`]9\I=#JRGUL[pdfK=Ul0LhUAd\>/9&(L@6NaGaGhob!d1%:;p<?W^71$N@>8,n"Wf=d.GT5p5t!k%9Fm-tQ?U?R*Qeqmc6jO%Ns/@R^&J8LACE]--t]GIL@Lo=GNoT5U;b4FFlX^:eje7o\WuM)6LJ3R]\*XK6f5#[[iJ=30Y\\gUYF0K*KC1.,rPNIOO[,=u7(jlb2C-1qVjS*]qPb%.A+?EWMo6KcFC%@/Y4?Se]E7%I!"ALOIQeC%!b*C>Bj6:7'(Z2R^cipdTtO/L,""3-96eMLD7X9D=Y2-C^s0M;[R;gX*T/)gu.!;nfNc<9C%dpS8Q[58ZQfMX+s8o,`b282>QKOjQcS1"\UnJ>aX13Xn=Xf8QLO1_W[bQJ16Xl-KWS_).k8aZZ"@Sod`9>,@OOnOq0Am%3Q18C1.B&4P[aq>NC62Cl]7druOY^=g7eJ0`8%\qPi_Ef:l,o:*G&%rlVKdV'O,3*Zh$mNUJq&o7bi!u28=U(0q?pH92;<fVI?L$&i+:MTDcjh:IRGG]Us3u>!.7eqYE\1U['gf+6TE,O*6)?PG'71ZM<C0k?-tDTLh0$!DHn?%VM3fMs.DH(OlugO4,,KLZQIlJpA;3j!iFmO2X[_RII-UN(.keG/aI_lKD'eIdAJCaM;q)H>`n4opNUk'+'3H/J-dhRONl8u"FJk7hZ4^IrUlp2MA58gUUW1'=4_;KM>FfnZcA_Im]n9IoX;1q5SjS?R]dC?[@@V7\<(YLZU8jHRDKP,9hRh1:-d5ucZ-J9o\`(&Y_rtl)R2;qJ41%-WWK[uT=VN'pi$PZ2@`(YKUip&mjgm6/X/o8J!'-Rh9m.%Kd`Y_Tr?qY0Yu'Tf68e[8ech'o<VtaUIJ=\@b]cVgV%0SVZ'T_f(5h[c3_DHjW.+IJ<rp>'A1r+?Vn=IYg;7NbaGQ>VMl`#/:/t\h*36k_HKGPKU8gaG8=&rRWkZ&UPff!b`M4,2.o$d)R7tq0P],;Oe&lpWd`>!5V$e>5\Ea'kY/tpuasf14>.V;EJVC(*>G]aF+Mso$^N"UDASH<LScp:A&QZ5GZalp>c6JFb05)<9Gh_Ju``SMpUuXp@P8?[e!AhE0%_@6:gCTG8fU,k(YTccBQ?YB?pd'(N+dbPXUu,a?'B[C9BZPJ"9_SBto`'mAHg:,RSFq^`^Z&cD%R8eicJIF/FRWmq43nS&=Y?u3,,_99Q&"B]MHkpoPOf7l.`@dfn+h[YQiVK<+rar[K\?$GIeS(K4+6oqP%0(_:X:H!1U/9^/"L/sQK5M>G:K1*;r)\=7b.G_Q"m;DP'H,YX(+@ioQQgq;/kEu_M'LT?"$#l@lqMiH?IUEP[VE9]uA7+27<C;LRA.pGEa:!Cnr_-bM:,^VgRqC<ftZJZSD2re$ZnDNaB/)QGRbe8?\l<XP'W;9SQ"MNC?LAjEt4eqUk9e^XCdD0629A0..;K-cZpFH:G_f07"UA.sFV\PI&hujIbK3p'8,6:Q5aUU9FM%_DR8l1g2h81_Y*1`00^#W!4l?f$`'MS?ZmcW[pR3>ZY3*qB&hQ=m%on+M6MjE8*(hkLoduBn$$[TDY^oX!2k>"&+YFCB~>endstream
+Gau0@D,8n?&H:NnEF1%I,XS";48B.d.;WgS2Z8A`9^4Ne36iM1WrIP2,^fd%1'ppVQe\/#mWn`_"C1kek!,+2k6[Yb&0N#>1E_5^5]R>4V"^e=7@4bB:u(je5GSnaiMG(G]7>"R.<.K>4^1XtdD]YOLIj'Sr8Qgi(LJ>2K]LdOgK>0oQqt2l]O3,5@8Z+]+ZKnBGmnOT#bs'loIt^H/)-@Ui6VHLKV@^"h,aX;hC[a?bf2?!+k.>85efZk&lSibm62^1R].h_EQ\XXXhBIaOf4L&2*<:N6)KqjH+ANaVb_[mC+'dgMCHcVOtb/H-fF*.S&VM/a>%KFQqW$:PU;a6fn"VL`q40$:;7UM"AhQG\DhC]iZND-1d:NJd)%7eh[^ic@Y_f,^1dVSj.>!>C10&iE#Y2$7M4r]%&e%5j[P/rdZPOoVDhcOG>cO6F]$>Z&!>=5O#1+5c5*g,[&Au4@SO_R(J[`0CF]$+ZGZXVkOBQbBu%n%^>B9nCh?m5h*%CB9j3<ZXM0*uP:6+]fVBjGl3ojMI'qqejQ4&%c^[W/H/6-bI"k.oii(#4"S"&8$;t1<=CqVK>c@mG[&#NS=!Gn%H-2%S"U7WRH<OG8_Lor)F0>-9:!t.t6+r9iqS-tgF;D*9qWe^A%WB0\DZ?:SN*/gPq@9h8U<VN&/+d[Sg@dY?,E0=a<gseK]>[!BpQEpCEdlgd?Ohk5eaJ&6Vf:gmBU;knArnJkm:Cim"5XE9Wp^#^8leF'"!g:q'1n#$LQO:Y-PlW)KAMK0.NT@H:ak%LYH4>+Z$]N)OJ4Qi"bk_D<$*67L7_#T](cLAEHCj@kLlMXIl9kNLSOa_jQ_)A6cu.kc?OD\o0NFaQqV5d*e5?<otc=<?drKD/c~>endstream
 endobj
-42 0 obj
+67 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2129
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2214
 >>
 stream
-Gau0D?$"c3&Ui97fLObX7?\ESb',o63/O0(p!&8g[!fG?*f+'YLd?Ol5V)9+mjq#PEbL1$VXfXVM8\E?mQ%le"Q4nCJbtq&!3asmIMG*Z_E*Gpnfh1C_dYe*3bk94hM`L][(gt:=ZhbCnGT9AdXoJV!--qN0Fc--$0/)4Ws*l/W8TZ^CF4L]obUa1L!1R=R74@s:ENXa#HrEpHlc$qi$InU%MS>p-jYtQDVgDd#^.HGlki/t*'jn;RIADTDZWt7:SY+g4g`-8+`X*Njll$O$iJp,%cI61V[iMVV)X]YIMG3-2_bVDYf<"J_%m=OX[:9*Pa2VH<EV)F))*V^^E9uVWK/B$I.*dqo5r0+G+A?!+3]@F%dP,<%`UAr?VOts`J!6\"#)pbCP/3J<`S.qJY8662"8Q$A-VG)HZT'A`[ZtoXO.<adU:I)0"9,\``1chIQ.G//4cU1-D2"<_1Ph3(8-e+JlSIZ$+kcs"9p0Q]"%OrgR&okMIi/@/Hm$p&#tAA):JgNRH-u<I<]D/_3E>Z)CNgG_H?AF@aGsp,c"+#L;pM.(];%$6e>5a>DCt/#Hq6U#PB.k39T!t%rQ';FrjSb\#`!U`r/[Net=Kck.(Vj:dE/3_QH.`c4(+""ijT0nslUOLkgBe23Qk$_1LKaV7co@`)/mgrf_'O&a<qA*O`>8*N_Q#c7+s_%J+R%e)2&aJ,]K+Gq(UO7CW@Ce;gKg6?`?q%:a0h;4E.#c&t5e-Q<;nd$4hCgU$08$<u+cJs(P:/gT0W][En"<Q4Fr%;/nEN9.&'MorT:Kq.!X5[&2Wfg;G_PfV/6X+[jqoWGqD7E-!UgUBgBh%e-82g[l\MViEaojC?UP7E_C=sFb7YY#5s4U`"^(3kS^nsj4-o2\r:((MCLORmBY?Z&#/+i8!!?8(3N?$U!>P_<`DB8P$tkJ4hb<TEhr;QuO*87=O++_:]am'nX?:cg)kZlgZ0W*"Ad[V12f[WX]*$RW@X.p,O*2n5\dQnpEF8lsT2bkCSe196Db'GVsncl:a+BGJ%71Z\H*ieUiO6$t`(X9qsc%$i#th)>cm_bIgelk8[$J<C"_.@S;Tc&r<I@PpUMBlILY[)aSGD,<=rbV\(^e^Q%c]ntXVZ&[J<[Y<.8%s#s4*O2fij*eXXJL.6WLTGYP+1A'js4b9CIkhC-=(j6K56fJ&aY>V\F?89k;`i&7/>6Tue/_c$$rP!9G6?BZIA3>^W@M_jNGq*g^Ad<WgVrRAkOlFt2n*]i0Ae=nZ7C^5q5+=]%%-FK`TE:CVt,*0O4B$[\#\-L(;F.$A_*oH6VQu`.X`rCe)]M1PN:.,>"qBibd^Z!+RIS@:[e9-Kp"KVAMRa^8ZEThcDmmu!iFn@!G6jd")92,;`j4NY%njY&JkCL05fWR?JdBl/Ctt]W"D#2kHtl:jb+QF?C7kJS^M^BolP*,KN(hB<=ZIqL*e-U"p`R4NMabE'DeV"cX%Ma+"eWrE=hbh-?qG1XtY]f#6"<@:4@N9G8Q]9poD:e/lf>r\3BmrIlPe7dC!e:Hb5H@lBZF(/?j"-msLoT>A5^l!Rt:edhH\sBm=M7XY'&,8?_S(AO^5ik9sLloTVu+-`N:'W,3X>lg#iN@8mJp)R%iCUflhLHbr/1IEo>&#+M'>N+TC#mMR$-dc,3[,0r2=;^:A9Be$<Q"'c5G_cm(3FManoK9^23)]uKA#V=4#XQd"X&-aNK%f`CLbB0K_Q`6o>UdGZHRgq3,H9_YM7GB?()[<TD5;bA.oVUMu'K;,n^B_m>`PA2;H$F$#a,T9nM<ak@rTqArUL4V2pC!#Y57_,Js3CBG)DPr+e[DKKd#MEH:s.aT;0'J>3.=0&46%\ZHfJ1+rVEMNdH&^*6t<4MQHU@3#MbsI0Bdjtr+,5n9'1`'ef9O^rjfYoBLpL)lZ`]4d0k]%1Oaoe4SG"2j-dBSpM_#607INiCp)+l"IA5<g;c*5&Ad9N94qo8O#Ms[fHe""252p],(dn;3I'RCQ<G\:f$"c/L'0GY^h`u&M0U/6qC[QHmBbD)s$FCr"u#4kht6%iBGhW4k[T7UC,DVa<i9K52U+\.G;h"4dui@3_6c5pW7h<"]WK"LaUG,bPa*8V9tKlcdg/GC"6T"^YQ~>endstream
+Gb!#]=`56<&:XAWR$XOb@BHrHe3(:%*<]B)`);[5^!J9%@a$,W,hIqNlT=/KQE=YFa?U:ZP'4t+Huj\*)>he$J%keEb5qU6_!.[+IK5QlplQB/A-<^4UE<#!S(*A`X'tt^$fbcZK^eb8/aN\VQCdkX!+B93j`#VCFaO3s2-'-!&LHCc^uRRNrj:\9p;@QG:[WE1n_-#W*=RNR"u!sEJeUEohbOoqqJ_,2=%AuG15`^iJfNd[mg\Ph*6(KU&5T?2M@7m^MYj\!T6kQ($D2Wnp%9Jq4ue6k0*C]BCQ$!;`]0P<=^H0LQVn_K(2MWQflgc<3cO+ROp8$<Ibu4o5!8glXA<MX;JQtGrp^Z"dj7rH_"j.*2gW5*8K<%DHYh_T.qR*(^[K`;4ufMO55$)>^6^qfeg3O$:i0S^L,Bm)&Fk\g;$P7-_Lgh_LmS40AEKKEV!pE!L?Zl9#(&'_Oq3*5MUm<b"^;c#o#4.o9c(OZIlY5^0>9pHO"DImc.Bbt2?Mkg"h:m60145AZ0RHHkG>&IU4lRDIb>&imXj8U?Of0O$bMOK!4REI4/Z*j!Eim.@89F4oEf&+bW3l5=/%Q0^pG^Cr`U^J/DFN0JPei!3Duch@>.uP:oJDtk7#H;37EW-i0n\slEFJT9QtI&Si=d\OR-L8Sk(gsL1JI;D3;^HjbrCdCGh)p6aIDs9-d,U9@[>8U;&b=$2r!X0+#4hT;MMFXqgpEXCrT/[`tcem;L&f=.cZ[?%*c!r&1+;'ubN/aE0J+);ugNRSH($7HSXu,B=6gdJ7m172T)sXAholQ@:qK4"dnmO5J;*NUU;k*hPI'UT3&md;\l((28IE+<)Xu*YrX*M5)3H%9_>bi/#r^c@;pGeWL7fUt,r)S.=2(n-reb_@LSr=kF0e,[a;oc(o$YJ+JQ/?dl(,Gi,nC*QCXu2`+!er^+WGB-!k*hiKNriJ4?d1I\:Y$ef9UF1>d6k\YTj!]m(XY6]Jbk62HAY[V&g=70fUP[#W:S_^:b]>GcDi!d)$Z;GSNj?DU-!YZG)B?mhe+r4=MU,5nb]`o6*_N%8Bl476.Bm'9V&Uk:Sh^BmsJdR::k^9s,[DEF[b'#nS,MU*-'s14YW:]oA:)Bk;"Ra'j]V<C0`0EHab@r-d,Ld'cX5>l4)-:iZV0u@lB/`UqN%fQHUXKN5M@U,%(/tluFJuZQ!3*<S7PWZO@'AlsT"'4jDjIEX.?uU*%TPOu'>,JA[DEGdR'iDmLM?7`JN5$4T:W4C/+,0%S=.!e"cWJIeE2Mk[YsI"G?G(=19kM1?s$XF)h($.dDkU'';XmO)VfD%kNK>D?!\A9GA%pPK>5YidAr`(I]ZOJbou!a&I-Ng`,7$:Vq:#3cE"Na^OH/9fNrGbeQL5"3'S.bSHB%tYMH:\IN!&;1XdIA*cGb"_F.#!?b3eR"sXL![:.aHjZ$@;fXap%9XEZ@J8_T.e6nRNX%_<DJ_9P;0N#tjo=N!Ya&o$,c>De.9I\0gX@Y@nnHV5R7d^i7'P5SjK97%N4;]#?!&H<119Y;LG+;aglMm=4((0[]ZW$47mVQ5griY4M9ARTZYOD;'E+%kd/)(]t\K/a8TGc4E[:b#tB8/LLp1?n#i[cY('94U2/R?oRO:`Y3!CKl4">LVYRr2jokpB[>-O(=0ogtoIhjof*d7hAQ!ZoTSccq8a)-p7%X?h-X1#7_T-/-YkT;WLE<l[2EO.Vu>IbLU^p9*1n)5_$DhP)91k%<K@>#TQ:B0H)IUX#ZQmY?oMWeb\e,h@saCdpi_:Vb\MPXn.i0E[g;fYGaJ`RWs/r`Jn$BZRjOq=0pnLuDVBKM/Ss-kD<cF@CF7iCDa=RW&M>q-j;Be96S/+FA:)GUZ;9)co<i2Pn6OJ:At!1gE$lh1)'M0kY_Kf3JZO%U7R\fa&T7m,e?CCka,IeR&?se6(P33^TGe3@hF^IVF=2U<uKP&u%5HDe%TnW^5f(Jf_h1Z-<'!7mjJ8I!/rE:_`LofUR/)lBYAdLNAh[DMTh6'IC:9!uo0Yh><tC-,gUQ=lKebULZegnU@d;c`%B@2EKZgPA7:t/1t!<+m0-DZl/<`Ue9^pSG%gq0;)D[/1]YlFOAFQ]H3>N`6s>a5D_BC#Sn+]OW*[k[nSF@_B+E$JO!km.[a\Nb-3nWXu9'0d>[IuDc%Ub5jis-Bl\c&>$\U^=Bk9Jo/f4njs<MAY1.!Cqc>cR+00Zbci~>endstream
 endobj
-43 0 obj
+68 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 429
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2357
 >>
 stream
-Gat$rbAP0N&A7ljk*T2j`-F?$<2gL,,^Q*dokYU,\4pFO*"[U,-)<,hVd;KkGB[YBbi$ADlVCXaNu>qn"r8>.",giGCl)jq%V2L`2"!u"iLP]X:O.b#ZpcomiFUr+"pfjAXb&LdXJa]-b2QRRXXNY"]d(/XkcSOWLf5Ao9Vkg-1eH.=N'S,KnfRs-,/t7UQT:`O:8GTP7M4_o.`ASfe)=>:9ig=?^9&\<5gjR#.rlbsq/!ncDXmHf5/Jq-$KG7hk$KlPI9>@l:0E;+?id>%`]@f-E+OLk=.cDjen=qOF9WR/K7<9'$#d!&;nL#CBj0'6!BW*gjK6qd;W4G-%K_ouFX9XN;]h9I.`Yl:%oK8;N.i[5Xr@UsgrQp%Fk9Hi6HCsaBq9k1WNXRZ0+JA(Nlj7)'Zsj&[B\GVktM4%T*u[06i~>endstream
+GauHL?$"c3&UjDWfXWYX3ta,CT5L9a2!O'rdcADC1S*b<6p_Mq&E!^WX8;QR$[tXuP-$)$A24gd";Y,+3P.8oPXbG7`rGXnkiFC%]h'Ztk]TDZ,am$H4*l=%nbYa:1/Fc0FPXZ,`m`UM2Pu8EDTrB"]D='Q1)af<>"P'!52X#McX&YY02*tiTBZ&"h>W+p40Y,J0RpO?b%:nMP5/RLNMi#bZ!0-,mj(Wj1]$a)$V]GaQtFO`,ahB*V!2uc/D;IG2]'6f4M>ZS9Ut.Af*FW_cEn*Sgc?JIRGZ!D?T6#$dSY<R994PXRP$+k9^lTYi)LqW:\uM8<F&YI_$PQPG%.mN4!u(Vs,[/U&WZG/[EdOM2qF+aA\B%Kda[?1d!@r]T`V>M'K2-8n$T/L)MYf<Y[(bkQ,C2-gm44k6!6QY)+h[ZUeIq,S4MU\_.#TFXh,NoLV!-3DMLDX-Xg>N0Sibsj$W]iV5,_k6D%e"?(gRS_McF!Q,5B#[E@rO,H=?S=jU'LfSg?H$?;dGd@YKBS55VF*fj"$DiO:s$ZSZ#W/^>CM6Nq$J=@WLIOE_;N)*T"P%#GbhoN*![@t+heXJ9FOr;T\]NWil-JF>D(@>MEfO[J2&JGr]3AO1ieOBV%,:b)up/rJUdS[&[@R@)Nqc4YeD7W9c8gmt,l,dj[Xc&c;`WiH5]E]a^2GS#'nSQnKZuWT#5+XOq1DH3OY#,Lc_`_:Q8$HJQ)%q)E=>t>"'K^%r2BWC-Fofb^35c`e^7?7?k's]$m%I!88FLESNrhBc0=B"k%'E^7nE2tj9r7s4@n0kYC<%jQ>I1U_!.Gl7++98m_Mb7V<%,"0ed%J(&LBbnLad9)D=)@8c<A-d-uM1"D:h\'9\hXk`6qjq#L73=j#VgqMX5Qcp#a.V!BT6(_X<;fql6r.`S/4fg^C4k&Kc(Pnq3rnJU9),4WWIW#u:9BpaH/H250Q=,+,Ii'>J`HQZ-_92(Vt@JWlu#qjCP>G;AY0%T^5^6FRoq]CQP]%VH0.,ID]$HX($+7oFTN7EPZ]XGYo,1]=JT@&BoI[FV^I6H>HJQ-L"gg^s=,,TCl*s7)QOg"[IW20>%W!kTJdn6UjI4e#];:8Zb:=#Rn?*9TdY'C""]f4'_dblOLt5JkE".22/8=X<W`93c3CGV-^?2Cb!d-nDDoA:s)S>LsLkZ(P,!J/aKgBVjfojL[#`O?a6iC7ZD$Pmu"]4'>5u6$<;Eo5)L^D\)WZd2-Hca3.Y#Y,#^C)lM#=DKDLn2a=YTJ.Vcj?#/Eu!*G=o]_TZ*'d4#;mX=(mI..1@`BDM5!hu^u3Dbo7Z_dtpoo<u#'3[(?!=JI!@>Xl>egOtomQ>e*f51:#Y+t@ZE.'/B\oe;3J3&L).U`MioLiic:b?VHRT84nmZ-J`:J,,OAaMmnq'M*<<kpbp;P#f/.c">eTG4Wc3Y_]kO$Xg">UVt3E,@Sc7h/-[o8i*RU5&e_BUr<W,P3\XQ[JJWr1>$#o@DTmXNrRKS#7Vkj5PCcq=*`;jjmW&ImE,B.r/0^r23/5/,`<VlB3TU>c5@gV\4_4)Tt\=#4m^PakGFZnpGjECXR7T7<^^`dVM#a".Ut#_,tGfpTd\bH`QUHUK"YT9*s*hZHKG7=,XbN1'Z$/Q-s*YV;-lRAR.X;I'b#":hY][O$bLBkl8``;UV<9V=S12pZID=@8P`0Dr'ibYsSX5CMZhAThoF8a@P9U]2h)11BZ`k'4K-I=bT=[p&6UU/m/$[<OA@a#ZR<XW,9O23ehZKdFR0:=!dJP>^sA#PG="%$9@*-[k!KN7g7*q>\@+LhLT#oj:In[L^PV>1m[eIO!rUV0u>BqL](+/@aZ0"M%!eR<%/q>g@-r4!a7WqX,$dgh;q"&jUlt05mR$#if:`hON]8Zr[hB+#4`gfdH&:D06'IrBg7es!;)OuVGX-N[VWDGIma-l#:mQ0epBT-j)EM9h!6j@i353c`cMNl4iX4D35-OGj;mZbNJ7@I2`d;`Zc=!7D"<OEl77&0m-'?_L#)==nBU0UUj`Q[j2p0R7MVH`2uQlR/@P`/_rKGNd^EL,4G::&kW\cg91.e.?q=_2N!+upcuKp(OsfmR\RljS5BF@L3rk2]\<d9%cS2!mG7gRA:$=lHOu@GG8qLK9"Pn+]clUFQ5s&A2T+C=McE=u^cgZC>eVjF'HmC3l2G!<1.=0^qF?9Cm0NWU.T*"k2dsGIrWYiYu[ZVia:<)JLVtLg=)7%:CL?8nTl"'c1AD-&>+F?s%b0iY2rj6ImVa">`O=lUE\8?i0%#D(ZT5tLrW&D7kMlm5@di/n-Q17d\V;eDcpbh[TJ2MP<nH7)L3T;M[AB=N/VT#83N@t28<#8PR~>endstream
 endobj
-44 0 obj
+69 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2449
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 815
 >>
 stream
-GauHM>ArQ1&q9SYR(&9cE"kmp`Tl29h<[_<gN/gn-jgYJTV\p<%7M`l(!$?g)!YQVG#mp_>:d"e7<(<YENWXMnA0mqrL]DV5;(mZ-@d4l`<q4<MdZ&]4tJ%APBJ8F@Tpq.kM@abk/e$<J*Jn.B]KAZ"C;A?OJJ.\EV%r`#PcQ:L<iQE9`,hF?XWDa`!uFY;;rn.rN9u+R[;=_i@G0d:$,$7JsSqmO="r@ET0EkS]Ks3..WN,8r.!7S%$-8geWBi4AL4Q;D3^Q:V@&)Eq23[i^T.KJep7N?eXLle*$!CKHMQh_LSl#prq?Y=YA<FUK%VmE6[qoHrbq=./rPkfh%]Z=aP>M#?_\Tld+/ib^r<:!4(`FJf/ucC8'0[$'q=e]0R!f*d<PNX]U,m8lZS$VQh\%n6iN[#1bXb&9@Gsg-DX/BUq`1B5X52>T1e=J3Uq*Fg?[a2=4)L\@7pK28XKQX=DI/Y*E8BL<K7<>u^r!Ph&Oe7VVWbeXDer:i_d\:-iT=0=YQm1@U]3KNW@-W<60%=k0-DZ2B0Td<Hn?L<6F!#0s]="+.Y3SZ76T"G>96;HLYAV9s+*GdcCF5cP=d;AEg/p([q1Z60_eYQT3if''q5@W0l=%u\Eo0-C4D^Nb7;q!aJK(8DZANJ.TfE>G/4;P!%q"CZ(mi[k+X_^o&2k]THY3DNb3*fo?-l$L-/S,!@A[QUnuYi""H0%t7oQt6b.G8!^l;RmN]Ocrj\Mab8+MnYQ>r12FT^s")`jS@m-bmk1$)2TBh*NYKuJ75a6Xl^C5\Wo:0\X,:tn%@L?#6tl652"Wb.nG&rjNQCSku>j9,VPl/26:ng=HjTj\^G."(;QbNFYRb(%@.DP;3MWPeqP\H_61-cEKrKjqY^&H%M?Ah$-jW5VDUm(,4pYQZX!c"k,,J,TD>cHN\^)Z5F_N^G]QLC0e"F5rKphFRV,q.QbhI85pNJf9`gu;h+P*<a=CRTpLdV7?Bup8)M"/3'r0Lt`8d#eoQ7nu^"MhBq8]:#a5.Y3GHb_Q$Xr>02s@9Nmqs]CCNj,a+dc+\T&^3B9A7nBqKrj]^<f>\lah$26'+QBGikdi/[Mj9>#L"`$cKmG0a'f9S`^1^k:SU7+5dL5W\)*6p](2'bj7,,Ibj+p.4Ek]#+#s(>Td"E_5LQ#,C7<?q#5JE`M$?4;-LgOCcC-OJT(cc'ET]OR5&O'WlG)[<Yo"$<".ifib_+DNlF1DRgQ@Q+CN3^r?`r<W'l[KPoJ;!8Ya@-Z`6@j'eJ>XeS%F*j*LX+Zm``N-rKH1bnnHTP%^^hZDqhk8nK-g'MKg_`%dnt.R[p)l77sLB8#>H(:CDH3i>\.U<.;r/6C7n_'1D51ffS0GB@7BiJ`=Cqkl_?kB[*VC/$8j[5/#.LP9NT$5ECEoa[u21S^!#:I4LA,_.Pgk!YY%;`B+_h+64bCAL\8kLZT^0^^j1?Dl]GIaMb2oD@_MMeCkKk#qGuE>ce2gNQ!_MYkr+ASJo@V>X?EicNN&O)?6^Y.,SP.DqEY^Chf[(HS+VDgS#]ocp$f>GKLq:=%\Z((-%j*N8)UI7qI>$Rl,;A^?a*d!<s5%%FYU0D^^ipbPIi(Xi&`kM]82)^Ep_WX?LPWd:k8ghN^1?ujLBlUEDn@!I:t_l:]i/7udMF#XSRKb0$oKj+'fG_75V3gOq?R^tbn0.*ro8ZD&1!D4T(7Gub4&i]06/+(0TKe:bjWY!7C>/k'o-$-s1UJ`m')9r*Tl'IYl@#s2G-iELja.7HTG=m[G[8H`%'ouUbb4;GG_43Mp`uGtEnN"Y4[Ok@-.k\A*Yp7>C=nq_7dgJB#9Z)K:^#s1Q`2G[fbDH-+;;',V:K/r))Y%jkG$qc6k*rgM]a1U/LhfSq5#%HV,!pf(T`eu+\W@!D"fsS^2SI$XR%C1$283A#g2<-%B;6V[_^NB0s00pd.BmXZ5c(_n`/INZ3HbRGS%ML!$'S:.j_ZK*#bPnW/^Ki8]3=-K^4(AXNV965rmVL0\s@]#W>Qj.H7?,lgf;h-j($?+QlnkSff_u=Gr_2=Jtsc@Nj-MNnnpZA]4mXA"'[A\=M:K76>bgj.CK)*\HP`E-^d>\k8GodFX;9-RG0U(e%l,MBS;Z-0D&#LXLTIBg3ABQk%[m8oPu6ZK'2huF>Te\!ISLi't]3@2;Hccd;G30Q7A'(J]kGd.$_'!X0QhaW*!?r7QqTYbP0.r2^kBd#lh1,#bn*IiOeMfd:(>#8l1YVWhK6X@D[`361KWJCZtl,R+mAJ>Zo+G+5j[WoT.UBeP@E.m(/GtFm_6Kit>NFZfB.JUY=5cV5gZX7$ltK8j^A=K6r079!7oQXhf$L(ADKL/D(%cYp@KB7at\n7dQT9a=WXtU]J)-4[?q)do8V1V.;b*9NcbOG4Li+mdDdR;"DXR;e#i#MB1enjsHZGC5S+u]tpE\j*0ZhQTejK(H%BCao~>endstream
+Gau0B;/_pX&:Vs/\ArJb=UZ.bhDVdtb;Q=?eR%t/_'PcW41!2[r;3#eUhQ_A705o8"h)1Xn%8Hl0Ncba*WCs$i+!8cDA]ShneJAgL`ud,fD4G#U>HO`pKLf#5)=HH-5!mqc.ZN44aOts&>IOH2/mPVs6U`m/K4C.<@dAoO?Z#0f#+'6iA$m!So08AjBNhU1lOBsJtdsNesJ1S^tkml*T&GJ(G_#',_cL_?Nt6E<5Z2a/b(j`-Kq+15"sANqg^8$Q8!Qo5%h6Ua:$CW-6]A=M8Bn/b/O)a.`aL&@A23n2!uXZgOE]\=VPE0`K%RO%'i(d+W1W8$jg-@r/tj&YbQ$kO(9BmNr;daO-q&)^HA$7R7#Em^\GWuGR"0NSqa0$'@=o]#`%j4=],XT@OnRRfLSGQK+XtCSWW.:4qU^tCp9&b15s*g)9-=DjM)*fS.sB/<`Z)1=Mi5E#'SFn9!'bSWqYF.8-Q;<1bQSNb#JnfWd5Wu,>;\`@fW,hN#L<RfFPD:p(lA!.36O(]g/FNWERIXb;%:9FQ;G@*M-m+NhG"DT60R&4$NeMo]sV>_<*8p&U]03?"m,'a]AH^H*]/j<+S"MHBVOZX2DZ:e=]:?NnT`_VmL0:F18R4O-G]H5,0;(piMCX=JNdMXg[ih1M:L`/3L;jGo*[3JV9aeZ?*K6VFQlqW5em%SK;#"M@EF!.VhTeOOiEB\V.7lXjE_]TR:r_?)JCj(bApAd/+pSZ*J7`d.8r[;4%B33anOERL?7'mFIUE]oNT]j\G6[mOD+o5#u@^aj*`#OT4":a+U,3e:+L8i\.bQLBm~>endstream
 endobj
-45 0 obj
+70 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2539
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2317
 >>
 stream
-Gb!;eD/\/g')q<+0j*?6mil@4]rUnl[[S>Lf65ouHi7F3^dtiO7NtiqEpA.()!](8Psf>L"n#3[NqbNMLVoNmL(lc>J@bdP)W94)]Qd/%qQSfX%7pik[rB&fHsQA-$&Pl:le=uB`G$=-pV2$0'=r<8`0C$.ppaK:bL_5m3eop/fC4gBQ;p/eq?sBS_<"GS7%mDnpc+1X-f[a\VLB'W8`DT#'-Kk;BbJ>&58PSul\4[nL*;C@W$.$\P4i5tHs1o&HsM]B-,bRlU6rT"HsI<Kd4D0arU7uOGn;)028"2$"8+`PBT/l@hhdn9<[\9H/8rahg)k6qlm84`8Pbk2:XR;MF`Jk>U]c-Xq%^7GCkXe@I\l$`+^$2h`qo*KW0?f'=[UaH\Q_:#%UosKeR7%$)dou85.S$eF)]:7GTB%A@U*gH:)+dc-Sh!l<E6jm>k5#F*3<oH;TKk4H*I&KJTWCM#QqNr?n?5hiMrk:Qn-QDTpkF,[q'CJ[+kMc-V+JESphkIJN%VqV,d?lf-Ra/$']8PB@QO&fMp\3SNo3*i:=!(:992-moY$h=r#l`(o8hD=G)]9JLrbBYg]Uhbf^n&4MLu4E#9uX*?>HHoHkKr*DFWc9p-I=*u@`Oe&Cc79`H8jq&?ZaD0Tf0S#'/fjlQtFc6_(t1D$j*NR\(L=^)/S#0[p%Tjdb^g&)6thbOe<_]`*%ch3g!7;;\O!AuM/$p]6`[:not:ebg\.B7,DYYmQFho)Kj+I*u*qE*aac`c9<jL4+f(gs"=8S5r5"97)44fc*"^qU1cboF<OpD9Pc/H-(A?Dskj2eK/6YAV/miDQc][0;bpL'.IAo>YrC3!Ve*qhcK[$*r_%3rsn6h<?tu>hli0GH:+l\,=?#mXl.X'Af2r>*]?;o('``os"Zf#_taQh29<`<G9p5o)pj50;?97+i?$rCpXn>ob8h_1X?;h"c4<i\.]/ip]6%^7UfKq!GDtt?Z+Mp,A!J$R6OTT5uIb=MYPp2NM3Uhf(.f&e*MYL-/auo_[eD?8,]ARO)-`B')%+%2<!G1`[B9qpB?7(&)^u9QZ^&=5B'R1>J7;h]@#c\G7?q6GI'NjFrFfCS'SGhraFQqe$/hucDnt_o/41,qrS<i99GQnQ$#rGcRMdGb7+^`8oeU4R>[\Gm+l\<SLk".<W)m(V/:#CWeUh.HM)<bq7pgWfrW_9o@Da9GH1EE<\*fcY5a^IXPRb%rii7SRn^'N>05%OJr*)M<cGb*+BcWsS[uW5i:F^"TRLg6diKDj,d<64p:e>J>$WnQQd_%:@\Nr,n#<_KhB[[gPfu.=f54N=C+uP?^beQ&7_eGb=+@m_p\Df)r.<G;9IpOam#G9f*4a5@,>LefK!XITiu?4\1iJVMaa/R&G0WK]cMPM9chX0u_\dM'7hjX:_i@qW9mMc1Xu]k1(Sg'`nBe:"?ufOHVNPBE85#6N;DjjL>*l"Z?QMRI?85s.<cHNA:nq3b4/<lGdEGHH>;?LS+BtlVJ75fNMBhJHmgHurn!s$sXLB8CI=;lB5Vauc]b!_lQ[/4O1e\/;7oL&nmZ.GK)i"-talsq2V-]7W2bi9cTg5p/:CP]#SQe,G+1#o!cE/$SO'+D4As'n&l'M\\M[3u-r7K95d+mO6hKgUk,&1n7<SsAHdNh4RGXdO^1$o_lC<iW+XjWRFh^Lbk8ja4S;L1$Z5.ZKZ*Buh>SOe1L)?Y]?4NG'JQ#l!hhCDYq_1ps@Zm()QIPq0_Dj\nXqgYukl/pko8'-K6kOOaNAmd.'nUePhV/6MI.]';ni3Kbp_t9R$eH**Fo)!At0M4GD16(FNlhr@k:CoPjk?mGhKlj#0#Zcbt[BLrtZ7W?^h+B24%[Xh=H\"-<^4KMk;>+h!'YND1i%dNu1mS7+/a(NuVr2r'qT:cYjQ^hR)U#/'@3o($$TMmF*ulH0Q0/4EQ'rXlc'ufgUe['I#ACj5RNiNWC9,2dE@s6[b&fKKaa%<fFqoJ%?VK\\JFWSNKZ1;-ZCk?**\DJkML3hadNYAcdWpd<ET=:feH&k]6f>X6Qi<TLFR:,WOE<Z&10eUkB/"VD]I>84NWaaQ7"m8e\$"k+9$r1;TQtY[KieU:31\gNkVK`IbLhU]KH?>dUefi.@Q.h*h%qDHpEb9;1e\D.j4#c25jih9omQCT3r^h/#"goL:cc$H*]\>PO.dp-a7c<Ub8U38d-a)PSfep*KB+Es\_\_O5IqmSB>f#kkl)LoEGH=_LXOb\-go/d%l^4+a1A+qZLS:or$[G2I1=BG9M6OQAge_,euG0AOh3-!6k7id]nCr0Xff0UKtY4t]?IMN;dIThhNlO+j+;n,H;:iOYicpgT=J3nd]l\k1MrtLa<Rr8=XdhjR!CK8h-sKF2cp^$]\C6[B06'4p\OZ*?o_=+Be(P$C#[ch9s_StX'0o9BXHK-D@idUbGXsZiT\!cElZe#8[IN)qF5E.Xh9h^>(UH<+Z\D+FnpaS(.op3MJI8Qd_E+ri`nE7@_LY?)Y`NKcVj0[@a%IuKk0s(1OC*`W40S%^BVW!R/~>endstream
+Gau0E?#SK-&q/*0R)ej9<\8gaZ0aTc_+gBSfELsl^]c=;2E)8JP#P`eq`U`=m)4&](Cgd/WBQ'tR58p0W$-<Q-hMmY.FI;rICp%=m*]]9@6`u)m$9!)M]WbsSP_([\$!m>6#SFs%t!s>Vd?qN_D:sA%(asS\nENu?@SSBke#fBm[24$nptEQd-NtLgs/!65+Wj6hs-5GSdS$JEORm"@"d(A,Q-n`iFkam?SCpDqEbrjpA;\1:FQ_WSR>_%/"u4H?T:ip[h0Z$F[gU/8o[!2'VTJ'#`E&^+/VDS6Q`MD'TO.Kh9^^mq*1k0P&?6#\_5[$?i-l58%j5VYS1=P6[JS"jcZ=X4nU86.T-iOgeTL!-.eSY98Q2nAQC3n>*M[DB:726`tTt:nN`#"N9SH&;rEOFOaf?`CS`KBo6e(_E_23``Zq`"&Xc@^=d?G:E*f+"EqXJPrU]DeqVV2Ig!."05oKt;k8flPmbd87SVfh=!Wqk89-f65L\olTrIUo/b':gY\t.dEZt9-Td/TsoYZpV<)LCb%M^@*<Bc\dB8E(4.;R22&U]>nM.q)!?KJULb!$$qf`I=j3F?:>k`S'e-^>*_;j6Ph^*0$OYho6^]G@UY4bdcr2%e0&Ua"[ZV<h'qNP#.Ij'/2tup6)8BGUtCJ[T<6=Of3DBi#Op5ah;C>.*</Kn\Qq5<3i<Ge#YrL&C+D'iWA@M;GR4_9ch#s])DZiO.4i$6Sg.rU[WA!LBT$LTN8mY*+70NLd%a_EFijcMOn"9W(<c-MP%P[kD3hE<G_@/D#qM0B:rQP$e895g!E?*fqL?kB9Vob3HrSSd?F)ZU6Qtm:TeOJIY5Hui`?:J"+Hm7>Zf8CL(_42d=t>j"^l>C*MDB)_^T2`!?Pa\l^A<u!j$67e[`$g]LFY3ckZ6A0P!h@q]#&ml[(koWo,6`\F*[URu/N7cnlajlkH#g4^(f"q`HIq:;h"eNIgeS$XE7G`pCk2<gT.1Dfa%_#sUtBLdNCcQ4Y$[U0,Y"(:lN;(UqsqC;co`q/]:hf+MV^K,Sm16ML`\R9_O?jYiR3m?HGfKKFU,N"[(J>ZnhQ%Xu$t(U%bdO5`<"e;pWq(T`ANKj?F?cmkjs-5,]"f-IHVaeInYe_bG*gAkg"1HrM;HG)8'>oikI;1%8?.B2IB]k1q[CLNtQ3XaElT=/W)#O&]#:i/CtjrbTkR\H_=MGBkG9?jbB*BTouh]6L$<]5]o(917,6Mk4b&7q/I=s5;X4&9HlTm"k9j!ZCa;s_H!Vei+YPp]=QlI@^Eq^Oq#*0E*NP5?_kmM[VB<3^'QeV5pTL;+m,Dbb?or>]OC.b%Lu9XTO5ZU8f9T")^-aH0X.$oicr]N*8bdj_*Ff&JP%Gi[HrHsm>E+)e/m\HF^'fNm)qb$b*4Le8^?FqGF5(MPUa3X/amYH":V/qrYi'!X_=Hu]Pfe:P.c0GSZ]E+,do.%l:BF0An,'kho<abah4*XB_4LKEnccT"isIUubOkG8>If;PEK2beM0n9i-mrF/(aNCu.P'-#<:M3>d%3Fq*k!eo_n-cX*eV9:r1-TI?'Zr&hs_g]Id$Z-G_auN0D1H2d;Rltfd.Qh"dhs+)(i+MP('@4k>@_Q1hO-et9*Y(!uf0$9b2qpOWe4'9K!N3->Hi24n@t/keN,S,RFnE"r%b")=qCmXW-bHO1=X%=Yq^3Lh`L.HLDI/7lpn8f^,6P"2^,n%C2$4cJp(i!,V!fefXp$0sQgetB#WE#T80X@p6)Ddf'p]8sZ'!F+/#dQQCs^I0P*hsr0SZoC7b)mX$OG.+L!D(]I$q8X'F_+-RB7+-ba!TdZ1q*pmo:o=n1tpXLN7Lil?/P^`ieQ^SaO+<LT"]ARf&UiY7^Tj!e^h%I9DkP9$2:c`,u^$8)<GNkcEnOaR2U!H)*.M'd?a;?OVK7rbW"qe_J,`1rGDGl#tdZ)$TU7#A!RQcu*>MM"]G<a@gd.59bicg_gUJ.?il6RQD5t4Sp<7O_rIeYh+B6M6W(hSr)tJj_]+e==Tr=O[8DLJ3ftLqU%;2j&Fg@`E_WH-Wb?cSB>CEDE+3\k!%paQudLZSnstmQ=VAF!I\"q\1$kh'rqMfr#ZurE5f>:K\Fh[bWOY$Nmkm48L!"FQi<",GdFIlE<j7TC;jjbbj*ohkgS?nMl)jl@B8WcNd=Jq0q#Q9l*ctNTL'@'_$Oht1Vi.%.mQ:KT9g*s*7nnGT.u[%`-d=Z[D=N1!0ioCA18PnRV?JnBJ@hQpp'@R>?KL#p(QaM>b!=#P@X\<@'uOMn(^HX*d-OT2f-.8if3hBKP9IT4;d!&J*>m!.1OF3~>endstream
 endobj
-46 0 obj
+71 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2032
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1681
 >>
 stream
-Gatm<99\*g'#*[5oOTOFC<R8=5/cM=Fu!8sH*Upafr_C!V+!:2GX+Lu5V^KdhZ?>GR\@+4P]`+G!7Cc<"9!AkLBT6EGJ@8an9,8MpHJ?QX:+Mb080!'pglVc3pUu&0="er^[<\KGSMmjjhKO'".`[=@c%Q$)-CSfbjU&]r!WG*8\kLd)Ys-3rW;C-XLOHM;&FOdHp$Nf-gu?&C)&9En</#2#75WHkkdp[TDgkB6>0u*;]1<r*'sg+[.%,p'8Oo?O0c$r!F+OeO>p1FCA)f4q$TEHI<bSfgnFs'XWo=*]aqncFAD@s\)reXT;[p"!`K_Ng1&XMSs3hbkS#1)NcE!Oih`iriOiYFPP-+=YR`GfQcM2jR1t!GL2tpTp4QWOVL]'+EQmVN</4I'aI1$WIg0+,[UfNN#B-Ff+[[EKJIMWlL@**P0II?;CQ@irm(>bsYB#I[.:>UY00fm$!Z$M)d%42E3?!QCk0V6h1/nCdOgT`Q2/J)eM/,rK2FacUPf"S/OOu>olfJqjd%E(#,]"cC0RK6D4^*!*O*?o;CRoK+f4#9I$Z1uHaD"-g-]p-PaKd5%Qc^IrY/[qS%dlN;^h'#iIlFl6akG)ba#"Kf^=FP<DgQ.?"eaFWgcP@ggltb=C/BT]q&;OkYkcj@oeaSgQ)mCa#SkgWM/@`OdfOQEDM>Vd+lo^Q8<GSKYbIb?(&`h_MR#t`d%<uNI06PU_i+gqfBrML<aKV0TALEl-I4.+I!akC3H-KW^t4fa^stEg9T>RO:ftXL#nsH#/h#bNG^7!^P^)\9S*$iT!*cO<!`^(EXWW%Rke`'9GMBEdZDScle1^]Fph\!9p,!V:V*4RK@Cc`[9:&3]72D5oE$>QhW>EIA0EO[>r%PHd(-QQUFpj'](qB",.=p-OprB/(6E1BPU&5K;r_6`F&;8o?F,/#:N`:GiN%Uk>mA)L)l?%reW9#ZJ1FW[VZ=BIdLKURjc@#EX2]0rQU?\9]7ZIcAl=*k#4BlmqG702n(T0Kh$X(")C]8Q+9!65>D\h1R9iF9-FT_4sa>flDMJX(H-3`U22B)Q=-)&,C)srg64V,:!?sSoq0'*b>EODL&MY@7hA_)^Dp\P/<8o>AXbMoa=RV`mSVS,".A)VB/*JTeF-D3^(Uqs?s'l6Jh[Mk+,%SgH-Ub,RJ)Jh8RFL_A\j4kB_$r'bt'TFg;00)*rILF=%]sD48XH0164NJLkP@f\V6N7\e/^l6@hBujH,QIcSB,P!;lIIU-&$N&*MD3Y$K_1fV3j"8J\h57@Q?%4cM'h8*DJ<iR1KK12P)kJl`Cr@fRN^G2S[u.uchN=>qhqK2g<)lp:+N,\7Y4T".42J^T]PYCMR^8;\n!nig+278%5!Z"\D^,JPhVKs[7B6%Pgk"'UR-FU2IM;4nB-jc/`U"*q\\IcO3PH'Zi8<u@7XrUMCkA8+DpjirDMXHqQb5,/7$[\W.]o&A:1'.\LFMcrAZPel))0B)!qIjid0FtB;;Pbn?1>3<YJP!3;*^:Ib4"JD;_*\ms;RJZZ<[;_VL4d1sD3EB\h:/S<QMoA/q;516.64>CoA#hhsgI?aLNBEumHJ5FI%RE>kL@6r;!O>Io\V&mEt@7ZO0AA5e?LlDKiS[XT64)pK's[Z/g5p:@dp`t:n:E9fCrRZ`n@'HQ"4$)Th^<`;UcT[!,i&ql/N'g1tm:#M@:l^\_YD%6GKmrmKSVr8EZV1S`i>(N.n"='%'[&Et=5]r'Dn[#@KR2!ZP[1BJ7i(gYP1W=P"9s3-?"Dk$T4gSY),jcH'?#J9FT$6#n?g,&V(0*:71oMSXW3r*RcP?+Vk^$kPp"RejE69>jRKELCP[5SbGFT!;:;[2%i'HK=R-`Fp/'SZ,iL']1Xq%+<]1MW!nnrbQ[5db(#*;K_eLZ4GO[P)+cPlfRd\u:]<o6f&T6FT@Z+]C*_C'Y,A^7&SV,s/9#*".#-e";*-Dn2HB:d#=67^O]UDp7/Vlh8!\2/X6LS#iedAD8)'qE@ZJp"M]F"D?f\JfL_A+WWZ!jhn-,g^Ek~>endstream
+Gau0DgMYb*&:Ml+b[YgYW0T*"]l.VIV?(`%-;G?b'I[XOZIqdE92[\GpNoG:m)2K_/0"eK0-l</BBG^%3M[/a6N98!Ld$j`_rm,u/r_Xoqa$jo=*-ViqK5c@`505@NU#tbhB3_+4aR+-VsZfP>E?Xo9>.L7<m^C"L\l.=0O3'aP9nEPT^bers67aES/Lt(5?a]EN]-S7nSm.J%4I$P>;sQ;57HS.mOjO(I<d*=/,T8fl;L!$5pmN#T5qM-qA\t3^;\_A%HCh!!88i,N5IRMNo0^jV@N9F%L]f?4cJD1k;KFQ]:7B$4YmY\j.SDQKmUEgWmD3l:,n-JX]IZ^j%lMVWZWH`][86%<&%I;95>qW/0uV6'eO''P+?Sj9.AqdQnc7@?pPX"1m[5`:BU'l$b*kDR*KBjP".FlUj9s;QO-DGTcLK4ARnk`:76ha9WlXD<(X&5W@Z<H_HE9W%F:OpKeUOBP4CW".86p91G!4@_M/X_m,kAB[T'='g`:?hgP^\35]8#**[,<LH@$qV1eDp4hP^2>KsuV/PH!ShcKY2ripLW1H$f/CoA/g,O/ql1ZVUT*77rurFhCYk-^5mQdjds_CnX73W)1Ksb4(rU]-8/P._iGoHJr'QW[lYc>1fs0ML7tHAT#ILB.L-/p]D6,#K"k=6"r;NQVUbi3]2)G"1bfm54LmX,'%*n^b+Y0n/;]sQ%*_GEjr@kO^$SdL`FDLY&C-,q1=77FeFohZm(B9"Xai*U_J*#6<pf&ptBaE(WN%sGA5<H='f*95$8O>gCh/%"lAO5?ja\2Wg]2H>2tI&euOX2n>_Qr[nEP>GMs$kIC"UpMgJt20XtHt;_X]b&3eRu6Ql2(=i'GTW`V)*;G(ugoIkc+V;*<)&>jR=+q^X5]HVcXpPk?61WT1RP\IDK'h"IU9RD%c?EAjX9PA7nV6g:]!7^V)fR+0-42C<>moT.@mDFI(Dm`+S5\PbtHuopm0sLlq\Z>Ai%+ptKj`Eub8e80qIc[=d&!Xg/j:)FmjK8IBn2k^\]tfY-R#4n-NL%I<"s[Xmc*^ZH*6<.&/kicnB=W9JF9aJ&^cS]C,m=qYZ?!^odNA/nVs.i_1IF)4(5MB<?`*ITCQXIl([:Den+T:)-GCC&:-1aScpNL=2_#s*VZOj\*j<^)C83X^d.WS+ia*-uM>>.GOheHeEEs>-cpM"NV,$6I9dn5*VO:+aW1Ib`0TK`Hihfl<Ji?\"G4SUa6cVWJ0kXN&TQdQ'026&ZIa7)Ioaj[@Zj>kN6_P264WKsHAj]4nn/a@pS/'Ti2)oDboc3&d+\'!`c^]HneQ6U.LQ\/`q:CYnFJ<uSHu"*/.W!VmV)Eh"WcI\_$]<--QK;g6g[U:qbcM^tea`hCM.F&_[tt0D5TU[".V!=K;J)=Qgql$ZL7_4H%rHEq\aB-Ap.#'lE/=48"DEc:?u#P<ePpSue%c.#VjWMUlL#MLr]A-P(dC9Ef-";6b[]I6%=R^)0b<'i$mh,!b[O+/\0kfEL@M(Heph]T#(`/eX?UTG^sP7X]OdoU+&8Nu)I;"SB4nI3r3M^i?cjWI;nh'^h09cE1jPd#DXIDf)stAO5@bW&K3I5_R_&/S4lgWbM1MG40CSa&o16j+%*`6E$"KV[oChp2A)ArpE9q+HI!>JWn`p&ObO+]lo&^!LB$]3h*W64W8SAt~>endstream
 endobj
-47 0 obj
+72 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 927
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2800
 >>
 stream
-Gau1-bAQ&o'Sc@.MLV$CAlr!_c-*J:dpOpc``AO&JUik2M2b%U,[K#??Vjd&2hR&.^ttHe&,GgEk9a&"0ELQ*$OOJhnb+12%?X_b&W)TV@@d^b_-fi+lqOhFIkm"I/=GMnC2/6+Vb<.K&n2c*22SZ#2lerV/3!?ZWASJk5lMMo)_\[E-B:D*,sP2QE,QgiZRhWd+DHub@1&/ePbnbQ(BKAs$.SCc-mD4cM)_)gD"uOi(&T"5#,?)c$'EYlbYZBCdPGJ[^#(hq`\^!@6QpICKr4++Du8Ns\1dgu&3?MkK];h(>e3H!Nm)\*VGk69i@Jn,Csd4Dn;SA;ZpN.o<HCf^ET'-8aXfLoi@'-X_K-DpIH/=e"2d2IbWo:)10S/)N"W/i9<34DVnj'LiRY)a=XtjF7jYkk$:Yf&0GmUF7nS!KCK>9!Z/U>b*#iLpmRlVd$11)ZlA]O9.sZDr3q`GVaB)N=A7t^dR,3%J'7tr@:X[]s<`j(X>pE=.$dC8@NE5]QY:#OcL3#soMW^.,V[^[IY79o&nZ_HN,n*_^L,fNt9u$C/.r>R_L+=ZaN8D?-*1bLO/XPrmn#Ht"W4M)#HLA6jKk:"\p^)+%(bL,h[_7dYb0F_SDsf[3N;XD`Q)I*o_0k?[j00,ul*p,-U@7im<,&]1>-%2enNu@X/"2)*&SLaDfmUD1Q]%>W=7at?`?N(0^*'_7A=\,M[6@ccU_Kn2g,`*(cr,2P*eSt2=sfL,S)ba-e+eWCNMH,jot'4dDmKP[KI7b@U\GE6j<)!XmhaTJkKA7eo_I`%^KS,60-dscL9#nJTVa*,TVM8oW%[;D0?:\)I_O%h+%C(?XCJC$;Y9E&_HG_rrsp-pP1)]e:Z=lprqh"]H[U+K>2@D(,OpEW1M_6(#j&R)L%>CXQtc6oI-+#tSjVuLZKuZp~>endstream
+Gau`Umr-r?')eE:K%M`!(U7fPGIiP3dS807?*]r:*#roOE1eN2Ag<4;P)AT&lgG93ac<LQ:=.usTMB$;3:l:WbTde,2ZAEus(KO,a"_@8Ke2SpnVi18TZ>&2luILEf1GMW0^-teB>sJ8gE2@Y?+0X0kHl?_X:N1@_n$ko[UbAuL\ja<@"`.$4O&0BSrLLhn]t``CJDR!pBR0fh=fEH_/M6rFSdU+@^jVoT=lou%bTr?-[:&^P56bW]jT2s9@iR@K2M/C_X:5!6p-`Q6bGBp&$[`jid&oFVXQDJrK#9WBf"pKl`.k>+^rb)$&llHC+N-nTssstF+:7,YZl#<b\64%?*^\-T/X"3AYWWu)['S24<&s#T6ed$ZeUB:aE$Sh>J&]?;eJ9m%9@jlfM][>j3]*D$c?R[/_PVb`b%!BY;3MCfnEg4D?QH.,Sp6I@>2,3Q,]q`c2JK`e0;1jY6/rbR5?H17a=pE_ieWE7&2Q^dl>1m4gW(`AqaV8^5BTu:74rfd;$QCT!DJ!Cs2i-2N3?J!/mW-nnB9b:Lg9nPY(3$h$GbpOK*ag33,VNms1KS(Vc650m:k5Bd1g]NU\6.XX-<1+C#B#1gc-*dZ9W%MI'Hk&u)5#G]T_6MQb9["*&L2Ss!ZEdse'lp=o#kh'*\\\i(noE;7ZT`qZL=D>`-2G)cUn630C"N"R!k;O!A7WYj@ZHmqs/-LX1G_i!l8;6USkGQE7c&#8%eLfsl%1R2MX?_]EN)!8\]QpIBEVXm/cC%j_m?3=Z7I2n!<m=RR^3#FNF1R/<%LmL^Af,430)5+KsLRem#^=j9D$Yc6nD&:>S>G_VtEtg0t2c5Z2=1PI`bE_';O)2,!PZ4c:m'*n??(ko0)62e#@ImH$j<p!(>8_lE/cE#,Vr.J41goU)g"Q]'Vuf2=?d4al/j,_%/XA-^FNkFe#^m*FE#345XTeNDqAYeTYsB@&.of2X,q(,/?2;r257qWFQ:<tCbnFiYeEPd.^&qCV;PfNNagI+2U/oK?R3]M)"RP][1sQEeM-l$_1ptcq&Xg`sB-tr6DXm%7?#:R>):&s8YWH`;L.S^c*bEn:L&HE.&6L.OPDabo5XF+&@Vq)NTMMnuejcN:,Ri)OPH7<.K4?4DgY>g^(C?jUh6\RWQKn[mn2s+LmYd<FO"-Rf,*eb+Z0TNqe4.K6'FpYi\594_;*=id1VH)P[WQ]0s3D6$D1HG<3R*C2:Qi%[df,P.fk5k8)mL8]NPE#r)@L=:o:a^',?+CpLt&_QeU2&e2_UYeXXiK1!q]5e7YUS.X#t1^_N\F-GQ/7/EduDLntoDcID.i%0"-Iu6(<g=F\QqF`$JR.b="dTG>0?@F3ol#LmCgb"W"(Rc+'n5F>>iXY6.biFjA.r*_WGPAo-j4ZG>S2dZX6$#$#<+b!O8AaQD2lW[1I&N!AH0mf3(<Q'E#3<I:%T9PK:p0?&=``Zc'uMKX\S=J8f\'VL<oeQ$fmYFOK<jaSjMlAM+\5S5e-CnF#O>'QhHP"BpfJ)a8T6lp5a)<dsLY(*r]O;1U-&nGCUVDuk\&bZG%=r\*FA_Dp'$57>;_N<ku"b<n:S"$]^]AGD^UP1D:d/8%Bdh"B"AZ87fq4XJjrb:n(%YamCVhu@RTlX;,+maEMaJ;?O34TT^@T,!+)$(GIG(.mG"Kp7G:uleNWgk.gXuiETFu=Th8>[XEYFHqZ"&"PT!_Uq'g32-O^(cq;*b4(XG'Q?X6EG,SO,>Z@"6?AsB[S:u9#5tF,goHE4+R\CKEcHBj8GeQb[oci^od^.NYXaJMq3%I`LWs+Epg',BC+4i$sOX*Yi\fFh.gFQ<Ws0gbQl?HI&8U4:5L;/$T/Tbf$o^R`uEr;G6\!3l/Y8,raOmOh@b_8HtM\X2No>A*Il2!G8mi]d=^V&.MHOJ#gB7.agYg!/g1RZ*)`5``-PFED"n.-*9T(G614PiS^(4(`Mg.e6D8<jiiVc/0<,o%HP2oDnGc"cYWO_UT3(E-1AQ(Is4ah'Rm4YICh?Qa)cR','r:o=e-bDqN,*[$Cc^a6Jcn>]Xu@Vb\RFZ_0Ut:.g0K$9iI,Q%%1A[%$IseH:n8M81tZ8J'8h5hq?HW-Q6Z=aG5%AdW"O91'WkFEOIW$h.7ma/mPAdc=a#5OZ_4p^#^X9$,o.Kc&As(f&GtAW7^!he0<;/N4JNJmVar*TE2hUkETcN-pij6$GX`CfK3&c,TtIbe5OA;PffjZ[4UMDF.#H,c#K(\pNL_BIO)ud"X'rchP"`ia=*1CA\_=&hi26)d>c_/'WdD_i0CC8ID>?H"_I<4c_B,,Gb4bSOe^et-OK8gEPGpVSf;B$U0TD6c[/3Vh.@8Q7]X78^MIf@C-hUK8ZiYThd2`;#hu@]PTecTf]#-*plEY0LmVn\886M*2Fe#<0fXg[XT=9EFk16G2$Z*$D=M*u4U:lm_5T$)@cUMnG;NF2.OkT<fKZqV0$4Ps:^/:%QeCXqEX&NJOZ6^/-V#p?\8p;V%A[4?M6.]skCM7+MN1p3l>k)\T8S:fDpri'Cl$g4t=dNBrc-u@SpZ(k7S'-_"qTd"7`VK;==7?07I<SciC>B?DebO?Y$\qX9DSPnbV"`=%p7kF58kZ)(ksDP'm;u"ddpIu+`)A<88V8A,;VE[AJNAKH"rt-N+2))"*aA62p1n6bMickq_e05sdSD1WTFRNIq9d.V!k^;(l'0/4QJbkL*9/8]6o0G%PHL,KqteU;3:k=ElgZphNZ\3IL>I+VKJ06DSu\Abh\qK8<&eSp\h,RNXLe>.:?WZT]\#oV>q"@Irr?Y'n3?~>endstream
 endobj
-48 0 obj
+73 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2304
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2739
 >>
 stream
-Gb!#\?$"c/&q/B8f]c),C<*4I,uJELg;N6OUJ)?U\UDj56nUp\+M[uM1qLI$c2n\k=dEVV\MJZ=A4#(4K<o2,L`h?^,54%"!Ihe9X7m2o1#/$*V*PH41Ut.<Hl[;Z=YQSHC%j_\7cVTMJZ#,d8M>>#&WEJ-L*S*]2%8Al\\3_N"uUd=Z=W#C\@[O.T?5l`G=H9dUuU98;=`pp5rP.LaU!K74;l0W"BcX3fbeW+(^):h#L^4XdpS\4%AQc;9Y16,g^ZLY^(1"lZ64lQb^pQ"HLQ%gN4c,4L*6%opQGp""a'E$L+"8tieYAehP.D_/e-TDM&KrcNro<.k]<7?^!A*cVW.rRIQhlo3V:F;"B3&I;*pn]%b6FSLaQTA:]gEjN.ja*%;GtX=/\D/(17m<'pD8n-9%SiYSG_CO5l256%L=tKf-Y&\d,*L)Po#$gRO#/OsOJDRTZfS"Ya)h+4fdbBl:C<%>%`(Roefj'q?kP17%*2PnF9XZP@5Z'pDH<Z`Q\1S,dH^D:[Z<1-HFO#@Fs0E<ka\!W%"o)PQ'=)./rgco;H2kBTjam:PffUJYKS:hj!_XY_6sh7N_uGm.r:>4[?hV1W,HKE[Z6,B3P'M0QqZUU;[jMI=l!4T.#tLj8:V)Ff(^GEsWHA'85O8U$XK6/JGd*%i*-hK!$X\a2?@*'_;Vk\6Ne]&<\ui6j*JC'[@@$<U@X5q6(N7OX(T%Hb=a6qLK8dGbJLNCK-'JP%t8%HEe:l:jK/.Z*km8mi9j:I4Y>Q7BC'8fiP>#gt<tp3NSV^7uJ<Qs8M>n>.)DKiY9?IJ$GPk)/*23po1^4494J2[pO!Ee,@CYm-qudg:gX^\6)BP13&?Y_>AW\+E2jElitgY[I8/#oU2V(/J&l"_j`8aI*03'YpC(`fNbn,9)`G7XEm`m6,N;M@.jurb9V&0/?sOq)d)bCTcD=E.eW)HeLE<B=I@3es]g$P+\S0i::n[#eI`KUMN^LQR#lX%p.c[246t<addV,50i!uB$I/l;L+Z'9<A)"61>WR`$m8Y7@iH*Xgf6ZdT:ZIm=qEN3XoR)VF_Pa7RS%!+iF\_PA)_*b;]N^;#\*t-T@?FY"?S1:q$%]_3eK?q4pUZCM#.6T9s5oCd]/Z_8Nf,!lbb#I]@\bjnAQ5e'27g5Kp:fbic_ubr]OjHp1Ih'/R%fci;plPpO;+/RUJ`4.ku[@6Q&^biac2H<^T&%O/E4`CT/7W]Q=%`(b:E2!c<=HdCL9rIaM.PIEb@\!?3RUZ:<*1>Ok`(WH5N9RTRoQW(D#lYNCt]<#7_ok!7M%LmAM@V%'%*MkF)-t![li"g'.ljD1JHK@^+[47hd$>01WA`sP9C]qr/S6$/<Q!C"@-oMme/VSS,!B6N@"Y4Kc66KZ=](Y.Vhb`MI\:HLn^k>0XD"a^99@#PDJP6_&XtQ:oAPdDa:'l=eNh>.nm0J1'DLX(\Jr6%'\'e)./e%,r_mI5fcOHS6`Z`rI[1HHPL:?%Wq^K6Y)JJj%[8fG75A#TPTpV;o)>UP-$.ta;:B6\kanGq^jk*Gfp&.pIc#t!XqE3R.k--jrf8Y;I/J$6?(5uhY[Z.=31,%.?5c:fe[1s]jR,oh$NOdI@9e#CcmF^W)RbO-*<*X=_9L(C9neFbNBZqu7)eV[p@^8q%Da2HnEefDK1ijk<\0'VCq&i$6\RMim><sD*D;"/MG6G%tg*,qMRguKR=>,nb3->p/U<sRTNi2EX3KU5S#<E>`DQXpb9=>CV/Lr/h/7uUiDKCfIholR_a@=M,`'9[ShYCX[jcJ\,\+mhYYGBh$]n;j[E<GF1.S_*+Vt%;KI-HsVB%qU$k$+*8^^hHYo/I`g!62h^CMkXPdNoYSE(c213/(k([p#Q6Qc<J:Jh9f@=]lqDgH[8@(JZ6*m"moBPd-RNE7"(Y"da=qOPEfK!k<$R,]pO"<L025;M=@.d;d(]9D#ef/$61Ybq"r$Q\CLt'UVJD<"<!(?9Q&kY4"&GD'SO7gpBbf<K_[9Ou$G9mdtl`^hDHZKDcku>;BV^gndE6n2lY68m4rU9s.cr^<DuLNt1gOJ.]FZ*PgQS?_GR4_K43iFf.c382Y`Z+sHOZ[7r:@$a3V-R;,tW/c@!IUHKIF8.*FZheIQZgAn&D^[bfVf/s>?Ba!6sXACR;jgC]_@:r/J]JGG,U0c3;>X9anhQ70ue7biqI#ZSH#[a>dqJL\o@Br]es6in'rZuJ%[QYk>;)nDr0Qtl;rAXJp*Y@B#pi<6]1g;=!7.D'tgk$]6b_=M>:+ScZY-0HSW:c!!cFP1Zo)K!p"(%Zc-N~>endstream
+Gau0E>Ar9+&q801R()`0fS\dKCi9h"8@N:FTJ#p`cH@CbZp`Yb,Z5eb\j!n.bYT*+OY<u#MZRm8O[IDQ1Z)Hu6PodumVeHmI%8%GB-7$mbSK+I]E-6j_X6^Tjf3P\nqQdM;Z,tULVYt6_qRu#U^_br4n--+oQqi8J_'#)LKf![>f2fJN5`QLloWGj7H/'/L'([&Cj5RNg,a./*r#Lun4%Y+DhO_bh]E#@s5aTSYHMJcjC$mL"%ZfZm!@^O>7;$Ds$;(5]8^dg#Z[E<!0rkGj1*OOldif$W=&_mJN%rH8#+eolGCTT]'u'<qjh&BT;6jWVbV8K4hp;Y!l+9)QdCVq1_q7@*)[P9ZR#hg).9.=#!_)a%$,[IGm+0&rGCJl-"Ij*OcW4T=1nOf8%esbVWEp`MI3F%>:;oo_p-[!+'pDH^atk3IiW-dnACVnarJ:bT"ef&o7TbP)X=c#\9uR10D=a9cX[1Q9Z19QMpR4ug\(QJ#E81IfoLNS1iI3BhR3&h@C^:0mK_?5-jas[aiGGX+<pdM$s3jd\_:tk*O`)L;jt63nW_4Qb><.uEm7ao5qJ!aLIY-A)GHH+>i>Wl$k83B^ofX6Q>i3I)m2AdeW-:Wm%`hnU=&;@%uaE[qn_bl3RA$$fY@P/1"42J>,?&W//l847KKRb_60/Jb7$#_Mc_N3(.'@EZ3ZO,B!FX@']Psi4l8&*@D7:Q7pdh_CZ0Gh0iXn5JG"qQ3[gr1q#hGf(#YqF-h?9WFS_IUh&lU2=A<4Y!L80hJC/n.XATWa")AsuJ'^"05?X/hHj9t*q7Ak?TI?8/W.TBBo:+-nE$e;=LeB;mak=K9M3&q'Ot(DipXjo$#BuL++sU9M#9nOp$rr'b?j*^DG-)uI)YUe@7dA(Pn!m<b$pe6A;Y6G0[Wl#67rfWE88dpgmJ8RM[GMNt::?kE)KVAB_(j?"LO2j/0(R3@MhrC;N&U0TQnK=L%$e1<pD=GWD,%!.fU+:U`[p28+)>0_2mJGQh.Xr/5]a?l!I%2Tn1T_*Q'c`;jBkM318j7:0i+BFg@_gl-bn]4Q+jtrW+WUa3Oq10`c.EN_Al3-M\OK33S4$^hJ^Y0fh?-UHrg&Cl^s[2,LN&f#p".dVX4S0/\?:IcRjU&8cW28#n34g/>]'U%]b9sV@9ZTGn"Tk'FEZKM9`Rq9kk)A1ZF:S.R4uuk(m_kK=3R/\O47jkG`I9'n0=,acW8"m@7f)`Lu`GPEV@Y*E!$DP/U:YQodU,ooH\0D]]]'-GcY^cnG@4LS]#'!.f3@=4]'6[6Au-_.\427bF1OB;u*c)=NV2-P-6<ZHYUujXS@gd-7]0kYV]ZE=>>%(!o[^F'4AVm3:bMd0IA,fh&l$:tJV7A^]0XQ(cBF64C]n*<dlq[<#EhNlQW-MaWmC$tmX<a<d9."jniTk(DbH_5&d:9G9k/L@54PX]lk!X/(0nC2KDpJ69TVAQ>\3(p[+mCdRY@?1nS)\flf;(nIsr+'pqi0iRm\e6f%Zp(,m"n*dX63W7Q2:-(<6.u\P?V%NB4NiA,=L`9X/]?lrAek/.c0h$_KcUZZh58g#QcJT6pQ/i=GEt_t"+ue^!&c>]Q_5"JI_2e3PRUHE*'iDM`+Q8U#2pcA%q%8S*rqRB?%q8L1^&YLq@qMei^<V,T.;Q?(:r6nBo%S;>#a'.M#45M#)6*9`'Loc!H*0Bebus43g3GOkTPH-\78'@h)mk=#D4[>B%N1;kd%=PoPLQl_\tqEM*W*P<q*&mS4'%LtJGpq@QB#jFBc[43B0-rZ9s.WTfN$&*XS%T!e#)_9b2o+%NiLg(H%bsCGi3-0G6d;8iF(NF,[\=oe-$'D0+!SngO/@rc)m@Jj/>6+Z:*:`SM@5tWg\R.Z4agJWp+W=DW(CG>G$f'/IPY7QLm>QiI5\C49'QSA%2Hm;#l#SY!jU#DStLVRWhuggluEmH`dk'"L+@D7%+aL/nriCZ&ZYlU7.f[[H'._3G+BraPEld`#fM63aC?)T8MZ)bROAYK:FH1kn<[,?$.6Rq"H"JS#$9/=&Jr$ALeD[b-;c>#BH5saQ"RRkLCVWZg%ZDR&CO1?Dl7,cQ_cG6A_Ref9EG;1n_uW@-]ACiCDQ?m#kYpk:2>$cGE?K(;%>@X#2."e<tEM7:X4"-4.8TOM"N"Ud^Sl1SI0=Ws7$9:R0ck4jHQ71gNHNPYPEW:a?mdg'/Y#"npU$c#2u\6I!%t/(@'@hQU^Vj^I9U-$8QnVKpE_,q1nQ>f>8;h70`2NpF5JU26Pa`F*QZ!-@<;gSopsr0K>kAr1eW*P-1N[*dudH*!r^Kg[J7rfkn8@1@gOl&`OHM`=j#Iua8/Oi_?;:`D7<*V3I^bo-0bD@1!X%>]rVqIZai&]XFeG.`)G=T-WX?a(#m;sV*m,bSA+*fc%\[kF.?h;mYir#-=F`d_UQMBU,QJg7bl"deR4BB<BG3t.u*2,_msWS#"Yn7`:1(X:B.e&S7f(G@[+TMMLS&J(?hB_7UPl!fP5-HqagCMqcZFq[s=YfVZI81hq'UQuhL9G\a]o$K6+%f-Oa7nPeV)uQEr7j[s47>0H./M,4m*'#;aiI3-jb56(@CuBg(--rB64pVBDWCchn(gsXeC4,NQ?1XU(q9kk$@VLe;G3FqA-b^-i\B4;%&-ljTSaWPt!rnF7?RPgT#ajEZ\DBBCCqSEM]2s=E^al.+C,%cG>UdesL%=pmj2U.kb'_D0V3j;4dT!mT\dknB#>&EZC]~>endstream
 endobj
-49 0 obj
+74 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2069
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2632
 >>
 stream
-Gb!#\6$M'A'#+6EbUqO4M]jO,P'V2=GdhVY9bY_;,o;@S8r,bA$\2:-?b^LZ;R%b,8m8pB?DJq](sI@`o?@MOO?s:WpoGBa+-uEm14q-5AIVe)'X56%\'),8cMBK+ABM(krUXPT/a)3urqL?^]HQ"RTZiQ=-95:G@!$[@o+l3a>.>?F'Dc(?quk43f\D*BdiqSFo#n2;Gd&fgc0+n5$H]B>Qh_&Q=cm:%&jH6j/1FtRB&\qAOd$#+0V,)_]`4hek3W'"DeFFSAk<K=&8Kb63/:Qa9K:`1Z2hf.b6cCVP/C)$1g?3t_7*^fk^tRPRU;<FK`7*m<*k]t<[P?VqD*gWN>R]62=qFRL7d-N5!K>PrLs8Q@[8R:n391)KdbUR*#A).Qi)>c[HOuAh]FnG-KRFKhU2[_ObYHn,jh48qj$>@C!j:9_%ZSQJe_mWOFGFF1/!W1=;F[:R"]j6(h<7s0ePBjXqb0Y5"KG<mt,P>*h>[]:]_NJKC&lfF%K9EiudjacJ5YOK?->=+HldI.jM]SHsF2Z%RqQ3Hj1$?YBS>sFD/<hBnT)\#@5N'eY;VFGN7DOgHaPeX<m06Q5\ALg;++Tia.b$<f7u%#=;W/EX2BM`QB8iGrh!7+24.:#Q147ol4`DZ#LlD(>EMEZ_?bdE;,fsqoRVObn7Fj`KT-R(TR@hii[uYpp)-n=oPNO9X4r@^).'(a(^_!q-j]S/W;<XF<JBdN8L:0(#3,&K;C0LA-)/HmY1j;i<?T_\eA>ID<JSfCT`0lPi6J_*3;$"KSG4,B]XUCs2EOk[=52NYUG5[;a-a8=_&t.\qO">[O0`7;^#6WNm.76S#t%]>\_+\UJP00^p.fE6]6+m>L@E/C:t81SP+KYrfmT>)W4"N/(Ve4^ua9ReHid6jN"4LU-c#*AK4e;&9Aqr4&Wc@Z@&NqVj$p8k:Q6si9S&%>T(]Y]$k!)p,_3ZAFc6T=aIAkqE\&&pHLG5+m0rWp7kZ%r3'Y=]P(N_HeHqY;>`42X=1EkOfq2c(]dG)f]ZD6D_gK`aG`(=4B)=t#Jq[d(cmndPQdi#]js4b<J.Mem%E)%88s+!.uS_?^q714ea<g+',U8RnGC9rc'L8;8*=0RAH].'&3^ArY=M3kk<*'%p'oks:p0!H3%)U-mMO"#eSlTZj1N_W-"u:]gE#O:+tHF.>#Dq(63i6-'36ut-WFW(^m=CKn-st8^En6Ib_4,WcuK,R^p:9ndT.3D*4#Y.Xf=Lb4(0GAe/hA?p7=cWi1;NC>(RL*R`2jZ#Qbq+)W@_+b!*YSfRQF%b(E+U1P$K5\@d'Y1r2@lg"r'?KTZ-VpAqQY_K\J/iB^e26(U8!814$$FB!?NlS[^I@3g69QE59`q_af7A,Pi@1d;j(>mF[+PGr7f56n^$BRRh(8boh.cm*],0e[1WiaVqTe#uI3]o?c0[iQCI(m@aUb`V,;ack*]e.o@+A20YE)#QiP)o6^8ZrO!#Z,V.?TP4j=)<?REi79<kHfY`iLabr<T;0HDeUW`YgbKfhm,_0<gmRX@YO6L3ckT]A=p1tE>9;+=;0d;fr!pYK0Y,"l3#o,inAkZNX,hn#Tf#[0gWhThO?m9Kjq*T\A%n=!r"%]/p4MfeQi/RN=6)&ogXqL(cjQ\2oOL-Kq;(Gac/(S_juMt[m!\cA'h7n;&++TY'/G(nZrS$U?isYR0^P^S$>Zpu6<d*gX13<UcO/94<3`[mf)=0=+kkC()og4\MW(e"YA&:f9(Et*'h5[2Y0fcu9WLr?34I%KW:N-2YTb=dLN<P;/$eM%cHd9(]0+&U^Mj\]cRcDhFN#H^MRG0bQd,LQGGqUq1]8c&CnO"l>fF8V,mX]&W03bJ37S+':m72Y'=`RMRT=[@;EAcXMQ4Icmon<nZ\PD[0cKW[,-.\!Z7f^!_=4:X8[f=>;(Pk45/Too`rC:S80GQB@Vs3VNUkmg=tOnfaCq0:1-$/Ahf,>/#ng<F'J#bG]*'anhJ6e#gkt9'Tj_9*3aQM<F2b.W7Q%j<5<A'ps0AtIXbWHIfc^T>6#b$jXk<>&4'Y^FA7l_dn'BqYrrMhRr;~>endstream
+GauHMD/\/g')nJ0_/Gf)`/<[N["eal9tLZh=mS&gmbK$O_+9g07NtiqMX104pC&LoEbrce2gZr\`>2fmSp=r1+WIaOrl+jm.2dJV_bNG9/0;$bN5_Q*`,73\LRY'B8'RN;1o=>ec0s&!4IJoum-3!CBgUUV5)H$8)\-PhOr]%b^&GfbXYB+!X-siS@lIcIc/36GcCFD1j!X.q_a.p?1nDkq__I(HfPN=]Etl[D$2aAD&V_s!<7l4JMC'QKZLPFHc'iPS]0?'#rj9+.0lRJ$cN$5r-2BN9^$kj'Rm-MuKV3j,UQ/d=Q"Pa;b$U4(\0%>;@eTHiFC">g=`G4]Ned8>AB2H@Dma/E/4Ar((b<"'7XV>7&Z&=L19HE[>NA+*QO?jXKGU`N8nPs"D9a4,;]8GqDTn"sm,,g[562>b@-c'J3*Z3eiP9\-*j!TRGd8ClG'jCUV6Z*t"di-nPA*s!(47aAI]0:p%W[co&jEF&A;O?I@h$Emj,*(ulh'3KiLGu=a168VI<0_G==bXbX-YlT;52645Pk-siA'Ml#_2e/4AKVGjqsM07s#_6B"9N_`TOI'V2R?Nr:oR]HOrgs/[KS"'iLh>]5VR0MZTSlCgIKb=%49QL+Sg#,r<,CW\3`PGJN9&CtpC%-l<mXK(,\mYXKm-OjZ_1EZb^V5_bNY5)Aj5LT`G.[NbC[[bCk.%,d/6>5;;<V$%XU(.L>Tk\I\=7&>lQ(nC(@a7esT05*3[BQIHhpWA:c(r'2UcoMNKI/)=\ok+9qq<&:ghM+h)7qo=SI^XD_E[1C.&SN@JXNjpJ4"&Puk'2(a[MHY6Qe#lW4M^=RA/q!8)Z7:OP6A_Fl2lG#7ta8V+o81:KM$qjQGC_q"`f_Ed=TK2/gXC1e96-S@B[JY]=THn[_5QuSoVm?mb1[;YgF8feJ<sl&5r1Wb%ts?Q,<Tng(7O32.2dd;Mhm@M,8jNieanUclCq(<:j00nYdBZpgd$&PG&T#o]8Pi"03+"fZI%1MZmHk:`Ob[Bd+'LVbKpBF=p<N:B'F"7jAX`?u+m6.PWgRl&b-R-&rRjEiudC*"#>]J5/N[PpGMH<EUI-8t[gf:l#o_(r`&L+2E*f.$b=d`d[ZioD;@!@MN!@^ImV`TCKdUX_N0<Ek\0ZW#`h*ctE&r"=bp_6^H6A^]O#(jQ=;T]\@*8*IR@X[%sS8/Hnic8_3JW@b3sAWF,oSM3s%Z>D-f=&rB\[cpd#1$s'P,NX@+3@X\S37o!$DP-tVhZ:]`h#IAHTYMY;aAhO=+\AE+`:"+VOn^)\.:(\kdYGbKUjrbGG4;7$i\D+sLGd+OE%HHn**:F"YhY'-8FQ-#8=r.SROYi1/%?:0g%QSLF&6M=e=EY(T0,Y*#8Lj??6T#hEf-2sn'%B3q1:;+L:jSg;+m'blBUgH]q#7R!Y<R#0(dI6U\Z\5+UNER%]\,G,C_3F3Yr1S&fbkUkMb$[gG>I$p0/k4&c'+Zu\_+5G@C*B?[50Z$I>ojWg7:#1OEe,F9s;BpM[X2MI3m$XXjTIr[9/$GPn!P$&S*/..BUp@'Ip,Q5rcD[,6u1H0W>MgY@OT\<:"ir)@Pj=ZbHt.o:6tZ^SrMaXK8qD]C](6oZ6bbFHT"2_6C6!-^VIQ8i9;:;JSkO:`W1t+e53k<,n8c%Je-<(B3?TGRHB.UR4-CDH)TG/s..h[rsjA]j>s@$dA&CVS"b"_s),QHrn;`V;_N%VYm-qG0l]J4(UAX)^jd&EZCN\NP`,A$A+:+L]hGiclUUTW6b[U5da+oUS7c);1#'=c&r$X:']btLu0EBEbWs.`=97=^V$r??9f0sgNoVq"Wp]#Tn9]B"2G(9`$S-,Y\S7*5jqG<-12>uptX[<L83.gBaOa8-&e:Y5^$(%psE:(0%\>"DcsjTHC_iE/49lV$k;NCK2)j!q4lHZUSg\ah_2V(YrM#=nJdQQGsFO\)3"W@23l?o7qm=2ia(dDDT,/3`2k7e.W%M8D0`ura;^?QE2OM@:Dc]LRG3opk-gGRkNe,:?o=J*0esKgJHJXamCQX7$RH=]5'PW'aY%g\k[6H=`B/-[oGu;Nf-VI^HjgqA;W4T*WfBk*DUXr]d(NUSaUM43*H)Ft15WdGro#K$:7o.MBGZ.%S5<qm/m:D4Qjs(6YHHN8#0+,-=dC7s!4F-:]/oo$olmk)[g2CCNW2=m=,Xft^*M4pNq7;T^4-oQ_:`0$_eS`A0+@lGeOuD+?kDd@-h44a4S<.T?#BNNl#Oco\e!`<abBfeL!r]+E3t<1gZ.WVMQ;BI$O,-RVoq$NBq=O$"B';:H/%!Emd<DQH;??UiS[&3!21QXcC_b2gj7N&SmhPnK[Nh,>3!2RcI@a,U<<PJjGW4/q&+IuC$Im)kAM(n<F[K@`[dL6SJsbbGE.D>c2#])YE79?)\)(U%D;!TTiEV*3,1fK*FNJA*5/5N4P,Ra/uuCKmQ,nWS5\l_j<V]2)/b[l7>IdVa]'O>^M@g';!s6epV)9.O<ak+X`leu'G;@8no6%B)E7p5g@j/G4dtb"(Y?I4fl0%.[*&po*%hL-JN]Cf.g&UjYBJ=_?C)sHN4_XtKRM^U=o<%7?-j8m7b;cUL,qm2HO<)\;:P6o"4C`6>]osf`/ag%.D/AH~>endstream
 endobj
-50 0 obj
+75 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1880
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1875
 >>
 stream
-Gb!Sl=``=U&:WfGfXIju)^]feGtVqb:#kB7Pj(hI+E8jI-39P8Xm"Yd!$783bHtM7e*1O8&f4g2gB2e"E5;]m^R$7^069+bUd.)1B0ZP3_#+Nlk0C*XXi)JA91_W$IMbd(+27cW=,*F)QU4)s#JOho.q*JoH$04\("Vk%'+HI@LA<^N?^^;iGf%6@61g.pL0O,/GWPNq&4dd8,;066#F*4?r:QOH!a%OY4Yd:6'L2t5k`TZS<5?`RjP2cu[[;:N>>^``F6aD&dNkRVrU6mW/qbgZZV)C;,\kk@PVSZgEr@>u@q(;Zn&Pj,T;-#2:g<]Zh1lOf0hGOS46P6pW,L17"_X/C,cq7Dj+PN7AumHRCTp<H6(DJe:cJM%SfXni:(t"Tf#+%`I'&c,($HXRR_;,:r1kIEH@_<]WaHcJF.EF!F9\^E(E#SS*+N,8YS&3ErZ.(9;qY;f9.,cLdb&SHZfTFl/t1=G40/gul'1H6F^&i5E->U;]<&>rM2t?n@nts/5L^"JCc6ht?53,e#6S*Of/_Et'l[RjWH)<FR,6`pXiMcu<`2%4A=+VQ$;#)Nfp7gc8^<d,>7]1Ph2iP'K5>CI!_fE@^UO9H>Po3L:`3c)_p#Qa/ZsVTC)3^NY#Y_C(XJ"jlX'4?5jTK*K*"r$QCr9/"su54d;$VA_o-INFak]\+4T7jSU@k6JbA/NDSFBN8%oSO_BIe8O8[iEH5lhK5WUiK=u?E=2Z/RM..h:_@W8NNBG>EfL-U(=#1>(N*HO/X]$K3fn5)t'c&[@t\k'$W!XlF'D0qBKe)WaV02`n8;1^J_1un;7EhBP"9PLRoXgqd#ONAEN3*dK*6XeM_U63^AEcI(3XU#cPN8GdX=J+GhO[A@j$5Qab2+US\TOcdC]?\f[DXPZ/d3_bMpfA$<HZF;f`J83$Mfd\SWcKl[>[Y5QhJn[<jP7PGHVjOF_gC^2`!_2#8E(sp2ZPTjAS5[A$1g?WejUfCV,J!nNKCho.%!g)9&c!&JTjX?FoB5\P/L3/;]nY9curZ60Xbm:5%e4e*o#;pn%WA>j*%l8NIkp\mgX-N:qf:0*G/,Hq/ci.!s\-THA5UEZ.`t`)@+2Bk(-fsfR%!3Z+5D243kTbgf?Dib,6KD*Yj7/S,I1i#\!:uZMn#uJSIU0,@VLP2DF[^L#dY4dRNJiO,A9`&0h7'hFi]@9Bl1+*>S=)&0C:[6^p)B;VW.m8ecSFia]jX-h8>hKklHsm<"#+5j5[C8SeVX?"tk$?uI.2N9%5UM\gQ<-Lpc!k.b=]FEaCh41(<KV=a'anNRG]bD8;EDML5>(@:;ZTjR?MJaUP\eRl2I@.VaJcmU'/`ROnQ0c>Dr0+ZidKnD=4dOaQQmHo6L&6MpUWt29j[u8n$b09J:K3OW!nHsB:,1AH:.UY,#M?R?pbqp1T?trW+W,'+ph=g;_NTQ^E@#`HCXe8N#.uFe;RF$*Z.8E-"a9l6R>c\@k:k7sL]r'1XTO`nfeV6P%eeGpC&lWZKSA72KKfK`2Y9ftm'S6@f5\\]PB,Q7ZTJmTmZ3!X!6-b_^\:>%/l<H6iN#C@FK.t]USNEKPMkWWh(&!o:`U9t$%&d`s-jY4!9J<*9+dTo4b3sT/$#V6[NGO+s[AE3u(bES'D<[XpNqVLek>g>EBD'@"r$0d\X@q#f_Du6Z+dM35OkQ:"pN;u_3aTjP@Ea7g2(NZInJcj:]KN%.+$PmboV`eiQ!BaA<P\iB#=Ih(O;SLYAiHZ]OCEpO\VtCL0m?RXZ:N_fd'S_>qZ@$K1=alfEZSmC$eoPSX_YXa[`eB$dZ*K4:VcVJ$o7giT:/%q;-@q]DK$GR6"Y$lJ[raQ=b]TJh$rN/qO-_c<1;?`j>PB!Vu,P*o+/YZ'Wh~>endstream
-endobj
-51 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1984
->>
-stream
-Gb!#\_/e:"'#!lehC[M7&LKaU,dSl%@rJp#p22EB-XW<-K:$=+"&BHGnF'9bOGjlF@8s(Dm6rK*R-F%jh=#J:`=u7HrQh2=rk6.KG:CrKRgSCBR:GghD`=G0UZ7hTZHu\=j7?fiaB/0GJ,UI3H=46A7@khDAsqN,@/TH9oileU%erSt,Pr!fI`:HAHJP,JMg:W4o06!Hq46u;j_C(*(.abe.aODOQLcq=k4nkH;)61@j9Ch>H'6M$@'Q(GX5dP&f;"s.haV89Q:ZgB+)92^^5\:tR]c5rJ,Xj\U+$k1?a&>2YY+He/d5ha/l9I;Xh!Cb*E[&pbE$\apR`Orce$?N4d`usUUQ?1'_2cZoe+..5lYO?1&d"[l>6A1]u`A(NRR.apaeR61ql:bWG/n2oVW@81ZN<J29YR0,Nk3t!TioO5^sTr['-RnY*DrHPA)esZc+]=ArlJZAlOXBat?LIhBCGa;>AF*!=9%+n0^c);`"P##eo'Dp&IEfR=[Sp@N/16=O`uLEX)`M1g^M&)1*$4haLM1G!"`-Vg,,Q%mH5t;)euE9VQ5<c5Y_8\>60(S_X[&QJTr0qKF]s5\tl38c])"]?5n\96^]Uj`!IXYo^.&#8:5OCEp>8g[Q#s_g.(,6GY(k5rc_CL@:k(OqDJ!+LgAQZ"<7qVoZlGJpN.J(l4o"r>nrhf_`s[Y^WM'k]7pI!c@lf@kje?i4Ik1L.Ssag^Xt=>.K7VnTZ=qla'=Kh8FFF#?/EnLUI);5!>jl+]=Q;$WLm5^5o65)FW%ZF&76(=:/fn$iQaeLl7*h?7MD!D\fDHMc%T#7pF0g"Zm3L2k@@rm=$gtF'bRi/s+4bR=,<<WQ5ERE+C\M/gBm7Qsfj.mfYBGJmptJ,o9%0GESo+<1V"BAp=6UorZ"h=RBlG:m&#22,N$_KaX;Tba2+:3dX0?d+3X*S]!e5EVW8#k+aR_+Zj!/J#%>'HqD$ocqq;_'RsLGq;q56O*@mE9lX"8X!s9[-'NoFHL=WGn_2lI,E*J`DT;c)ibOi36&7'(rg#oJWiLM,1JQdcpp)EWYcQ^m7^lXOXmn^%&M++!Xe8Ks.%^5sI5F6fi1HF4cRb2Fm"*ih!cGR>5s_fBMl86A$K&3)N-L,0g=V+S.,CXfeILQj+)*`kOXO;`G/N-+Ce]Se?E=cc#,nK6YZ('TdWUH&-+]Vm('>$WhkXnNH6Klt7+'f\#H"!V8B&h#:r*sHEjj78Q0%Jk8$i-H<;BUD1]S`pi_2K4+E0J#'=-1*_rP?rDD[-f%:TiIU89$gMfThb_'5)Vp'A2Ar*.?>bj@)Jgb?3@/e*2.S]ddLQ:4&mR^*/429A[^KD")3Jpn"3/CB5_Vq587%tZ]QT/F@DJ]1>OkH(RZ0%ANinJ"jHZ=ci$li_'X1cqG#&"*@IE\Is7G].YK`1_"\I*#pu\#QYqSAuGjLU(0cK]"@$HFpWY+`aQX=de)c3_n%gJ`]5<4!R8l];qG(/T.s)\lOTm!28.gZ&U=J,[S8N>Gk9TTB578pP!qkDA(gk38`%Qs.`\'GAS:$1oLfM/fpqQn)!Y=\p?s849<6L/I>4!S`iMKhZj;%qP3YDVt-ipF?g>:M/_EZ$!h.j(DFG)VZjM?"J0RnH\ob,'=j1mfXl`$BW0JHdVJZA0P2]dJ++djX^>0A2Cd=@b7+[s,i6.;ZDQu8j0,"IQY/5U/gYO6Ttb48o(;JMr)aVAFQ$e%D-C6#+'eTt<Bg4Y/k22hcNSVs;]i'O:DAE<%n,9#M%aW.HU&Pn8)S5sD#[98n+:nMLdn5?f)[@17ol8ZY,JnDJoMEkb(83Fc<<W5;#7k(ik%"J=\iU\f+>90VD8<8>skS2G4N=da/R'8`pG+Io$sefQ4)u2d?*,l2%,S"/*c&`n&-8nM:2bZdQpjkd(*i8PWq>I&XP2SDmBN7,:Zu.#9l=6S%\Ekpf5^`2qQTlnijLu\;3;iBiM^o2eb05oaOC*!tkJk9E~>endstream
-endobj
-52 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 942
->>
-stream
-Gau0AgN)%,&:N/3m%]_X@=mK5GtT,;eVl,c8LH0Zks4<uKM)@R!6S0R^&sNr=jsh/>[GJp([(-F$Xf<Q!tN]?R8s=V'"GHG5[?qKJ9o.dA-'#IoQAYP6K6bH[/3WGILlYrGl1UQ"gkoV!_Q^b\<a7Kn^VJ=K3O<BQ;#f0Hj.VT,d/e*&*&!hnUc6f2!h=h@2-6c+%R5:JK"Xs4\ETlDEa#8#7i',VXut`GYit[4!a+*8r-!hUT^Gf[ZJ!1;O]#8>+^S3!u("/!ZG1Q(KW4c\+NOq6`0r*]N#I%(ldJuf<CDBjoU\I+YNP5M]">m0!6N4OhgOHkMf7"HS%\4h=XTP&33MnUs4?f5T?P#,DGArM+N7:Jbl$9bArAG,a\YDJkaK_o/dbMi>nslUS/GLC(5Mm"3WI3XQl)^h&NM?JYSMcaNZlF"u^f>X?r!U1n'0c@!lbt-0r3WR%#m0Tr?k=W/D=NknA40U]4BV..O.6/@eYVfc<ZFa-,ge/S%&Lo%VOb9X%6J#u`i&bS!m4EA87k<q;1ehJMZeP.6SaM.5^Vmr;:hlQ*!gm>&JE4e@GK>:)Nh;s8;/`[M6oqj6oGL;(oU9Ve&HYPGM(A[Ytc/G9%agI(WZHnY&rPQLN'RNLMO,-/+Kr$hE_jNW.UAG5u[)"S)g3E,ea':GrshtW&oR['4;ADA6N[>;<YiN*^H;EVfLq%$ld[fMeb]'rIAi<KrZF:YM3q+L]tHg`oe[agFWY[jUmb0OhmI6/S#l8T_76$/WbG,7"9)72EE?YJ)aBRTHmm?=/\V\t`4=ruDTpi='*f8J=SQg<c(mHT*nWXQVODV2>M<)s_IRC41U6+.S,g]-"@m0PjOKh:nEX"`eZImOm5S+Z0\`@V!u]h[^j&'#kV'Kdrij")!E)kPdJL.t0n4/ofqhH*o+O2L7N;Rk2niIoTC=E%d#~>endstream
-endobj
-53 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2431
->>
-stream
-GauHNh/h=/&qAM?YqJ%Y1H%sXhq+d5[<pNI?(KW=^>oGE<t\u*?i\Q2s8*ac+-K?T<$Yct1U2HVp>ZBcZ.K3\(L/*Vs0Me$q#RX:#nRFS9-Ct/_nu_hH!#H"[$8W<$n5of*A7]Yd"AfWjiS!Fp_!jh6c#OP>6,PLJ)9(uT*cnBLQsa?ItWS1nF4`-gDL\"eFCHD-kburk<s;`]`=QNN'eM7'D[;L+aj-'iV9W[P`85kG=!AY#QiV7gK"gYMiWe"MdEm6Tb+bsj$R!$^+PqK@HC=)8FuG\0eQR^Y&>bNaC%;j!TW/U;(@\Qr$%#MPo4td,t]^egsQ#Z:imO":==rI-,_#t$LnP]+"[%U"2.',P([B8=0>_?-*Fc+-l$^'+DoV*Yi0m;T,>nN?l@*/'_([.`<q:*dG0:;.P*lhqjpI-0,:oYQH^_[1@#@[W$Ehr2l0".^s+[XQgQqsW,#Ncd.g<;J&V(.gTXASD`roId$Ss<eOB/6mHonHJ0c^jrW4WP!]H3W<5;n`Es+'GUOr#Va0&aZV8tHWc33u#gl"A$lhnBbJ"Pn.^mRSeChXWLFU=PFd@*A;.c:YSUMeZA5^SFZ>De[e!b#oq)Zf`96HKTd29S9p.X#f5^pO%QGG[q_6*IhNMQLh1&%BAb5RA(W+a"WQ2bUZsd-_V%QpF'N=$G1tI=cs8)1EOV-]%^'qG>U<^+Pq/#(?VKi[1qrK+f2r&/]O^UIF6q+"'eh=!VqjO9j$R$NfHtpIRW?@*_><'"_I:_+CBJNsI^:j)2G:Si=cZpnr).8N=\W7aXetK4L.On".IcdRh`eG7%sq#?.-a(nS\!O!cs:j<W$(9Q<hk.?#L$MJj&r[$[U[,Y\7-)m^pJG442<_6k5Qp5q^lU4X6bhrd:ab@s+1HV>!W;k)gu3kU+5K1*E[3bFV$=3F47_oI$&SnD*_C%Aof]^'.2d#hE:WMds&6SKA`rkOaVVpptlU7b?`5$tDWJs@H(r-n[dIm<rmL'*9F7\MgnVbf?UllHS(e%&rP'3gllUWe6g<R*>2?EuWDR"<[ZO"CU*(tUJq&?.(E3D[&O^u??e6Spu8.\smJCeBq,bpu=RSo_k>H!$71BM<$Hs-_t2)hYg]s(&tCN5%.,Ru+.KksE6b8.[(j$Y0Zud.mE^;-6CjXf!:$6gbM=#KbCAY]<%[7D\'.R*E?0]>^MI-5ZX&@e\)m?#![gkgo6#nGuI$:>L24<k'nn^2d>HnYmbk*!M)Jh`%8q@[WoXH2Yr%J)iWA0/0P'!7[!?#/\Z:,Or&$q:$R,](@-Q[mHtS`jVu?]NYXi$InVMVR-Y[`$S$D(C<s4A9ubk2DCXGI/doZ/qK?lXgI/f/t;1-<1!:m1^[N?\aaJ/R,cgg+d"iB-C#8qPDD1&Q'6n40tH%r"bgZK_%N0=V#`!^SD1)i[:X.n&psSI(DN_\:'M$f#Ta'<.p"VHJJhSSp2#C/%5Vb5kKWBRl`*!h7@YoV#f-=:o4N`9OEh%#kn!j"$%eR("OlTR-S7PMo$I)[0j0>'"^9SbXDG$IlA8Tm8FRZc'$cGdaX%uA,FpB1#f'do2qaue=_1igZ(8(Campcp)R81sEookW2Bg:!5b+Oa(_j()&X?2hb3#S!O9h$L!tHYRJ2s+Q&1>XbKRc\"6qDB?:GDO``\CFdY9@DENPJpXE:X1:F&Gb@EJ=O)lbT*IYbT1uHD#BRFGfT^09a6ESshpf]48@7+rVs<h!Cj&qkS[Bo750:ADlt".KpG"cV2u^iKBOT4O+=NIXQ*UPSS<)Eo"q;]ATr>W2113A6_:N]l\K?IpWc^ZEK4"MM%$C%X&`iU.o8Y/Q3N,.kK,A)]ZECToj*qRf70mlb6t!e'l_=NBa4<=)7"KT""*rVg)"BXc@"n#T^n^mea,qmjY]qdt2+'$'K/?oa!_"[X&jg>7.4]I[fco.CRdS9MW?tR,<>,:#u$_gZiL%]VYDn[bmtGH\u\51d\Vb6Mc/#I.%?Ld8;+&muNoXEM$5!qJE""JS8[OGO4'aaYXnC#nr*Jq/:_)o5@[uYf>c/LT4\d.3sf5X4,m?VJ?A(b7*gm9^$`7N^R`LE(KM_n'rq%9)lNkb!/'GhFR=P^9E*_e5g0gH0n5>(\_^M;9^h-''(sB).^jK__Ri4;cmrOAPIql;V)Xs@0X'Y7u>Q^BiG`\=[L@`N44V3f+#YE]kp@<r$(YEf9CNmL^&82PkJZ\l@!Tu-3>,1s5Ql6;TOH(NS,>9lps)\TME.j`9(2/)5"hf-U.@M_]%-R)".`3gjetI'=WY.)_l&.dBHpuG#Ro%%*o1HQr:hW&RSKVY.]9#+X@aQ?1S]4,dPYT>sQoNWqE36C65UC,6P:C*`6^[)=,.%7AuU%#e\Xg(d-BMDWs>ob%cXG2.Qb'PbOe9MiD84\]SVhQRUDYcSoVT(B4K(%r`$~>endstream
-endobj
-54 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2146
->>
-stream
-Gb!;dD/\Gm')q<+0jbF`(9sTXgUQ6n]j`qA@JAJfh%)qq-l?Z/EL.jiP-W^<ou3#Um)4(;g]^+W!TJd9_e8,"H,^GL&45H,(Ce/E(NB16Jgc@B"]626YkS4e(8Lb(2_tmuR[SH\6'C?94FtPFH:](R\Imn"&47)ZBap$Ys8;+%r+o3I7j_FehSA,,/A@t@p@`$2*2NCJ=#Af=(JJJJ36<;1k-I1A682-/BUZi`eL3ss1Qqa[1_'!i)T]3<R!&E8pb_h]F?^[[Rg(T@j"*`pBHGIG&^ugM.%8Q^.%#3sS>Ys4L1$THj"-t'8dHS8+J$c0*%#Y,)PR"N7)ss$'Fr[?Tc+H/p,>\hV^qc?UW,pjL09GrO%clW&;ALoO5TQk6[5L?#;ZGGnpLSG_##aY>K3"0CG=,F;VK!#UZ<JPriQ2=7I^*jJ@ZOTh&GCmiCKa&0GltjF6ici5Q,9i:[[D.-h;P/`"QcqVU==sB)rbL\U+<-pVFQKQr'm&nc;dH\#(gm20/&WCEo3n,"2fdIXk!,KNT@YgGUbb^l:4%CXcSX[X_l4MA9LN&n/[p%GVk0X-MUF?<4-B(/$?I=U\\8Es(3JXV!%cNJ0\V%?i)?"hKu'WDN`_chk`S:CZ.QKp!4JV%Xbb%$sVcZteB9)l5t0[rFOdm0?iO$b[!\X(_g,[KU0O&G.n:D4j@X(Z'IN)XRNaL!h95_&9oG.%%aXn+6b8j0sZGr<l5O#,JP4XBIn?2%$cND`e$\$SIe//<)E'l+p%OO'ha<1Qbih=UAD:o<_(lro/j.#hCUl2(lGEH4,?;4t[1ScqoO4"M7Mm$k'mrK-dIU6u?\Q!`ccr0W[Q:GFu.E^rl`79#,%M[ii2#@;'HC+#pEc$!V=6UM5EFj,5I[^Z*-Y@1\,a3(k5c^)rrkkbU-<IU-AJ@A@"1.!ehB`saX5\7EPoZt_/oOc^Jc.(MfaH\UR/bL]E!qj?2J@sN^C6]umbKTF_d2fBMa5Q(DfpGY<ar9_D6X1.!d&iAdMPf:bD!"HhI%a['H]OVeM[O@]$Y8Nrk374l#q9Qn2=eR[V-0*EU:_J<cNNCo1\eNo^!clOXF%If_CSd"0fe>"g>acga%0<H.$Dm?6`DMk;[G(t@.X,blnaa=cCBr949kFJSs0pFOG<^K,W:IOta'W,%Ue)AYLGN@/Reu,bfE^;?4J'P(`etbOJ[%_8nTSk]m%Ep!HGK7"*!=[5[ctr@VL5)Br4@kZeQUlpC\7;6MdsmdXeFYg>[d]b54A'*%\^2k.<+f"Y5:!`gDVaQ1p]&S.eXK)`W\fDiKUC][`eS+(12I?>+omCHG1E4og!6Y5Oo4sP$+[d+8I,Z0-'MB't$D_TGTWgbT*)LX(1gP%UGh$Oi<P=i5jnM$)'7Z_VMX6BIM"2B[Din/mS6t7cHt9ZP.XEahjAo;[42F3//jLP%j>t][3bT!`thml8/.0a*K-m'CU7Gf-r2moB+!_(LR#<7JYFk%Fb6!oL4HKQELm<(`/Vb=G&C9Qr%g;Gj3Ds2hn+<=9i8k'pm]r,u$YlY@FSQg55.8Q`3a*%h,87Uako_i6kK::bC(?X4g<aS-b@'QCi+gS0tN.'\0A3kg2:,DLIKil?+MKUg$D/WPdGZ![TdZ>,*E1-MRK$S/&gS/H];t\/c[\f>IpD]qG9'pm!]eJ[]P%fiN0%;3T(7E<+oNf6'hF!Gb>GO!OFn^m-e?>T-C6\MQuefqh1i5&")_^KA?!dE)TPmPBk;'B`9YD*)6t'@tsG9RoT8U.4Mh?XJK[b9+.(8-tm]\>Ij_#_$oY_d-4MFRpKdCFtgiR]7/_:hmG$'L/JALbaKrC0Bd/'lsC+a*cF?/tc5aBUITCm&\m/kW9W,iC8RVqI.k/-kT:]4$dGFKW7N"dKcj,$C,!E5AOTT]1ZDcE/g-62/:SY=>S'Q?t\IIb"`8h.*S;24O^AJSn[o]$d\HZj`rt3O%r$^odAl.gH0!9J'bB52CQp/H\Qti(-U6Ph8E1h3q%BL_ll%pf2f*SM^>@`KE?3B978]T,]=Y[^if:GCQK%3loqK]P2Yg'R&HIT%p*'Y=Z/9_md1t/L/Q2%oq\dkV#H+]4XR^sXJF_/gM_K,a6r7&?[.,O4n\WOQC:BQ:piXbk5I+,@.X^%Qief~>endstream
-endobj
-55 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1924
->>
-stream
-Gau0D9lo&I&A@C2m,V&%,;UMm;:=OTO/,LjW=rL(>^BP89+irbci@b!q=U9^8QiJG/"TTjQ:6=^h=pX'5p8p1$DIKh<WKn<iRQZo_?e^QKX5%jlZ7<W*o2eOPsmCiV,dOXM!)l8M;e!&.JSVBD?rfN6kDk)Xb-)t:KMJmP9g>";)KbOL%Q6a^LVCIn'#EA0MCikMP`K4K#MaJ`H);#aYJ\g&1hF%\4GQKY>I!+G,2\oB<r_K5m?lU1g'J/,[?<mNc%<jh\JK\Mf9H5+K\*lUEH(]X!EA=T+<08K(k-7=`oOR0n5e4pl]M5@E8L:Xm8HNUC7K^Fnlq6P\WX::gjgD:r8N/6#+Vs.R5sI<,:MF\.TgTb.p&DgL)E$O5KJV]'R)e>=k.PkJfCJn:($gL1QHgC#J#tPrG!1B/%"/$uHn+Z_uVOP#X4%%c9coJ85D+_]H\iS[q6=13@&XDTU[bV4o0qI^+uD>#GPDqBj9Kg6c+8d,iuWSqan?'"kD0;2s0Iai3BMV=$Jr/BIHf[LS:jO7NYV8JF<(jZ#Ae53l*K&=`b(L/RDkc*d'P?J&;gZin^,KhR-I%YSk5/>_b<'Vm7"r!!M](n*]oOs.%>,n3CjLb'q`;QCu/oh-,@asEkoC2Md0,mo9"BE_"@`6SR9ZQ<>GSR8](CoQA-Ag_rs4oG4Gd8pR?VIV8<mDGsh`mOKf/5Rb\L=Zk`f:D18.[t3P*NObeEqNZI6JorrYs=E9Wq*Fg2-K2[.TCUZJ:`n*dPCEuYlB,\6E2!d[M>u$^tb%Yi*F&+]/Fa]FCXFgR8CB0MN&nF.-AJ8$jm*9<f0d=Uc32-ONPXd2Hr#kA>%SQ^F.`%bLCl4O_a\.K(4CE17peCMo5_)&VO#BD;p\kW2WE?4+Ro3(P]"+>#!p6Q,.*MNcc*)jTjS"(+4!CHL'nG50[,d;^UC%;cRML[sg0d#mceReepdJs5.gFelm&O9`.(0en78ZY"t\0.#/a52Lrt?J`Gn0blkL9fG^lL1TC%)f.Yn>'Q8]JF?>%pSTa_BiFW/FCl^fD9s[iEJ>QJT4>BS'I2X+N.UN*"U3:naDT*V$I`rJ:`_auP7T0#I?C,=Id*e5U!#903P'@*<*J)R.Z.#RUM$eo_FD.WmR/opZgLK$WrOgikRBB</%9cEm#V5FSHg5gKJ#67+(Y1)b!j=Go#>eoV%Cqd0-'/H!#:k(^!1>O"pmshI?ms(?Q.(K]V*Qcg\=\CJ8MR-[67&]JWgIbOc@r6Ja6tX%h2jF`8Ba-0>-rgZCJ[Wpoo7,&F2Q_/)?q_\`Idk%FHBuWh%?OE`M&kE%rLrL9\ZGIJ#j";QnK5Q;;3,EQo]6AoA/sGJR*3P^F3:$"tcA\=Aci.X"uEXHX+s);q;h+)G6,4)jt]QliPjIR5.qnD0"i?_:&l_8U*9BH='0lUT(W3"7H>fP"WskeQ(4!:r\^8?AlClC]^_X--P^OJq>/Q>5:c89ZpjOB.`&0n&fL$#aNQ0]+&a=]RrpWoEq\3'FAo_--Ir@g6H3AdO]j#9)2fd^c"$X/#eDfFfV];.8o=lg`C0417*A68P=F`a3=2cg14`S,XF8cU]$J@$^/E=l-H6,iK$`s*m'"Q2*^&a4.?H'GaUs@=LTu5_[NtCn3mcET<!m"+W$<O?l69YKn;r3dWe(+GME2L-!Be#/YF8KBF9%pkT&>u,und?Sne]<4hEiBL1mLAK,X,re``g6@gR71Ui<gbm&q\VM&TmS<40L0+)r`):-%u2GFWVLqE&]AU*CV3g2&j\Zk8!grN@ga-JArHrdNQ!BYh@J9h%>.Cp8$DpB=p*<r5@7lfH@SN1n!Ed8s`sD2%u!+*J/5$E?0pPfJT>%p]FWl/F'%CDu;&76eTV.QlCf+$I(A@mB5OB_>GM#&p2d+!S%PlR=G.1BF9N!QlKu>Q~>endstream
-endobj
-56 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2007
->>
-stream
-Gb!;d968iW'#*s=oOVg+PR-;<JBZ85AB0OND+djiii5rkBE2NC1W[d*2##U?p#%"9U<I;;3TMBM0TD[lYP[Vj!q=$]_#;LrJ6*\7nN)1CKM;J5m)?2S#FCq5+1'oOop1!4*hI`+10Gn8I/U*=I\G@45SA;b6m6>]@/g#bq@[ZSC%rLe%dWRko,0IDZatd5Q>u--ao,FPE$4>?X&Tug_+Ttl&uOT`E=eoP>eQPN1$iMX^G:h_,_cMh9A`q_s4)'Oq`+I_2VFCB+f'SF`K2sjTAu%EJTJ;O+QD:&%Y8b`J/A!s3XHl+l4W5DM4tQe"Bu07=JCnsJi!GGlNgNt_?q7m$`-9@,h@lO@p=5NNKSqPFOM4_!F$-QM_[en_[cEK'c8-f0::F=&%`0#+LINl@S)Y]-qh]QaQC!4STRQ+`pD8<_"-Mq30Ns?LZ@nr)NI'G%DY=>=k0B0oK7(q21JJFL:k07g'2+`24>1ZKe%(i,Y1f%5D85Z/M%d<($:a5a[ji(X-FsOW=Vs0Tqh^R\H=GLZmKMG2l5h+)HsM5i@l5^m-)pgOEsS#&/KF(8\ccM^$=Gc9h*ZWjR-D#G$<!#[[j@<:9IB$QpR[=(,`XD9psGT)qF2S2fQo'(>,?).']K&KBZ8L4I$LefOOsFA@Z$-;)r,UZs&``N"H/8:E$Z8VX)REg`\6dX]jKl*7t:PThbpk5kK<F0-F2;UcET%U$X\)$S[gU<4h@N\L=lNg*ndl-V9e"Zkn7]cs2*_H"X2or%;VpMoLi08V=:J2(-8N9VSH%(bM@!7Y`OM0n^\9I1-`)a3-+fC!i$L=Mp3"@4n&mpX5+oHiFrB",t9607;(VJgcIaZ\/(N,"#a^$L!C%((-nSP-Gu5`fQ$u7saX?VP63u%8p>B;-Qj#8>R9,Tri=l@nrCk:oi"E_@F!?90GQa1c%i_bj<__hjGSqFG=fI&eN9K-/V0;:Ao6Gp+'])d)6@Q*7g[6>pX4eKEbXu0gdPZA51(Z??Im2*bY@Z;(/!_Od``;-<,0DU4e)fC9](EQ@8g.$Z+RD04['hpL0b47(sLGJIEjcA1VUe/cNWll:sC%%Gm3PY;!SBY3fF;h@XS':muoEW.h:3_O^ffM4YnW*!aNrb^d:*<!RAi$hM*(Bl^?eG_H_(@pf6mVZWfDqX0$]6#];Nbcf*q&d)CPrb3LmXJ3Gj%FGeU-%+&OCJC2b\N,M:>G@5+:nsC@D_:%-N$FC\"UbCS]r_d>?>.kS0$LF&=4A^:%9.'I%EeX%MhHf@LAY"!rF;tO9q9<^0R2nl5$c3E56PmFV;ZI:GY*p4%.S*"-*W27cih>^1KNNHGe/aaGMn2(4?VJb6Gch%j+HJFCsZA.5G6"\)5EDuZFXt0rSS\9[)9fR@/qB3KgRVU&@$5ibQ@S;-g"t&Ho&8Sp#@bkor!TEK4drnIkVpnp%HF96&Li!Qp'UX9$bdNA!NqkRu*9"Ss,##MP)0+';Rq%>VUqq5B%cHQl@19:#fc6!Ei-qR>CN$faH0V9+E]]-BdoP5k@;:IO05(oP#Ge_NG,GKklb05#I-)$n1A)\f.h@kp1(6%C@=kjjqhr:=tG*%I=<o7ND*#C)jBWceU)1Vor7N<4:TNVTLY;1GlWK+Qpon2H62dims[]DLTb)FF@\(iW9h6_]JJ000o953@mG`l//<;Ki.]b8fNN2SijcMHnO6qJ^@8%>i)_.h="l@%\1gh+kp"mac0Nbi+ZB;6m4=elhrZ=p)Ji><HomU5*_>J:n\r$"KV4k#5p'PdGB@b3,VBN%Necl:IqR;$/]Cd@A;Z:RIk^K56Yct.(=Mr<HtJ?%+3g7]t\jcmdg5;p[:%Zs8BrQnp\^;<?eJge`K#,*1hG4kRYnOBru,FJ?W;XKcl>scN(iTjbB>@T"OM>^hm/a!P??7k;-<9l(KGAQn2]["R*du(I[T(&;Y!rIKgoY]_q<OQZ"L+IsJBrq>Jk4Df4G2F?+p#R=XCY^i#.sCo)Be5NVl$m_J2(EF==Z~>endstream
-endobj
-57 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1746
->>
-stream
-Gb!#]9lJcG&A@sBbb]i6O]=etg3ZKA\1$:0C#WMR^+e!VAj_[f8]>XurIXmG;o_q&Po%-P[R`R,HUH(t-3RRmJQ.,_*8pbsc=[99#E'!]hup9O_pr5g3,1ol-aZ7ik.0N-d3S;Ak>/Lk0@[K7,3!k*HPS2gna,];$LT`#pe4+Jq&cj9#)b\tgs.uii&O*qj"8U3RHMMPM<BZP`6fk$@W:=WO>qi]O!?$&bt->W#([EkO@'krcD:9TiHFj9oJl,PM]E=;2g,6no$QL=$#:s0",GB5T9F8g1?a,J!K!oo*jK15(J:"f*;*K-_o-<1g93.]kgg.0NC:&'R6k.6N<oI[q6N5uogrYU=8Rb@Pta'3["6CX-4fs_5uHi-;nHl3B8\P0r,65ZHOE@:_IN-FqZl]1gI;*a6B/b`V@B#Pi>fkHL+3:;NNf-;!Ym/'8^lrr:(*tTUE@7AUN_r4M`_![)f,do9=?CE3\Ns#D>O$QjR)mCU\n<V`tq:RQLBnq/-:cK8cdIGk;+2,:1WOKca-NEUTfj&1kQh$\<"';^7BFdP]hsIJ6P6LPuDIUT\"4Z+ep>Bq@!uc1<pO0Q"l9_R+<SK1KZ)0XLhh;JPfD1$l.t2<nI`.XAN!=)<7ZH1Mnh"HfT4rUK]]pK&194U?Rcea]c?=E+'/LeihT=mU3c-f<_JkKM3kg4I=b%5,$[g0)E3#*1t_I]OfPD8K8i,G9-H/\2r*-D0Mj<[dWX%YAUL]^<AdcYMLjt(IdkF)S02!AO?2tDO/J,9[PCYR+$DLcS(X.)p5[R1e"fWg@4-AfoscL&tVp\(ArC'j-nFKWd[Bgl1B(TFPm7kL;b(IdS4Q9-tr0:=8#V_'U9+fhcTuL2$tb-f'Ju<&+,4'6J=$d!-uZ6DV6@74JC1sMY?]2Vl1\Yri5-@hm=(\@RT_m`G!);$Sh4Z7uHeh!ODkMif9ET7%r5\BTO)oZ"hbBlfB#J"9kg-c.I;-`>1@*UiKD1k!I1T6=&hVBC$[*!j>@4q]js:L\l[=#tuVW9InG(aUr&tMUGV%oa]YKWh-"&\C7qE[!I/QJe&LTpF_[88bl<bFJLte!D1t%#CB48+3,`SeUe<&Wk/?,n;>9nH*uSN"):?b=?ruk<VQ7$HD\8oelVbF8tS6D;T/'Wn:]k,nA32h!YmRd$N7739VeLCMV6EIRsO4"<R7FTWh!#o6Z#bu7i:]JEN'$^9UMAEEBot_(6B[sV8Di[]M^%#`gPNZg4gcK$uITk@(K=Fmib,eekE1!$s_E+IIu?mCj<pT(WXE.\<etsV1@<;?5T+)=R3AS^\s;Q58E!l@oML_n]^\H0SSih[b#"&kuN6;:T?>BOKG.GV"W%,[`/!`DGf6YgjeWm+hP5"bg$ZbV:E/rRVHqJV')OlQO:-;hNYZG^geMs'FLI/(at)):3R$o%@NB)("J[RolO_,dZc\;,@p'L[fu3<K9.#Q\'8'eY\341AL)<rVi>XD#ZujETjl]`l(^D-9OZX3bcKO61bbU4jW%2(5"MoL;-7e+@,3#EJk5jcL7'pGcAek;[C1UU;%9A[W-.bK`t_=WTOk)8"Ib^@Ek[7U::B35$U((-@;s;oYOD-(p?^ssi"lRs-n/3d^1?#:]H6BD18K+IX7Nf'A(@&Z[[d^='Wt&'eMDsub\`rLF]aEP97[SsWktQYT[,kDhCiT2(HE3ZEr,@0ko<sYCoZ=uNACrWf(D52&+?K8rio;'DF]'O3plJDN;`uH^4>J~>endstream
-endobj
-58 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1412
->>
-stream
-GauHL9lo&I&A@C2]VF2cBp.J2gmakeS^'3;@k75K(RSH*YXs?L^aT'R*Isq:`ug7E.2Qtp!"Z^1m4K.]i58(CI^9qP?/Xp/5S.C%+GdZ9M[Q%,-4c;h,kYV.FPMB?AoTS%B))A)9"Ub6%?L^!LfnE=C.usg>bBu5-A>5h[&j*-M`WJ=[;]>ci[FGnjDe0ZgR@<%o6E<RiMFXY#uc(_'Ei-%X5>:2K[iJ4>=OaA7&U^<^,PN<.U5b5:ECi%gJT[ml<MU!ahu%)r89O@nGVsX7m:ONL`/eH+TfD'-#dZp:K`^3@bL\\5&m^8-un&sEI^]9;^Lm(i0qfWK\>q[o5g[iq8T?\3sSN5)M'^'_T?iR=n'#mQsR0%DSr7@)<P77k>..r<g/lZF]0d@/GnrHh@rZEDllp>0YF9L(OK78#mIM'K.4Z0EFVPT8=1]sAmF8OnOcB=P<pECqd=`CAU@&h1l#!!Opb;2])B9'/]A6(m$@Cc^9uZ6OX-KAOushCj5!/N#?`uZXDu-H/lsrK/nDs1QN@t.)dGpZYAp>5-qEV5j.@#PZ6A<\e1ZKk+!Rc>S=hZ,,kOtQ%9^1`(`_!Ym+,l`^FInT)^(,q'1E=-jeQ]:eSL58)A;l(pf%T2;LBd%.(<X9cUQ1gF+Csj\7M*=930LGDG9HUp_C3sj(*@Ks.s8*88BaEjm=("#(L^=D_&[k8t7V9Xku#n:6M4pF7X)2>=)O'=]&"-2/-09cUp76eme.H_!6i0Qt[;GG:V6SM"D;MW3`727'\fB?^#;lmS:'O2Wo*Zh(R<>jC7JR]+jMIP-TG%,r:SKXV>`_oq[4UE1m`A.Qc_>X'_Q3X"rt<G=?gHas&^5Enli?SWXoq8eO&(l%T!!:coO<s.um<Idi52;*+S=ZA#u.M3I==8HK9V/*cAFgSuZ^]]8bRm<Y$L`s5J>Rk4kV1fd6^^Pu>Llg+;lI9B6j"EiOeS`rAF+mJosrY)*l'DP)eH+4<t"8D.Jn+sU=%Mc^@Eg`LNR4(Xf6pNTYg:__lJFCQXSLpgQn+G&"mErfPHj:^aCl,*h@9iIHjsZIqZ!p=E;'&>,X_f`3"B]8><c(UcJq"^_@l@-W8&ba\-Y-1UZ>@3'W%4am2Rt>jdLqefQ)JL(RudB8cF\,fSrqZTD[C`jr%WggV6M?9UDu#>?+fkWciCc^JNc[3Bj_Zpa'(-_4mH9<lB?>=E,+,-G5Ytq'nfODX3ag^4XONtm#dD2I!:P1<0<jt>BQ:E:GQ-(UN+n#A$`Zj",<m$-Mju%5(%j@HjnrFj.g$0>CrR:]/HND3R8R`?502+(^M'$]Si"J.V5+>DPGC*co8,P=J67\Hi$!_#p90]fG-,1&Mn*SDAt)fffW/#LF]ff??)/\mJU=CFU>Id::4U+V_F*cZA-K9A&!_9~>endstream
-endobj
-59 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2274
->>
-stream
-Gau0E?$"c1%Xn)T^gjrcX-W[Oa0t=+Ao?&PNSU$"OI7,VJh:jg;B`$LrqALI52sRR>^)^)fF^Q64?*<NkSX0CLH,2H3Pae]I(Y7Y:11>YGSgluE<W[;kFkh89VN+0S_)2__.YqO&)d8]?1W`lD@GPb8mmab[2dIE^<^H]h3!D,e0V+*YkSG=J$?JS3MU!q%ED8NP2X]5d:>:4"s\pNj68Ok5Vs@unRN';?TZXH2B?'T3?1NK+lk<qoqQ7"T7V@OYKfM5h:j2I@+(Z86P+P+TbED8;c*Tn>^cSH0RX3GqKS,f4CKe(R)(cZY;R=/Qd1lWG..8!rbCK8TNs/;a62J"Sprq21(LhcW\L#F/r0c1Gm.hf8o%"F:bn@Y]enGcU"$4r$=c5q+H6#iI2>_XE$)M;[3pkV]H"bAZ&mD>>d'u1"+i$oaH[It[X$h+h??F!SEXj0Hh74-eSP5WS"%CY\$&Z#7L.4#Y0l&I)4Ve,6o];uIo7LG%QN7.*c>"4(T*i-)bTtSq/ORf?UOj_nW;1VKQhC%,a/FL#W,<d3RGbJarJ'Fg*n.%pe3`QU^.t]!,scc<;UNaOEWBqK9P3Zn*N+!LUamQ-^11(5M;VT]=&efAmBCR#/!.sl^5NA+sU3T8jQ<,PnY?`DiHaXV:$:j)e8><b&"'[n)/Hq4O\T*.4V)!k_COd;)L.8-4:&V4&;5E8FM^^pA`+up=lLG^Lr%&/oGP;PB&L:O2l?I@<*47`q[FZ/34Ek>GDmfV=R13G<m*TEoZ7+<UhWe6>f]1#A=q;LS2KdQDl](UX^,8@s&SGR<2cco9[D@6?2J2JB4+nO(A24r'mH*`31nE!rP78V=YPj()3lJCr$E.$QhW\JVH+B;i2X.JBea>9ua@<lRAac;L=fF#a6&oF1a;`\0gsNp^PO+&\l?\d0VGY95ns_eu7Atj2CmGPJ9VFC2BLh7:"*DkK#Yt1cRdiH3O-rpt"#W/bMZp;ULC*&HiA"(*FVGK.3X&n=725H]D'VRT'3K^mA)#$;2*-D5K',<lTa;cpPL+6eM+uCi[J8E&'D=!O#SUYFNG4T&dlFgDu;D`tn>LX6URsS[U#TGHeA"LKg"c1?K@JGGJ9q:gV$V=53mS%f=`8UM`mQF-*?&ok-Z5`4o;D/Q$G=>AtPG77Id6;E/N_L0gP9%R@/kn<VEW7<:_C@WPMQ[TI(Bm0Kj]G&1mHa;?IVAo+:OrNe),bHN,1ciNF&2[aDeMXlYbKr#JH\_s&?NFo%e>^G,S/Cf"\*Oo!X@*rU$U."T/XQ3?gk@M1fi9%k#oT!g,Xe3JTF-BO$RG&:j@L&4MglmJEbE-%oAHbmqOQo7\3i/-<nb<b*!qI;9"K3k[\o"O63[NOtc<8=m\X"eRRe#Z>gd`+9Q!55,`t8SGB[o#N&0Hm**TVIk%M.(C)!e+.bL2%89bN]eO]gbO-XZ&b3M+/Xp5g@dYB:=nN$Ke;.:tdOZ8*fp;8EF00C>J$D@iGC\[YeE@(BiMA#XhY1G2:Y*@k[B@H#=^RZinrTl^HLbQS6o!k+u5i:)k:-*?bNb_]^k>B&IX5HL!2oD&*Tri6s621>Ud2[d9G\X;gja5'nsC]Mpt*1d=AC"M+UjI@h$%t-?c_qs4)6SJufZhMU3Xn@kl*OKVA4RC11g#_ut-.>]bO$L"UZ`))Q^1HEo6Ub/]-eFgU*KY1q%&U]\Yr>R9XR_U`A1mPdk=@\VN=[X4@-Ir;FSD%G"*@a!12F6GS_?PPJP*I&0"_4dH;mP\;Q:Eh)/7G%<lXpO9'p&>D3UY!/3)u,#"uJ+HEU^jN1WA^hq"pQ;n^K">1aiV@R#.IH\g8H6':&Fm4BN3>a:<n93;n.&iDaIS:qTa8)7d;o>]2dA7q'/''><m<<SfP.nlP0::X,o#>8lgBkC!Iq,=cM128%^AkKhQK3iJ-XOpnWJ7%=-i@Dn:NKNc+P\%/7XLU5<HnfrDV!nWSA3?g"p'tVJD4d\8r6kcd>pYe+-WsAo$8djYD>G]`Ki9iGKF^%[T/bp*3E9f_c>fBbi]\Y7QXnKB:"k]s>*d^K7e#++%"ntSMTl37q%!cB13Lu[e8?l)De)B&J`%KF?g(.47ihMJ=aNRXr)Qgu>+;Nn\#p+2Y-5GkpD3Fji(N=Ia^*GbE;+HSF\`&r#]?.<d]u\In2D"GIK@2[6:sa^lScJs>W\?/SddV^JR@45e=I%YW>5.3X`fsel!YkuX"`X9T$u!!@sPuB\Y<&'5Ge:b0@PgW=(Yb/0**8,-sj:MS-..6(Cr72]`~>endstream
-endobj
-60 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1675
->>
-stream
-Gau0DgMYb*&:O:SS4E#l<@q@>SUF.h,Roi.2fZH3TKke9@uCdbW[).CJ%m+KYnJL-Z:J>3,ifAHcHJ:):5BKO#lW)V!'\Wsr[^GS@D5,H#;PA-31US/%bd+\0QBV'mGEQd,afrg4T<h\B@-D_Ob?#RETFbI(nQ/d42i"')HTU59`0J;&'Y&qmWNCnE>6@5egd-Tg^C!c=Yu]mQmT-bRNe-=@5pu#HTh^EC^.1j16-u47Y/Zl'[5:g"RZJD%t5#bfVUrfA2XmWOVWA20#q+e]t6:NPg]ouZ,<<On67lCmKC#bI2;3rs7s`%kfcE_jq@./+riQ*#2psm:;X\?]u'8KAZRAsAQB\LCS[sYPpC&QKOPg`'K%d/8_BQ+2Nl5uQn_Pk6k+%LV6N]"aoWZk9=K=mL_H"(]k8jIVBor>.@7(f[3=9g#$[FIV,dbegq'[hKhOc^Mk$o?QVqO5Hmf.W`l4*<8MVNYf$MY'Ug\<k@CRFo7GY_EBiUJE^_ukW#7l@A0BDabL`P"B-cr/7_Xm7\XH.;4*IPFj%I]*lF`DkW1;C?0rdK$;F7oM&o_de1^HmujWH=Wu8i+YUK[O"eV$1'RSf&6b=K!N^cHW&A-HAj9q^:Fn[2H@mlWPm!g8#@RdT%SE0*SCJ+,D9a2[I/!Na<#A6O&-C/?ReI>73d&NPu^*=h`gGgDYdgkQ"qQfr0br2,oT*0-YH*q[nrXYDTN\o')TbNAaX*PVki`X<;b$()7Y=&P03]TWI=Ri5QghafK'dCTflR+)QiETi*4**I+blJgiIHWhu(rmlXUuH8SQ8hm<MXG,+^.+l"H?f1Y=#EUS:i%IR<Q'[3F7))+c+!_FnR3O@&1@aS=h8-O56QSODV4E>4T.L.VkL+9/GI=q:%P4*G3ou>/HfF,(g_hMkYccV/'f3!'1/9E0i0*iMn70ZeYU-8^/'`PhDmsMkZpifd1Zi^F=U!e8m!B4D%`eEaNr<h1^X(mop4W.`F,lZkWZbKQ3P;7;O_EN;7s#BpO*.1Pd,NGY0eRE1Pd#qDG_C1Y;YF-\=1=fi!I[g^n:Ujt@>Ul&%5#db#H:GH;5Da%CgM-M@->%3kPW=E3qDQ;odX9/8hk\#I59@;?oZ=N&h'a+7`\HVFSIPp4dK/s0$oMm]<,#(+'f?aaaQk"MX=>2'OlhnbDqj7WMorIrBaYjR"_D7:9J`)#d65ao@3!P%[%pjiP':BYXP]@**(DQM+[]QN9L:/h>EekQ;6\KT5#lXFFV3P@$)7j5\\$oT)f2mE/**Mj#i*"ghC*74Fq8WfBMENZSiQc;]<Ad+N)Dr8rcOkpUZAm]^A%Ts0'q*GWA/n%RWe9IMeQYFaRZ]VE:?e4f%=r0WQc#53D]8&\h0/k*V+!oXu!L]O>4qKiuZ2D1\>SHAn\*;h.sb0FF=!N(5Lt)?NGK9Dm2*IenV&'(l.=DRr10j]JuGA2#`IpG0\tfa"(2b@-50DXp3dXBF7C91G5pHbZ]%^o*AA1+g%hU=0iV&`)jMBk2lX`h04J&S;a@aVpMoD/f][ge:2[&0S3XW^_\a@<CZl7e?+LW:e`bWa5u16c[O6To_//nALM4,mY>LHcU/pY]1*2Kc$arJ#2N?1[Tl_qptm^)!R<1Bs8QKjkCm-#SZL%RDn^V/4MCW6F#1S@4qENoZeL(j_1*WBBG:~>endstream
-endobj
-61 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1964
->>
-stream
-Gb!Sl>Ar7S'Roe[3%r1^+f9CgA/E.6G"oO`c'gQ4>C_8?O)6cfWK:'lpX]r*/TrDs1)DA8&j)n70&QJL/p+o1#Me<WS-$@6K&N+*Xp8#aE!$`geOMU4lJ;-5SVW6ketcIsr[8bA5!8jEF*jRElU'eJ%t)\q9;-iYI<c1O)ASc@OjiAM\G?P6^KY\.B1@GBK(/#h(U![r7,tQ8O+9XW3:nC;;;f#_#[cH]8,s/`;5t$+&dFH7B]P7poj7ce^!FC(?=R2-4G]M`";%KE],hiTU50&m/\eGMj$7&"nB:tnZ<2@S"f)*(BL@sdeV]oigT&-3Y>q\2FUM_YE..WZ&Vap^N(I[t&D(nLU"fECF6LqjNW8QQ29D/<FrRDP)6#f!],FSh+J\HYSYLq-Oste=)9d>W)RqI6bQ;3F28W$6%+VO".VXkkrH$)&>6X$o@jBNe^j?/g"%1>r!ZB4X!a6hsTB:_OaP()T-O($3"<XnFj92iC>bf^Y;ZTS6CrQB&C<j'Q!$<r@%@ngO<%q.Z!,bDYT/fGcKIX'*dGFC@%:;!tB0Est==`*MV+Y].&Eg0C&;d3!].p(;:F7*pn_J?=1k9FQc.)k=bGPZuM\ejX#Vt"$nS)m&_*+^cNgmfT.=Ar7WCHid$2Yg`\,O739YVJUkM.WZ.>_Us4<%N9/dJ;,e)=H4nL`U-,-qu;H)G2E%94^S4TB'i6,8rH1>5nfCti)^g6t+dL<kQQa9jCkF.P'<k)GX_N+nG++]FQc0l!AC.=P&%67fGh:t)Q=k%5.:G#3#i3d#Q=,ugEh<j^@-.,ru,"oBmhf]_>+BVY.NjJoj4.2@5bg;&Ke:]GqZ8U5rV6k)I$i+XO'3N;E\Sq'eU0LNZA$D:k]TN<ETLaBrEcAmM)g%LFB*X]gIHZb`hep(`VDnX%6B3\d,]$+;;G,[$6p6SNIF]b[3hmcOj-N6U3fNT)>f25$J]XcYWk>+,9JX])tPOHIaP-8&H6V/+_itD;X5k(;W0PG"c/:2`[;"P<X)Z"J.$N<938ZB;/[709K!bb*c.hWORoZYmUNp>,>i3h-L/nfXeF[A!g6D'R0.(ma66CRt!`@@f9d.`>r/c.N4HFek<c=srH.rK9F`W\;+M@ItVP$F?:MUWA6@42psbi(jfKUmWj1ql*RRA$?UN]q1(QHCQM\O*F/'S+%KNd;N$^An.06mMU8.H3Hc$m4!pf]G@g-taZDdn+B1dL@cuko=%@#pJ,+Aa?lcS`b/>l><O'Rs4eP&M$7(KZk))Yh`&=qB*\mh%o]Rne&`fOdd/1EoOmKfFPZ^j5FjoUR$914Pncm5mjtN9.Eq3a%3r7XJ94*jrlDdC-^6i?W;XHjf%rY;5ki`!L5=KGS*Sl3U]$_G<X[EHnG."cEF^r%uM=U:PHm2mMpFl;pHE6'N6A[c;pj+6a6.:%EZka<,(e\L%k5%CL\l(a^5KV+m<.%A]S8j"GS_$-\d-t7<]Uj$l!:[NB>RCOc[_44%94Q.k2SRC(/g0SkJd3`j^5jbK6_,hD:f6:Ji("At*ao.F.;!Y!Qk4Y_c'36SYh4#_P(=3n!`IiPX=1)Y9:h;d2HUOeu:;3Gpat^3Ufs3nQ7l<k&4fUKSG>?^9m9>U^AaMUngK(=ettg5^SeoA&J?P"G?E2[Lgk#@ugahIpFo't3N%+W+!G#QrBXKeWCP/Kkf=N_X#of/u"CRN`$>MI/!#NHIjQ6$>O/h%Q@c4>JMiZ8=,)29Y_TZ>jbhbsWY"/puL8]s7&^Xo.hhigJ2s3mFD*[T<=?>c>-(Sc7C^%B&2UCWERAHq`ZbAdOO/.@S<u4E7,fa*"[MECWeVgX!_M+?)7BbGtBGI=to$A/;+Eep_]r\\Y-Okk_&aVBPj5<"p02K%RBP`I&Jm]W1./e&c;nV4WN<K)nooJ]brmcC%6mN7Q"YC2/crIYoM"$B3;C=;3=`6>K*e*ScLaRb#j_%s$6F9E~>endstream
-endobj
-62 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 891
->>
-stream
-Gb!TT>>O95&;B$5.uo]ll6=3c:7M]1><riOONLJX,,*An1an3=SO0s'IcXhG^!Hp.*af^3<bH60IHJ^%K`_ReIZFl05JkfuJhi93TH<VW]"mROHF2C"5e'BSD4J,k%t,8KUUiAlRXHW48f1fFFt:oYgg$K27LOpnUmrh.GDmRs3],TnXl1<GT)X!L$eFI&+:O[]5ls:C=TB(ZPQj=#SQWnKZW/n04cf@Z$?5EpYl0jIg:FR2Xc9Xj%OW=;L%T,AW4bd`71KEVgjjB^/l][gF5_fbnR43i8ml[QR;JJf_R4P^XW:Upf2W19RhFV58kc$1P,]/Z0N!ZqW'_f%@XHlE0`WGlOlC'4+s]m<W2\2iEGS%NcV%OiGqKdC$N]"r:C:O.RDQe^E?(SsL!Xhp:UCt[4;I,][[i\-Em`rDjE$a4,h6m^.8tZ!VKX9;:Q+5k%GKDh's1<VXX,o'B,,MH@eKXGd&"3P?e*J+dfRDE7mYV2h+[$qW,:^eZuo24B%e%YJ5b'Y([1foj(\340N3!CZkb*>B/>NX;@*Li+.M2!Sg/$Xf>ei9m2dkKR\T7(k]=<roRFeedcb<_eNQ,n?H^T?16fP?[2LWl+Tl:-DLO0HJ"Gb9<o0U?$AaE22bUg\!'UDSJW`H-<Jd,sP-TB;A0-IYI!l30mXJq,S]PN<oMjm3m*gY*c`9a*6^_TI-2PefU,D:'Q4&d6Y,'9a*8d0mh6me9e?)gY1=Pm%j3IHa"6CQk+$eEQ"N0?D'p*-oZKgdSUmO\QK9qNIj0QX723fIUq33=2(8?0k7!G8uEr)UQp#A;*kK7S"q"/Mdq]+4GSBbJb$1+m#,B82Xcl5[_jLgr+.g'Cc8^dt&XR)dOY$Us3CF?8WoZ.fCYl4Wf8uJE~>endstream
+Gb"/'D/\/e&H;*)E<nJ</L"3`Z3oqcJgNpq[WC1;fDl!S,>g?<8T[NRNq_j`UgE?]APUfaE.c!2-1`N_I/)K<GBC[;O)'3n'&`B`?C\XcH>o"!)qY0r]S3\M_:LtgM="-/P.'3?_e9b[Y^R<crIEX_*kA]a^8FIO@<heIdi!P!<5:RneYIEo(LQ+[\K5YMR4uGUdC6$$J#/bXO%,]_JfWlf?B!LOFlN`k^)g\V`LptC$j&KtTS,"@lr!Y`J5:e.\=PeN(-<['Q^69A-gaNh+E9NVpotWiH9i;>pO!69M&h/$GCi0\I,LBCRKXYs*.sg6,M10S6_pXTGq<XS77i`<fpE%#Y[,:D+rAh6G<q2(_aP[^0@"t_g!(#;HBt6fR:oF!2jI@<.&aB7/R<q.=mrQhrGiG4bUUeZSTq1IX3=4YNR"(Qk?Fk0]_:t&o3&ml`n-97\A<RA1@jh.h2QbIj$:rkj$M2`e+NAKTkPYNH93c^aqXcmk47USCc:I;K4b)lSj]:,^Y)QE$"3)2jd;jqA4g]l7lU@KAlPk=*B]_kJ'4,qMsp;@rOl`&k9?aao!0N@AehDA;"BR^A;G3@]Y5k_SC%be7akP'X+CDFdn53M:Bd04=@rp.*W0laKT,&h0%At85#Q^p(3e0%%$T)&'/-SkZs`X&-?`ZK27)jW*k^WhM6fS@_Dlj8c(!0]JVJm1GSNoWC:]1.+oZ@\]eB_`T'BHZ-C0srX+TSo+75/ud.8>Rg:B83$XNmcN9*&7Zr0`iPUOPPII&]1i\pK5M>J"KBhD!4APBneX-]$lC]#P-P>`[i3A3-;Nj&nlY4ujDJ&N4(_+BB0hXO8\*BNG:OhX8^Jgbn$TfNeMN87n&'Ki3i@cZ%l)3A*3Cm9(B)tUWOR/?H_+EDWR=Q%4q;8GeUT;>CHGXcu#%N,Z0kj^DbL)MtH<Gcb4;R)`a"]L#S1<T<^hUZqp"^q%INJ*c[M1e"ZUST4p(bAD(G"n>#.-GCs@SF<OH2!N9+RCM3GQ0\bJmFoDM,lPghk0l;q:"HIps%o=B7IcOE4"]6J2n@-=.%&Q5/!-HbN$m^eneZ%7+&!gC.U/X85"sgI\UQ_BBtb1#H\T`NgP('T@SFgF]u8/XgIf>D/jKT`Hs;t%DVQoGt<RRo9%_(e!_"S8(dL?Irf?PIPg^]f++Wi'm._eE3AmoMhd#/G(')Dn42'm3FAFPbU@4eF_5AQ9UNi4@-J;!QZF>s=K"oje5i(UQj$aZD7f-b_+WQDHS4,A=)i.oO^K^\h&djZc!e9OFTe(bMQ=I-cA[3fifR4)oO5C#jfSReM[<^(NS-h?+P`[ESp*u\Id0=S:<-Eoio%qh[0A?$a6E5-PCXbA<g^CD,@GbI`5=]GNi<'mdpUU?7&6FpAk]4qa0@-n%./Q,W1.TbKJ]"IIAhn(L(C2)[\+'O<EA>Q@8>oeV>0ujM&Ws/&U!,GWX",:f$rKjdQ4QX*L!>&S2Tjm$(H4nPbS>LpFj'++kd%/NUb5qgcY&3O#t6f&X(ZnWlrquNG8X9EXn%\9V)8/F/?_<JJknX8X@a61`K23g0%p+,jG_]NWu5b7JEbW9#eO3*gLboDb%<ZS`Kfifr3C-6_MUfDd;&%]cZ4c)NicsCu$2%gi[0%?Rf*sjolRQH,1;YEN7?];8Pl+3,Yo`RP'oHT^hLA8aT/E_3Z'u.(of,#)pf/">jH4f1Z_Hgg`KjmmYqhUsaBimi:Q2D7u5A17bl:!lm:"!eRr_(;A7$a*H]U1SXJn7KCe,gJNK#RE8-VP)U,i"!q*R]*=VAV),/TO"C)aHE++cDl@&(UTtP&1T3;?1F&M_8_%$M*Te^qRu55&d"mkl^*!fh"FWamabi7m>$$%fr!g]S*P2~>endstream
 endobj
 xref
-0 63
+0 76
 0000000000 65535 f 
 0000000061 00000 n 
-0000000123 00000 n 
-0000000230 00000 n 
-0000000342 00000 n 
-0000000537 00000 n 
-0000000642 00000 n 
-0000000837 00000 n 
-0000001032 00000 n 
-0000001227 00000 n 
-0000001422 00000 n 
-0000001618 00000 n 
-0000001814 00000 n 
-0000002010 00000 n 
-0000002206 00000 n 
-0000002402 00000 n 
-0000002598 00000 n 
-0000002794 00000 n 
-0000002910 00000 n 
-0000003106 00000 n 
-0000003302 00000 n 
-0000003498 00000 n 
-0000003694 00000 n 
-0000003890 00000 n 
-0000004086 00000 n 
-0000004282 00000 n 
-0000004478 00000 n 
-0000004674 00000 n 
-0000004870 00000 n 
-0000005066 00000 n 
-0000005262 00000 n 
-0000005458 00000 n 
-0000005654 00000 n 
-0000005850 00000 n 
-0000005920 00000 n 
-0000006204 00000 n 
-0000006449 00000 n 
-0000007219 00000 n 
-0000009563 00000 n 
-0000011841 00000 n 
-0000012707 00000 n 
-0000014684 00000 n 
-0000016730 00000 n 
-0000018951 00000 n 
-0000019471 00000 n 
-0000022012 00000 n 
-0000024643 00000 n 
-0000026767 00000 n 
-0000027785 00000 n 
-0000030181 00000 n 
-0000032342 00000 n 
-0000034314 00000 n 
-0000036390 00000 n 
-0000037423 00000 n 
-0000039946 00000 n 
-0000042184 00000 n 
-0000044200 00000 n 
-0000046299 00000 n 
-0000048137 00000 n 
-0000049641 00000 n 
-0000052007 00000 n 
-0000053774 00000 n 
-0000055830 00000 n 
+0000000133 00000 n 
+0000000240 00000 n 
+0000000352 00000 n 
+0000000547 00000 n 
+0000000652 00000 n 
+0000000847 00000 n 
+0000000924 00000 n 
+0000001119 00000 n 
+0000001314 00000 n 
+0000001510 00000 n 
+0000001706 00000 n 
+0000001902 00000 n 
+0000002098 00000 n 
+0000002294 00000 n 
+0000002490 00000 n 
+0000002686 00000 n 
+0000002882 00000 n 
+0000002998 00000 n 
+0000003194 00000 n 
+0000003390 00000 n 
+0000003586 00000 n 
+0000003782 00000 n 
+0000003978 00000 n 
+0000004174 00000 n 
+0000004370 00000 n 
+0000004566 00000 n 
+0000004762 00000 n 
+0000004958 00000 n 
+0000005154 00000 n 
+0000005350 00000 n 
+0000005546 00000 n 
+0000005742 00000 n 
+0000005938 00000 n 
+0000006134 00000 n 
+0000006330 00000 n 
+0000006526 00000 n 
+0000006722 00000 n 
+0000006918 00000 n 
+0000007114 00000 n 
+0000007184 00000 n 
+0000007468 00000 n 
+0000007759 00000 n 
+0000008562 00000 n 
+0000011068 00000 n 
+0000013700 00000 n 
+0000014932 00000 n 
+0000016938 00000 n 
+0000018997 00000 n 
+0000021325 00000 n 
+0000022380 00000 n 
+0000025066 00000 n 
+0000027790 00000 n 
+0000030003 00000 n 
+0000031084 00000 n 
+0000033496 00000 n 
+0000036187 00000 n 
+0000038108 00000 n 
+0000040376 00000 n 
+0000042237 00000 n 
+0000044846 00000 n 
+0000046304 00000 n 
+0000048763 00000 n 
+0000051041 00000 n 
+0000053217 00000 n 
+0000055395 00000 n 
+0000056370 00000 n 
+0000058676 00000 n 
+0000061125 00000 n 
+0000062031 00000 n 
+0000064440 00000 n 
+0000066213 00000 n 
+0000069105 00000 n 
+0000071936 00000 n 
+0000074660 00000 n 
 trailer
 <<
 /ID 
-[<c1ab5552724db03be6cc56a47741681b><c1ab5552724db03be6cc56a47741681b>]
+[<affd2478cc79bfaca67951d0379ea10f><affd2478cc79bfaca67951d0379ea10f>]
 % ReportLab generated PDF document -- digest (opensource)
 
-/Info 34 0 R
-/Root 33 0 R
-/Size 63
+/Info 41 0 R
+/Root 40 0 R
+/Size 76
 >>
 startxref
-56812
+76627
 %%EOF

--- a/schemas/FUSE_JSON_SCHEMA.md
+++ b/schemas/FUSE_JSON_SCHEMA.md
@@ -3,7 +3,7 @@
 This folder defines the JSON side of the FUSE mod format.
 
 - `fuse-mod.schema.json` is the authoritative JSON Schema for hand-authored and editor-exported `.json` files.
-- `fuse-mod.example.json` is a compact example that exercises track, spans, areas, industry ordering, built-in and custom industry components, loaders, turntables, roundhouses, stations, scenery, spawn points, span-anchored scenery, splineys, telegraph poles, labels, speed signs, masks, suppressions, map tiles, scene clones, world removals, progression data, audio definitions, mixinto metadata, package settings, and editor state.
+- `fuse-mod.example.json` is a compact example that exercises track, spans, areas, industry ordering, built-in and custom industry components, loaders, turntables, roundhouses, stations, scenery, spawn points, span-anchored scenery, splineys, water surfaces, telegraph poles, labels, speed signs, masks, suppressions, map tiles, scene clones, world removals, progression data, audio definitions, mixinto metadata, package settings, and editor state.
 - `umm-info.schema.json` documents the Unity Mod Manager `Info.json` shape FUSE expects for API mods, data packages, and asset-pack packages.
 - `umm-info.example.json` is a data-only map package manifest that depends on `FUSE`.
 
@@ -15,7 +15,7 @@ Top-level object groups:
 
 - `tracks`: nodes, segments, spans, areas, and optional removals for deleting base-game track objects.
 - `operations`: loads, industries, loaders, turntables, and passenger stations.
-- `world`: scenery, spawn points, splineys, telegraph poles, map labels, map masks, map tile overlays, scene clones, and optional removals for base scene objects.
+- `world`: scenery, spawn points, splineys, polygonal water surfaces, telegraph poles, map labels, map masks, map tile overlays, scene clones, and optional removals for base scene objects.
 - `progression`: progression trees and map features.
 
 Map declarations are complete replacement worlds by default. `map.suppressBaseWorld`
@@ -27,7 +27,7 @@ uses custom terrain as an overlay on the stock world.
 - `editor`: optional editor-only state that FUSE can ignore at runtime.
 - `extensions`: optional namespaced third-party data.
 
-`mixinto` is optional metadata for converted RailLoader/Strange Customs conditional mixin files. The converted file remains a normal FUSE fragment, but FUSE checks `mixinto.requires[]` immediately before runtime apply. If any required mod is missing, older than `notBefore`, or newer than `notAfter`, that fragment is skipped without faulting the rest of the package.
+`mixinto` is optional metadata for converted RailLoader/Strange Customs conditional mixin files. The converted file remains a normal FUSE fragment, but FUSE checks `mixinto.requires[]` and `mixinto.conflictsWith[]` immediately before runtime apply. A missing/out-of-range requirement or a matching conflict skips that fragment without faulting the rest of the package.
 
 ```json
 {
@@ -36,6 +36,9 @@ uses custom terrain as an overlay on the stock world.
     "sourceFile": "CNRI_FoxysLimestonePatch.json",
     "requires": [
       { "id": "CaptainFoxy.NantahalaLime", "notBefore": "1.1" }
+    ],
+    "conflictsWith": [
+      { "id": "Some.Incompatible.Route", "notAfter": "3.0" }
     ]
   }
 }
@@ -65,6 +68,46 @@ Enum `values` are treated as exact strings. FUSE does not normalize or rename se
   }
 }
 ```
+
+Native modular packages can connect a setting to authored content with a
+top-level `featureRules` dictionary. When a rule does not match, FUSE omits
+only its named targets from the runtime copy of the definition. The source JSON
+stays intact, so changing the option and reloading restores the objects.
+
+```json
+{
+  "settings": {
+    "enableExtraYard": {
+      "type": "bool",
+      "label": "Extra Yard Tracks",
+      "scope": "profile",
+      "default": true,
+      "reloadRequired": true
+    }
+  },
+  "featureRules": {
+    "extraYard": {
+      "setting": "enableExtraYard",
+      "operator": "equals",
+      "value": true,
+      "targets": {
+        "trackNodes": ["yard:n:4", "yard:n:5"],
+        "trackSegments": ["yard:s:extra"],
+        "trackSpans": ["yard:span:extra"],
+        "scenery": ["yard:prop:bumper"]
+      }
+    }
+  }
+}
+```
+
+Operators are `equals`, `notEquals`, `greaterThan`,
+`greaterThanOrEqual`, `lessThan`, and `lessThanOrEqual`; ordering operators
+require a number setting. Target keys cover track, operations, world,
+progression, and audio dictionaries. Industry components use
+`industryId/componentId`. Every target must be authored in the same definition,
+which prevents an option from accidentally deleting base-game or dependency
+objects. Rules are native FUSE data and are not projected into RailLoader JSON.
 
 All editable game objects are stored in dictionaries keyed by object ID. The ID is not repeated inside the object body. This keeps editor updates simple: replacing `tracks.nodes["murphy:n:001"]` updates exactly one object without array searches or ID duplication.
 
@@ -100,11 +143,12 @@ The shipped examples cover the public authoring cases:
 | Audio pack | `fuse-mod.example.json` | `audio.whistles`, `audio.horns`, and `audio.bells`. |
 | Industry component pack | `fuse-mod.example.json` | Built-in component types plus a fully-qualified custom component type with `fields`. |
 | Load component pack | `fuse-mod.example.json` | `operations.loads.*.fields` can carry reflection-bound custom load data. |
-| Package settings | `fuse-mod.example.json` | Top-level `settings` with bool, enum, color, user/profile/server scope, and reload metadata. |
-| Mixinto | `fuse-mod.example.json` | `mixinto.target`, `mixinto.sourceFile`, and conditional `requires`. |
+| Package settings | `fuse-mod.example.json` | Top-level `settings` with bool, enum, color, user/profile/server scope, reload metadata, and object-level `featureRules`. |
+| Mixinto | `fuse-mod.example.json` | `mixinto.target`, `mixinto.sourceFile`, conditional `requires`, and conditional `conflictsWith`. |
 | Progression section | `fuse-mod.example.json` | Root `progression.sections[]`, delivery phases, unlock features, and interchange transfers. |
 | Map mask | `fuse-mod.example.json` | `world.mapMasks` for terrain/object mask authoring. |
 | Scene clone | `fuse-mod.example.json` | `world.sceneClones` for base-game object cloning/retargeting. |
+| Water surface | `fuse-mod.example.json` | `world.waterSurfaces` for FUSE-owned lake planes and optional stock-lake material reuse. |
 | Span-anchored scenery | `fuse-mod.example.json` | `world.scenery.*.anchorSpanIds`. |
 | Signals | Not included | Signals are deferred and should not be treated as supported yet. |
 
@@ -279,7 +323,11 @@ Track segments may also set optional companion-mod gauge metadata:
 }
 ```
 
-FUSE stores `gauge` for mods such as NarrowGaugeMod; base Railroader track geometry remains unchanged unless a companion mod acts on it.
+FUSE stores `gauge` for mods such as NarrowGaugeMod; base Railroader track
+geometry remains unchanged unless a companion mod acts on it. Native values are
+`Standard`, `Narrow`, `DualGauge`, `DualGauge_L`, `DualGauge_R`, and
+`DualGauge_T`; the additional legacy aliases accepted by the schema are read
+compatibility values, not recommended new output.
 
 Asset and prefab references are URI strings:
 
@@ -316,6 +364,13 @@ Spliney `type` describes the physical spline family, not its material flavor:
 - `road`: normal road spline. Use `style`/`profile` for dirt versus pavement.
 - `terrainRoad`: terrain-carved road spline. Use `style`/`profile` for dirt versus pavement.
 - `trestle`: auto-generated trestle spline.
+- `objectLine`: repeats a scenery asset or safe scene-path prefab along a
+  piecewise path. Use this for fence panels, retaining-wall sections,
+  guardrails, hedges, and other rigid modules that must not be stretched into
+  a road/river mesh. Set exactly one of `assetIdentifier` or `prefab`, then use
+  `spacing`, `instanceScale`, `rotationOffset`, lateral/vertical offsets,
+  optional terrain snapping/slope alignment, and the bounded
+  `maximumInstances` safety limit.
 
 Converted Strange Customs `FlowyThingBuilder` data must inspect `style` and `profile`; entries with `style: "River"` or river profiles should be emitted as `type: "river"`, not as roads.
 When converting `FlowyThingBuilder` entries, preserve the legacy default `offsetY: -0.1` if the source omits it; the field keeps road and river surfaces at the same vertical bias Strange Customs used.
@@ -392,6 +447,7 @@ FUSE treats these as overlays on top of the base game's `StreamingAssets/Maps/<d
 - `tracks.areas` are applied at runtime and are used as preferred parents for FUSE-created industries. Area and industry `order` values are also used when rebuilding company-window location ordering.
 - `operations.loads` are applied at runtime by creating or updating `CarPrototypeLibrary.instance.opsLoads` entries. Use `units`, `density`, `unitWeightInPounds`, `importable`, `payPerQuantity`, and `costPerUnit` when the custom load needs full behavior parity with legacy mod data. Custom load mods may use `fields` for reflection-bound field/property values on the runtime `Load` object.
 - `world.mapMasks` are applied at runtime using the default behavior above.
+- `world.waterSurfaces` creates editable polygonal lake planes. Supply at least three world-space points; `sourceLakePath` reuses a specific stock lake's material/profile, while `materialName` selects a loaded material explicitly. `lockHeight`, `snapToTerrain`, `uvScale`, `triangleDensity`, `maximumTriangleArea`, `yOffset`, and `enableCollider` control generation. This native-only contract is intentionally not projected into RailLoader JSON.
 - `world.telegraphPoles` are applied at runtime by generating pole instances along the provided point path at the requested spacing.
 - `world.telegraphPoleMovements` are applied at runtime by translating existing base-game telegraph pole graph nodes by index. FUSE forces the telegraph manager to refresh when possible.
 - `world.spawnPoints` are applied at runtime by creating or updating `Character.SpawnPoint` components under a FUSE-owned world root.
@@ -453,3 +509,58 @@ Asset-pack-only packages can expose existing Railroader `AssetPack` runtime stor
   "FuseAssetPacks": ["SCAssetPacks"]
 }
 ```
+
+Track nodes and segments also preserve the newer graph structure metadata while
+remaining compatible with released Railroader builds that expose the older
+four-way style enum:
+
+```json
+{
+  "tracks": {
+    "nodes": {
+      "murphy:n:diamond-west": {
+        "position": { "x": 10, "y": 2, "z": 20 },
+        "rotation": { "x": 0, "y": 90, "z": 0 },
+        "isDiamond": true
+      }
+    },
+    "segments": {
+      "murphy:s:steel-yard-bridge": {
+        "startNodeId": "murphy:n:001",
+        "endNodeId": "murphy:n:002",
+        "style": "bridge",
+        "bridgeSupportsSteel": true,
+        "yard": true
+      }
+    }
+  }
+}
+```
+
+`isDiamond` marks a graph crossing node. `bridgeSupportsSteel` selects the
+steel-support bridge variant, and `yard` is independent of bridge/tunnel
+structure on game builds that expose combinable flags. Existing `style` values
+(`standard`, `bridge`, `tunnel`, `yard`) remain valid. Partial legacy overlays
+can set `preserveBridgeSupportsSteel` and `preserveYard` just as they already use
+`preserveStyle`.
+
+`Catalog.json` identifies a runtime store. A local `Bundle` is not required for
+a definitions-only catalog whose asset references resolve to another store.
+
+Use `FuseDefinitionOverrides` when a package intentionally supplies
+`Definitions.json` for an existing store without supplying a new catalog/bundle:
+
+```json
+{
+  "Requirements": ["FUSE"],
+  "FuseDefinitionOverrides": [
+    {
+      "StoreIdentifier": "fm-flatcar03",
+      "Path": "DefinitionOverrides/fm-flatcar03/Definitions.json"
+    }
+  ]
+}
+```
+
+Paths are package-relative and cannot escape the package directory. A string
+entry is also accepted and infers `StoreIdentifier` from its parent folder.

--- a/schemas/fuse-mod.example.json
+++ b/schemas/fuse-mod.example.json
@@ -24,7 +24,8 @@
       "label": "Depot Props",
       "description": "Show optional detail props around the depot.",
       "scope": "user",
-      "default": true
+      "default": true,
+      "reloadRequired": true
     },
     "yardDetailLevel": {
       "type": "enum",
@@ -45,6 +46,18 @@
       "scope": "server",
       "default": "#D6C89A",
       "advanced": true
+    }
+  },
+  "featureRules": {
+    "optionalDepotProps": {
+      "setting": "enableDepotProps",
+      "operator": "equals",
+      "value": true,
+      "targets": {
+        "scenery": [
+          "murphy:scenery:depot"
+        ]
+      }
     }
   },
   "tracks": {
@@ -661,6 +674,40 @@
           }
         ]
       },
+      "murphy:fence:001": {
+        "type": "objectLine",
+        "assetIdentifier": "example-pack:fence-panel",
+        "spacing": 3,
+        "instanceScale": {
+          "x": 1,
+          "y": 1,
+          "z": 1
+        },
+        "rotationOffset": {
+          "x": 0,
+          "y": 90,
+          "z": 0
+        },
+        "snapToTerrain": true,
+        "placeAtEnd": true,
+        "maximumInstances": 256,
+        "points": [
+          {
+            "position": {
+              "x": 10,
+              "y": 1,
+              "z": 24
+            }
+          },
+          {
+            "position": {
+              "x": 52,
+              "y": 2,
+              "z": 27
+            }
+          }
+        ]
+      },
       "murphy:waterfall:001": {
         "type": "waterfall",
         "profile": "default",
@@ -680,6 +727,39 @@
             }
           }
         ]
+      }
+    },
+    "waterSurfaces": {
+      "murphy:lake:millpond": {
+        "points": [
+          {
+            "x": 92,
+            "y": 1.5,
+            "z": -42
+          },
+          {
+            "x": 132,
+            "y": 1.5,
+            "z": -38
+          },
+          {
+            "x": 128,
+            "y": 1.5,
+            "z": -12
+          },
+          {
+            "x": 88,
+            "y": 1.5,
+            "z": -16
+          }
+        ],
+        "lockHeight": true,
+        "snapToTerrain": false,
+        "enableCollider": false,
+        "uvScale": 1,
+        "triangleDensity": 0.2,
+        "maximumTriangleArea": 50,
+        "yOffset": 0
       }
     },
     "telegraphPoles": {

--- a/schemas/fuse-mod.schema.json
+++ b/schemas/fuse-mod.schema.json
@@ -91,6 +91,10 @@
             "$ref": "#/$defs/settings",
             "description": "Package-declared FUSE settings. Runtime values are stored outside the mod folder and scoped by user, profile, or server profile."
         },
+        "featureRules": {
+            "$ref": "#/$defs/featureRules",
+            "description": "Native FUSE rules that include authored objects only when a package setting matches. Rules are evaluated on map/package load."
+        },
         "editor": {
             "$ref": "#/$defs/editor"
         },
@@ -113,7 +117,7 @@
         "uri": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^(vanilla|path|scenery|asset|rail|file|empty)://.*$"
+            "pattern": "^(vanilla|path|scenery|asset|rail|file|empty|fuse)://.*$"
         },
         "vec3": {
             "type": "object",
@@ -185,6 +189,14 @@
                         "$ref": "#/$defs/modRequirement"
                     },
                     "default": []
+                },
+                "conflictsWith": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/modRequirement"
+                    },
+                    "default": [],
+                    "description": "Legacy conditional incompatibilities. The fragment is skipped when any matching package/version is enabled; the rest of the package remains active."
                 }
             }
         },
@@ -294,6 +306,82 @@
                 }
             }
         },
+        "featureRules": {
+            "type": "object",
+            "description": "Dictionary of stable feature-rule ids. A false rule omits all named targets until the next map/package reload.",
+            "propertyNames": {
+                "$ref": "#/$defs/id"
+            },
+            "additionalProperties": {
+                "$ref": "#/$defs/featureRule"
+            }
+        },
+        "featureRule": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "setting",
+                "value",
+                "targets"
+            ],
+            "properties": {
+                "setting": {
+                    "$ref": "#/$defs/id",
+                    "description": "Id of a setting declared by this package. The setting should set reloadRequired=true."
+                },
+                "operator": {
+                    "type": "string",
+                    "enum": [
+                        "equals",
+                        "notEquals",
+                        "greaterThan",
+                        "greaterThanOrEqual",
+                        "lessThan",
+                        "lessThanOrEqual"
+                    ],
+                    "default": "equals"
+                },
+                "value": {
+                    "description": "Comparison value. Its JSON type should match the referenced setting."
+                },
+                "targets": {
+                    "$ref": "#/$defs/featureTargets"
+                }
+            }
+        },
+        "featureTargets": {
+            "type": "object",
+            "additionalProperties": false,
+            "minProperties": 1,
+            "properties": {
+                "trackNodes": { "$ref": "#/$defs/stringArray" },
+                "trackSegments": { "$ref": "#/$defs/stringArray" },
+                "trackSpans": { "$ref": "#/$defs/stringArray" },
+                "trackAreas": { "$ref": "#/$defs/stringArray" },
+                "loads": { "$ref": "#/$defs/stringArray" },
+                "industries": { "$ref": "#/$defs/stringArray" },
+                "industryComponents": {
+                    "$ref": "#/$defs/stringArray",
+                    "description": "Industry/component references formatted as industryId/componentId."
+                },
+                "loaders": { "$ref": "#/$defs/stringArray" },
+                "turntables": { "$ref": "#/$defs/stringArray" },
+                "stations": { "$ref": "#/$defs/stringArray" },
+                "scenery": { "$ref": "#/$defs/stringArray" },
+                "splineys": { "$ref": "#/$defs/stringArray" },
+                "waterSurfaces": { "$ref": "#/$defs/stringArray" },
+                "telegraphPoles": { "$ref": "#/$defs/stringArray" },
+                "mapLabels": { "$ref": "#/$defs/stringArray" },
+                "mapMasks": { "$ref": "#/$defs/stringArray" },
+                "mapTiles": { "$ref": "#/$defs/stringArray" },
+                "sceneClones": { "$ref": "#/$defs/stringArray" },
+                "progressions": { "$ref": "#/$defs/stringArray" },
+                "mapFeatures": { "$ref": "#/$defs/stringArray" },
+                "whistles": { "$ref": "#/$defs/stringArray" },
+                "horns": { "$ref": "#/$defs/stringArray" },
+                "bells": { "$ref": "#/$defs/stringArray" }
+            }
+        },
         "tracks": {
             "type": "object",
             "additionalProperties": false,
@@ -401,27 +489,16 @@
                     "type": "boolean",
                     "default": false
                 },
+                "isDiamond": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Marks this node as one half of a diamond crossing. FUSE preserves it on game versions that expose diamond-node routing."
+                },
                 "groupId": {
                     "$ref": "#/$defs/idRef"
                 },
                 "tags": {
                     "$ref": "#/$defs/stringArray"
-                },
-                "gauge": {
-                    "type": "string",
-                    "enum": [
-                        "Standard",
-                        "Narrow",
-                        "3ft",
-                        "3 ft",
-                        "ThreeFoot",
-                        "Three Foot",
-                        "DualGauge",
-                        "Dual",
-                        "Mixed",
-                        "MixedGauge"
-                    ],
-                    "description": "Optional NarrowGaugeMod metadata. FUSE stores the value for companion mods; Railroader's base graph still uses the normal track geometry."
                 }
             }
         },
@@ -463,6 +540,35 @@
                 "tags": {
                     "$ref": "#/$defs/stringArray"
                 },
+                "gauge": {
+                    "type": "string",
+                    "enum": [
+                        "Standard",
+                        "Narrow",
+                        "3ft",
+                        "3 ft",
+                        "ThreeFoot",
+                        "Three Foot",
+                        "DualGauge",
+                        "DualGauge_L",
+                        "DualGauge_R",
+                        "DualGauge_T",
+                        "Dual",
+                        "Mixed",
+                        "MixedGauge"
+                    ],
+                    "description": "Optional NarrowGaugeMod segment metadata. FUSE stores the value for companion mods; Railroader's base graph still uses the normal track geometry."
+                },
+                "bridgeSupportsSteel": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use steel bridge supports when style is bridge. Older Railroader builds that only expose the four-way style enum retain bridge style but cannot represent this extra distinction."
+                },
+                "yard": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Marks the segment as yard track independently of bridge/tunnel structure on Railroader builds that expose combinable track flags. The legacy style value 'yard' remains supported."
+                },
                 "partial": {
                     "type": "boolean",
                     "default": false,
@@ -472,6 +578,16 @@
                     "type": "boolean",
                     "default": false,
                     "description": "In a partial patch, keep the existing segment style instead of overwriting it."
+                },
+                "preserveBridgeSupportsSteel": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "In a partial patch, keep the existing bridge-support material flag."
+                },
+                "preserveYard": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "In a partial patch, keep the existing independent yard flag."
                 },
                 "preserveTrackClass": {
                     "type": "boolean",
@@ -1333,6 +1449,20 @@
                     ],
                     "default": {}
                 },
+                "waterSurfaces": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/dictionary"
+                        },
+                        {
+                            "additionalProperties": {
+                                "$ref": "#/$defs/waterSurface"
+                            }
+                        }
+                    ],
+                    "description": "FUSE-owned lake polygons built from world-space boundary points and loaded Railroader water assets.",
+                    "default": {}
+                },
                 "telegraphPoles": {
                     "allOf": [
                         {
@@ -1435,6 +1565,7 @@
                     "default": {
                         "scenery": [],
                         "splineys": [],
+                        "waterSurfaces": [],
                         "telegraphPoles": [],
                         "mapLabels": [],
                         "mapMasks": [],
@@ -1452,6 +1583,9 @@
                     "$ref": "#/$defs/worldRemovalArray"
                 },
                 "splineys": {
+                    "$ref": "#/$defs/worldRemovalArray"
+                },
+                "waterSurfaces": {
                     "$ref": "#/$defs/worldRemovalArray"
                 },
                 "telegraphPoles": {
@@ -1570,7 +1704,8 @@
                         "road",
                         "terrainRoad",
                         "trestle",
-                        "waterfall"
+                        "waterfall",
+                        "objectLine"
                     ]
                 },
                 "profile": {
@@ -1589,6 +1724,55 @@
                 },
                 "tailStyle": {
                     "type": "string"
+                },
+                "assetIdentifier": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Scenery asset repeated by an objectLine spline. Mutually exclusive with prefab."
+                },
+                "prefab": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Prefab URI such as path://scene/World/... repeated by an objectLine spline. Mutually exclusive with assetIdentifier."
+                },
+                "spacing": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "default": 5
+                },
+                "instanceScale": {
+                    "$ref": "#/$defs/vec3",
+                    "default": { "x": 1, "y": 1, "z": 1 }
+                },
+                "rotationOffset": {
+                    "$ref": "#/$defs/vec3",
+                    "default": { "x": 0, "y": 0, "z": 0 }
+                },
+                "lateralOffset": {
+                    "type": "number",
+                    "default": 0
+                },
+                "verticalOffset": {
+                    "type": "number",
+                    "default": 0
+                },
+                "snapToTerrain": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "alignToSlope": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "placeAtEnd": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "maximumInstances": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 4096,
+                    "default": 1024
                 },
                 "points": {
                     "type": "array",
@@ -1620,6 +1804,64 @@
                 "width": {
                     "type": "number",
                     "exclusiveMinimum": 0
+                }
+            }
+        },
+        "waterSurface": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "points"
+            ],
+            "properties": {
+                "points": {
+                    "type": "array",
+                    "minItems": 3,
+                    "items": {
+                        "$ref": "#/$defs/vec3"
+                    }
+                },
+                "sourceLakePath": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Optional scene path whose LakePolygon profile/material should be reused."
+                },
+                "materialName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Optional exact loaded material name. When omitted, FUSE uses the source or a loaded stock water material."
+                },
+                "lockHeight": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "snapToTerrain": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "enableCollider": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "uvScale": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "default": 1
+                },
+                "triangleDensity": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "maximum": 1,
+                    "default": 0.2
+                },
+                "maximumTriangleArea": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "default": 50
+                },
+                "yOffset": {
+                    "type": "number",
+                    "default": 0
                 }
             }
         },

--- a/schemas/fuse-mod.schema.json
+++ b/schemas/fuse-mod.schema.json
@@ -1705,7 +1705,10 @@
                         "terrainRoad",
                         "trestle",
                         "waterfall",
-                        "objectLine"
+                        "objectLine",
+                        "object-line",
+                        "fence",
+                        "retainingWall"
                     ]
                 },
                 "profile": {
@@ -1731,8 +1734,7 @@
                     "description": "Scenery asset repeated by an objectLine spline. Mutually exclusive with prefab."
                 },
                 "prefab": {
-                    "type": "string",
-                    "minLength": 1,
+                    "$ref": "#/$defs/uri",
                     "description": "Prefab URI such as path://scene/World/... repeated by an objectLine spline. Mutually exclusive with assetIdentifier."
                 },
                 "spacing": {

--- a/schemas/umm-info.example.json
+++ b/schemas/umm-info.example.json
@@ -17,6 +17,7 @@
   ],
   "FuseLoadPriority": 100,
   "FuseLoadAfter": [],
+  "FuseConflictsWith": [],
   "FuseLoadBefore": [],
   "FuseDataFiles": [
     "track.fuse.json",
@@ -26,5 +27,11 @@
   ],
   "FuseAssetPacks": [
     "SCAssetPacks"
+  ],
+  "FuseDefinitionOverrides": [
+    {
+      "StoreIdentifier": "example-existing-store",
+      "Path": "DefinitionOverrides/example-existing-store/Definitions.json"
+    }
   ]
 }

--- a/schemas/umm-info.schema.json
+++ b/schemas/umm-info.schema.json
@@ -77,6 +77,14 @@
       "default": 0,
       "description": "FUSE-specific package ordering priority. Lower values load earlier; ties fall back to dependency order, then package id."
     },
+    "FuseRequires": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/dependency"
+      },
+      "default": [],
+      "description": "FUSE data package ids that must be installed and enabled for this package to apply."
+    },
     "FuseLoadAfter": {
       "type": "array",
       "items": {
@@ -92,6 +100,14 @@
       },
       "default": [],
       "description": "FUSE-specific data package ids that must load after this package."
+    },
+    "FuseConflictsWith": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/dependency"
+      },
+      "default": [],
+      "description": "Package ids and optional version bounds that this complete data package declares incompatible. Matching enabled packages prevent this package from loading and are shown as author-declared incompatibilities."
     },
     "FuseDataFile": {
       "type": "string",
@@ -123,6 +139,33 @@
         }
       ],
       "description": "FUSE-specific relative folder or folders containing Railroader AssetPack Runtime stores, for example SCAssetPacks."
+    },
+    "FuseDefinitionOverrides": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/definitionOverride"
+        },
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/definitionOverride"
+              },
+              {
+                "type": "string",
+                "minLength": 1
+              }
+            ]
+          },
+          "default": []
+        }
+      ],
+      "description": "FUSE-owned replacement for AssetLoader definitions-only store routing. Paths are relative to this package. String entries infer the target store identifier from the parent folder; object entries can name it explicitly."
     },
     "Settings": {
       "type": "object",
@@ -197,10 +240,31 @@
             },
             "NotBefore": {
               "type": "string"
+            },
+            "NotAfter": {
+              "type": "string"
             }
           }
         }
       ]
+    },
+    "definitionOverride": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Path"
+      ],
+      "properties": {
+        "StoreIdentifier": {
+          "$ref": "#/$defs/id",
+          "description": "Exact existing AssetPackRuntimeStore identifier whose Definitions.json is replaced. If omitted, FUSE uses the definition file's parent folder name."
+        },
+        "Path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Package-relative Definitions.json path, or a package-relative folder containing Definitions.json."
+        }
+      }
     }
   }
 }

--- a/scripts/Sync-Wiki.ps1
+++ b/scripts/Sync-Wiki.ps1
@@ -42,6 +42,7 @@ $blobBase = 'https://github.com/F-U-S-E-E/FuseDevelopmentGroup/blob/main'
 # docs/ file -> wiki page name. Order drives the sidebar.
 $pageMap = [ordered]@{
     'GETTING_STARTED.md'      = 'Getting-Started'
+    'CHOOSING_A_WORKFLOW.md'  = 'Install-Convert-Or-Author'
     'FAQ.md'                  = 'FAQ'
     'MIGRATION_FROM_LEGACY.md' = 'Migrating-From-Legacy-Mods'
     'SETTINGS.md'             = 'Settings'
@@ -51,13 +52,15 @@ $pageMap = [ordered]@{
     'FUSE_INSTALLER.md'       = 'Installer'
     'FUSE_CONVERTER.md'       = 'Converter'
     'PACKAGE_AUTHOR_GUIDE.md' = 'Package-Author-Guide'
+    'AUTHORING_RECIPES.md'    = 'Authoring-Recipes'
     'EXTERNAL_EDITOR.md'      = 'External-Editor'
+    'BASE_GAME_MAP_AUTHORING_AUDIT.md' = 'Map-Authoring-Coverage'
 }
 
 # Sidebar grouping.
 $sections = [ordered]@{
-    'Players'         = @('Getting-Started', 'FAQ', 'Migrating-From-Legacy-Mods', 'Settings', 'Console-Commands', 'Troubleshooting', 'Known-Issues', 'Installer')
-    'Package Authors' = @('Converter', 'Package-Author-Guide', 'External-Editor')
+    'Players'         = @('Getting-Started', 'Install-Convert-Or-Author', 'FAQ', 'Migrating-From-Legacy-Mods', 'Settings', 'Console-Commands', 'Troubleshooting', 'Known-Issues', 'Installer')
+    'Package Authors' = @('Converter', 'Package-Author-Guide', 'Authoring-Recipes', 'External-Editor', 'Map-Authoring-Coverage')
 }
 
 function Convert-Links {
@@ -147,6 +150,9 @@ and Alina's Map Mod packages.
 
 **New here?** Start with [Getting Started](Getting-Started).
 
+**Not sure whether to install, convert, or edit a mod?** Use
+[Install, Convert, Or Author](Install-Convert-Or-Author).
+
 **Coming from Railloader or another legacy stack?** Read
 [Migrating From Legacy Mods](Migrating-From-Legacy-Mods) before installing
 anything.
@@ -154,6 +160,7 @@ anything.
 ## Players
 
 - [Getting Started](Getting-Started) — install, verify, update, uninstall
+- [Install, Convert, Or Author](Install-Convert-Or-Author) — choose the correct tool
 - [FAQ](FAQ) — legacy mods, multiplayer, saves, performance
 - [Settings](Settings) — every setting and its default
 - [Console Commands](Console-Commands) — every ``/fuse.*`` command
@@ -165,7 +172,9 @@ anything.
 
 - [Converter](Converter) — converting legacy mods
 - [Package Author Guide](Package-Author-Guide) — the authoring contract
+- [Authoring Recipes](Authoring-Recipes) — common map, industry, loader, and JSON tasks
 - [External Editor](External-Editor) — the standalone desktop editor
+- [Map Authoring Coverage](Map-Authoring-Coverage) — base-game subsystem crosswalk and live acceptance boundary
 - [JSON Schema Reference]($blobBase/schemas/FUSE_JSON_SCHEMA.md) — the data contract
 
 ## Offline manuals

--- a/scripts/Sync-Wiki.ps1
+++ b/scripts/Sync-Wiki.ps1
@@ -46,6 +46,7 @@ $pageMap = [ordered]@{
     'FAQ.md'                  = 'FAQ'
     'MIGRATION_FROM_LEGACY.md' = 'Migrating-From-Legacy-Mods'
     'SETTINGS.md'             = 'Settings'
+    'PERFORMANCE_TESTING.md'  = 'Performance-Testing'
     'CONSOLE_COMMANDS.md'     = 'Console-Commands'
     'TROUBLESHOOTING.md'      = 'Troubleshooting'
     'KNOWN_ISSUES.md'         = 'Known-Issues'
@@ -59,7 +60,7 @@ $pageMap = [ordered]@{
 
 # Sidebar grouping.
 $sections = [ordered]@{
-    'Players'         = @('Getting-Started', 'Install-Convert-Or-Author', 'FAQ', 'Migrating-From-Legacy-Mods', 'Settings', 'Console-Commands', 'Troubleshooting', 'Known-Issues', 'Installer')
+    'Players'         = @('Getting-Started', 'Install-Convert-Or-Author', 'FAQ', 'Migrating-From-Legacy-Mods', 'Settings', 'Performance-Testing', 'Console-Commands', 'Troubleshooting', 'Known-Issues', 'Installer')
     'Package Authors' = @('Converter', 'Package-Author-Guide', 'Authoring-Recipes', 'External-Editor', 'Map-Authoring-Coverage')
 }
 
@@ -163,6 +164,7 @@ anything.
 - [Install, Convert, Or Author](Install-Convert-Or-Author) — choose the correct tool
 - [FAQ](FAQ) — legacy mods, multiplayer, saves, performance
 - [Settings](Settings) — every setting and its default
+- [Performance Testing](Performance-Testing) — reproducible load, menu, stutter, editor, and Toolshed acceptance
 - [Console Commands](Console-Commands) — every ``/fuse.*`` command
 - [Troubleshooting](Troubleshooting) — symptom to diagnostic
 - [Known Issues](Known-Issues) — current limitations

--- a/scripts/build_pdfs.py
+++ b/scripts/build_pdfs.py
@@ -24,6 +24,7 @@ MANUALS = [
                    ("Frequently Asked Questions", P("docs","FAQ.md")),
                    ("Migrating From Legacy Mods", P("docs","MIGRATION_FROM_LEGACY.md")),
                    ("Settings Reference", P("docs","SETTINGS.md")),
+                   ("Performance Acceptance Testing", P("docs","PERFORMANCE_TESTING.md")),
                    ("Console Command Reference", P("docs","CONSOLE_COMMANDS.md")),
                    ("Troubleshooting", P("docs","TROUBLESHOOTING.md")),
                    ("Known Issues", P("docs","KNOWN_ISSUES.md")),

--- a/tools/build_installer_exe.ps1
+++ b/tools/build_installer_exe.ps1
@@ -84,6 +84,7 @@ $args = @(
     '--clean',
     '--noconfirm',
     '--onefile',
+    '--windowed',
     '--name', 'FUSE-Installer',
     '--icon', $IconPath,
     '--distpath', $OutputDir,
@@ -137,10 +138,14 @@ if (-not (Test-Path -LiteralPath $exePath)) {
 }
 
 Write-Host "Smoke check: running '$exePath --help'..."
-$smokeOutput = & $exePath --help 2>&1
-$smokeExit = $LASTEXITCODE
+$smokeProcess = Start-Process `
+    -FilePath $exePath `
+    -ArgumentList @('--help') `
+    -WindowStyle Hidden `
+    -Wait `
+    -PassThru
+$smokeExit = $smokeProcess.ExitCode
 if ($smokeExit -ne 0) {
-    Write-Host $smokeOutput
     throw "Smoke check failed (exit=$smokeExit)."
 }
 
@@ -152,25 +157,49 @@ if (-not [string]::IsNullOrWhiteSpace($BundledFuse)) {
     Write-Host "Self-check: installing bundled FUSE into a throwaway dir..."
     $ProbeDir = Join-Path $WorkDir 'selfcheck'
     if (Test-Path $ProbeDir) { Remove-Item $ProbeDir -Recurse -Force }
-    New-Item -ItemType Directory -Force -Path $ProbeDir | Out-Null
-    $selfOutput = & $exePath --no-pause --game-dir $ProbeDir 2>&1
-    $selfExit = $LASTEXITCODE
-    Write-Host $selfOutput
+    $ProbeUmmDir = Join-Path $ProbeDir 'Railroader_Data\Managed\UnityModManager'
+    New-Item -ItemType Directory -Force -Path $ProbeUmmDir | Out-Null
+    New-Item -ItemType File -Force -Path (Join-Path $ProbeDir 'Railroader.exe') | Out-Null
+    New-Item -ItemType File -Force -Path (Join-Path $ProbeUmmDir 'UnityModManager.dll') | Out-Null
+    # PyInstaller's windowed one-file launcher can return control to a PowerShell
+    # invocation before its extracted child process has finished. Start-Process
+    # -Wait follows the GUI process tree, so the assertions below cannot race the
+    # actual install (the old direct '& $exePath' check intermittently reported
+    # a missing Info.json while the child was still writing it).
+    $quotedProbeDir = '"' + $ProbeDir + '"'
+    $selfProcess = Start-Process `
+        -FilePath $exePath `
+        -ArgumentList @('--cli', '--no-pause', '--game-dir', $quotedProbeDir) `
+        -WindowStyle Hidden `
+        -Wait `
+        -PassThru
+    $selfExit = $selfProcess.ExitCode
     if ($selfExit -ne 0) {
         throw "Self-check failed (exit=$selfExit): bundled FUSE install did not succeed."
-    }
-    # Match the inspected package id, not just the word FUSE (which also appears
-    # in the static "bundled FUSE:" / "FUSE:" output labels), so a non-FUSE
-    # payload can't silently pass the self-check.
-    if ("$selfOutput" -notmatch 'id=FUSE(\s|$)') {
-        throw "Self-check failed: bundled package is not FUSE (id=FUSE missing from install output)."
     }
     # Confirm extraction actually wrote the mod to disk.
     $installedInfo = Join-Path $ProbeDir 'Mods\FUSE\Info.json'
     if (-not (Test-Path -LiteralPath $installedInfo -PathType Leaf)) {
         throw "Self-check failed: expected $installedInfo after installing bundled FUSE."
     }
-    Write-Host "Self-check passed: a manual run installs FUSE to Mods\FUSE."
+    $installedManifest = Get-Content -LiteralPath $installedInfo -Raw | ConvertFrom-Json
+    $installedId = if ($null -ne $installedManifest.Id) { [string]$installedManifest.Id } else { [string]$installedManifest.id }
+    if ($installedId -ne 'FUSE') {
+        throw "Self-check failed: bundled package id is '$installedId', expected 'FUSE'."
+    }
+    $assetLoaderInfo = Join-Path $ProbeDir 'Mods\AssetLoader\Info.json'
+    if (-not (Test-Path -LiteralPath $assetLoaderInfo -PathType Leaf)) {
+        throw "Self-check failed: expected FUSE's data-only AssetLoader alias at $assetLoaderInfo."
+    }
+    $assetLoaderManifest = Get-Content -LiteralPath $assetLoaderInfo -Raw | ConvertFrom-Json
+    if ([string]$assetLoaderManifest.FuseProvidedCompatibility -ne 'FUSE.AssetLoaderCompatibility') {
+        throw "Self-check failed: the AssetLoader alias is missing FUSE's compatibility marker."
+    }
+    $assetLoaderDll = Join-Path $ProbeDir 'Mods\AssetLoader\AssetLoader.dll'
+    if (Test-Path -LiteralPath $assetLoaderDll) {
+        throw "Self-check failed: old AssetLoader runtime DLL remains installed at $assetLoaderDll."
+    }
+    Write-Host "Self-check passed: FUSE and its DLL-free AssetLoader dependency alias were installed."
 }
 
 Write-Host "Built: $exePath"

--- a/tools/fuse_convert.py
+++ b/tools/fuse_convert.py
@@ -332,7 +332,7 @@ CORE_LEGACY_REQUIREMENTS = {
 def is_core_legacy_requirement(package_id: object) -> bool:
     value = str(package_id or "").strip()
     lowered = value.lower()
-    while lowered.endswith(".fuse") or lowered.endswith(".rail"):
+    while lowered.endswith((".fuse", ".rail")):
         value = value[:-5]
         lowered = value.lower()
     return lowered in CORE_LEGACY_REQUIREMENTS
@@ -405,6 +405,10 @@ def fuse_package_id(requirement_id):
         return None
     if text.lower().endswith(".fuse"):
         return text
+    if text.lower().endswith(".rail"):
+        text = text[:-5].strip()
+    if not text:
+        return None
     return f"{text}.FUSE"
 
 

--- a/tools/fuse_convert.py
+++ b/tools/fuse_convert.py
@@ -4,6 +4,7 @@ import json
 import math
 import re
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import legacy_json
@@ -397,11 +398,9 @@ def convert_conflict_references(value):
     return result
 
 
-def fuse_package_id(requirement_id):
-    text = str(requirement_id or "").strip()
+def converted_package_id(package_id: object) -> str | None:
+    text = str(package_id or "").strip()
     if not text:
-        return None
-    if is_core_legacy_requirement(text):
         return None
     if text.lower().endswith(".fuse"):
         return text
@@ -410,6 +409,12 @@ def fuse_package_id(requirement_id):
     if not text:
         return None
     return f"{text}.FUSE"
+
+
+def fuse_package_id(requirement_id: object) -> str | None:
+    if is_core_legacy_requirement(requirement_id):
+        return None
+    return converted_package_id(requirement_id)
 
 
 def legacy_load_after(mod_folder):
@@ -478,7 +483,7 @@ def legacy_conflicts_with(mod_folder):
     ]
 
 
-def _mixinto_requirement_ids(value):
+def _mixinto_requirement_ids(value) -> Iterator[str]:
     if isinstance(value, list):
         for item in value:
             yield from _mixinto_requirement_ids(item)
@@ -499,7 +504,7 @@ def _mixinto_requirement_ids(value):
         yield from _mixinto_requirement_ids(child)
 
 
-def _dedupe_dependency_ids(values):
+def _dedupe_dependency_ids(values) -> list[str]:
     seen = set()
     ordered = []
     for item in values:
@@ -519,7 +524,7 @@ def mixinto_metadata(mod_folder):
     metadata = {}
     ordered_files = []
 
-    def record(target, reference, requirements, conflicts_with):
+    def record(target, reference, requirements, conflicts_with) -> None:
         referenced_file = extract_file_reference(reference)
         if not referenced_file:
             return
@@ -535,7 +540,7 @@ def mixinto_metadata(mod_folder):
             "conflictsWith": conflicts_with or [],
         })
 
-    def visit_target(target, value):
+    def visit_target(target, value) -> None:
         if isinstance(value, str):
             record(target, value, [], [])
             return
@@ -2400,7 +2405,7 @@ def convert_mod(mod_folder, out_folder):
     rail_data_files = list(written)
     info = {
         "$schema": ".\\schemas\\umm-info.schema.json",
-        "Id": f"{mod_id}.FUSE",
+        "Id": converted_package_id(mod_id) or f"{mod_id}.FUSE",
         "DisplayName": f"{mod_name} (FUSE)",
         "Author": author,
         "Version": version,

--- a/tools/fuse_convert.py
+++ b/tools/fuse_convert.py
@@ -310,12 +310,32 @@ CORE_LEGACY_REQUIREMENTS = {
     "railroader",
     "railloader",
     "rail-loader",
+    "railloader.injector",
+    "railloader.interchange",
+    "assetloader",
+    "alinanova21.alinasmapmod",
+    "alinasmapmod",
+    "alinamapmod",
+    "alinanova21.mapeditor",
+    "mapeditor",
+    "mmapeditor",
     "zamu.strangecustoms",
     "strangecustoms",
     "zamu.confusingsupplements",
     "confusingsupplements",
+    "zamu.foryourconvenience",
+    "foryourconvenience",
     "fuse",
 }
+
+
+def is_core_legacy_requirement(package_id: object) -> bool:
+    value = str(package_id or "").strip()
+    lowered = value.lower()
+    while lowered.endswith(".fuse") or lowered.endswith(".rail"):
+        value = value[:-5]
+        lowered = value.lower()
+    return lowered in CORE_LEGACY_REQUIREMENTS
 
 
 def extract_file_reference(value):
@@ -327,10 +347,12 @@ def extract_file_reference(value):
     return match.group(1).strip().strip("\"'")
 
 
-def convert_requirement(item):
+def convert_requirement(item, *, filter_replacement_capabilities=True):
     if isinstance(item, str):
         requirement_id = item.strip()
-        if not requirement_id or requirement_id.lower() in CORE_LEGACY_REQUIREMENTS:
+        if not requirement_id or (
+            filter_replacement_capabilities and is_core_legacy_requirement(requirement_id)
+        ):
             return None
         return {"id": requirement_id}
 
@@ -338,7 +360,9 @@ def convert_requirement(item):
         return None
 
     requirement_id = str(item.get("id") or item.get("Id") or "").strip()
-    if not requirement_id or requirement_id.lower() in CORE_LEGACY_REQUIREMENTS:
+    if not requirement_id or (
+        filter_replacement_capabilities and is_core_legacy_requirement(requirement_id)
+    ):
         return None
 
     result = {
@@ -361,11 +385,23 @@ def convert_requirements(value):
     return result
 
 
+def convert_conflict_references(value):
+    if not isinstance(value, list):
+        return []
+
+    result = []
+    for item in value:
+        converted = convert_requirement(item, filter_replacement_capabilities=False)
+        if converted:
+            result.append(converted)
+    return result
+
+
 def fuse_package_id(requirement_id):
     text = str(requirement_id or "").strip()
     if not text:
         return None
-    if text.lower() in CORE_LEGACY_REQUIREMENTS:
+    if is_core_legacy_requirement(text):
         return None
     if text.lower().endswith(".fuse"):
         return text
@@ -373,12 +409,18 @@ def fuse_package_id(requirement_id):
 
 
 def legacy_load_after(mod_folder):
+    required, load_after = legacy_dependencies(mod_folder)
+    return _dedupe_dependency_ids(required + load_after)
+
+
+def legacy_dependencies(mod_folder):
     path = mod_folder / "Definition.json"
     if not path.exists():
-        return []
+        return [], []
 
     definition = load_json(path)
-    result = []
+    required = []
+    ordered_after = []
 
     requirements = (
         definition.get("requires")
@@ -390,20 +432,73 @@ def legacy_load_after(mod_folder):
     for requirement in convert_requirements(requirements):
         package_id = fuse_package_id(requirement.get("id"))
         if package_id:
-            result.append(package_id)
+            required.append(package_id)
 
     load_after = definition.get("loadAfter") or definition.get("LoadAfter") or []
     if isinstance(load_after, str):
         load_after = [load_after]
     if isinstance(load_after, list):
         for item in load_after:
-            package_id = fuse_package_id(item)
+            item_id = item
+            if isinstance(item, dict):
+                item_id = item.get("id") or item.get("Id")
+            package_id = fuse_package_id(item_id)
             if package_id:
-                result.append(package_id)
+                ordered_after.append(package_id)
 
+    mixintos = definition.get("mixintos") or definition.get("Mixintos")
+    for requirement_id in _mixinto_requirement_ids(mixintos):
+        package_id = fuse_package_id(requirement_id)
+        if package_id:
+            ordered_after.append(package_id)
+
+    return _dedupe_dependency_ids(required), _dedupe_dependency_ids(ordered_after)
+
+
+def legacy_conflicts_with(mod_folder):
+    path = mod_folder / "Definition.json"
+    if not path.exists():
+        return []
+
+    definition = load_json(path)
+    conflicts = definition.get("conflictsWith") or definition.get("ConflictsWith") or []
+    return [
+        clean(
+            {
+                "Id": reference.get("id"),
+                "NotBefore": reference.get("notBefore"),
+                "NotAfter": reference.get("notAfter"),
+            }
+        )
+        for reference in convert_conflict_references(conflicts)
+    ]
+
+
+def _mixinto_requirement_ids(value):
+    if isinstance(value, list):
+        for item in value:
+            yield from _mixinto_requirement_ids(item)
+        return
+
+    if not isinstance(value, dict):
+        return
+
+    requirements = value.get("requires") or value.get("Requires") or []
+    for requirement in convert_requirements(requirements):
+        requirement_id = requirement.get("id")
+        if requirement_id:
+            yield requirement_id
+
+    for key, child in value.items():
+        if key.lower() == "requires":
+            continue
+        yield from _mixinto_requirement_ids(child)
+
+
+def _dedupe_dependency_ids(values):
     seen = set()
     ordered = []
-    for item in result:
+    for item in values:
         key = item.lower()
         if key not in seen:
             seen.add(key)
@@ -420,7 +515,7 @@ def mixinto_metadata(mod_folder):
     metadata = {}
     ordered_files = []
 
-    def record(target, reference, requirements):
+    def record(target, reference, requirements, conflicts_with):
         referenced_file = extract_file_reference(reference)
         if not referenced_file:
             return
@@ -433,11 +528,12 @@ def mixinto_metadata(mod_folder):
             "target": str(target or "").strip(),
             "sourceFile": source_file,
             "requires": requirements or [],
+            "conflictsWith": conflicts_with or [],
         })
 
     def visit_target(target, value):
         if isinstance(value, str):
-            record(target, value, [])
+            record(target, value, [], [])
             return
 
         if isinstance(value, list):
@@ -449,8 +545,11 @@ def mixinto_metadata(mod_folder):
             return
 
         requirements = convert_requirements(value.get("requires") or value.get("Requires"))
+        conflicts_with = convert_conflict_references(
+            value.get("conflictsWith") or value.get("ConflictsWith")
+        )
         reference = value.get("mixinto") or value.get("Mixinto")
-        record(target, reference, requirements)
+        record(target, reference, requirements, conflicts_with)
 
     mixintos = definition.get("mixintos") or definition.get("Mixintos") or {}
     if isinstance(mixintos, dict):
@@ -2226,7 +2325,8 @@ def _emit_track_group_coverage_warning(declared_initial_groups: set[str]) -> Non
 
 def convert_mod(mod_folder, out_folder):
     mod_id, mod_name, version, author = meta(mod_folder)
-    load_after = legacy_load_after(mod_folder)
+    required, load_after = legacy_dependencies(mod_folder)
+    conflicts_with = legacy_conflicts_with(mod_folder)
     mixinto_sources, mixinto_order = mixinto_metadata(mod_folder)
     mixinto_order_index = {name: index for index, name in enumerate(mixinto_order)}
     source_files = sorted(
@@ -2302,7 +2402,10 @@ def convert_mod(mod_folder, out_folder):
         "Version": version,
         "ManagerVersion": "0.27.10",
         "Requirements": ["FUSE"],
-        "LoadAfter": ["FUSE"] + load_after,
+        "LoadAfter": ["FUSE"],
+        "FuseRequires": required,
+        "FuseLoadAfter": load_after,
+        "FuseConflictsWith": conflicts_with,
         "FuseDataFiles": rail_data_files,
     }
     save_json(out_folder / "Info.json", info)

--- a/tools/fuse_convert.py
+++ b/tools/fuse_convert.py
@@ -474,7 +474,7 @@ def legacy_conflicts_with(mod_folder):
     return [
         clean(
             {
-                "Id": reference.get("id"),
+                "Id": converted_package_id(reference.get("id")),
                 "NotBefore": reference.get("notBefore"),
                 "NotAfter": reference.get("notAfter"),
             }

--- a/tools/fuse_converter.py
+++ b/tools/fuse_converter.py
@@ -550,6 +550,18 @@ def has_direct_native_fuse_data(source: Path) -> bool:
         return False
 
 
+def has_native_fuse_data(source: Path) -> bool:
+    if not source.is_dir():
+        return False
+    try:
+        return any(
+            path.is_file() and path.name.lower().endswith(".fuse.json")
+            for path in source.rglob("*")
+        )
+    except OSError:
+        return False
+
+
 def has_direct_compiled_plugin(source: Path) -> bool:
     if not source.is_dir():
         return False
@@ -619,7 +631,9 @@ def detect_kind(source: Path, requested: str) -> str:
     if requested != "auto":
         return requested
 
-    if source.is_dir() and has_direct_native_fuse_data(source):
+    if source.is_file() and source.name.lower().endswith(".fuse.json"):
+        return "native"
+    if source.is_dir() and has_native_fuse_data(source):
         return "native"
     contains_compiled_plugin = source.is_dir() and has_direct_compiled_plugin(source)
     if (

--- a/tools/fuse_converter.py
+++ b/tools/fuse_converter.py
@@ -1292,9 +1292,15 @@ def convert_input(input_path: Path, out_root: Path, kind: str, clean_output: boo
                     "unsupported-code-package",
                 )
             else:
-                raise RuntimeError("no convertible RailLoader JSON data detected; use the FUSE installer for code, asset, map-tile, or native packages")
+                report.add(
+                    "ERROR",
+                    "No convertible RailLoader JSON data detected; use the FUSE installer for code, asset, map-tile, or native packages.",
+                    working_source,
+                    "unsupported-package",
+                )
 
-            scan_legacy_warnings(working_source, report)
+            if detected in {"route", "audio"}:
+                scan_legacy_warnings(working_source, report)
         except Exception as exc:
             report.add("ERROR", str(exc), working_source, detected)
 

--- a/tools/fuse_converter.py
+++ b/tools/fuse_converter.py
@@ -621,19 +621,18 @@ def detect_kind(source: Path, requested: str) -> str:
 
     if source.is_dir() and has_direct_native_fuse_data(source):
         return "native"
+    contains_compiled_plugin = source.is_dir() and has_direct_compiled_plugin(source)
     if (
-        source.is_dir()
-        and has_direct_compiled_plugin(source)
+        contains_compiled_plugin
         and not detects_direct_route_data(source)
         and not detects_direct_audio(source)
     ):
         return "code"
-    if detects_audio(source) and not detects_route_data(source):
+    route_data = detects_route_data(source)
+    if detects_audio(source) and not route_data:
         return "audio"
-    if detects_route_data(source):
+    if route_data:
         return "route"
-    if source.is_dir() and has_direct_compiled_plugin(source):
-        return "code"
     if find_map_tile_sources(source):
         return "map_tile"
     if find_asset_pack_sources(source):

--- a/tools/fuse_converter.py
+++ b/tools/fuse_converter.py
@@ -34,7 +34,7 @@ import convert_fuse_audio  # noqa: E402
 import legacy_json  # noqa: E402
 
 
-TOOL_VERSION = "0.2.0"
+TOOL_VERSION = "0.2.1"
 DEFAULT_STEAM_MODS = Path(r"C:\Steam\steamapps\common\Railroader\Mods")
 DEFAULT_MANAGER_VERSION = "0.27.10"
 JSON_MANIFEST_NAMES = {"definition.json", "info.json"}
@@ -541,6 +541,24 @@ def has_direct_asset_pack_sources(source: Path) -> bool:
     return has_direct_asset_pack_children(source)
 
 
+def has_direct_native_fuse_data(source: Path) -> bool:
+    if not source.is_dir():
+        return False
+    try:
+        return any(path.is_file() and path.name.lower().endswith(".fuse.json") for path in source.iterdir())
+    except OSError:
+        return False
+
+
+def has_direct_compiled_plugin(source: Path) -> bool:
+    if not source.is_dir():
+        return False
+    try:
+        return any(path.is_file() and path.suffix.lower() == ".dll" for path in source.iterdir())
+    except OSError:
+        return False
+
+
 def detect_direct_kind(source: Path, requested: str) -> str:
     if source.is_file():
         if source.suffix.lower() == ".zip":
@@ -562,17 +580,21 @@ def detect_direct_kind(source: Path, requested: str) -> str:
     direct_assets = has_direct_asset_pack_sources(source)
     direct_json = has_direct_convertible_json(source)
 
+    if has_direct_native_fuse_data(source):
+        return "native"
+
     if requested == "route":
         return "route" if direct_route or direct_tiles or direct_json else "unknown"
     if requested == "audio":
         return "audio" if direct_audio or direct_json else "unknown"
-    if requested == "asset":
-        return "asset" if direct_assets else "unknown"
-
     if direct_audio and not direct_route:
         return "audio"
-    if direct_route or direct_tiles:
+    if direct_route:
         return "route"
+    if has_direct_compiled_plugin(source):
+        return "code"
+    if direct_tiles:
+        return "map_tile"
     if direct_assets:
         return "asset"
     return "unknown"
@@ -597,12 +619,23 @@ def detect_kind(source: Path, requested: str) -> str:
     if requested != "auto":
         return requested
 
+    if source.is_dir() and has_direct_native_fuse_data(source):
+        return "native"
+    if (
+        source.is_dir()
+        and has_direct_compiled_plugin(source)
+        and not detects_direct_route_data(source)
+        and not detects_direct_audio(source)
+    ):
+        return "code"
     if detects_audio(source) and not detects_route_data(source):
         return "audio"
     if detects_route_data(source):
         return "route"
+    if source.is_dir() and has_direct_compiled_plugin(source):
+        return "code"
     if find_map_tile_sources(source):
-        return "route"
+        return "map_tile"
     if find_asset_pack_sources(source):
         return "asset"
     if is_json_file(source):
@@ -647,7 +680,8 @@ def update_info_json(output: Path, update: dict[str, Any]) -> None:
 
 def write_reports(report: ConversionReport) -> None:
     report.finish()
-    write_json(report.output / "conversion-report.json", report.to_dict())
+    report_folder = report_output_folder(report)
+    write_json(report_folder / "conversion-report.json", report.to_dict())
 
     lines = [
         f"# FUSE Conversion Report - {report.output.name}",
@@ -696,7 +730,13 @@ def write_reports(report: ConversionReport) -> None:
         )
     if not report.entries:
         lines.append("| OK |  |  | No warnings or errors. |")
-    write_text(report.output / "conversion-report.md", "\n".join(lines) + "\n")
+    write_text(report_folder / "conversion-report.md", "\n".join(lines) + "\n")
+
+
+def report_output_folder(report: ConversionReport) -> Path:
+    if report.status != "failed":
+        return report.output
+    return report.output.parent / "_conversion-reports" / report.output.name
 
 
 def write_batch_reports(source_root: Path, out_root: Path, reports: list[ConversionReport]) -> None:
@@ -717,8 +757,9 @@ def write_batch_reports(source_root: Path, out_root: Path, reports: list[Convers
 
         report_name = slug(report.package_id or report.output.name or f"report-{index}", f"report-{index}")
         report_stem = f"{index:03d}-{report_name}"
-        json_source = report.output / "conversion-report.json"
-        md_source = report.output / "conversion-report.md"
+        source_report_folder = report_output_folder(report)
+        json_source = source_report_folder / "conversion-report.json"
+        md_source = source_report_folder / "conversion-report.md"
         json_dest = audit_dir / f"{report_stem}.json"
         md_dest = audit_dir / f"{report_stem}.md"
         if json_source.exists():
@@ -1199,7 +1240,6 @@ def convert_input(input_path: Path, out_root: Path, kind: str, clean_output: boo
         output = out_root / output_name_for(original)
         report = ConversionReport(original, output, "unknown", status="failed")
         report.add("ERROR", "Input path does not exist.", original)
-        output.mkdir(parents=True, exist_ok=True)
         write_reports(report)
         return report
 
@@ -1225,13 +1265,38 @@ def convert_input(input_path: Path, out_root: Path, kind: str, clean_output: boo
             elif detected == "audio":
                 convert_audio(working_source, output, clean_output, report)
             elif detected == "asset":
-                convert_asset(working_source, output, clean_output, report)
+                report.add(
+                    "ERROR",
+                    "Asset-pack-only package detected. FUSE loads supported asset packs directly; install this package with the FUSE installer instead of converting it.",
+                    working_source,
+                    "unsupported-asset-package",
+                )
+            elif detected == "map_tile":
+                report.add(
+                    "ERROR",
+                    "Legacy map-tile package detected. FUSE's Alina compatibility loads supported tile data directly; install this package with the FUSE installer instead of converting it.",
+                    working_source,
+                    "unsupported-map-tile-package",
+                )
+            elif detected == "native":
+                report.add(
+                    "ERROR",
+                    "This package already contains FUSE-native data. No conversion is needed; install the original package with the FUSE installer.",
+                    working_source,
+                    "unsupported-already-native",
+                )
+            elif detected == "code":
+                report.add(
+                    "ERROR",
+                    "Compiled code mod detected. The converter only translates RailLoader JSON data and cannot reproduce DLL behavior; install a compatible code mod directly or ask its author for a FUSE-native version.",
+                    working_source,
+                    "unsupported-code-package",
+                )
             else:
-                raise RuntimeError("could not detect package type; use --kind route, --kind audio, or --kind asset")
+                raise RuntimeError("no convertible RailLoader JSON data detected; use the FUSE installer for code, asset, map-tile, or native packages")
 
             scan_legacy_warnings(working_source, report)
         except Exception as exc:
-            output.mkdir(parents=True, exist_ok=True)
             report.add("ERROR", str(exc), working_source, detected)
 
         write_reports(report)
@@ -1347,14 +1412,14 @@ def print_summary(report: ConversionReport) -> None:
         print(f"  counts: {counts}")
     if report.warnings or report.errors:
         print(f"  warnings={report.warnings} errors={report.errors}")
-    print(f"  report: {report.output / 'conversion-report.md'}")
+    print(f"  report: {report_output_folder(report) / 'conversion-report.md'}")
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Convert legacy Railroader mods to FUSE packages.")
     parser.add_argument("inputs", nargs="+", help="Legacy folder, zip file, or JSON file. Drag-and-drop works on Windows.")
     parser.add_argument("--out", default=None, help="Output root. Default is Railroader Mods if found, or FUSEConverted for --batch.")
-    parser.add_argument("--kind", choices=("auto", "route", "audio", "asset"), default="auto", help="Force a package type.")
+    parser.add_argument("--kind", choices=("auto", "route", "audio"), default="auto", help="Force a JSON package type.")
     parser.add_argument("--clean", action="store_true", help="Replace existing .FUSE output folders under the output root.")
     parser.add_argument("--batch", action="store_true", help="Treat each input folder as a container and recursively convert every recognized child mod, zip, or JSON in it.")
     args = parser.parse_args()

--- a/tools/fuse_installer.py
+++ b/tools/fuse_installer.py
@@ -9,6 +9,8 @@ executes package code.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
 import os
 import re
@@ -28,9 +30,39 @@ if str(SCRIPT_DIR) not in sys.path:
 import legacy_json  # noqa: E402
 
 
-TOOL_VERSION = "0.2.0"
+TOOL_VERSION = "0.7.0"
 BUNDLED_FUSE_NAME = "bundled_fuse.zip"
 MANIFEST_NAMES = {"info.json", "definition.json"}
+LEGACY_MANAGED_FILES = (
+    "Railloader.dll",
+    "Railloader.Injector.dll",
+    "Railloader.Interchange.dll",
+    "StrangeCustoms.dll",
+)
+ASSETLOADER_ID = "AssetLoader"
+ASSETLOADER_DLL = "AssetLoader.dll"
+ASSETLOADER_COMPATIBILITY_MARKER = "FUSE.AssetLoaderCompatibility"
+ASSETLOADER_COMPATIBILITY_MANIFEST = {
+    "Id": ASSETLOADER_ID,
+    "DisplayName": "AssetLoader Compatibility (provided by FUSE)",
+    "Author": "FUSE",
+    "Version": "1.0.1",
+    "ManagerVersion": "0.27.10",
+    "Requirements": ["FUSE"],
+    "LoadAfter": ["FUSE"],
+    "ContentType": "Compatibility",
+    "FuseProvidedCompatibility": ASSETLOADER_COMPATIBILITY_MARKER,
+}
+# UMM reflects a code mod's assembly before calling its entry point. If that
+# assembly references a loader contract FUSE replaces, FUSE must already be
+# loaded so its AssemblyResolve bridge can provide the compatibility types.
+# Detect the actual metadata reference in the DLL instead of maintaining a
+# brittle list of third-party package names.
+FUSE_LEGACY_STARTUP_ASSEMBLY_REFERENCES = (
+    b"Railloader.Interchange",
+    b"Railloader.Injector",
+    b"StrangeCustoms",
+)
 LEGACY_DATA_KEYS = {
     "tracks",
     "loads",
@@ -57,6 +89,26 @@ WINDOWS_RESERVED_NAMES = {
     *(f"lpt{index}" for index in range(1, 10)),
 }
 
+# Keep this explicit and narrow, matching FuseReplacementCapabilityCatalog.
+# These are compatibility contracts FUSE actually provides; unrelated Zamu/Joo
+# package ids must still be installed normally.
+FUSE_REPLACEMENT_IDS = {
+    "fuse", "railroader", "railloader", "rail-loader",
+    "railloader.injector", "railloader.interchange", "assetloader",
+    "alinanova21.alinasmapmod", "alinasmapmod", "alinamapmod",
+    "alinanova21.mapeditor", "mapeditor", "mmapeditor",
+    "zamu.confusingsupplements", "zamu.foryourconvenience",
+    "zamu.strangecustoms", "strangecustoms", "confusingsupplements",
+    "foryourconvenience",
+}
+
+
+@dataclass(frozen=True)
+class PackageRequirement:
+    package_id: str
+    not_before: str = ""
+    not_after: str = ""
+
 
 @dataclass
 class ZipPackage:
@@ -70,6 +122,8 @@ class ZipPackage:
     manifest_member: str
     member_count: int
     notes: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    requirements: list[PackageRequirement] = field(default_factory=list)
 
     @property
     def root_label(self) -> str:
@@ -83,6 +137,32 @@ class InstallResult:
     destination: Path
     message: str = ""
     backup: Path | None = None
+
+
+@dataclass
+class CompatibilityAction:
+    component: str
+    status: str
+    message: str
+    source: Path | None = None
+    destination: Path | None = None
+
+
+def package_id_aliases(package_id: str) -> tuple[str, ...]:
+    normalized = (package_id or "").strip().lower()
+    if not normalized:
+        return ()
+    aliases = [normalized]
+    if normalized.endswith(".fuse") or normalized.endswith(".rail"):
+        aliases.append(normalized[:-5])
+    return tuple(dict.fromkeys(aliases))
+
+
+def replacement_id_key(package_id: str) -> str:
+    normalized = (package_id or "").strip().lower()
+    while normalized.endswith(".fuse") or normalized.endswith(".rail"):
+        normalized = normalized[:-5]
+    return "railloader" if normalized == "rail-loader" else normalized
 
 
 def normalize_zip_parts(name: str) -> tuple[str, ...] | None:
@@ -136,7 +216,10 @@ def find_member(
     root: tuple[str, ...],
     file_name: str,
 ) -> zipfile.ZipInfo | None:
-    expected = path_key(root + (file_name,))
+    file_parts = normalize_zip_parts(file_name)
+    if file_parts is None:
+        return None
+    expected = path_key(root + file_parts)
     for info, parts in files.items():
         if path_key(parts) == expected:
             return info
@@ -167,6 +250,64 @@ def candidate_roots(files: dict[zipfile.ZipInfo, tuple[str, ...]]) -> list[tuple
     return selected
 
 
+def archive_layout_errors(
+    archive: zipfile.ZipFile,
+    files: dict[zipfile.ZipInfo, tuple[str, ...]],
+) -> list[str]:
+    errors: list[str] = []
+    unsafe_members = [
+        info.filename
+        for info in archive.infolist()
+        if not info.is_dir()
+        and not info.filename.replace("\\", "/").startswith("__MACOSX/")
+        and normalize_zip_parts(info.filename) is None
+    ]
+    if unsafe_members:
+        preview = ", ".join(repr(name) for name in unsafe_members[:5])
+        suffix = f" (+{len(unsafe_members) - 5} more)" if len(unsafe_members) > 5 else ""
+        errors.append(
+            "Archive contains unsafe member path(s) that cannot be installed: "
+            f"{preview}{suffix}. Rebuild the ZIP without absolute paths, '..', drive prefixes, or invalid Windows characters."
+        )
+
+    by_path: dict[tuple[str, ...], list[str]] = {}
+    for info, parts in files.items():
+        by_path.setdefault(path_key(parts), []).append(info.filename)
+    duplicate_paths = [names for names in by_path.values() if len(names) > 1]
+    if duplicate_paths:
+        preview = "; ".join(" / ".join(names) for names in duplicate_paths[:5])
+        suffix = f" (+{len(duplicate_paths) - 5} more)" if len(duplicate_paths) > 5 else ""
+        errors.append(
+            "Archive contains duplicate or case-colliding member path(s): "
+            f"{preview}{suffix}. Keep one file for each destination path."
+        )
+
+    manifest_roots = sorted(
+        {
+            path_key(parts[:-1]): parts[:-1]
+            for parts in files.values()
+            if parts[-1].lower() in MANIFEST_NAMES
+        }.values(),
+        key=lambda item: (len(item), path_key(item)),
+    )
+    nested_pairs: list[tuple[tuple[str, ...], tuple[str, ...]]] = []
+    for index, parent in enumerate(manifest_roots):
+        for child in manifest_roots[index + 1:]:
+            if len(child) > len(parent) and starts_with(path_key(child), path_key(parent)):
+                nested_pairs.append((parent, child))
+    if nested_pairs:
+        preview = "; ".join(
+            f"{'/'.join(parent) or '.'} contains {'/'.join(child)}"
+            for parent, child in nested_pairs[:5]
+        )
+        suffix = f" (+{len(nested_pairs) - 5} more)" if len(nested_pairs) > 5 else ""
+        errors.append(
+            "Archive layout is ambiguous because one package manifest contains another package manifest: "
+            f"{preview}{suffix}. Put sibling packages under separate folders such as Mods/PackageA and Mods/PackageB."
+        )
+    return errors
+
+
 def read_zip_text(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> str:
     if info.file_size > MAX_JSON_BYTES:
         raise ValueError(f"JSON file is too large to inspect safely: {info.filename}")
@@ -178,7 +319,17 @@ def read_zip_text(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> str:
 
 
 def read_zip_json(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> Any:
-    return legacy_json.loads(read_zip_text(archive, info))
+    # Comments and trailing commas remain tolerated for old RailLoader files,
+    # but the installer must not silently invent missing closing braces. A mod
+    # author needs the real file/line failure before the package reaches game.
+    return legacy_json.loads(read_zip_text(archive, info), repair=False)
+
+
+def describe_json_error(member_name: str, exc: Exception) -> str:
+    line = getattr(exc, "lineno", 0)
+    column = getattr(exc, "colno", 0)
+    location = f" line {line}, column {column}" if line else ""
+    return f"{member_name}{location}: {exc}"
 
 
 def string_field(data: dict[str, Any] | None, *names: str) -> str:
@@ -235,6 +386,62 @@ def looks_like_legacy_data(archive: zipfile.ZipFile, files: dict[zipfile.ZipInfo
     return False
 
 
+def is_railloader_manifest(data: dict[str, Any]) -> bool:
+    """Recognize both data-only and code-only RailLoader packages.
+
+    Code-only packages commonly contain only Definition.json, an ``assemblies``
+    list, and DLLs. Requiring a data JSON file made the installer reject exactly
+    the hosted compatibility packages FUSE is intended to run.
+    """
+    if not isinstance(data, dict):
+        return False
+    package_id = string_field(data, "id", "Id")
+    if not package_id:
+        return False
+    return any(
+        key in data
+        for key in (
+            "manifestVersion",
+            "ManifestVersion",
+            "assemblies",
+            "Assemblies",
+            "mixintos",
+            "Mixintos",
+            "requires",
+            "Requires",
+        )
+    )
+
+
+def parse_requirements(*values: Any) -> list[PackageRequirement]:
+    result: list[PackageRequirement] = []
+    seen: set[tuple[str, str, str]] = set()
+    for value in values:
+        entries = value if isinstance(value, list) else [value] if value else []
+        for entry in entries:
+            if isinstance(entry, str):
+                requirement = PackageRequirement(entry.strip())
+            elif isinstance(entry, dict):
+                requirement = PackageRequirement(
+                    string_field(entry, "Id", "id"),
+                    string_field(entry, "NotBefore", "notBefore", "MinimumVersion", "minimumVersion"),
+                    string_field(entry, "NotAfter", "notAfter", "MaximumVersion", "maximumVersion"),
+                )
+            else:
+                continue
+            if not requirement.package_id:
+                continue
+            key = (
+                requirement.package_id.lower(),
+                requirement.not_before,
+                requirement.not_after,
+            )
+            if key not in seen:
+                seen.add(key)
+                result.append(requirement)
+    return result
+
+
 def ensure_fuse_id(value: str) -> str:
     text = (value or "").strip() or "LegacyDataPackage"
     return text if text.lower().endswith(".fuse") else f"{text}.FUSE"
@@ -262,6 +469,7 @@ def package_from_root(
     info_data: dict[str, Any] = {}
     definition_data: dict[str, Any] = {}
     notes: list[str] = []
+    errors: list[str] = []
 
     if info_member is not None:
         try:
@@ -271,7 +479,7 @@ def package_from_root(
             else:
                 notes.append("Info.json was not an object.")
         except Exception as exc:
-            notes.append(f"Info.json could not be parsed: {exc}")
+            errors.append("Info.json could not be parsed: " + describe_json_error(info_member.filename, exc))
 
     if definition_member is not None:
         try:
@@ -281,7 +489,7 @@ def package_from_root(
             else:
                 notes.append("Definition.json was not an object.")
         except Exception as exc:
-            notes.append(f"Definition.json could not be parsed: {exc}")
+            errors.append("Definition.json could not be parsed: " + describe_json_error(definition_member.filename, exc))
 
     source_folder = root[-1] if root and root[-1].lower() != "mods" else zip_path.stem
     member_count = sum(1 for parts in files.values() if starts_with(parts, root))
@@ -290,7 +498,11 @@ def package_from_root(
         package_id = string_field(info_data, "Id", "id") or safe_folder_name(source_folder)
         display_name = string_field(info_data, "DisplayName", "Name", "name") or package_id
         version = string_field(info_data, "Version", "version")
-        kind = "fuse-data" if has_fuse_data_marker(info_data) else "umm"
+        kind = "invalid" if errors else ("fuse-data" if has_fuse_data_marker(info_data) else "umm")
+        if not errors and kind == "fuse-data":
+            errors.extend(validate_fuse_data_members(archive, files, root, info_data))
+            if errors:
+                kind = "invalid"
         install_name = safe_folder_name(package_id, safe_folder_name(source_folder))
         return ZipPackage(
             zip_path=zip_path,
@@ -303,27 +515,124 @@ def package_from_root(
             manifest_member=info_member.filename,
             member_count=member_count,
             notes=notes,
+            errors=errors,
+            requirements=parse_requirements(
+                info_data.get("Requirements"),
+                info_data.get("requirements"),
+                info_data.get("FuseRequires"),
+            ),
         )
 
-    if definition_member is not None and looks_like_legacy_data(archive, files, root):
+    if definition_member is not None and (
+        errors or
+        is_railloader_manifest(definition_data) or
+        looks_like_legacy_data(archive, files, root)
+    ):
         legacy_id = string_field(definition_data, "id", "Id") or safe_folder_name(source_folder)
-        package_id = ensure_fuse_id(legacy_id)
         display_name = string_field(definition_data, "name", "DisplayName", "Name") or legacy_id
         version = string_field(definition_data, "version", "Version")
+        has_legacy_data = looks_like_legacy_data(archive, files, root)
+        if has_legacy_data:
+            notes.append("RailLoader data will be converted in memory and applied by FUSE.")
+        if definition_data.get("assemblies") or definition_data.get("Assemblies"):
+            notes.append("RailLoader plugin assemblies will be hosted by FUSE compatibility.")
+        if not errors:
+            errors.extend(validate_railloader_data_members(archive, files, root))
         return ZipPackage(
             zip_path=zip_path,
             root=root,
-            kind="legacy-data",
-            package_id=package_id,
+            kind="invalid" if errors else "railloader",
+            package_id=legacy_id,
             display_name=display_name,
             version=version,
-            install_name=safe_folder_name(package_id, safe_folder_name(source_folder)),
+            install_name=safe_folder_name(legacy_id, safe_folder_name(source_folder)),
             manifest_member=definition_member.filename,
             member_count=member_count,
             notes=notes,
+            errors=errors,
+            requirements=parse_requirements(
+                definition_data.get("requires"),
+                definition_data.get("Requires"),
+            ),
         )
 
     return None
+
+
+def data_file_names(info: dict[str, Any]) -> tuple[list[str], list[str]]:
+    value = info.get("FuseDataFiles", info.get("FuseDataFile"))
+    if value is None:
+        return [], []
+    values = [value] if isinstance(value, str) else value if isinstance(value, list) else []
+    errors: list[str] = []
+    if not values:
+        errors.append("Info.json FuseDataFile/FuseDataFiles must be a file name or a non-empty list of file names.")
+        return [], errors
+    names: list[str] = []
+    for index, item in enumerate(values):
+        if not isinstance(item, str) or not item.strip():
+            errors.append(f"Info.json FuseDataFiles[{index}] must be a non-empty string.")
+            continue
+        parts = normalize_zip_parts(item.strip())
+        if parts is None:
+            errors.append(f"Info.json FuseDataFiles[{index}] contains an unsafe path: {item!r}.")
+            continue
+        names.append("/".join(parts))
+    return names, errors
+
+
+def validate_json_member(archive: zipfile.ZipFile, member: zipfile.ZipInfo) -> list[str]:
+    try:
+        value = read_zip_json(archive, member)
+    except Exception as exc:
+        return ["JSON could not be parsed: " + describe_json_error(member.filename, exc)]
+    if not isinstance(value, dict):
+        return [f"{member.filename}: FUSE/RailLoader data JSON must contain an object at the root."]
+    return []
+
+
+def validate_fuse_data_members(
+    archive: zipfile.ZipFile,
+    files: dict[zipfile.ZipInfo, tuple[str, ...]],
+    root: tuple[str, ...],
+    info: dict[str, Any],
+) -> list[str]:
+    names, errors = data_file_names(info)
+    members: list[zipfile.ZipInfo] = []
+    if names:
+        for name in names:
+            member = find_member(files, root, name)
+            if member is None:
+                errors.append(f"Info.json declares missing FuseDataFile '{name}' in package root '{'/'.join(root) or '.'}'.")
+            else:
+                members.append(member)
+    else:
+        members.extend(
+            member
+            for member, parts in files.items()
+            if starts_with(parts, root)
+            and len(parts) == len(root) + 1
+            and parts[-1].lower().endswith(".fuse.json")
+        )
+    for member in dict.fromkeys(members):
+        errors.extend(validate_json_member(archive, member))
+    return errors
+
+
+def validate_railloader_data_members(
+    archive: zipfile.ZipFile,
+    files: dict[zipfile.ZipInfo, tuple[str, ...]],
+    root: tuple[str, ...],
+) -> list[str]:
+    errors: list[str] = []
+    for member, parts in files.items():
+        if not starts_with(parts, root) or len(parts) != len(root) + 1:
+            continue
+        name = parts[-1].lower()
+        if not name.endswith(".json") or name in MANIFEST_NAMES or name.endswith("report.json"):
+            continue
+        errors.extend(validate_json_member(archive, member))
+    return errors
 
 
 def inspect_zip(zip_path: Path) -> tuple[list[ZipPackage], list[str]]:
@@ -332,6 +641,7 @@ def inspect_zip(zip_path: Path) -> tuple[list[ZipPackage], list[str]]:
     try:
         with zipfile.ZipFile(zip_path, "r") as archive:
             files = zip_file_parts(archive)
+            layout_errors = archive_layout_errors(archive, files)
             roots = candidate_roots(files)
             for root in roots:
                 package = package_from_root(zip_path, archive, files, root)
@@ -339,7 +649,12 @@ def inspect_zip(zip_path: Path) -> tuple[list[ZipPackage], list[str]]:
                     label = "/".join(root) if root else "."
                     warnings.append(f"{zip_path.name}: unsupported package root '{label}'.")
                     continue
+                package.errors.extend(layout_errors)
+                if layout_errors:
+                    package.kind = "invalid"
                 packages.append(package)
+            if layout_errors and not packages:
+                warnings.extend(f"{zip_path.name}: {error}" for error in layout_errors)
     except zipfile.BadZipFile as exc:
         warnings.append(f"{zip_path.name}: not a readable zip file: {exc}")
     except OSError as exc:
@@ -387,6 +702,8 @@ def unique_path(path: Path) -> Path:
 
 
 def install_package(package: ZipPackage, mods_dir: Path, replace: bool, dry_run: bool) -> InstallResult:
+    if package.errors:
+        raise ValueError("; ".join(package.errors))
     destination = mods_dir / package.install_name
     backup: Path | None = None
 
@@ -434,13 +751,623 @@ def install_package(package: ZipPackage, mods_dir: Path, replace: bool, dry_run:
             backup = None
         raise
 
-    return InstallResult(package, "installed", destination, "", backup)
+    status = "updated" if backup is not None else "installed"
+    return InstallResult(package, status, destination, "", backup)
+
+
+def validate_game_dir(game_dir: Path) -> list[str]:
+    errors: list[str] = []
+    if not (game_dir / "Railroader.exe").is_file():
+        errors.append(f"Railroader.exe was not found in {game_dir}")
+
+    managed = game_dir / "Railroader_Data" / "Managed"
+    if not managed.is_dir():
+        errors.append(f"Railroader_Data\\Managed was not found in {game_dir}")
+    return errors
+
+
+def unity_mod_manager_installed(game_dir: Path) -> bool:
+    managed = game_dir / "Railroader_Data" / "Managed"
+    candidates = (
+        managed / "UnityModManager" / "UnityModManager.dll",
+        managed / "UnityModManager" / "UnityModManagerNet.dll",
+        managed / "UnityModManager.dll",
+        managed / "UnityModManagerNet.dll",
+    )
+    return any(candidate.is_file() for candidate in candidates)
+
+
+def find_legacy_managed_files(game_dir: Path) -> list[Path]:
+    managed = game_dir / "Railroader_Data" / "Managed"
+    if not managed.is_dir():
+        return []
+    by_name = {item.name.lower(): item for item in managed.iterdir() if item.is_file()}
+    return [
+        by_name[name.lower()]
+        for name in LEGACY_MANAGED_FILES
+        if name.lower() in by_name
+    ]
+
+
+def backup_legacy_managed_files(files: Iterable[Path], mods_dir: Path, dry_run: bool) -> list[tuple[Path, Path]]:
+    existing = [Path(path).resolve() for path in files if Path(path).is_file()]
+    if not existing:
+        return []
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_root = mods_dir / "ModBackups" / "FUSEInstaller" / f"LegacyLoader-{timestamp}" / "Managed"
+    moved: list[tuple[Path, Path]] = []
+    for source in existing:
+        destination = unique_path(backup_root / source.name)
+        moved.append((source, destination))
+        if dry_run:
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(source), str(destination))
+    return moved
+
+
+def read_loose_info_json(folder: Path) -> dict[str, Any] | None:
+    """Read a UMM manifest for install-state checks without executing code."""
+    for name in ("Info.json", "info.json"):
+        path = folder / name
+        if not path.is_file():
+            continue
+        try:
+            value = legacy_json.loads(path.read_text(encoding="utf-8-sig"), repair=False)
+            return value if isinstance(value, dict) else None
+        except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+            return None
+    return None
+
+
+def find_loose_info_path(folder: Path) -> Path | None:
+    """Return the existing UMM manifest path without changing its casing."""
+    for name in ("Info.json", "info.json"):
+        path = folder / name
+        if path.is_file():
+            return path
+    return None
+
+
+def manifest_contains_dependency(value: Any, package_id: str) -> bool:
+    expected = (package_id or "").strip().lower()
+    if not expected:
+        return False
+    if isinstance(value, str):
+        return value.strip().lower() == expected
+    if isinstance(value, dict):
+        actual = value.get("Id", value.get("id", ""))
+        return str(actual or "").strip().lower() == expected
+    if isinstance(value, list):
+        return any(manifest_contains_dependency(item, package_id) for item in value)
+    return False
+
+
+def append_manifest_dependency(manifest: dict[str, Any], field_name: str, package_id: str) -> bool:
+    current = manifest.get(field_name)
+    if manifest_contains_dependency(current, package_id):
+        return False
+    if current is None:
+        manifest[field_name] = [package_id]
+    elif isinstance(current, list):
+        current.append(package_id)
+    else:
+        manifest[field_name] = [current, package_id]
+    return True
+
+
+def references_fuse_replaced_startup_assembly(assembly_path: Path) -> bool:
+    """Inspect CLR metadata strings without importing or executing the DLL."""
+    try:
+        data = assembly_path.read_bytes()
+    except OSError:
+        return False
+    return any(reference in data for reference in FUSE_LEGACY_STARTUP_ASSEMBLY_REFERENCES)
+
+
+def find_legacy_umm_startup_dependency_manifests(mods_dir: Path) -> list[tuple[Path, Path, dict[str, Any]]]:
+    """Find code mods that need FUSE loaded before UMM reflects their DLL."""
+    if not mods_dir.is_dir():
+        return []
+
+    candidates: list[tuple[Path, Path, dict[str, Any]]] = []
+    for folder in sorted(mods_dir.iterdir(), key=lambda item: item.name.lower()):
+        if not folder.is_dir() or folder.name.lower() in {"fuse", "fuseinstaller", "modbackups"}:
+            continue
+        info_path = find_loose_info_path(folder)
+        manifest = read_loose_info_json(folder)
+        if info_path is None or manifest is None:
+            continue
+        if str(manifest.get("Id", manifest.get("id", ""))).strip().lower() == "fuse":
+            continue
+        assembly_name = str(manifest.get("AssemblyName", manifest.get("assemblyName", "")) or "").strip()
+        if not assembly_name:
+            continue
+        assembly_path = folder / assembly_name
+        if not assembly_path.is_file() or not references_fuse_replaced_startup_assembly(assembly_path):
+            continue
+        if (
+            manifest_contains_dependency(manifest.get("Requirements"), "FUSE")
+            and manifest_contains_dependency(manifest.get("LoadAfter"), "FUSE")
+        ):
+            continue
+        candidates.append((folder, info_path, manifest))
+    return candidates
+
+
+def repair_legacy_umm_startup_dependencies(mods_dir: Path, dry_run: bool) -> list[CompatibilityAction]:
+    """Make legacy code mods load after FUSE, with recoverable manifest backups."""
+    candidates = find_legacy_umm_startup_dependency_manifests(mods_dir)
+    if not candidates:
+        return []
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_root = mods_dir / "ModBackups" / "FUSEInstaller" / f"CompatibilityManifests-{timestamp}"
+    actions: list[CompatibilityAction] = []
+    for folder, info_path, manifest in candidates:
+        package_id = str(manifest.get("Id", manifest.get("id", folder.name)) or folder.name)
+        backup_path = unique_path(backup_root / folder.name / info_path.name)
+        try:
+            append_manifest_dependency(manifest, "Requirements", "FUSE")
+            append_manifest_dependency(manifest, "LoadAfter", "FUSE")
+            if not dry_run:
+                backup_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(info_path, backup_path)
+                temporary_path = info_path.with_name(info_path.name + ".fuse-installer-new")
+                temporary_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+                os.replace(temporary_path, info_path)
+            actions.append(CompatibilityAction(
+                component=package_id,
+                status="planned" if dry_run else "updated",
+                message=(
+                    "Would add FUSE to UMM Requirements/LoadAfter so FUSE's legacy API bridge is active "
+                    "before this assembly is reflected."
+                    if dry_run else
+                    "Added FUSE to UMM Requirements/LoadAfter so FUSE's legacy API bridge is active "
+                    "before this assembly is reflected; the original manifest was backed up."
+                ),
+                source=info_path,
+                destination=backup_path,
+            ))
+        except Exception as exc:
+            actions.append(CompatibilityAction(
+                component=package_id,
+                status="failed",
+                message=f"Could not repair legacy UMM startup order: {exc}",
+                source=info_path,
+                destination=backup_path,
+            ))
+    return actions
+
+
+def folder_contains_file_named(folder: Path, filename: str) -> bool:
+    if not folder.is_dir():
+        return False
+    expected = filename.lower()
+    try:
+        return any(item.is_file() and item.name.lower() == expected for item in folder.iterdir())
+    except OSError:
+        return False
+
+
+def is_fuse_assetloader_compatibility(folder: Path) -> bool:
+    info = read_loose_info_json(folder)
+    if not info:
+        return False
+    marker = info.get("FuseProvidedCompatibility")
+    package_id = info.get("Id", info.get("id"))
+    return (
+        str(package_id or "").lower() == ASSETLOADER_ID.lower()
+        and marker == ASSETLOADER_COMPATIBILITY_MARKER
+        and not folder_contains_file_named(folder, ASSETLOADER_DLL)
+    )
+
+
+def find_fuse_assetloader_compatibility(mods_dir: Path) -> Path | None:
+    if not mods_dir.is_dir():
+        return None
+    for child in sorted(mods_dir.iterdir(), key=lambda item: item.name.lower()):
+        if child.is_dir() and is_fuse_assetloader_compatibility(child):
+            return child
+    return None
+
+
+def find_installed_mod_by_id(mods_dir: Path, package_id: str) -> Path | None:
+    if not mods_dir.is_dir() or not package_id:
+        return None
+    for child in sorted(mods_dir.iterdir(), key=lambda item: item.name.lower()):
+        if not child.is_dir():
+            continue
+        info = read_loose_info_json(child)
+        installed_id = str((info or {}).get("Id", (info or {}).get("id", "")))
+        if installed_id.lower() == package_id.lower():
+            return child
+    return None
+
+
+def read_installed_package_versions(mods_dir: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    if not mods_dir.is_dir():
+        return result
+    for child in sorted(mods_dir.iterdir(), key=lambda item: item.name.lower()):
+        if not child.is_dir():
+            continue
+        manifest = read_loose_info_json(child)
+        if manifest is None:
+            definition = child / "Definition.json"
+            if definition.is_file():
+                try:
+                    value = legacy_json.loads(
+                        definition.read_text(encoding="utf-8-sig"),
+                        repair=False,
+                    )
+                    manifest = value if isinstance(value, dict) else None
+                except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+                    manifest = None
+        package_id = string_field(manifest, "Id", "id")
+        if package_id:
+            version = string_field(manifest, "Version", "version")
+            for alias in package_id_aliases(package_id):
+                result.setdefault(alias, version)
+        result.setdefault(child.name.lower(), string_field(manifest, "Version", "version"))
+    return result
+
+
+def version_numbers(value: str) -> tuple[int, ...] | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    matches = re.findall(r"\d+", text)
+    return tuple(int(item) for item in matches) if matches else None
+
+
+def compare_versions(left: str, right: str) -> int | None:
+    first = version_numbers(left)
+    second = version_numbers(right)
+    if first is None or second is None:
+        return None
+    width = max(len(first), len(second))
+    first += (0,) * (width - len(first))
+    second += (0,) * (width - len(second))
+    return (first > second) - (first < second)
+
+
+def validate_batch_dependencies(
+    packages: Iterable[ZipPackage],
+    mods_dir: Path,
+    fuse_available: bool,
+) -> None:
+    package_list = list(packages)
+    by_id: dict[str, list[ZipPackage]] = {}
+    for package in package_list:
+        for alias in package_id_aliases(package.package_id):
+            by_id.setdefault(alias, []).append(package)
+    duplicate_groups: dict[str, list[ZipPackage]] = {}
+    for package in package_list:
+        aliases = package_id_aliases(package.package_id)
+        duplicate_key = aliases[-1] if aliases else package.package_id.lower()
+        duplicate_groups.setdefault(duplicate_key, []).append(package)
+    for package_id, duplicates in duplicate_groups.items():
+        if len(duplicates) <= 1:
+            continue
+        sources = ", ".join(
+            f"{item.zip_path.name}:{item.root_label}" for item in duplicates
+        )
+        for package in duplicates:
+            package.errors.append(
+                f"Duplicate package id '{package.package_id}' appears more than once in this batch ({sources}). "
+                "Remove the duplicate archive/root so installation order cannot overwrite it."
+            )
+
+    installed = read_installed_package_versions(mods_dir)
+    installed_fuse_available = fuse_available or "fuse" in installed
+
+    # Repeat until stable so a package whose own preflight failed cannot satisfy
+    # another package merely because both happened to be present in the batch.
+    # Existing installed providers remain valid fallbacks when an update ZIP is
+    # bad, and forward references within a healthy batch are supported.
+    changed = True
+    while changed:
+        changed = False
+        fuse_provider_available = installed_fuse_available or any(
+            "fuse" in package_id_aliases(candidate.package_id)
+            and not candidate.errors
+            for candidate in package_list
+        )
+        for package in package_list:
+            if package.errors:
+                continue
+            for requirement in package.requirements:
+                required_id = requirement.package_id.lower()
+                replacement_id = replacement_id_key(requirement.package_id)
+                if fuse_provider_available and replacement_id in FUSE_REPLACEMENT_IDS:
+                    continue
+
+                provider_versions: list[str] = []
+                if required_id in installed:
+                    provider_versions.append(installed[required_id])
+                provider_versions.extend(
+                    candidate.version
+                    for candidate in by_id.get(required_id, [])
+                    if not candidate.errors
+                    and candidate.package_id.lower() != ASSETLOADER_ID.lower()
+                )
+                if not provider_versions:
+                    bounds = requirement_bounds(requirement)
+                    batch_provider_failed = required_id in by_id
+                    if batch_provider_failed:
+                        message = (
+                            f"Dependency '{requirement.package_id}'{bounds} required by "
+                            f"'{package.package_id}' is in this batch but failed preflight. "
+                            "Fix or remove the failed dependency package, then retry the batch."
+                        )
+                    else:
+                        message = (
+                            f"Missing dependency '{requirement.package_id}'{bounds} required by "
+                            f"'{package.package_id}'. {dependency_install_hint(requirement.package_id)}"
+                        )
+                    package.errors.append(message)
+                    changed = True
+                    break
+
+                if not requirement.not_before and not requirement.not_after:
+                    continue
+                if any(version_numbers(version) is None for version in provider_versions):
+                    note = (
+                        f"Dependency '{requirement.package_id}' is present but has no readable version; "
+                        f"the installer could not verify {requirement_bounds(requirement).strip()}."
+                    )
+                    if note not in package.notes:
+                        package.notes.append(note)
+                    continue
+                if any(
+                    requirement_version_matches(version, requirement)
+                    for version in provider_versions
+                ):
+                    continue
+
+                available_versions = ", ".join(sorted(set(provider_versions)))
+                package.errors.append(
+                    f"Dependency version conflict for '{requirement.package_id}': "
+                    f"'{package.package_id}' requires{requirement_bounds(requirement)}, "
+                    f"but available version(s) are {available_versions}."
+                )
+                changed = True
+                break
+
+
+def requirement_version_matches(version: str, requirement: PackageRequirement) -> bool:
+    if requirement.not_before:
+        comparison = compare_versions(version, requirement.not_before)
+        if comparison is not None and comparison < 0:
+            return False
+    if requirement.not_after:
+        comparison = compare_versions(version, requirement.not_after)
+        if comparison is not None and comparison > 0:
+            return False
+    return True
+
+
+def dependency_install_hint(package_id: str) -> str:
+    if replacement_id_key(package_id) in FUSE_REPLACEMENT_IDS:
+        return (
+            "Install or update FUSE (or include FUSE in this batch); FUSE provides this "
+            "legacy dependency contract, so do not reinstall the replaced legacy DLL."
+        )
+    return "Install/enable that package in Mods, or include it in this batch."
+
+
+def requirement_bounds(requirement: PackageRequirement) -> str:
+    parts = []
+    if requirement.not_before:
+        parts.append("not before " + requirement.not_before)
+    if requirement.not_after:
+        parts.append("not after " + requirement.not_after)
+    return " (" + ", ".join(parts) + ")" if parts else ""
+
+
+def find_legacy_assetloader_paths(mods_dir: Path) -> list[Path]:
+    """Find old AssetLoader runtime files while excluding FUSE's data-only alias."""
+    if not mods_dir.is_dir():
+        return []
+
+    found: list[Path] = []
+    for child in sorted(mods_dir.iterdir(), key=lambda item: item.name.lower()):
+        if child.is_file():
+            lower_name = child.name.lower()
+            if lower_name == "assetloader.zip" or lower_name == "assetloader.dll":
+                found.append(child)
+            continue
+
+        if not child.is_dir() or is_fuse_assetloader_compatibility(child):
+            continue
+
+        info = read_loose_info_json(child)
+        package_id = str((info or {}).get("Id", (info or {}).get("id", "")))
+        has_runtime = folder_contains_file_named(child, ASSETLOADER_DLL)
+        if has_runtime or package_id.lower() == ASSETLOADER_ID.lower():
+            found.append(child)
+
+    return found
+
+
+def backup_legacy_assetloader_paths(
+    paths: Iterable[Path],
+    mods_dir: Path,
+    dry_run: bool,
+) -> list[tuple[Path, Path]]:
+    existing = [Path(path).resolve() for path in paths if Path(path).exists()]
+    if not existing:
+        return []
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_root = mods_dir / "ModBackups" / "FUSEInstaller" / f"AssetLoader-{timestamp}"
+    moved: list[tuple[Path, Path]] = []
+    for source in existing:
+        destination = unique_path(backup_root / source.name)
+        moved.append((source, destination))
+        if dry_run:
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(source), str(destination))
+    return moved
+
+
+def should_repair_assetloader(args: argparse.Namespace, paths: list[Path]) -> bool:
+    if not paths:
+        return True
+    if getattr(args, "repair_asset_loader", False) or getattr(args, "repair_legacy_loader", False):
+        return True
+    if args.dry_run or not sys.stdin.isatty():
+        return False
+
+    print("\nFUSE now replaces the old AssetLoader runtime. These paths remain installed:")
+    for path in paths:
+        print(f"  {path}")
+    print("They will be moved to a dated backup and replaced by a data-only dependency alias.")
+    try:
+        answer = input("Back up and replace old AssetLoader now? [Y/n]: ").strip().lower()
+    except EOFError:
+        return False
+    return answer in {"", "y", "yes"}
+
+
+def install_assetloader_compatibility_alias(mods_dir: Path, dry_run: bool) -> Path:
+    existing = find_fuse_assetloader_compatibility(mods_dir)
+    if existing is not None:
+        destination = existing
+    else:
+        preferred = mods_dir / ASSETLOADER_ID
+        destination = preferred if not preferred.exists() else mods_dir / ASSETLOADER_COMPATIBILITY_MARKER
+
+    if dry_run:
+        return destination
+
+    destination.mkdir(parents=True, exist_ok=True)
+    manifest_path = destination / "Info.json"
+    temporary_path = destination / "Info.json.fuse-installer-new"
+    temporary_path.write_text(
+        json.dumps(ASSETLOADER_COMPATIBILITY_MANIFEST, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary_path, manifest_path)
+    return destination
+
+
+def should_repair_legacy_files(args: argparse.Namespace, files: list[Path]) -> bool:
+    if not files:
+        return False
+    if args.repair_legacy_loader:
+        return True
+    if args.dry_run or not sys.stdin.isatty():
+        return False
+
+    print("\nFUSE cannot safely run while these old managed loader files remain:")
+    for path in files:
+        print(f"  {path}")
+    print("They will be moved to a dated backup, not deleted.")
+    try:
+        answer = input("Back up and remove the old loader files now? [Y/n]: ").strip().lower()
+    except EOFError:
+        return False
+    return answer in {"", "y", "yes"}
 
 
 def default_game_dir() -> Path:
-    if getattr(sys, "frozen", False):
-        return Path(sys.executable).resolve().parent
-    return Path.cwd().resolve()
+    start = Path(sys.executable).resolve().parent if getattr(sys, "frozen", False) else Path.cwd().resolve()
+    # FUSE-Complete keeps utilities under ``Tools``. Let that copy work when
+    # the complete archive itself was extracted into the Railroader folder.
+    for candidate in (start, start.parent):
+        if (candidate / "Railroader.exe").is_file():
+            return candidate
+    discovered = discover_game_dirs()
+    return discovered[0] if discovered else start
+
+
+def parse_steam_library_paths(text: str) -> list[Path]:
+    """Read Steam's old or current libraryfolders.vdf path entries."""
+    paths: list[Path] = []
+    seen: set[str] = set()
+    for match in re.finditer(r'"path"\s+"([^"]+)"', text or "", flags=re.IGNORECASE):
+        value = match.group(1).replace("\\\\", "\\").strip()
+        if not value:
+            continue
+        key = os.path.normcase(os.path.abspath(value))
+        if key in seen:
+            continue
+        seen.add(key)
+        paths.append(Path(value))
+    return paths
+
+
+def steam_roots() -> list[Path]:
+    candidates: list[Path] = []
+    if sys.platform.startswith("win"):
+        try:
+            import winreg
+
+            for hive, key_name, value_name in (
+                (winreg.HKEY_CURRENT_USER, r"Software\Valve\Steam", "SteamPath"),
+                (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\WOW6432Node\Valve\Steam", "InstallPath"),
+                (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Valve\Steam", "InstallPath"),
+            ):
+                try:
+                    with winreg.OpenKey(hive, key_name) as key:
+                        value, _kind = winreg.QueryValueEx(key, value_name)
+                        if value:
+                            candidates.append(Path(str(value)))
+                except OSError:
+                    continue
+        except (ImportError, OSError):
+            pass
+
+    for environment_name in ("ProgramFiles(x86)", "ProgramFiles"):
+        value = os.environ.get(environment_name, "").strip()
+        if value:
+            candidates.append(Path(value) / "Steam")
+    candidates.extend((Path(r"C:\Steam"), Path(r"D:\Steam"), Path(r"D:\SteamLibrary")))
+
+    roots: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.expanduser().resolve()
+        except OSError:
+            continue
+        key = os.path.normcase(str(resolved))
+        if key in seen or not resolved.exists():
+            continue
+        seen.add(key)
+        roots.append(resolved)
+    return roots
+
+
+def discover_game_dirs() -> list[Path]:
+    libraries: list[Path] = []
+    for root in steam_roots():
+        libraries.append(root)
+        vdf = root / "steamapps" / "libraryfolders.vdf"
+        try:
+            if vdf.is_file():
+                libraries.extend(parse_steam_library_paths(vdf.read_text(encoding="utf-8", errors="replace")))
+        except OSError:
+            continue
+
+    games: list[Path] = []
+    seen: set[str] = set()
+    for library in libraries:
+        candidate = library / "steamapps" / "common" / "Railroader"
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        key = os.path.normcase(str(resolved))
+        if key in seen or not (resolved / "Railroader.exe").is_file():
+            continue
+        seen.add(key)
+        games.append(resolved)
+    return games
 
 
 def resolve_bundled_fuse() -> Path | None:
@@ -497,6 +1424,9 @@ def print_package(package: ZipPackage) -> None:
     if package.notes:
         for note in package.notes:
             print(f"    note: {note}")
+    if package.errors:
+        for error in package.errors:
+            print(f"    error: {error}")
 
 
 def print_result(result: InstallResult) -> None:
@@ -511,6 +1441,85 @@ def print_result(result: InstallResult) -> None:
         print(f"  note: {result.message}")
 
 
+def write_install_report(
+    game_dir: Path,
+    mods_dir: Path,
+    targets: list[Path],
+    results: list[InstallResult],
+    scan_failures: int,
+    dry_run: bool,
+    compatibility_actions: list[CompatibilityAction] | None = None,
+) -> Path | None:
+    if dry_run:
+        return None
+    report_root = mods_dir / "FUSEInstaller" / "Reports"
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    report_path = unique_path(report_root / f"install-{timestamp}.json")
+    compatibility_actions = compatibility_actions or []
+    report = {
+        "installerVersion": TOOL_VERSION,
+        "generated": datetime.now().astimezone().isoformat(),
+        "dryRun": dry_run,
+        "gameDirectory": str(game_dir),
+        "modsDirectory": str(mods_dir),
+        "archives": [str(path) for path in targets],
+        "scanFailures": scan_failures,
+        "summary": {
+            "installed": sum(1 for item in results if item.status == "installed"),
+            "updated": sum(1 for item in results if item.status == "updated"),
+            "skipped": sum(1 for item in results if item.status == "skipped"),
+            "failed": (
+                scan_failures
+                + sum(1 for item in results if item.status == "failed")
+                + sum(1 for item in compatibility_actions if item.status == "failed")
+            ),
+        },
+        "packages": [
+            {
+                "status": item.status,
+                "kind": item.package.kind,
+                "id": item.package.package_id,
+                "name": item.package.display_name,
+                "version": item.package.version,
+                "sourceArchive": str(item.package.zip_path),
+                "sourceRoot": item.package.root_label,
+                "manifest": item.package.manifest_member,
+                "destination": str(item.destination),
+                "backup": str(item.backup) if item.backup else None,
+                "message": item.message,
+                "notes": list(item.package.notes),
+                "errors": list(item.package.errors),
+                "requirements": [
+                    {
+                        "id": requirement.package_id,
+                        "notBefore": requirement.not_before or None,
+                        "notAfter": requirement.not_after or None,
+                    }
+                    for requirement in item.package.requirements
+                ],
+            }
+            for item in results
+        ],
+        "compatibilityActions": [
+            {
+                "component": item.component,
+                "status": item.status,
+                "message": item.message,
+                "source": str(item.source) if item.source else None,
+                "destination": str(item.destination) if item.destination else None,
+            }
+            for item in compatibility_actions
+        ],
+    }
+    try:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        return report_path
+    except OSError as exc:
+        print(f"WARNING: could not write install report: {exc}")
+        return None
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
@@ -519,23 +1528,74 @@ def build_parser() -> argparse.ArgumentParser:
             "as arguments) to install those mods."
         ),
     )
-    parser.add_argument("zips", nargs="*", help="Zip files to install. Drag-and-drop works on Windows.")
+    parser.add_argument("zips", nargs="*", help="Zip files to install. Drag-and-drop accepts multiple files on Windows.")
     parser.add_argument("--game-dir", default=None, help="Base folder. Default is this exe's folder, or the current directory when run as a script.")
     parser.add_argument("--mods-dir", default=None, help="Mods folder. Default is <base folder>\\Mods.")
     parser.add_argument("--inbox", default=None, help="Folder to scan for zip files when no zip arguments are passed.")
-    parser.add_argument("--replace", action="store_true", help="Backup and replace existing mod folders.")
+    parser.add_argument("--replace", action="store_true", help="Backup and replace existing mod folders (this is now the default).")
+    parser.add_argument("--skip-existing", action="store_true", help="Leave existing mod folders unchanged instead of updating them.")
+    parser.add_argument("--repair-legacy-loader", action="store_true", help="Back up conflicting legacy loader DLLs from Railroader_Data\\Managed before installing.")
+    parser.add_argument("--repair-asset-loader", action="store_true", help="Back up the old Mods\\AssetLoader runtime and install FUSE's data-only AssetLoader dependency alias.")
+    parser.add_argument("--with-fuse", action="store_true", help="Install/update the bundled FUSE framework along with explicitly supplied mod zips.")
     parser.add_argument("--no-fuse", action="store_true", help="Do not install the bundled FUSE framework on a manual run; only process zip files.")
     parser.add_argument("--dry-run", action="store_true", help="Inspect zips and print planned installs without writing files.")
     parser.add_argument("--archive-zips", action="store_true", help="Move successfully processed zips to Mods\\FUSEInstaller\\InstalledZips.")
     parser.add_argument("--pause", action="store_true", help="Pause before closing.")
     parser.add_argument("--no-pause", action="store_true", help="Do not pause before closing, even when bundled as an exe.")
+    parser.add_argument("--cli", action="store_true", help="Use command-line mode instead of the graphical installer.")
+    parser.add_argument("--gui", action="store_true", help="Use the graphical installer when running the Python script.")
     parser.add_argument("--version", action="version", version=f"FUSE Installer {TOOL_VERSION}")
     return parser
+
+
+def should_preselect_bundled_fuse(args: argparse.Namespace, bundled_available: bool) -> bool:
+    """Return the GUI default while preserving drag-and-drop input scope.
+
+    A manual launch is the FUSE installation flow, so the bundled framework is
+    selected. Dragging explicit archives onto the executable processes only
+    those archives unless ``--with-fuse`` was explicitly supplied.
+    """
+    return bool(
+        bundled_available
+        and not args.no_fuse
+        and (not args.zips or args.with_fuse)
+    )
 
 
 def run(args: argparse.Namespace) -> int:
     game_dir = Path(args.game_dir).resolve() if args.game_dir else default_game_dir()
     mods_dir = Path(args.mods_dir).resolve() if args.mods_dir else (game_dir / "Mods").resolve()
+
+    preflight_errors = validate_game_dir(game_dir)
+    if not unity_mod_manager_installed(game_dir):
+        preflight_errors.append(
+            "Unity Mod Manager is not installed for this Railroader copy. "
+            "Install UMM first; FUSE itself is loaded by UMM."
+        )
+    if preflight_errors:
+        print(f"FUSE Installer {TOOL_VERSION}")
+        print("FAILED: Railroader installation preflight")
+        for error in preflight_errors:
+            print(f"  {error}")
+        print("  Put FUSE-Installer.exe beside Railroader.exe, or pass --game-dir to the correct folder.")
+        return 1
+
+    legacy_files = find_legacy_managed_files(game_dir)
+    if legacy_files:
+        if should_repair_legacy_files(args, legacy_files):
+            moved = backup_legacy_managed_files(legacy_files, mods_dir, args.dry_run)
+            verb = "Would move" if args.dry_run else "Moved"
+            for source, destination in moved:
+                print(f"{verb} legacy loader: {source} -> {destination}")
+            print("Legacy loader preflight: CLEAN")
+        else:
+            print(f"FUSE Installer {TOOL_VERSION}")
+            print("FAILED: conflicting legacy loader files were found:")
+            for path in legacy_files:
+                print(f"  {path}")
+            print("Run again and approve the backup prompt, or pass --repair-legacy-loader.")
+            print("Steam Verify can restore modified game files, but it may not remove extra DLLs; the files above must be moved too.")
+            return 1
 
     explicit = bool(args.zips)
     zips = find_input_zips(args, game_dir)
@@ -544,7 +1604,7 @@ def run(args: argparse.Namespace) -> int:
     # exe, alongside any loose zips found beside it. Dragging specific zips onto
     # the exe installs exactly those and never force-installs FUSE.
     bundle_on_disk = resolve_bundled_fuse()
-    bundled_fuse = bundle_on_disk if (not explicit and not args.no_fuse) else None
+    bundled_fuse = bundle_on_disk if ((not explicit or args.with_fuse) and not args.no_fuse) else None
 
     targets: list[Path] = []
     seen: set[Path] = set()
@@ -559,8 +1619,8 @@ def run(args: argparse.Namespace) -> int:
     print(f"mods: {mods_dir}")
     if args.dry_run:
         print("mode: dry run")
-    if args.replace:
-        print("replace: enabled")
+    replace_existing = not args.skip_existing or args.replace
+    print(f"existing mods: {'backup and update' if replace_existing else 'skip'}")
     if bundled_fuse is not None:
         print(f"bundled FUSE: {bundled_fuse.name}")
     print()
@@ -575,6 +1635,20 @@ def run(args: argparse.Namespace) -> int:
     if not args.dry_run:
         mods_dir.mkdir(parents=True, exist_ok=True)
 
+    scan_cache: dict[Path, tuple[list[ZipPackage], list[str]]] = {}
+    scanned_packages: list[ZipPackage] = []
+    for target in targets:
+        if not target.exists():
+            continue
+        scan_cache[target] = inspect_zip(target)
+        scanned_packages.extend(scan_cache[target][0])
+    fuse_available_for_dependencies = find_installed_mod_by_id(mods_dir, "FUSE") is not None
+    validate_batch_dependencies(
+        scanned_packages,
+        mods_dir,
+        fuse_available_for_dependencies,
+    )
+
     all_results: list[InstallResult] = []
     scan_failures = 0
     for zip_path in targets:
@@ -585,7 +1659,11 @@ def run(args: argparse.Namespace) -> int:
             scan_failures += 1
             continue
 
-        packages, warnings = inspect_zip(zip_path)
+        packages, warnings = (
+            scan_cache[zip_path]
+            if zip_path in scan_cache
+            else inspect_zip(zip_path)
+        )
         for warning in warnings:
             print(f"  warning: {warning}")
         if not packages:
@@ -594,8 +1672,28 @@ def run(args: argparse.Namespace) -> int:
 
         for package in packages:
             print_package(package)
+            if package.package_id.lower() == ASSETLOADER_ID.lower():
+                result = InstallResult(
+                    package,
+                    "skipped",
+                    mods_dir / package.install_name,
+                    "Old AssetLoader is replaced by FUSE; the installer will create a data-only dependency alias.",
+                )
+                all_results.append(result)
+                print_result(result)
+                continue
+            if package.errors:
+                result = InstallResult(
+                    package,
+                    "failed",
+                    mods_dir / package.install_name,
+                    "; ".join(package.errors),
+                )
+                all_results.append(result)
+                print_result(result)
+                continue
             try:
-                result = install_package(package, mods_dir, args.replace, args.dry_run)
+                result = install_package(package, mods_dir, replace_existing, args.dry_run)
                 all_results.append(result)
                 print_result(result)
             except Exception as exc:
@@ -605,19 +1703,367 @@ def run(args: argparse.Namespace) -> int:
         print()
 
         zip_results = [result for result in all_results if result.package.zip_path == zip_path]
+        assetloader_without_replacement = (
+            any(result.package.package_id.lower() == ASSETLOADER_ID.lower() for result in zip_results)
+            and find_installed_mod_by_id(mods_dir, "FUSE") is None
+            and not any(
+                result.package.package_id.lower() == "fuse" and result.status != "failed"
+                for result in all_results
+            )
+            and bundled_fuse is None
+        )
         # Never archive the bundled FUSE payload: it lives inside the PyInstaller
         # extraction dir, not beside the exe.
-        if args.archive_zips and zip_path != bundled_fuse and zip_results and not any(result.status == "failed" for result in zip_results):
+        if (
+            args.archive_zips
+            and zip_path != bundled_fuse
+            and zip_results
+            and not assetloader_without_replacement
+            and not any(result.status == "failed" for result in zip_results)
+        ):
             archived_to = archive_zip(zip_path, mods_dir, args.dry_run)
             verb = "Would archive" if args.dry_run else "Archived"
             print(f"{verb}: {zip_path} -> {archived_to}")
 
+    compatibility_actions: list[CompatibilityAction] = []
+    fuse_available = (
+        find_installed_mod_by_id(mods_dir, "FUSE") is not None
+        or any(
+            result.package.package_id.lower() == "fuse"
+            and result.status != "failed"
+            for result in all_results
+        )
+    )
+    assetloader_package_results = [
+        result
+        for result in all_results
+        if result.package.package_id.lower() == ASSETLOADER_ID.lower()
+    ]
+    if assetloader_package_results and not fuse_available:
+        for result in assetloader_package_results:
+            result.status = "failed"
+            result.message = (
+                "AssetLoader is replaced by FUSE, but FUSE is not installed. "
+                "Install FUSE first or include --with-fuse."
+            )
+        compatibility_actions.append(CompatibilityAction(
+            ASSETLOADER_ID,
+            "blocked",
+            "The old AssetLoader package was not installed because its replacement, FUSE, is unavailable.",
+        ))
+    if fuse_available:
+        legacy_assetloader_paths = find_legacy_assetloader_paths(mods_dir)
+        if legacy_assetloader_paths and not should_repair_assetloader(args, legacy_assetloader_paths):
+            print("FAILED: old AssetLoader runtime remains installed:")
+            for path in legacy_assetloader_paths:
+                print(f"  {path}")
+            print("Run again and approve migration, or pass --repair-asset-loader.")
+            compatibility_actions.append(CompatibilityAction(
+                ASSETLOADER_ID,
+                "failed",
+                "Old AssetLoader runtime remains installed; approve migration or pass --repair-asset-loader. "
+                "Paths: " + "; ".join(str(path) for path in legacy_assetloader_paths),
+            ))
+        else:
+            try:
+                moved = backup_legacy_assetloader_paths(
+                    legacy_assetloader_paths,
+                    mods_dir,
+                    args.dry_run,
+                )
+                verb = "Would move" if args.dry_run else "Moved"
+                for source, destination in moved:
+                    print(f"{verb} old AssetLoader: {source} -> {destination}")
+                    compatibility_actions.append(CompatibilityAction(
+                        ASSETLOADER_ID,
+                        "planned" if args.dry_run else "backed-up",
+                        "Old AssetLoader runtime was moved to a recoverable backup."
+                        if not args.dry_run else
+                        "Old AssetLoader runtime would be moved to a recoverable backup.",
+                        source,
+                        destination,
+                    ))
+
+                remaining = [] if args.dry_run else find_legacy_assetloader_paths(mods_dir)
+                if remaining:
+                    print("FAILED: AssetLoader cleanup verification found remaining runtime paths:")
+                    for path in remaining:
+                        print(f"  {path}")
+                    compatibility_actions.append(CompatibilityAction(
+                        ASSETLOADER_ID,
+                        "failed",
+                        "Cleanup verification found remaining AssetLoader runtime paths: "
+                        + "; ".join(str(path) for path in remaining),
+                    ))
+                else:
+                    alias_path = install_assetloader_compatibility_alias(mods_dir, args.dry_run)
+                    verb = "Would install" if args.dry_run else "Installed"
+                    print(f"{verb} FUSE AssetLoader dependency alias: {alias_path}")
+                    print("AssetLoader runtime verification: CLEAN")
+                    compatibility_actions.append(CompatibilityAction(
+                        ASSETLOADER_ID,
+                        "planned" if args.dry_run else "installed",
+                        "FUSE's data-only AssetLoader dependency alias is present; no AssetLoader DLL is installed."
+                        if not args.dry_run else
+                        "FUSE's data-only AssetLoader dependency alias would be installed.",
+                        destination=alias_path,
+                    ))
+            except Exception as exc:
+                print(f"FAILED: AssetLoader migration: {exc}")
+                compatibility_actions.append(CompatibilityAction(
+                    ASSETLOADER_ID,
+                    "failed",
+                    f"AssetLoader migration failed: {exc}",
+                ))
+
+        startup_actions = repair_legacy_umm_startup_dependencies(mods_dir, args.dry_run)
+        for action in startup_actions:
+            verb = "Would repair" if action.status == "planned" else (
+                "Repaired" if action.status == "updated" else "FAILED"
+            )
+            print(f"{verb} legacy startup order for {action.component}: {action.message}")
+        compatibility_actions.extend(startup_actions)
+
+    print("Install results:")
+    for result in all_results:
+        detail = result.message or str(result.destination)
+        print(f"  [{result.status.upper()}] {result.package.display_name} ({result.package.kind}) - {detail}")
+
     installed = sum(1 for result in all_results if result.status == "installed")
+    updated = sum(1 for result in all_results if result.status == "updated")
     skipped = sum(1 for result in all_results if result.status == "skipped")
     failed_results = sum(1 for result in all_results if result.status == "failed")
-    failures = scan_failures + failed_results
-    print(f"Summary: installed={installed} skipped={skipped} failed={failures}")
+    compatibility_failures = sum(1 for item in compatibility_actions if item.status == "failed")
+    failures = scan_failures + failed_results + compatibility_failures
+    print(f"Summary: installed={installed} updated={updated} skipped={skipped} failed={failures}")
+    report_path = write_install_report(
+        game_dir,
+        mods_dir,
+        targets,
+        all_results,
+        scan_failures,
+        args.dry_run,
+        compatibility_actions,
+    )
+    if report_path is not None:
+        print(f"Report: {report_path}")
     return 1 if failures else 0
+
+
+def run_gui(args: argparse.Namespace) -> int:
+    import tkinter as tk
+    from tkinter import filedialog, messagebox
+    from tkinter.scrolledtext import ScrolledText
+
+    root = tk.Tk()
+    root.title(f"FUSE Mod Installer {TOOL_VERSION}")
+    root.geometry("900x680")
+    root.minsize(760, 560)
+
+    game_var = tk.StringVar(value=str(Path(args.game_dir).resolve()) if args.game_dir else str(default_game_dir()))
+    bundled_fuse_available = resolve_bundled_fuse() is not None
+    install_fuse_var = tk.BooleanVar(
+        value=should_preselect_bundled_fuse(args, bundled_fuse_available))
+    update_var = tk.BooleanVar(value=not args.skip_existing)
+    archive_var = tk.BooleanVar(value=bool(args.archive_zips))
+    status_var = tk.StringVar(value="Ready. Select the Railroader folder and packages, then click Install.")
+
+    outer = tk.Frame(root, padx=16, pady=14)
+    outer.pack(fill="both", expand=True)
+
+    tk.Label(outer, text="FUSE Suite & Mod Installer", font=("Segoe UI", 17, "bold"), anchor="w").pack(fill="x")
+    tk.Label(
+        outer,
+        text="Installs Native FUSE, Unity Mod Manager, and hosted RailLoader-format mod packages. "
+             "Every package is inspected before an existing install is replaced.",
+        justify="left",
+        wraplength=840,
+        anchor="w",
+    ).pack(fill="x", pady=(2, 12))
+
+    game_row = tk.Frame(outer)
+    game_row.pack(fill="x", pady=(0, 10))
+    tk.Label(game_row, text="Railroader folder", width=18, anchor="w").pack(side="left")
+    tk.Entry(game_row, textvariable=game_var).pack(side="left", fill="x", expand=True, padx=(0, 6))
+
+    def browse_game() -> None:
+        selected = filedialog.askdirectory(title="Select the folder containing Railroader.exe", initialdir=game_var.get())
+        if selected:
+            game_var.set(selected)
+
+    tk.Button(game_row, text="Browse...", command=browse_game, width=11).pack(side="right")
+
+    package_frame = tk.LabelFrame(outer, text="Mod zip files", padx=8, pady=8)
+    package_frame.pack(fill="both", expand=False)
+    zip_list = tk.Listbox(package_frame, height=7, selectmode=tk.EXTENDED)
+    zip_list.pack(side="left", fill="both", expand=True)
+    for item in args.zips:
+        zip_list.insert(tk.END, str(Path(item).resolve()))
+
+    package_buttons = tk.Frame(package_frame)
+    package_buttons.pack(side="right", fill="y", padx=(8, 0))
+
+    def add_zips() -> None:
+        selected = filedialog.askopenfilenames(
+            title="Select one or more mod zip files",
+            filetypes=(("Zip packages", "*.zip"), ("All files", "*.*")),
+        )
+        existing = {zip_list.get(index) for index in range(zip_list.size())}
+        for item in selected:
+            resolved = str(Path(item).resolve())
+            if resolved not in existing:
+                zip_list.insert(tk.END, resolved)
+                existing.add(resolved)
+
+    def remove_zips() -> None:
+        for index in reversed(zip_list.curselection()):
+            zip_list.delete(index)
+
+    tk.Button(package_buttons, text="Add zips...", command=add_zips, width=13).pack(fill="x")
+    tk.Button(package_buttons, text="Remove", command=remove_zips, width=13).pack(fill="x", pady=(6, 0))
+
+    options = tk.Frame(outer)
+    options.pack(fill="x", pady=(10, 8))
+    fuse_check = tk.Checkbutton(
+        options,
+        text="Install/update the bundled FUSE framework",
+        variable=install_fuse_var,
+        state=(tk.NORMAL if bundled_fuse_available else tk.DISABLED),
+    )
+    fuse_check.pack(anchor="w")
+    tk.Checkbutton(options, text="Back up and update existing mod folders", variable=update_var).pack(anchor="w")
+    tk.Checkbutton(options, text="Archive successfully installed source zips", variable=archive_var).pack(anchor="w")
+
+    result_box = ScrolledText(outer, height=15, wrap="word", font=("Consolas", 9), state="disabled")
+    result_box.pack(fill="both", expand=True, pady=(6, 8))
+    result_box.tag_configure("success", foreground="#167a2f")
+    result_box.tag_configure("failure", foreground="#b42318")
+
+    status_label = tk.Label(outer, textvariable=status_var, anchor="w", justify="left", wraplength=840)
+    status_label.pack(fill="x")
+
+    action_row = tk.Frame(outer)
+    action_row.pack(fill="x", pady=(8, 0))
+
+    def set_result(text: str, success: bool) -> None:
+        result_box.configure(state="normal")
+        result_box.delete("1.0", tk.END)
+        result_box.insert(tk.END, text, "success" if success else "failure")
+        result_box.configure(state="disabled")
+        result_box.see(tk.END)
+
+    def copy_results() -> None:
+        root.clipboard_clear()
+        root.clipboard_append(result_box.get("1.0", tk.END).rstrip())
+        status_var.set("Copied the install results to the clipboard.")
+
+    def open_mods() -> None:
+        path = Path(game_var.get()).expanduser() / "Mods"
+        path.mkdir(parents=True, exist_ok=True)
+        try:
+            os.startfile(str(path))
+        except (AttributeError, OSError):
+            messagebox.showinfo("Mods folder", str(path))
+
+    def install() -> None:
+        game_dir = Path(game_var.get()).expanduser().resolve()
+        errors = validate_game_dir(game_dir)
+        if errors:
+            messagebox.showerror("Railroader folder not found", "\n".join(errors))
+            return
+        if not unity_mod_manager_installed(game_dir):
+            messagebox.showerror(
+                "Unity Mod Manager is required",
+                "Unity Mod Manager is not installed in this Railroader copy. Install UMM first, then run this installer again.",
+            )
+            return
+
+        selected_zips = [zip_list.get(index) for index in range(zip_list.size())]
+        if not selected_zips and not install_fuse_var.get():
+            messagebox.showinfo("Nothing selected", "Add one or more mod zips, or enable the bundled FUSE framework.")
+            return
+
+        legacy_files = find_legacy_managed_files(game_dir)
+        repair_legacy = False
+        if legacy_files:
+            listed = "\n".join(str(path) for path in legacy_files)
+            repair_legacy = messagebox.askyesno(
+                "Old RailLoader files found",
+                "These exact legacy loader files conflict with FUSE:\n\n" + listed +
+                "\n\nMove them to a dated backup and continue? Nothing will be deleted.",
+            )
+            if not repair_legacy:
+                status_var.set("Install cancelled: old managed RailLoader files must be backed up first.")
+                return
+
+        mods_dir = game_dir / "Mods"
+        legacy_assetloader_paths = find_legacy_assetloader_paths(mods_dir)
+        repair_asset_loader = False
+        fuse_will_be_available = (
+            install_fuse_var.get()
+            or find_installed_mod_by_id(mods_dir, "FUSE") is not None
+        )
+        if fuse_will_be_available and legacy_assetloader_paths:
+            listed = "\n".join(str(path) for path in legacy_assetloader_paths)
+            repair_asset_loader = messagebox.askyesno(
+                "Old AssetLoader runtime found",
+                "FUSE replaces the old AssetLoader runtime. These paths remain installed:\n\n" +
+                listed +
+                "\n\nMove them to a dated backup and install FUSE's data-only dependency alias? "
+                "Nothing will be deleted.",
+            )
+            if not repair_asset_loader:
+                status_var.set("Install cancelled: old AssetLoader must be migrated first.")
+                return
+
+        run_args = argparse.Namespace(**vars(args))
+        run_args.game_dir = str(game_dir)
+        run_args.mods_dir = None
+        run_args.zips = selected_zips
+        # Prevent the GUI's empty package list from implicitly installing every
+        # zip sitting beside Railroader.exe. Only listed files and the checked
+        # bundled framework are in scope.
+        run_args.inbox = str(game_dir / ".fuse-installer-no-inbox-scan")
+        run_args.with_fuse = install_fuse_var.get()
+        run_args.no_fuse = not install_fuse_var.get()
+        run_args.skip_existing = not update_var.get()
+        run_args.replace = update_var.get()
+        run_args.archive_zips = archive_var.get()
+        run_args.repair_legacy_loader = repair_legacy
+        run_args.repair_asset_loader = repair_asset_loader
+        run_args.no_pause = True
+        run_args.pause = False
+
+        status_var.set("Installing... Existing mods are backed up before replacement.")
+        root.update_idletasks()
+        output = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):
+                exit_code = run(run_args)
+        except Exception as exc:
+            exit_code = 1
+            output.write("\nUNEXPECTED INSTALLER ERROR: " + str(exc))
+
+        text = output.getvalue().strip()
+        success = exit_code == 0
+        set_result(text, success)
+        status_var.set(
+            "Install complete. Review the package-by-package results above."
+            if success else
+            "One or more packages failed. Successful packages were kept; failed packages did not replace existing installs."
+        )
+        if success:
+            messagebox.showinfo("FUSE install complete", "All selected packages installed successfully.")
+        else:
+            messagebox.showwarning("FUSE install finished with errors", "Review the failed package entries and report path in the installer window.")
+
+    tk.Button(action_row, text="Install", command=install, width=16).pack(side="left")
+    tk.Button(action_row, text="Open Mods Folder", command=open_mods, width=16).pack(side="left", padx=(8, 0))
+    tk.Button(action_row, text="Copy Results", command=copy_results, width=14).pack(side="left", padx=(8, 0))
+    tk.Button(action_row, text="Close", command=root.destroy, width=12).pack(side="right")
+
+    root.mainloop()
+    return 0
 
 
 def should_pause(args: argparse.Namespace) -> bool:
@@ -631,6 +2077,8 @@ def should_pause(args: argparse.Namespace) -> bool:
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
+    if args.gui or (getattr(sys, "frozen", False) and sys.platform.startswith("win") and not args.cli):
+        return run_gui(args)
     try:
         return run(args)
     finally:

--- a/tools/fuse_installer.py
+++ b/tools/fuse_installer.py
@@ -33,7 +33,7 @@ if str(SCRIPT_DIR) not in sys.path:
 import legacy_json  # noqa: E402
 
 
-TOOL_VERSION = "0.8.0"
+TOOL_VERSION = "0.8.1"
 BUNDLED_FUSE_NAME = "bundled_fuse.zip"
 MANIFEST_NAMES = {"info.json", "definition.json"}
 LEGACY_MANAGED_FILES = (
@@ -2234,6 +2234,13 @@ def run(args: argparse.Namespace) -> int:
     return 1 if failures else 0
 
 
+def installer_window_size(screen_width: int, screen_height: int) -> tuple[int, int]:
+    """Fit the preferred installer window inside a desktop-sized margin."""
+    available_width = max(1, screen_width - 48)
+    available_height = max(1, screen_height - 64)
+    return min(960, available_width), min(760, available_height)
+
+
 def run_gui(args: argparse.Namespace) -> int:
     import tkinter as tk
     from tkinter import filedialog, messagebox
@@ -2241,8 +2248,17 @@ def run_gui(args: argparse.Namespace) -> int:
 
     root = tk.Tk()
     root.title(f"FUSE Mod Installer {TOOL_VERSION}")
-    root.geometry("900x680")
-    root.minsize(760, 560)
+    screen_width = max(1, root.winfo_screenwidth())
+    screen_height = max(1, root.winfo_screenheight())
+    window_width, window_height = installer_window_size(
+        screen_width,
+        screen_height,
+    )
+    window_x = max(0, (screen_width - window_width) // 2)
+    window_y = max(0, (screen_height - window_height) // 2)
+    root.geometry(
+        f"{window_width}x{window_height}+{window_x}+{window_y}")
+    root.minsize(min(760, window_width), min(560, window_height))
 
     game_var = tk.StringVar(value=str(Path(args.game_dir).resolve()) if args.game_dir else str(default_game_dir()))
     bundled_fuse_available = resolve_bundled_fuse() is not None
@@ -2329,16 +2345,19 @@ def run_gui(args: argparse.Namespace) -> int:
     tk.Label(nexus_row, text="Nexus API key (optional; never saved)", anchor="w").pack(side="left")
     tk.Entry(nexus_row, textvariable=nexus_key_var, show="*").pack(side="left", fill="x", expand=True, padx=(8, 0))
 
-    result_box = ScrolledText(outer, height=15, wrap="word", font=("Consolas", 9), state="disabled")
+    # Reserve the action and status rows before the expanding result pane. Tk's
+    # packer allocates widgets in packing order; allowing the result pane to
+    # claim the cavity first can push the Install button below a short desktop.
+    action_row = tk.Frame(outer)
+    action_row.pack(side="bottom", fill="x", pady=(8, 0))
+
+    status_label = tk.Label(outer, textvariable=status_var, anchor="w", justify="left", wraplength=840)
+    status_label.pack(side="bottom", fill="x")
+
+    result_box = ScrolledText(outer, height=9, wrap="word", font=("Consolas", 9), state="disabled")
     result_box.pack(fill="both", expand=True, pady=(6, 8))
     result_box.tag_configure("success", foreground="#167a2f")
     result_box.tag_configure("failure", foreground="#b42318")
-
-    status_label = tk.Label(outer, textvariable=status_var, anchor="w", justify="left", wraplength=840)
-    status_label.pack(fill="x")
-
-    action_row = tk.Frame(outer)
-    action_row.pack(fill="x", pady=(8, 0))
 
     def set_result(text: str, success: bool) -> None:
         result_box.configure(state="normal")

--- a/tools/fuse_installer.py
+++ b/tools/fuse_installer.py
@@ -16,9 +16,12 @@ import os
 import re
 import shutil
 import sys
+import urllib.error
+import urllib.parse
+import urllib.request
 import zipfile
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -30,7 +33,7 @@ if str(SCRIPT_DIR) not in sys.path:
 import legacy_json  # noqa: E402
 
 
-TOOL_VERSION = "0.7.0"
+TOOL_VERSION = "0.8.0"
 BUNDLED_FUSE_NAME = "bundled_fuse.zip"
 MANIFEST_NAMES = {"info.json", "definition.json"}
 LEGACY_MANAGED_FILES = (
@@ -80,6 +83,16 @@ LEGACY_DATA_KEYS = {
     "spawnPoint",
 }
 MAX_JSON_BYTES = 64 * 1024 * 1024
+DEPENDENCY_METADATA_DIR = ".fuse-metadata"
+DEPENDENCY_METADATA_FILE = "dependencies.json"
+NEXUS_API_BASE = "https://api.nexusmods.com/v3"
+NEXUS_URL_RE = re.compile(
+    r"https?://(?:www\.)?nexusmods\.com/(?:games/)?(?P<game>[^/]+)/mods/(?P<mod_id>\d+)",
+    re.IGNORECASE,
+)
+UMM_VERSIONED_REQUIREMENT_RE = re.compile(
+    r"^(?P<id>.+)-(?P<version>\d+\.\d+\.\d+(?:\.\d+)?)(?:[^\d].*)?$"
+)
 WINDOWS_RESERVED_NAMES = {
     "con",
     "prn",
@@ -108,6 +121,9 @@ class PackageRequirement:
     package_id: str
     not_before: str = ""
     not_after: str = ""
+    display_name: str = ""
+    nexus_mod_id: str = ""
+    source: str = "manifest"
 
 
 @dataclass
@@ -124,6 +140,10 @@ class ZipPackage:
     notes: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     requirements: list[PackageRequirement] = field(default_factory=list)
+    load_after: list[PackageRequirement] = field(default_factory=list)
+    load_before: list[PackageRequirement] = field(default_factory=list)
+    homepage: str = ""
+    nexus_source: dict[str, str] = field(default_factory=dict)
 
     @property
     def root_label(self) -> str:
@@ -156,6 +176,18 @@ def package_id_aliases(package_id: str) -> tuple[str, ...]:
     if normalized.endswith(".fuse") or normalized.endswith(".rail"):
         aliases.append(normalized[:-5])
     return tuple(dict.fromkeys(aliases))
+
+
+def package_aliases(package: ZipPackage) -> tuple[str, ...]:
+    aliases = list(package_id_aliases(package.package_id))
+    identity = nexus_page_identity(package.homepage)
+    if identity is not None:
+        aliases.append(f"nexus:{identity[0]}:{identity[1]}")
+    source_game = package.nexus_source.get("gameDomain", "")
+    source_mod = package.nexus_source.get("gameScopedModId", "")
+    if source_game and source_mod:
+        aliases.append(f"nexus:{source_game}:{source_mod}".lower())
+    return tuple(dict.fromkeys(alias.lower() for alias in aliases if alias))
 
 
 def replacement_id_key(package_id: str) -> str:
@@ -413,19 +445,29 @@ def is_railloader_manifest(data: dict[str, Any]) -> bool:
     )
 
 
-def parse_requirements(*values: Any) -> list[PackageRequirement]:
+def parse_requirements(*values: Any, parse_umm_versions: bool = False) -> list[PackageRequirement]:
     result: list[PackageRequirement] = []
     seen: set[tuple[str, str, str]] = set()
     for value in values:
         entries = value if isinstance(value, list) else [value] if value else []
         for entry in entries:
             if isinstance(entry, str):
-                requirement = PackageRequirement(entry.strip())
+                package_id = entry.strip()
+                not_before = ""
+                if parse_umm_versions:
+                    match = UMM_VERSIONED_REQUIREMENT_RE.match(package_id)
+                    if match:
+                        package_id = match.group("id").strip()
+                        not_before = match.group("version").strip()
+                requirement = PackageRequirement(package_id, not_before=not_before)
             elif isinstance(entry, dict):
                 requirement = PackageRequirement(
                     string_field(entry, "Id", "id"),
                     string_field(entry, "NotBefore", "notBefore", "MinimumVersion", "minimumVersion"),
                     string_field(entry, "NotAfter", "notAfter", "MaximumVersion", "maximumVersion"),
+                    string_field(entry, "DisplayName", "displayName", "name"),
+                    string_field(entry, "NexusModId", "nexusModId", "modId"),
+                    string_field(entry, "Source", "source") or "manifest",
                 )
             else:
                 continue
@@ -440,6 +482,206 @@ def parse_requirements(*values: Any) -> list[PackageRequirement]:
                 seen.add(key)
                 result.append(requirement)
     return result
+
+
+def merge_requirements(*groups: Iterable[PackageRequirement]) -> list[PackageRequirement]:
+    """Merge edges by package id, keeping the first (most authoritative) edge."""
+    result: list[PackageRequirement] = []
+    seen: set[str] = set()
+    for group in groups:
+        for requirement in group:
+            key = requirement.package_id.strip().lower()
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            result.append(requirement)
+    return result
+
+
+def nexus_page_identity(url: str) -> tuple[str, str] | None:
+    match = NEXUS_URL_RE.search(url or "")
+    if not match:
+        return None
+    return match.group("game").lower(), match.group("mod_id")
+
+
+def nexus_api_get(path: str, api_key: str, timeout: float = 15.0) -> dict[str, Any]:
+    """Read one Nexus API v3 document without persisting the user's key."""
+    if not api_key:
+        raise ValueError("a Nexus API key is required")
+    url = NEXUS_API_BASE.rstrip("/") + "/" + path.lstrip("/")
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": f"FUSE-Installer/{TOOL_VERSION}",
+            "apikey": api_key,
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = response.read(MAX_JSON_BYTES + 1)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"Nexus API returned HTTP {exc.code} for {path}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Nexus API request failed for {path}: {exc.reason}") from exc
+    if len(payload) > MAX_JSON_BYTES:
+        raise RuntimeError(f"Nexus API response exceeded {MAX_JSON_BYTES} bytes for {path}")
+    loaded = json.loads(payload.decode("utf-8"))
+    if not isinstance(loaded, dict):
+        raise RuntimeError(f"Nexus API returned a non-object document for {path}")
+    return loaded
+
+
+def response_data(payload: dict[str, Any]) -> dict[str, Any]:
+    data = payload.get("data", payload)
+    return data if isinstance(data, dict) else {}
+
+
+def select_nexus_file_version(
+    package: ZipPackage,
+    versions: Iterable[dict[str, Any]],
+) -> dict[str, Any] | None:
+    candidates = [item for item in versions if isinstance(item, dict)]
+    if package.version:
+        exact = [
+            item for item in candidates
+            if (
+                str(item.get("version", "")).strip().lower() == package.version.strip().lower()
+                or compare_versions(str(item.get("version", "")), package.version) == 0
+            )
+        ]
+        candidates = exact
+    if len(candidates) == 1:
+        return candidates[0]
+    primary = [item for item in candidates if item.get("is_primary") is True]
+    return primary[0] if len(primary) == 1 else None
+
+
+def requirements_from_nexus_ranges(
+    package: ZipPackage,
+    game_domain: str,
+    payload: dict[str, Any],
+) -> list[PackageRequirement]:
+    data = response_data(payload)
+    definitions = data.get("dependency_definitions", [])
+    result: list[PackageRequirement] = []
+    for definition in definitions if isinstance(definitions, list) else []:
+        ranges = definition.get("ranges", []) if isinstance(definition, dict) else []
+        ranges = [item for item in ranges if isinstance(item, dict)]
+        target_mods: dict[str, dict[str, Any]] = {}
+        for item in ranges:
+            target_file = item.get("target_mod_file", {})
+            target_mod = target_file.get("mod", {}) if isinstance(target_file, dict) else {}
+            game_scoped_id = str(target_mod.get("game_scoped_id", "")).strip()
+            if game_scoped_id:
+                target_mods.setdefault(game_scoped_id, target_mod)
+        if len(target_mods) != 1:
+            package.notes.append(
+                "Nexus lists a dependency with multiple alternative mods; FUSE preserved it in the install report "
+                "but did not turn an OR-choice into a false hard requirement."
+            )
+            continue
+
+        game_scoped_id, target_mod = next(iter(target_mods.items()))
+        not_before = ""
+        not_after = ""
+        if len(ranges) == 1:
+            minimum = ranges[0].get("min_version", {})
+            maximum = ranges[0].get("max_version", {})
+            if isinstance(minimum, dict):
+                not_before = str(minimum.get("version", "")).strip()
+            if isinstance(maximum, dict):
+                not_after = str(maximum.get("version", "")).strip()
+        result.append(PackageRequirement(
+            package_id=f"nexus:{game_domain}:{game_scoped_id}",
+            not_before=not_before,
+            not_after=not_after,
+            display_name=str(target_mod.get("name", "")).strip(),
+            nexus_mod_id=game_scoped_id,
+            source="nexus",
+        ))
+    return result
+
+
+def enrich_package_from_nexus(package: ZipPackage, api_key: str) -> bool:
+    """Fill a genuine manifest gap using Nexus' file-version dependency data.
+
+    A Nexus URL in the manifest is required. Filename-number guessing is
+    intentionally rejected because installing the wrong dependency is worse
+    than reporting that external metadata could not be linked.
+    """
+    if package.requirements:
+        return False
+    identity = nexus_page_identity(package.homepage)
+    if identity is None:
+        return False
+    game_domain, game_scoped_mod_id = identity
+    details = response_data(nexus_api_get(
+        f"games/{urllib.parse.quote(game_domain)}/mods/{urllib.parse.quote(game_scoped_mod_id)}",
+        api_key,
+    ))
+    internal_mod_id = str(details.get("id", "")).strip()
+    if not internal_mod_id:
+        raise RuntimeError("Nexus mod details did not include an internal mod id")
+
+    files_payload = response_data(nexus_api_get(
+        f"mods/{urllib.parse.quote(internal_mod_id)}/files",
+        api_key,
+    ))
+    mod_files = files_payload.get("mod_files", [])
+    matches: list[dict[str, Any]] = []
+    for mod_file in mod_files if isinstance(mod_files, list) else []:
+        file_id = str(mod_file.get("id", "")).strip() if isinstance(mod_file, dict) else ""
+        if not file_id:
+            continue
+        versions_payload = response_data(nexus_api_get(
+            f"mod-files/{urllib.parse.quote(file_id)}/versions",
+            api_key,
+        ))
+        selected = select_nexus_file_version(package, versions_payload.get("versions", []))
+        if selected is not None:
+            selected = dict(selected)
+            selected["_mod_file_id"] = file_id
+            matches.append(selected)
+
+    if len(matches) != 1:
+        package.notes.append(
+            "Nexus page was linked, but the installer could not uniquely match this archive's version to one Nexus file version; "
+            "external requirements were not guessed."
+        )
+        return False
+
+    selected = matches[0]
+    version_id = str(selected.get("id", "")).strip()
+    ranges = nexus_api_get(
+        f"mod-file-versions/{urllib.parse.quote(version_id)}/dependencies/ranges",
+        api_key,
+    )
+    nexus_requirements = requirements_from_nexus_ranges(package, game_domain, ranges)
+    package.requirements = merge_requirements(package.requirements, nexus_requirements)
+    package.nexus_source = {
+        "kind": "nexus",
+        "gameDomain": game_domain,
+        "gameScopedModId": game_scoped_mod_id,
+        "internalModId": internal_mod_id,
+        "modFileId": str(selected.get("_mod_file_id", "")),
+        "modFileVersionId": version_id,
+        "url": package.homepage,
+        "fetchedUtc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    }
+    return bool(nexus_requirements)
+
+
+def enrich_packages_from_nexus(packages: Iterable[ZipPackage], api_key: str) -> None:
+    for package in packages:
+        if package.errors or package.requirements or not nexus_page_identity(package.homepage):
+            continue
+        try:
+            if enrich_package_from_nexus(package, api_key):
+                package.notes.append("Dependency requirements were filled from the Nexus API and cached for offline FUSE diagnostics.")
+        except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+            package.notes.append(f"Nexus dependency lookup was unavailable: {exc}")
 
 
 def ensure_fuse_id(value: str) -> str:
@@ -504,6 +746,12 @@ def package_from_root(
             if errors:
                 kind = "invalid"
         install_name = safe_folder_name(package_id, safe_folder_name(source_folder))
+        umm_requirements = parse_requirements(
+            info_data.get("Requirements"),
+            info_data.get("requirements"),
+            parse_umm_versions=True,
+        )
+        fuse_requirements = parse_requirements(info_data.get("FuseRequires"))
         return ZipPackage(
             zip_path=zip_path,
             root=root,
@@ -516,11 +764,13 @@ def package_from_root(
             member_count=member_count,
             notes=notes,
             errors=errors,
-            requirements=parse_requirements(
-                info_data.get("Requirements"),
-                info_data.get("requirements"),
-                info_data.get("FuseRequires"),
+            requirements=merge_requirements(umm_requirements, fuse_requirements),
+            load_after=merge_requirements(
+                parse_requirements(info_data.get("LoadAfter")),
+                parse_requirements(info_data.get("FuseLoadAfter")),
             ),
+            load_before=parse_requirements(info_data.get("FuseLoadBefore")),
+            homepage=string_field(info_data, "Homepage", "homepage", "Website", "website"),
         )
 
     if definition_member is not None and (
@@ -554,6 +804,15 @@ def package_from_root(
                 definition_data.get("requires"),
                 definition_data.get("Requires"),
             ),
+            load_after=parse_requirements(
+                definition_data.get("loadAfter"),
+                definition_data.get("LoadAfter"),
+            ),
+            load_before=parse_requirements(
+                definition_data.get("loadBefore"),
+                definition_data.get("LoadBefore"),
+            ),
+            homepage=string_field(definition_data, "homepage", "Homepage", "url", "Url"),
         )
 
     return None
@@ -1006,11 +1265,36 @@ def read_installed_package_versions(mods_dir: Path) -> dict[str, str]:
                 except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
                     manifest = None
         package_id = string_field(manifest, "Id", "id")
+        version = string_field(manifest, "Version", "version")
         if package_id:
-            version = string_field(manifest, "Version", "version")
             for alias in package_id_aliases(package_id):
                 result.setdefault(alias, version)
-        result.setdefault(child.name.lower(), string_field(manifest, "Version", "version"))
+        homepage = string_field(manifest, "Homepage", "homepage", "Website", "website", "url")
+        identity = nexus_page_identity(homepage)
+        if identity is not None:
+            result.setdefault(f"nexus:{identity[0]}:{identity[1]}", version)
+        result.setdefault(child.name.lower(), version)
+
+    cache_path = mods_dir / DEPENDENCY_METADATA_DIR / DEPENDENCY_METADATA_FILE
+    try:
+        cached = json.loads(cache_path.read_text(encoding="utf-8")) if cache_path.is_file() else {}
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        cached = {}
+    for item in cached.get("packages", []) if isinstance(cached, dict) else []:
+        if not isinstance(item, dict):
+            continue
+        folder = str(item.get("folder", "")).strip()
+        if not folder or not (mods_dir / folder).is_dir():
+            continue
+        source = item.get("source", {})
+        source = source if isinstance(source, dict) else {}
+        game = str(source.get("gameDomain", "")).strip().lower()
+        mod_id = str(source.get("gameScopedModId", "")).strip()
+        if game and mod_id:
+            result.setdefault(
+                f"nexus:{game}:{mod_id}",
+                str(item.get("version", "")).strip(),
+            )
     return result
 
 
@@ -1041,7 +1325,7 @@ def validate_batch_dependencies(
     package_list = list(packages)
     by_id: dict[str, list[ZipPackage]] = {}
     for package in package_list:
-        for alias in package_id_aliases(package.package_id):
+        for alias in package_aliases(package):
             by_id.setdefault(alias, []).append(package)
     duplicate_groups: dict[str, list[ZipPackage]] = {}
     for package in package_list:
@@ -1071,7 +1355,7 @@ def validate_batch_dependencies(
     while changed:
         changed = False
         fuse_provider_available = installed_fuse_available or any(
-            "fuse" in package_id_aliases(candidate.package_id)
+            "fuse" in package_aliases(candidate)
             and not candidate.errors
             for candidate in package_list
         )
@@ -1080,6 +1364,7 @@ def validate_batch_dependencies(
                 continue
             for requirement in package.requirements:
                 required_id = requirement.package_id.lower()
+                required_label = requirement_display_label(requirement)
                 replacement_id = replacement_id_key(requirement.package_id)
                 if fuse_provider_available and replacement_id in FUSE_REPLACEMENT_IDS:
                     continue
@@ -1098,14 +1383,14 @@ def validate_batch_dependencies(
                     batch_provider_failed = required_id in by_id
                     if batch_provider_failed:
                         message = (
-                            f"Dependency '{requirement.package_id}'{bounds} required by "
+                            f"Dependency '{required_label}'{bounds} required by "
                             f"'{package.package_id}' is in this batch but failed preflight. "
                             "Fix or remove the failed dependency package, then retry the batch."
                         )
                     else:
                         message = (
-                            f"Missing dependency '{requirement.package_id}'{bounds} required by "
-                            f"'{package.package_id}'. {dependency_install_hint(requirement.package_id)}"
+                            f"Missing dependency '{required_label}'{bounds} required by "
+                            f"'{package.package_id}'. {dependency_install_hint(requirement)}"
                         )
                     package.errors.append(message)
                     changed = True
@@ -1115,7 +1400,7 @@ def validate_batch_dependencies(
                     continue
                 if any(version_numbers(version) is None for version in provider_versions):
                     note = (
-                        f"Dependency '{requirement.package_id}' is present but has no readable version; "
+                        f"Dependency '{required_label}' is present but has no readable version; "
                         f"the installer could not verify {requirement_bounds(requirement).strip()}."
                     )
                     if note not in package.notes:
@@ -1129,7 +1414,7 @@ def validate_batch_dependencies(
 
                 available_versions = ", ".join(sorted(set(provider_versions)))
                 package.errors.append(
-                    f"Dependency version conflict for '{requirement.package_id}': "
+                    f"Dependency version conflict for '{required_label}': "
                     f"'{package.package_id}' requires{requirement_bounds(requirement)}, "
                     f"but available version(s) are {available_versions}."
                 )
@@ -1149,11 +1434,22 @@ def requirement_version_matches(version: str, requirement: PackageRequirement) -
     return True
 
 
-def dependency_install_hint(package_id: str) -> str:
-    if replacement_id_key(package_id) in FUSE_REPLACEMENT_IDS:
+def requirement_display_label(requirement: PackageRequirement) -> str:
+    if requirement.display_name:
+        return f"{requirement.display_name} ({requirement.package_id})"
+    return requirement.package_id
+
+
+def dependency_install_hint(requirement: PackageRequirement) -> str:
+    if replacement_id_key(requirement.package_id) in FUSE_REPLACEMENT_IDS:
         return (
             "Install or update FUSE (or include FUSE in this batch); FUSE provides this "
             "legacy dependency contract, so do not reinstall the replaced legacy DLL."
+        )
+    if requirement.nexus_mod_id:
+        return (
+            "Install/enable the required Nexus mod: "
+            f"https://www.nexusmods.com/railroader/mods/{requirement.nexus_mod_id}"
         )
     return "Install/enable that package in Mods, or include it in this batch."
 
@@ -1441,6 +1737,80 @@ def print_result(result: InstallResult) -> None:
         print(f"  note: {result.message}")
 
 
+def requirement_cache_record(requirement: PackageRequirement) -> dict[str, Any]:
+    return {
+        "id": requirement.package_id,
+        "displayName": requirement.display_name or None,
+        "minimumVersion": requirement.not_before or None,
+        "maximumVersion": requirement.not_after or None,
+        "nexusModId": requirement.nexus_mod_id or None,
+        "source": requirement.source or "manifest",
+    }
+
+
+def write_dependency_metadata_cache(
+    mods_dir: Path,
+    results: Iterable[InstallResult],
+    dry_run: bool,
+) -> Path | None:
+    """Persist install-time provenance for the in-game offline dependency graph."""
+    if dry_run:
+        return None
+    path = mods_dir / DEPENDENCY_METADATA_DIR / DEPENDENCY_METADATA_FILE
+    try:
+        if path.is_file():
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        else:
+            existing = {}
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        existing = {}
+    packages_by_folder: dict[str, dict[str, Any]] = {}
+    if isinstance(existing, dict):
+        for item in existing.get("packages", []):
+            if isinstance(item, dict) and str(item.get("folder", "")).strip():
+                packages_by_folder[str(item["folder"]).strip().lower()] = item
+
+    for result in results:
+        if result.status == "failed" or result.package.package_id.lower() == ASSETLOADER_ID.lower():
+            continue
+        package = result.package
+        folder = result.destination.name
+        packages_by_folder[folder.lower()] = {
+            "folder": folder,
+            "id": package.package_id,
+            "displayName": package.display_name,
+            "version": package.version,
+            "kind": package.kind,
+            "manifest": package.manifest_member,
+            "sourceArchive": package.zip_path.name,
+            "source": package.nexus_source or {
+                "kind": "installer",
+                "url": package.homepage or None,
+            },
+            "requirements": [requirement_cache_record(item) for item in package.requirements],
+            "loadAfter": [requirement_cache_record(item) for item in package.load_after],
+            "loadBefore": [requirement_cache_record(item) for item in package.load_before],
+        }
+
+    document = {
+        "schemaVersion": 1,
+        "generatedUtc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "packages": sorted(
+            packages_by_folder.values(),
+            key=lambda item: str(item.get("folder", "")).lower(),
+        ),
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_suffix(path.suffix + ".tmp")
+        temporary.write_text(json.dumps(document, indent=2), encoding="utf-8")
+        os.replace(temporary, path)
+        return path
+    except OSError as exc:
+        print(f"WARNING: could not write dependency metadata cache: {exc}")
+        return None
+
+
 def write_install_report(
     game_dir: Path,
     mods_dir: Path,
@@ -1490,13 +1860,18 @@ def write_install_report(
                 "notes": list(item.package.notes),
                 "errors": list(item.package.errors),
                 "requirements": [
-                    {
-                        "id": requirement.package_id,
-                        "notBefore": requirement.not_before or None,
-                        "notAfter": requirement.not_after or None,
-                    }
+                    requirement_cache_record(requirement)
                     for requirement in item.package.requirements
                 ],
+                "loadAfter": [
+                    requirement_cache_record(requirement)
+                    for requirement in item.package.load_after
+                ],
+                "loadBefore": [
+                    requirement_cache_record(requirement)
+                    for requirement in item.package.load_before
+                ],
+                "externalSource": item.package.nexus_source or None,
             }
             for item in results
         ],
@@ -1540,6 +1915,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-fuse", action="store_true", help="Do not install the bundled FUSE framework on a manual run; only process zip files.")
     parser.add_argument("--dry-run", action="store_true", help="Inspect zips and print planned installs without writing files.")
     parser.add_argument("--archive-zips", action="store_true", help="Move successfully processed zips to Mods\\FUSEInstaller\\InstalledZips.")
+    parser.add_argument("--nexus-api-key", default=None, help="Nexus API key used only during this run to fill missing dependency metadata. Prefer the NEXUS_API_KEY environment variable so the key is not stored in shell history.")
+    parser.add_argument("--no-nexus", action="store_true", help="Do not query Nexus even when NEXUS_API_KEY and a manifest Homepage URL are available.")
     parser.add_argument("--pause", action="store_true", help="Pause before closing.")
     parser.add_argument("--no-pause", action="store_true", help="Do not pause before closing, even when bundled as an exe.")
     parser.add_argument("--cli", action="store_true", help="Use command-line mode instead of the graphical installer.")
@@ -1642,6 +2019,9 @@ def run(args: argparse.Namespace) -> int:
             continue
         scan_cache[target] = inspect_zip(target)
         scanned_packages.extend(scan_cache[target][0])
+    nexus_api_key = "" if args.no_nexus else (args.nexus_api_key or os.environ.get("NEXUS_API_KEY", "")).strip()
+    if nexus_api_key:
+        enrich_packages_from_nexus(scanned_packages, nexus_api_key)
     fuse_available_for_dependencies = find_installed_mod_by_id(mods_dir, "FUSE") is not None
     validate_batch_dependencies(
         scanned_packages,
@@ -1724,6 +2104,10 @@ def run(args: argparse.Namespace) -> int:
             archived_to = archive_zip(zip_path, mods_dir, args.dry_run)
             verb = "Would archive" if args.dry_run else "Archived"
             print(f"{verb}: {zip_path} -> {archived_to}")
+
+    dependency_cache_path = write_dependency_metadata_cache(mods_dir, all_results, args.dry_run)
+    if dependency_cache_path is not None:
+        print(f"Dependency metadata cache: {dependency_cache_path}")
 
     compatibility_actions: list[CompatibilityAction] = []
     fuse_available = (
@@ -1866,6 +2250,8 @@ def run_gui(args: argparse.Namespace) -> int:
         value=should_preselect_bundled_fuse(args, bundled_fuse_available))
     update_var = tk.BooleanVar(value=not args.skip_existing)
     archive_var = tk.BooleanVar(value=bool(args.archive_zips))
+    nexus_key_var = tk.StringVar(value=args.nexus_api_key or os.environ.get("NEXUS_API_KEY", ""))
+    nexus_lookup_var = tk.BooleanVar(value=not args.no_nexus)
     status_var = tk.StringVar(value="Ready. Select the Railroader folder and packages, then click Install.")
 
     outer = tk.Frame(root, padx=16, pady=14)
@@ -1933,6 +2319,15 @@ def run_gui(args: argparse.Namespace) -> int:
     fuse_check.pack(anchor="w")
     tk.Checkbutton(options, text="Back up and update existing mod folders", variable=update_var).pack(anchor="w")
     tk.Checkbutton(options, text="Archive successfully installed source zips", variable=archive_var).pack(anchor="w")
+    tk.Checkbutton(
+        options,
+        text="Use Nexus to fill dependency gaps when a mod includes its Nexus page URL",
+        variable=nexus_lookup_var,
+    ).pack(anchor="w")
+    nexus_row = tk.Frame(options)
+    nexus_row.pack(fill="x", pady=(2, 0))
+    tk.Label(nexus_row, text="Nexus API key (optional; never saved)", anchor="w").pack(side="left")
+    tk.Entry(nexus_row, textvariable=nexus_key_var, show="*").pack(side="left", fill="x", expand=True, padx=(8, 0))
 
     result_box = ScrolledText(outer, height=15, wrap="word", font=("Consolas", 9), state="disabled")
     result_box.pack(fill="both", expand=True, pady=(6, 8))
@@ -2029,6 +2424,8 @@ def run_gui(args: argparse.Namespace) -> int:
         run_args.skip_existing = not update_var.get()
         run_args.replace = update_var.get()
         run_args.archive_zips = archive_var.get()
+        run_args.nexus_api_key = nexus_key_var.get().strip() or None
+        run_args.no_nexus = not nexus_lookup_var.get()
         run_args.repair_legacy_loader = repair_legacy
         run_args.repair_asset_loader = repair_asset_loader
         run_args.no_pause = True

--- a/tools/tests/test_fuse_convert_dependencies.py
+++ b/tools/tests/test_fuse_convert_dependencies.py
@@ -11,22 +11,23 @@ def test_fuse_package_id_replaces_legacy_rail_suffix():
 
 
 def test_convert_mod_normalizes_legacy_rail_suffix_in_package_id(tmp_path):
-    source = tmp_path / "LegacyRoute"
-    source.mkdir()
-    (source / "Definition.json").write_text(
-        json.dumps({"id": "acme.route.RAIL", "name": "Acme Route"}),
-        encoding="utf-8",
-    )
-    (source / "tracks.json").write_text(
-        json.dumps({"tracks": {"nodes": {}}}),
-        encoding="utf-8",
-    )
-    output = tmp_path / "LegacyRoute.FUSE"
+    for index, suffix in enumerate(("RAIL", "rail", "RaIl")):
+        source = tmp_path / f"LegacyRoute-{index}"
+        source.mkdir()
+        (source / "Definition.json").write_text(
+            json.dumps({"id": f"acme.route.{suffix}", "name": "Acme Route"}),
+            encoding="utf-8",
+        )
+        (source / "tracks.json").write_text(
+            json.dumps({"tracks": {"nodes": {}}}),
+            encoding="utf-8",
+        )
+        output = tmp_path / f"LegacyRoute-{index}.FUSE"
 
-    fuse_convert.convert_mod(source, output)
+        fuse_convert.convert_mod(source, output)
 
-    info = json.loads((output / "Info.json").read_text(encoding="utf-8"))
-    assert info["Id"] == "acme.route.FUSE"
+        info = json.loads((output / "Info.json").read_text(encoding="utf-8"))
+        assert info["Id"] == "acme.route.FUSE"
 
 
 def test_conditional_mixinto_requirement_adds_advisory_load_after(tmp_path):
@@ -83,7 +84,7 @@ def test_conflicts_with_is_preserved_in_manifest_and_conditional_mixinto(tmp_pat
         json.dumps(
             {
                 "conflictsWith": [
-                    {"id": "Other.Route", "notBefore": "2.0", "notAfter": "3.0"},
+                    {"id": "acme.route.RAIL", "notBefore": "2.0", "notAfter": "3.0"},
                     "Zamu.StrangeCustoms",
                 ],
                 "mixintos": {
@@ -101,8 +102,8 @@ def test_conflicts_with_is_preserved_in_manifest_and_conditional_mixinto(tmp_pat
     metadata, _ = fuse_convert.mixinto_metadata(tmp_path)
 
     assert manifest_conflicts == [
-        {"Id": "Other.Route", "NotBefore": "2.0", "NotAfter": "3.0"},
-        {"Id": "Zamu.StrangeCustoms"},
+        {"Id": "acme.route.FUSE", "NotBefore": "2.0", "NotAfter": "3.0"},
+        {"Id": "Zamu.StrangeCustoms.FUSE"},
     ]
     assert metadata["optional.json"]["conflictsWith"] == [
         {"id": "Conditional.Other"}

--- a/tools/tests/test_fuse_convert_dependencies.py
+++ b/tools/tests/test_fuse_convert_dependencies.py
@@ -5,6 +5,11 @@ import json
 import fuse_convert
 
 
+def test_fuse_package_id_replaces_legacy_rail_suffix():
+    assert fuse_convert.fuse_package_id("SomeMod.RAIL") == "SomeMod.FUSE"
+    assert fuse_convert.fuse_package_id("somemod.rail") == "somemod.FUSE"
+
+
 def test_conditional_mixinto_requirement_adds_advisory_load_after(tmp_path):
     (tmp_path / "Definition.json").write_text(
         json.dumps(

--- a/tools/tests/test_fuse_convert_dependencies.py
+++ b/tools/tests/test_fuse_convert_dependencies.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+
+import fuse_convert
+
+
+def test_conditional_mixinto_requirement_adds_advisory_load_after(tmp_path):
+    (tmp_path / "Definition.json").write_text(
+        json.dumps(
+            {
+                "id": "Conditional.Mixinto",
+                "mixintos": {
+                    "game-graph": {
+                        "mixinto": "file(optional.json)",
+                        "requires": ["Optional.Base"],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    required, load_after = fuse_convert.legacy_dependencies(tmp_path)
+
+    assert required == []
+    assert load_after == ["Optional.Base.FUSE"]
+
+
+def test_nested_mixinto_arrays_preserve_order_and_deduplicate(tmp_path):
+    (tmp_path / "Definition.json").write_text(
+        json.dumps(
+            {
+                "mixintos": {
+                    "game-graph": [
+                        {
+                            "mixinto": "file(a.json)",
+                            "requires": ["Base.A", "Base.Shared"],
+                        },
+                        {
+                            "mixinto": "file(b.json)",
+                            "requires": ["base.shared", "Base.B"],
+                        },
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    required, load_after = fuse_convert.legacy_dependencies(tmp_path)
+
+    assert required == []
+    assert load_after == ["Base.A.FUSE", "Base.Shared.FUSE", "Base.B.FUSE"]
+
+
+def test_conflicts_with_is_preserved_in_manifest_and_conditional_mixinto(tmp_path):
+    (tmp_path / "Definition.json").write_text(
+        json.dumps(
+            {
+                "conflictsWith": [
+                    {"id": "Other.Route", "notBefore": "2.0", "notAfter": "3.0"},
+                    "Zamu.StrangeCustoms",
+                ],
+                "mixintos": {
+                    "game-graph": {
+                        "mixinto": "file(optional.json)",
+                        "conflictsWith": ["Conditional.Other"],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manifest_conflicts = fuse_convert.legacy_conflicts_with(tmp_path)
+    metadata, _ = fuse_convert.mixinto_metadata(tmp_path)
+
+    assert manifest_conflicts == [
+        {"Id": "Other.Route", "NotBefore": "2.0", "NotAfter": "3.0"},
+        {"Id": "Zamu.StrangeCustoms"},
+    ]
+    assert metadata["optional.json"]["conflictsWith"] == [
+        {"id": "Conditional.Other"}
+    ]

--- a/tools/tests/test_fuse_convert_dependencies.py
+++ b/tools/tests/test_fuse_convert_dependencies.py
@@ -10,6 +10,25 @@ def test_fuse_package_id_replaces_legacy_rail_suffix():
     assert fuse_convert.fuse_package_id("somemod.rail") == "somemod.FUSE"
 
 
+def test_convert_mod_normalizes_legacy_rail_suffix_in_package_id(tmp_path):
+    source = tmp_path / "LegacyRoute"
+    source.mkdir()
+    (source / "Definition.json").write_text(
+        json.dumps({"id": "acme.route.RAIL", "name": "Acme Route"}),
+        encoding="utf-8",
+    )
+    (source / "tracks.json").write_text(
+        json.dumps({"tracks": {"nodes": {}}}),
+        encoding="utf-8",
+    )
+    output = tmp_path / "LegacyRoute.FUSE"
+
+    fuse_convert.convert_mod(source, output)
+
+    info = json.loads((output / "Info.json").read_text(encoding="utf-8"))
+    assert info["Id"] == "acme.route.FUSE"
+
+
 def test_conditional_mixinto_requirement_adds_advisory_load_after(tmp_path):
     (tmp_path / "Definition.json").write_text(
         json.dumps(

--- a/tools/tests/test_fuse_converter_classification.py
+++ b/tools/tests/test_fuse_converter_classification.py
@@ -54,6 +54,24 @@ def test_map_tiles_and_code_are_not_reported_as_converted(tmp_path):
         report_file = out_root / "_conversion-reports" / report.output.name / "conversion-report.json"
         assert report_file.exists()
 
+    assert all(entry.concept != "script-binary" for entry in code_report.entries)
+
+
+def test_unknown_package_uses_the_common_unsupported_error(tmp_path):
+    source = tmp_path / "Unknown"
+    source.mkdir()
+    (source / "readme.txt").write_text("not convertible", encoding="utf-8")
+    out_root = tmp_path / "out"
+
+    report = fuse_converter.convert_input(source, out_root, "auto", clean_output=True)
+
+    assert report.status == "failed"
+    assert report.detected_kind == "unknown"
+    assert any(entry.level == "ERROR" and entry.concept == "unsupported-package" for entry in report.entries)
+    assert not report.output.exists()
+    report_file = out_root / "_conversion-reports" / "Unknown.FUSE" / "conversion-report.json"
+    assert report_file.exists()
+
 
 def test_mixed_code_and_route_json_converts_the_data_portion(tmp_path):
     source = tmp_path / "Mixed"

--- a/tools/tests/test_fuse_converter_classification.py
+++ b/tools/tests/test_fuse_converter_classification.py
@@ -104,3 +104,29 @@ def test_mixed_code_and_audio_json_is_detected_as_audio(tmp_path):
     )
 
     assert fuse_converter.detect_kind(source, "auto") == "audio"
+
+
+def test_nested_route_shaped_fuse_fragment_is_detected_as_native(tmp_path):
+    source = tmp_path / "Native"
+    nested = source / "Data"
+    nested.mkdir(parents=True)
+    (nested / "track.fuse.json").write_text(
+        json.dumps({"tracks": {"nodes": {}}}),
+        encoding="utf-8",
+    )
+
+    assert fuse_converter.detect_kind(source, "auto") == "native"
+    assert fuse_converter.detect_direct_kind(source, "auto") == "unknown"
+
+
+def test_direct_fuse_fragment_is_rejected_as_native_without_output(tmp_path):
+    source = tmp_path / "native.fuse.json"
+    source.write_text(json.dumps({"tracks": {"nodes": {}}}), encoding="utf-8")
+    out_root = tmp_path / "out"
+
+    report = fuse_converter.convert_input(source, out_root, "auto", clean_output=True)
+
+    assert report.status == "failed"
+    assert report.detected_kind == "native"
+    assert any(entry.concept == "unsupported-already-native" for entry in report.entries)
+    assert not report.output.exists()

--- a/tools/tests/test_fuse_converter_classification.py
+++ b/tools/tests/test_fuse_converter_classification.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+
+import fuse_converter
+
+
+def make_asset_pack(folder):
+    folder.mkdir()
+    (folder / "bundle").write_bytes(b"asset")
+    (folder / "Catalog.json").write_text("{}", encoding="utf-8")
+    (folder / "Definitions.json").write_text("{}", encoding="utf-8")
+
+
+def test_asset_only_package_is_reported_for_install_without_fake_output(tmp_path):
+    source = tmp_path / "Assets"
+    make_asset_pack(source)
+    out_root = tmp_path / "out"
+
+    report = fuse_converter.convert_input(source, out_root, "auto", clean_output=True)
+
+    assert report.status == "failed"
+    assert report.detected_kind == "asset"
+    assert not report.output.exists()
+    report_file = out_root / "_conversion-reports" / "Assets.FUSE" / "conversion-report.json"
+    assert report_file.exists()
+    data = json.loads(report_file.read_text(encoding="utf-8"))
+    assert "install this package" in data["entries"][0]["message"]
+
+
+def test_map_tiles_and_code_are_not_reported_as_converted(tmp_path):
+    tiles = tmp_path / "Tiles"
+    tiles.mkdir()
+    (tiles / "tile.data").write_bytes(b"tile")
+    code = tmp_path / "Code"
+    code.mkdir()
+    (code / "Code.dll").write_bytes(b"assembly")
+    schemas = code / "schemas"
+    schemas.mkdir()
+    (schemas / "example.json").write_text(
+        json.dumps({"tracks": {"nodes": {}}}),
+        encoding="utf-8",
+    )
+
+    assert fuse_converter.detect_kind(tiles, "auto") == "map_tile"
+    assert fuse_converter.detect_kind(code, "auto") == "code"
+
+
+def test_mixed_code_and_route_json_converts_the_data_portion(tmp_path):
+    source = tmp_path / "Mixed"
+    source.mkdir()
+    (source / "Plugin.dll").write_bytes(b"assembly")
+    (source / "tracks.json").write_text(
+        json.dumps({"tracks": {"nodes": {"N1": {"position": {"x": 0, "y": 0, "z": 0}}}}}),
+        encoding="utf-8",
+    )
+
+    assert fuse_converter.detect_kind(source, "auto") == "route"

--- a/tools/tests/test_fuse_converter_classification.py
+++ b/tools/tests/test_fuse_converter_classification.py
@@ -42,8 +42,17 @@ def test_map_tiles_and_code_are_not_reported_as_converted(tmp_path):
         encoding="utf-8",
     )
 
-    assert fuse_converter.detect_kind(tiles, "auto") == "map_tile"
-    assert fuse_converter.detect_kind(code, "auto") == "code"
+    out_root = tmp_path / "out"
+    tile_report = fuse_converter.convert_input(tiles, out_root, "auto", clean_output=True)
+    code_report = fuse_converter.convert_input(code, out_root, "auto", clean_output=True)
+
+    for report, expected_kind in ((tile_report, "map_tile"), (code_report, "code")):
+        assert report.status == "failed"
+        assert report.detected_kind == expected_kind
+        assert report.errors > 0
+        assert not report.output.exists()
+        report_file = out_root / "_conversion-reports" / report.output.name / "conversion-report.json"
+        assert report_file.exists()
 
 
 def test_mixed_code_and_route_json_converts_the_data_portion(tmp_path):
@@ -55,4 +64,25 @@ def test_mixed_code_and_route_json_converts_the_data_portion(tmp_path):
         encoding="utf-8",
     )
 
-    assert fuse_converter.detect_kind(source, "auto") == "route"
+    out_root = tmp_path / "out"
+    report = fuse_converter.convert_input(source, out_root, "auto", clean_output=True)
+
+    assert report.detected_kind == "route"
+    assert report.errors == 0
+    assert report.output.exists()
+    assert (report.output / "Info.json").exists()
+    fragment_path = next(report.output.glob("*.fuse.json"))
+    fragment = json.loads(fragment_path.read_text(encoding="utf-8"))
+    assert len(fragment["tracks"]["nodes"]) == 1
+
+
+def test_mixed_code_and_audio_json_is_detected_as_audio(tmp_path):
+    source = tmp_path / "MixedAudio"
+    source.mkdir()
+    (source / "Plugin.dll").write_bytes(b"assembly")
+    (source / "horns.json").write_text(
+        json.dumps([{"layers": ["a.wav"]}]),
+        encoding="utf-8",
+    )
+
+    assert fuse_converter.detect_kind(source, "auto") == "audio"

--- a/tools/tests/test_fuse_installer.py
+++ b/tools/tests/test_fuse_installer.py
@@ -39,6 +39,22 @@ def test_should_preselect_bundled_fuse_matches_launch_scope(
     assert fi.should_preselect_bundled_fuse(args, available) is expected
 
 
+@pytest.mark.parametrize(
+    ("screen", "expected"),
+    [
+        ((1920, 1080), (960, 760)),
+        ((956, 768), (908, 704)),
+        ((800, 600), (752, 536)),
+        ((40, 40), (1, 1)),
+    ],
+)
+def test_installer_window_size_stays_inside_screen_margin(
+    screen: tuple[int, int],
+    expected: tuple[int, int],
+) -> None:
+    assert fi.installer_window_size(*screen) == expected
+
+
 def make_zip(path: Path, files: dict[str, str | bytes]) -> Path:
     """Write a zip whose members are given as archive-name -> contents."""
     with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:

--- a/tools/tests/test_fuse_installer.py
+++ b/tools/tests/test_fuse_installer.py
@@ -7,6 +7,7 @@ FUSE while a drag-and-drop run installs only the dropped mods.
 
 from __future__ import annotations
 
+import argparse
 import json
 import zipfile
 from pathlib import Path
@@ -14,6 +15,28 @@ from pathlib import Path
 import pytest
 
 import fuse_installer as fi
+
+
+@pytest.mark.parametrize(
+    ("zips", "with_fuse", "no_fuse", "available", "expected"),
+    [
+        ([], False, False, True, True),
+        (["mod.zip"], False, False, True, False),
+        (["mod.zip"], True, False, True, True),
+        ([], False, True, True, False),
+        ([], False, False, False, False),
+    ],
+)
+def test_should_preselect_bundled_fuse_matches_launch_scope(
+    zips: list[str],
+    with_fuse: bool,
+    no_fuse: bool,
+    available: bool,
+    expected: bool,
+) -> None:
+    args = argparse.Namespace(zips=zips, with_fuse=with_fuse, no_fuse=no_fuse)
+
+    assert fi.should_preselect_bundled_fuse(args, available) is expected
 
 
 def make_zip(path: Path, files: dict[str, str | bytes]) -> Path:
@@ -92,6 +115,20 @@ def test_ensure_fuse_id_appends_suffix():
     assert fi.ensure_fuse_id("") == "LegacyDataPackage.FUSE"
 
 
+def test_parse_steam_library_paths_supports_current_vdf_format():
+    text = r'''
+    "libraryfolders"
+    {
+        "0" { "path" "C:\\Program Files (x86)\\Steam" }
+        "1" { "path" "E:\\Games\\SteamLibrary" }
+    }
+    '''
+    assert fi.parse_steam_library_paths(text) == [
+        Path(r"C:\Program Files (x86)\Steam"),
+        Path(r"E:\Games\SteamLibrary"),
+    ]
+
+
 # --------------------------------------------------------------------------- #
 # Root detection
 # --------------------------------------------------------------------------- #
@@ -155,8 +192,29 @@ def test_inspect_legacy_data_package(tmp_path):
     packages, _ = fi.inspect_zip(zip_path)
     assert len(packages) == 1
     pkg = packages[0]
-    assert pkg.kind == "legacy-data"
-    assert pkg.package_id == "OldPack.FUSE"
+    assert pkg.kind == "railloader"
+    assert pkg.package_id == "OldPack"
+
+
+def test_inspect_code_only_railloader_package(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {
+            "SignalsEverywhere/Definition.json": info(
+                manifestVersion=5,
+                id="Joo.SignalsEverywhere",
+                name="Signals Everywhere",
+                assemblies=["SignalsEverywhere"],
+            ),
+            "SignalsEverywhere/SignalsEverywhere.dll": b"binary",
+        },
+    )
+    packages, warnings = fi.inspect_zip(zip_path)
+    assert warnings == []
+    assert len(packages) == 1
+    assert packages[0].kind == "railloader"
+    assert packages[0].package_id == "Joo.SignalsEverywhere"
+    assert packages[0].install_name == "Joo.SignalsEverywhere"
 
 
 def test_inspect_unsupported_zip_warns(tmp_path):
@@ -164,6 +222,292 @@ def test_inspect_unsupported_zip_warns(tmp_path):
     packages, warnings = fi.inspect_zip(zip_path)
     assert packages == []
     assert warnings
+
+
+def test_inspect_malformed_manifest_reports_exact_member_and_location(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {
+            "Broken/Info.json": '{ "Id": "Broken", ',
+            "Broken/track.fuse.json": "{}",
+        },
+    )
+    packages, warnings = fi.inspect_zip(zip_path)
+    assert warnings == []
+    package = packages[0]
+    assert package.kind == "invalid"
+    assert package.errors
+    assert "Broken/Info.json" in package.errors[0]
+    assert "line 1" in package.errors[0]
+
+
+def test_inspect_rejects_unsafe_archive_member_even_with_valid_package(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "unsafe.zip",
+        {
+            "Good/Info.json": info(Id="Good"),
+            "../outside.dll": b"unsafe",
+        },
+    )
+
+    packages, warnings = fi.inspect_zip(zip_path)
+
+    assert warnings == []
+    assert packages[0].kind == "invalid"
+    assert "unsafe member path" in packages[0].errors[0]
+    assert "../outside.dll" in packages[0].errors[0]
+
+
+def test_inspect_rejects_case_colliding_archive_members(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "duplicate-members.zip",
+        {
+            "Good/Info.json": info(Id="Good"),
+            "Good/Data.json": "{}",
+            "Good/data.json": "{}",
+        },
+    )
+
+    packages, _ = fi.inspect_zip(zip_path)
+
+    assert packages[0].kind == "invalid"
+    assert "case-colliding" in packages[0].errors[0]
+
+
+def test_inspect_rejects_nested_manifest_layout_as_ambiguous(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "ambiguous.zip",
+        {
+            "Info.json": info(Id="Outer"),
+            "Nested/Info.json": info(Id="Inner"),
+        },
+    )
+
+    packages, _ = fi.inspect_zip(zip_path)
+
+    assert len(packages) == 1
+    assert packages[0].kind == "invalid"
+    assert "layout is ambiguous" in packages[0].errors[0]
+    assert "Nested" in packages[0].errors[0]
+
+
+def test_inspect_native_package_reports_missing_declared_file(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {"Broken/Info.json": info(Id="Broken", FuseDataFiles=["missing.fuse.json"])},
+    )
+    packages, _ = fi.inspect_zip(zip_path)
+    assert packages[0].kind == "invalid"
+    assert "missing.fuse.json" in packages[0].errors[0]
+
+
+def test_inspect_native_package_reports_malformed_data_file(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "z.zip",
+        {
+            "Broken/Info.json": info(Id="Broken", FuseDataFiles=["data/track.fuse.json"]),
+            "Broken/data/track.fuse.json": '{ "tracks": }',
+        },
+    )
+    packages, _ = fi.inspect_zip(zip_path)
+    assert packages[0].kind == "invalid"
+    assert "Broken/data/track.fuse.json" in packages[0].errors[0]
+
+
+# --------------------------------------------------------------------------- #
+# Dependency and duplicate preflight
+# --------------------------------------------------------------------------- #
+
+def package(
+    tmp_path: Path,
+    package_id: str,
+    *,
+    version: str = "",
+    requirements: list[fi.PackageRequirement] | None = None,
+    zip_name: str | None = None,
+) -> fi.ZipPackage:
+    return fi.ZipPackage(
+        zip_path=tmp_path / (zip_name or f"{package_id}.zip"),
+        root=(package_id,),
+        kind="umm",
+        package_id=package_id,
+        display_name=package_id,
+        version=version,
+        install_name=package_id,
+        manifest_member=f"{package_id}/Info.json",
+        member_count=1,
+        requirements=requirements or [],
+    )
+
+
+def test_inspect_parses_umm_and_railloader_requirement_bounds(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "requirements.zip",
+        {
+            "Mods/Native/Info.json": info(
+                Id="Native",
+                Requirements=[{"Id": "FUSE", "NotBefore": "1.2.0"}],
+                FuseRequires=["Shared.Data"],
+            ),
+            "Mods/Legacy/Definition.json": info(
+                manifestVersion=7,
+                id="Legacy",
+                requires=[{"id": "Legacy.Base", "notAfter": "2.0.0"}],
+            ),
+        },
+    )
+
+    packages, warnings = fi.inspect_zip(zip_path)
+
+    assert warnings == []
+    by_id = {item.package_id: item for item in packages}
+    assert by_id["Native"].requirements == [
+        fi.PackageRequirement("FUSE", not_before="1.2.0"),
+        fi.PackageRequirement("Shared.Data"),
+    ]
+    assert by_id["Legacy"].requirements == [
+        fi.PackageRequirement("Legacy.Base", not_after="2.0.0")
+    ]
+
+
+def test_dependency_preflight_reports_missing_id_bounds_and_requester(tmp_path):
+    dependent = package(
+        tmp_path,
+        "Dependent",
+        requirements=[fi.PackageRequirement("Missing.Base", not_before="2.4")],
+    )
+
+    fi.validate_batch_dependencies([dependent], tmp_path / "Mods", fuse_available=False)
+
+    assert len(dependent.errors) == 1
+    assert "Missing.Base" in dependent.errors[0]
+    assert "not before 2.4" in dependent.errors[0]
+    assert "Dependent" in dependent.errors[0]
+
+
+def test_dependency_preflight_accepts_forward_reference_in_same_batch(tmp_path):
+    dependent = package(
+        tmp_path,
+        "Dependent",
+        requirements=[fi.PackageRequirement("Base", not_before="1.5")],
+    )
+    base = package(tmp_path, "Base.FUSE", version="2.0", zip_name="later.zip")
+
+    fi.validate_batch_dependencies([dependent, base], tmp_path / "Mods", fuse_available=False)
+
+    assert dependent.errors == []
+    assert base.errors == []
+
+
+def test_dependency_preflight_uses_installed_package_version(tmp_path):
+    mods = tmp_path / "Mods"
+    installed = mods / "Base"
+    installed.mkdir(parents=True)
+    (installed / "Info.json").write_text(
+        info(Id="Base", Version="2.3.0"),
+        encoding="utf-8",
+    )
+    dependent = package(
+        tmp_path,
+        "Dependent",
+        requirements=[fi.PackageRequirement("Base", not_before="2.0", not_after="3.0")],
+    )
+
+    fi.validate_batch_dependencies([dependent], mods, fuse_available=False)
+
+    assert dependent.errors == []
+
+
+@pytest.mark.parametrize(
+    ("available", "requirement"),
+    [
+        ("1.9", fi.PackageRequirement("Base", not_before="2.0")),
+        ("3.1", fi.PackageRequirement("Base", not_after="3.0")),
+    ],
+)
+def test_dependency_preflight_rejects_incompatible_versions(tmp_path, available, requirement):
+    base = package(tmp_path, "Base", version=available)
+    dependent = package(tmp_path, "Dependent", requirements=[requirement])
+
+    fi.validate_batch_dependencies([base, dependent], tmp_path / "Mods", fuse_available=False)
+
+    assert len(dependent.errors) == 1
+    assert "Dependency version conflict" in dependent.errors[0]
+    assert available in dependent.errors[0]
+
+
+def test_dependency_preflight_uses_only_explicit_fuse_replacements(tmp_path):
+    replaced = package(
+        tmp_path,
+        "ReplacedDependent",
+        requirements=[fi.PackageRequirement("Zamu.StrangeCustoms.FUSE", not_before="99.0")],
+    )
+    still_required = package(
+        tmp_path,
+        "HostedDependent",
+        requirements=[fi.PackageRequirement("Zamu.SomeKindOfMadness")],
+    )
+
+    fi.validate_batch_dependencies(
+        [replaced, still_required],
+        tmp_path / "Mods",
+        fuse_available=True,
+    )
+
+    assert replaced.errors == []
+    assert len(still_required.errors) == 1
+    assert "Zamu.SomeKindOfMadness" in still_required.errors[0]
+
+
+def test_dependency_preflight_rejects_duplicate_package_ids(tmp_path):
+    first = package(tmp_path, "Same.Id", zip_name="first.zip")
+    second = package(tmp_path, "Same.Id.FUSE", zip_name="second.zip")
+
+    fi.validate_batch_dependencies([first, second], tmp_path / "Mods", fuse_available=False)
+
+    assert "first.zip" in first.errors[0]
+    assert "second.zip" in first.errors[0]
+    assert len(second.errors) == 1
+
+
+def test_dependency_preflight_propagates_failed_batch_dependency(tmp_path):
+    top = package(
+        tmp_path,
+        "Top",
+        requirements=[fi.PackageRequirement("Middle")],
+    )
+    middle = package(
+        tmp_path,
+        "Middle",
+        requirements=[fi.PackageRequirement("Missing.Bottom")],
+    )
+
+    fi.validate_batch_dependencies([top, middle], tmp_path / "Mods", fuse_available=False)
+
+    assert "Missing.Bottom" in middle.errors[0]
+    assert "failed preflight" in top.errors[0]
+
+
+def test_failed_fuse_package_cannot_supply_replacement_dependency(tmp_path):
+    dependent = package(
+        tmp_path,
+        "Dependent",
+        requirements=[fi.PackageRequirement("Zamu.StrangeCustoms")],
+    )
+    broken_fuse = package(
+        tmp_path,
+        "FUSE",
+        requirements=[fi.PackageRequirement("Missing.Framework.Dependency")],
+    )
+
+    fi.validate_batch_dependencies(
+        [dependent, broken_fuse],
+        tmp_path / "Mods",
+        fuse_available=False,
+    )
+
+    assert "Missing.Framework.Dependency" in broken_fuse.errors[0]
+    assert "Install or update FUSE" in dependent.errors[0]
 
 
 # --------------------------------------------------------------------------- #
@@ -207,11 +551,137 @@ def test_replace_backs_up_then_installs(tmp_path):
         {"MyMod/Info.json": info(Id="MyMod"), "MyMod/new.txt": "new content"},
     )
     result = install_one(zip_path, mods, replace=True)
-    assert result.status == "installed"
     assert (dest / "new.txt").read_text() == "new content"
     assert not (dest / "old.txt").exists()  # replaced, not merged
     assert result.backup is not None
     assert (result.backup / "old.txt").read_text() == "old content"
+    assert result.status == "updated"
+
+
+def test_game_preflight_and_legacy_loader_detection(tmp_path):
+    game = tmp_path / "Railroader"
+    managed = game / "Railroader_Data" / "Managed"
+    umm = managed / "UnityModManager"
+    umm.mkdir(parents=True)
+    (game / "Railroader.exe").write_bytes(b"exe")
+    (umm / "UnityModManager.dll").write_bytes(b"umm")
+    conflicts = [managed / name for name in fi.LEGACY_MANAGED_FILES]
+    for conflict in conflicts:
+        conflict.write_bytes(b"old")
+
+    assert fi.validate_game_dir(game) == []
+    assert fi.unity_mod_manager_installed(game)
+    assert fi.find_legacy_managed_files(game) == conflicts
+
+    moved = fi.backup_legacy_managed_files(conflicts, game / "Mods", dry_run=False)
+    assert len(moved) == len(conflicts)
+    assert all(not conflict.exists() for conflict in conflicts)
+    assert all(destination.read_bytes() == b"old" for _, destination in moved)
+
+
+def test_assetloader_runtime_detection_backup_and_dependency_alias(tmp_path):
+    mods = tmp_path / "Mods"
+    old = mods / "AssetLoader"
+    old.mkdir(parents=True)
+    (old / "Info.json").write_text(info(Id="AssetLoader"), encoding="utf-8")
+    (old / "AssetLoader.dll").write_bytes(b"old-runtime")
+    old_zip = mods / "AssetLoader.zip"
+    old_zip.write_bytes(b"old-archive")
+
+    assert set(fi.find_legacy_assetloader_paths(mods)) == {old, old_zip}
+
+    moved = fi.backup_legacy_assetloader_paths(
+        fi.find_legacy_assetloader_paths(mods),
+        mods,
+        dry_run=False,
+    )
+    assert len(moved) == 2
+    assert not old.exists()
+    assert not old_zip.exists()
+
+    alias = fi.install_assetloader_compatibility_alias(mods, dry_run=False)
+    manifest = json.loads((alias / "Info.json").read_text(encoding="utf-8"))
+    assert manifest["Id"] == "AssetLoader"
+    assert manifest["Requirements"] == ["FUSE"]
+    assert manifest["FuseProvidedCompatibility"] == fi.ASSETLOADER_COMPATIBILITY_MARKER
+    assert not (alias / "AssetLoader.dll").exists()
+    assert fi.find_legacy_assetloader_paths(mods) == []
+    assert fi.find_fuse_assetloader_compatibility(mods) == alias
+
+
+def test_legacy_umm_startup_dependency_repair_backs_up_and_orders_after_fuse(tmp_path):
+    mods = tmp_path / "Mods"
+    alina = mods / "AlinasUtils"
+    alina.mkdir(parents=True)
+    original = {
+        "Id": "AlinaNova21.AlinasUtils",
+        "AssemblyName": "AlinasUtils.dll",
+        "EntryMethod": "AlinasUtils.UMM.Mod.Load",
+    }
+    (alina / "Info.json").write_text(json.dumps(original), encoding="utf-8")
+    (alina / "AlinasUtils.dll").write_bytes(
+        b"CLR metadata before Railloader.Interchange after"
+    )
+
+    actions = fi.repair_legacy_umm_startup_dependencies(mods, dry_run=False)
+
+    assert len(actions) == 1
+    assert actions[0].component == "AlinaNova21.AlinasUtils"
+    assert actions[0].status == "updated"
+    repaired = json.loads((alina / "Info.json").read_text(encoding="utf-8"))
+    assert repaired["Requirements"] == ["FUSE"]
+    assert repaired["LoadAfter"] == ["FUSE"]
+    assert actions[0].destination is not None
+    backup = json.loads(actions[0].destination.read_text(encoding="utf-8"))
+    assert backup == original
+
+
+def test_legacy_umm_startup_dependency_repair_preserves_existing_dependency_shapes(tmp_path):
+    mods = tmp_path / "Mods"
+    plugin = mods / "SignalsEverywhere"
+    plugin.mkdir(parents=True)
+    manifest = {
+        "Id": "Joo.SignalsEverywhere",
+        "AssemblyName": "SignalsEverywhere.dll",
+        "Requirements": [{"Id": "SomeLibrary"}],
+        "LoadAfter": "OtherMod",
+    }
+    (plugin / "info.json").write_text(json.dumps(manifest), encoding="utf-8")
+    (plugin / "SignalsEverywhere.dll").write_bytes(b"xxStrangeCustomsxx")
+
+    actions = fi.repair_legacy_umm_startup_dependencies(mods, dry_run=False)
+
+    assert len(actions) == 1
+    repaired = json.loads((plugin / "info.json").read_text(encoding="utf-8"))
+    assert repaired["Requirements"] == [{"Id": "SomeLibrary"}, "FUSE"]
+    assert repaired["LoadAfter"] == ["OtherMod", "FUSE"]
+
+
+def test_legacy_umm_startup_dependency_repair_skips_unrelated_and_already_ordered_mods(tmp_path):
+    mods = tmp_path / "Mods"
+    unrelated = mods / "Unrelated"
+    unrelated.mkdir(parents=True)
+    (unrelated / "Info.json").write_text(
+        info(Id="Unrelated", AssemblyName="Unrelated.dll"), encoding="utf-8"
+    )
+    (unrelated / "Unrelated.dll").write_bytes(b"ordinary code")
+
+    ready = mods / "Ready"
+    ready.mkdir(parents=True)
+    (ready / "Info.json").write_text(
+        info(
+            Id="Ready",
+            AssemblyName="Ready.dll",
+            Requirements=[{"Id": "FUSE"}],
+            LoadAfter=["FUSE"],
+        ),
+        encoding="utf-8",
+    )
+    (ready / "Ready.dll").write_bytes(b"Railloader.Interchange")
+
+    assert fi.find_legacy_umm_startup_dependency_manifests(mods) == []
+    assert fi.repair_legacy_umm_startup_dependencies(mods, dry_run=False) == []
+    assert not (mods / "ModBackups").exists()
 
 
 def test_install_name_colliding_with_staging_dir(tmp_path):
@@ -234,6 +704,64 @@ def test_dry_run_writes_nothing(tmp_path):
     result = install_one(zip_path, mods, dry_run=True)
     assert result.status == "installed"
     assert not mods.exists()
+
+
+def test_install_report_records_each_package_result(tmp_path):
+    game = tmp_path / "game"
+    mods = game / "Mods"
+    package = fi.ZipPackage(
+        zip_path=tmp_path / "one.zip",
+        root=("One",),
+        kind="umm",
+        package_id="One",
+        display_name="One Mod",
+        version="1.0",
+        install_name="One",
+        manifest_member="One/Info.json",
+        member_count=2,
+    )
+    result = fi.InstallResult(package, "installed", mods / "One")
+
+    path = fi.write_install_report(game, mods, [package.zip_path], [result], 0, dry_run=False)
+
+    assert path is not None and path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["summary"] == {"installed": 1, "updated": 0, "skipped": 0, "failed": 0}
+    assert data["packages"][0]["id"] == "One"
+    assert data["packages"][0]["status"] == "installed"
+    assert data["compatibilityActions"] == []
+
+
+def test_install_report_records_compatibility_failure(tmp_path):
+    game = tmp_path / "game"
+    mods = game / "Mods"
+    action = fi.CompatibilityAction(
+        component="AssetLoader",
+        status="failed",
+        message="Old runtime remains installed.",
+        source=mods / "AssetLoader",
+    )
+
+    path = fi.write_install_report(
+        game,
+        mods,
+        [],
+        [],
+        0,
+        dry_run=False,
+        compatibility_actions=[action],
+    )
+
+    assert path is not None and path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["summary"]["failed"] == 1
+    assert data["compatibilityActions"] == [{
+        "component": "AssetLoader",
+        "status": "failed",
+        "message": "Old runtime remains installed.",
+        "source": str(mods / "AssetLoader"),
+        "destination": None,
+    }]
 
 
 # --------------------------------------------------------------------------- #
@@ -319,24 +847,91 @@ def make_fuse_payload(tmp_path: Path) -> Path:
     )
 
 
+def make_game_dir(path: Path) -> Path:
+    managed = path / "Railroader_Data" / "Managed" / "UnityModManager"
+    managed.mkdir(parents=True)
+    (path / "Railroader.exe").write_bytes(b"exe")
+    (managed / "UnityModManager.dll").write_bytes(b"umm")
+    return path
+
+
 def run_installer(argv):
     args = fi.build_parser().parse_args(argv)
     return fi.run(args)
 
 
 def test_run_no_args_installs_bundled_fuse(tmp_path, monkeypatch):
-    game = tmp_path / "game"
-    game.mkdir()
+    game = make_game_dir(tmp_path / "game")
     monkeypatch.setenv("FUSE_INSTALLER_BUNDLED_ZIP", str(make_fuse_payload(tmp_path)))
 
     rc = run_installer(["--no-pause", "--game-dir", str(game)])
     assert rc == 0
     assert (game / "Mods" / "FUSE" / "FUSE.dll").exists()
+    alias = game / "Mods" / "AssetLoader" / "Info.json"
+    assert alias.exists()
+    assert json.loads(alias.read_text(encoding="utf-8"))["Requirements"] == ["FUSE"]
+
+
+def test_run_migrates_old_assetloader_when_fuse_is_installed(tmp_path, monkeypatch):
+    game = make_game_dir(tmp_path / "game")
+    old = game / "Mods" / "AssetLoader"
+    old.mkdir(parents=True)
+    (old / "Info.json").write_text(info(Id="AssetLoader"), encoding="utf-8")
+    (old / "AssetLoader.dll").write_bytes(b"old-runtime")
+    monkeypatch.setenv("FUSE_INSTALLER_BUNDLED_ZIP", str(make_fuse_payload(tmp_path)))
+
+    rc = run_installer([
+        "--no-pause",
+        "--repair-asset-loader",
+        "--game-dir",
+        str(game),
+    ])
+
+    assert rc == 0
+    assert (game / "Mods" / "FUSE" / "FUSE.dll").exists()
+    assert (game / "Mods" / "AssetLoader" / "Info.json").exists()
+    assert not (game / "Mods" / "AssetLoader" / "AssetLoader.dll").exists()
+    backups = list((game / "Mods" / "ModBackups" / "FUSEInstaller").rglob("AssetLoader.dll"))
+    assert len(backups) == 1
+    reports = list((game / "Mods" / "FUSEInstaller" / "Reports").glob("install-*.json"))
+    assert len(reports) == 1
+    report = json.loads(reports[0].read_text(encoding="utf-8"))
+    statuses = [item["status"] for item in report["compatibilityActions"]]
+    assert statuses == ["backed-up", "installed"]
+    assert report["summary"]["failed"] == 0
+
+
+def test_run_rejects_old_assetloader_package_when_fuse_is_unavailable(tmp_path, monkeypatch):
+    game = make_game_dir(tmp_path / "game")
+    monkeypatch.delenv("FUSE_INSTALLER_BUNDLED_ZIP", raising=False)
+    old_assetloader = make_zip(
+        tmp_path / "AssetLoader.zip",
+        {
+            "AssetLoader/Info.json": info(Id="AssetLoader"),
+            "AssetLoader/AssetLoader.dll": b"old-runtime",
+        },
+    )
+
+    rc = run_installer([
+        str(old_assetloader),
+        "--no-pause",
+        "--archive-zips",
+        "--game-dir",
+        str(game),
+    ])
+
+    assert rc == 1
+    assert old_assetloader.exists()
+    assert not (game / "Mods" / "AssetLoader").exists()
+    reports = list((game / "Mods" / "FUSEInstaller" / "Reports").glob("install-*.json"))
+    assert len(reports) == 1
+    report = json.loads(reports[0].read_text(encoding="utf-8"))
+    assert report["packages"][0]["status"] == "failed"
+    assert "FUSE is not installed" in report["packages"][0]["message"]
 
 
 def test_run_drag_zip_installs_only_that_mod(tmp_path, monkeypatch):
-    game = tmp_path / "game"
-    game.mkdir()
+    game = make_game_dir(tmp_path / "game")
     monkeypatch.setenv("FUSE_INSTALLER_BUNDLED_ZIP", str(make_fuse_payload(tmp_path)))
     mod = make_zip(tmp_path / "MyMod.zip", {"MyMod/Info.json": info(Id="MyMod")})
 
@@ -346,9 +941,28 @@ def test_run_drag_zip_installs_only_that_mod(tmp_path, monkeypatch):
     assert not (game / "Mods" / "FUSE").exists()  # drag-drop never force-installs FUSE
 
 
+def test_run_multi_package_zip_isolates_bad_json_and_installs_good_package(tmp_path, monkeypatch):
+    game = make_game_dir(tmp_path / "game")
+    monkeypatch.delenv("FUSE_INSTALLER_BUNDLED_ZIP", raising=False)
+    bundle = make_zip(
+        tmp_path / "Mods.zip",
+        {
+            "Mods/Good/Info.json": info(Id="Good"),
+            "Mods/Good/Good.dll": b"good",
+            "Mods/Bad/Info.json": '{ "Id": "Bad", ',
+            "Mods/Bad/bad.fuse.json": "{}",
+        },
+    )
+
+    rc = run_installer([str(bundle), "--no-pause", "--game-dir", str(game)])
+
+    assert rc == 1
+    assert (game / "Mods" / "Good" / "Good.dll").exists()
+    assert not (game / "Mods" / "Bad").exists()
+
+
 def test_run_no_fuse_flag_skips_bundled_fuse(tmp_path, monkeypatch):
-    game = tmp_path / "game"
-    game.mkdir()
+    game = make_game_dir(tmp_path / "game")
     monkeypatch.setenv("FUSE_INSTALLER_BUNDLED_ZIP", str(make_fuse_payload(tmp_path)))
 
     rc = run_installer(["--no-fuse", "--no-pause", "--game-dir", str(game)])

--- a/tools/tests/test_fuse_installer.py
+++ b/tools/tests/test_fuse_installer.py
@@ -370,6 +370,106 @@ def test_inspect_parses_umm_and_railloader_requirement_bounds(tmp_path):
     ]
 
 
+def test_inspect_parses_umm_version_suffix_without_changing_package_id(tmp_path):
+    zip_path = make_zip(
+        tmp_path / "gp38.zip",
+        {
+            "GP38/Info.json": info(
+                Id="GP38ATSF",
+                Requirements=["GP38SoundMod-4.4.1"],
+            ),
+        },
+    )
+
+    packages, warnings = fi.inspect_zip(zip_path)
+
+    assert warnings == []
+    assert packages[0].requirements == [
+        fi.PackageRequirement("GP38SoundMod", not_before="4.4.1")
+    ]
+
+
+def test_nexus_dependency_enrichment_requires_manifest_url_and_unique_version(tmp_path, monkeypatch):
+    package = fi.ZipPackage(
+        zip_path=tmp_path / "water-car.zip",
+        root=("WaterCar",),
+        kind="umm",
+        package_id="WaterCar",
+        display_name="Water Car",
+        version="1.0",
+        install_name="WaterCar",
+        manifest_member="WaterCar/Info.json",
+        member_count=1,
+        homepage="https://www.nexusmods.com/games/railroader/mods/503",
+    )
+
+    def fake_get(path, api_key, timeout=15.0):
+        assert api_key == "secret"
+        if path == "games/railroader/mods/503":
+            return {"data": {"id": "internal-source"}}
+        if path == "mods/internal-source/files":
+            return {"data": {"mod_files": [{"id": "file-a"}]}}
+        if path == "mod-files/file-a/versions":
+            return {"data": {"versions": [{"id": "version-a", "version": "1.0.0", "is_primary": True}]}}
+        if path == "mod-file-versions/version-a/dependencies/ranges":
+            return {
+                "dependency_definitions": [{
+                    "ranges": [{
+                        "target_mod_file": {"mod": {"game_scoped_id": "712", "name": "Shared Scripts"}},
+                        "min_version": {"version": "2.2.0"},
+                        "max_version": None,
+                    }],
+                }],
+                "dlc_dependency_definitions": [],
+            }
+        raise AssertionError(path)
+
+    monkeypatch.setattr(fi, "nexus_api_get", fake_get)
+
+    assert fi.enrich_package_from_nexus(package, "secret") is True
+    assert package.requirements == [fi.PackageRequirement(
+        "nexus:railroader:712",
+        not_before="2.2.0",
+        display_name="Shared Scripts",
+        nexus_mod_id="712",
+        source="nexus",
+    )]
+    assert package.nexus_source["gameScopedModId"] == "503"
+    assert package.nexus_source["modFileVersionId"] == "version-a"
+
+
+def test_dependency_metadata_cache_is_offline_and_preserves_other_packages(tmp_path):
+    mods = tmp_path / "Mods"
+    existing_dir = mods / fi.DEPENDENCY_METADATA_DIR
+    existing_dir.mkdir(parents=True)
+    cache = existing_dir / fi.DEPENDENCY_METADATA_FILE
+    cache.write_text(json.dumps({
+        "schemaVersion": 1,
+        "packages": [{"folder": "Existing", "id": "Existing"}],
+    }), encoding="utf-8")
+    package = fi.ZipPackage(
+        zip_path=tmp_path / "car.zip",
+        root=("Car",),
+        kind="umm",
+        package_id="Car",
+        display_name="Rail Car",
+        version="1.0.0",
+        install_name="Car",
+        manifest_member="Car/Info.json",
+        member_count=1,
+        requirements=[fi.PackageRequirement("Scripts", not_before="2.0.0")],
+    )
+    result = fi.InstallResult(package, "installed", mods / "Car")
+
+    path = fi.write_dependency_metadata_cache(mods, [result], dry_run=False)
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    by_folder = {item["folder"]: item for item in data["packages"]}
+    assert set(by_folder) == {"Car", "Existing"}
+    assert by_folder["Car"]["requirements"][0]["id"] == "Scripts"
+    assert by_folder["Car"]["requirements"][0]["minimumVersion"] == "2.0.0"
+
+
 def test_dependency_preflight_reports_missing_id_bounds_and_requester(tmp_path):
     dependent = package(
         tmp_path,


### PR DESCRIPTION
## Summary
- fix dual-format UMM/FUSE lifecycle handling and reset compatibility state safely
- make native and auto-converted RailLoader packages profile-selectable and gate all content when disabled
- classify optional conditional mixintos correctly and extend dependency reporting across data, UMM, equipment, asset, and code packages
- remove the once-per-second Live Diagnostics window rebuild while preserving scroll and bottom-follow behavior
- reduce cold equipment-catalog work by bypassing Lego's expensive container postfix when a store cannot contain an edited identifier
- log total catalog work, slow-store count, worst store, and the slowest measured FUSE runtime-pump phase for frame-spike attribution
- publish a reproducible low-end-system performance procedure covering load, menus, stutter, scenery, Tile Editor, and Toolshed
- rebuild and visually verify the 33-page user manual and 34-page package-author guide

## Validation
- `dotnet test FUSE.Tests/FUSE.Tests.csproj -c Release --no-restore`: 2269 passed, 9 opt-in real-pack fixtures skipped, 0 failed
- `dotnet test FUSE.Core.Tests/FUSE.Core.Tests.csproj -c Release --no-restore`: 126 passed, 0 failed
- `dotnet test FUSE.ExternalEditor.UiTests/FUSE.ExternalEditor.UiTests.csproj -c Release --no-restore`: 96 passed, 0 failed
- `python -m pytest -q`: 88 passed, 0 failed
- `dotnet slopwatch analyze -d .`: 0 issues
- FUSE wiki published: 15 pages plus Home/sidebar, wiki commit `3e54f4f`, source `0447e49`
- PDF QA: all pages rendered; page counts and extracted text verified; no blank/orphan final page

## Runtime acceptance still required
The automated release gate is green, but the performance checklist deliberately remains open until a fresh large-mod-set Railroader run records click-to-open buy-menu latency, worst frame/main-thread time, queue/GC evidence, and confirms locomotive/railcar customization behavior. Follow the new **Performance Testing** wiki page and attach its evidence bundle. The two known ALW scenery entries remain upstream bundle/catalog defects and are quarantined rather than treated as graph failures.